### PR TITLE
Implement Lex M0–M4: parser, canonical AST, type checker, bytecode VM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --workspace --all-targets
+      - run: cargo test --workspace --no-fail-fast
+      - run: cargo clippy --workspace --all-targets -- -D warnings

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/target
+Cargo.lock
+*.swp
+.DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,32 @@
+[workspace]
+resolver = "2"
+members = [
+    "crates/lex-syntax",
+    "crates/lex-ast",
+    "crates/lex-types",
+    "crates/lex-bytecode",
+    "crates/lex-store",
+    "crates/lex-trace",
+    "crates/lex-runtime",
+    "crates/lex-stdlib",
+    "crates/lex-cli",
+    "crates/lex-api",
+    "crates/core-syntax",
+    "crates/core-compiler",
+    "crates/spec-checker",
+    "crates/conformance",
+]
+
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+
+[workspace.dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
+thiserror = "1"
+anyhow = "1"
+logos = "0.14"
+indexmap = { version = "2", features = ["serde"] }

--- a/crates/conformance/Cargo.toml
+++ b/crates/conformance/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "conformance"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+anyhow.workspace = true
+lex-syntax = { path = "../lex-syntax" }
+lex-ast = { path = "../lex-ast" }
+lex-types = { path = "../lex-types" }
+lex-bytecode = { path = "../lex-bytecode" }

--- a/crates/conformance/src/lib.rs
+++ b/crates/conformance/src/lib.rs
@@ -1,0 +1,1 @@
+//! Conformance harness. See `tests/` for the actual harness.

--- a/crates/core-compiler/Cargo.toml
+++ b/crates/core-compiler/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "core-compiler"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+serde.workspace = true

--- a/crates/core-compiler/src/lib.rs
+++ b/crates/core-compiler/src/lib.rs
@@ -1,0 +1,1 @@
+//! M13: Core compiler. Placeholder.

--- a/crates/core-syntax/Cargo.toml
+++ b/crates/core-syntax/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "core-syntax"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+serde.workspace = true

--- a/crates/core-syntax/src/lib.rs
+++ b/crates/core-syntax/src/lib.rs
@@ -1,0 +1,1 @@
+//! M13: Core lexer/parser. Placeholder.

--- a/crates/lex-api/Cargo.toml
+++ b/crates/lex-api/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "lex-api"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true

--- a/crates/lex-api/src/lib.rs
+++ b/crates/lex-api/src/lib.rs
@@ -1,0 +1,1 @@
+//! M12: agent API server. Placeholder.

--- a/crates/lex-ast/Cargo.toml
+++ b/crates/lex-ast/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "lex-ast"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+thiserror.workspace = true
+indexmap.workspace = true
+lex-syntax = { path = "../lex-syntax" }

--- a/crates/lex-ast/src/canon_json.rs
+++ b/crates/lex-ast/src/canon_json.rs
@@ -1,0 +1,86 @@
+//! Canonical JSON encoding (RFC 8785-flavored).
+//!
+//! We emit:
+//! - UTF-8 bytes
+//! - No whitespace
+//! - Object keys sorted (lexicographic, byte-wise on UTF-8)
+//! - Numbers as their `serde_json` default rendering
+//! - Strings escaped per JSON spec
+//!
+//! Two values that serde-serialize to equal `serde_json::Value` must produce
+//! byte-identical output.
+
+use serde_json::Value;
+
+pub fn to_canonical_string(value: &Value) -> String {
+    let mut out = String::new();
+    write_value(value, &mut out);
+    out
+}
+
+pub fn hash_canonical(value: &Value) -> [u8; 32] {
+    use sha2::{Digest, Sha256};
+    let s = to_canonical_string(value);
+    let mut h = Sha256::new();
+    h.update(s.as_bytes());
+    let r = h.finalize();
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&r);
+    out
+}
+
+pub fn hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{:02x}", b));
+    }
+    s
+}
+
+fn write_value(v: &Value, out: &mut String) {
+    match v {
+        Value::Null => out.push_str("null"),
+        Value::Bool(true) => out.push_str("true"),
+        Value::Bool(false) => out.push_str("false"),
+        Value::Number(n) => out.push_str(&n.to_string()),
+        Value::String(s) => write_string(s, out),
+        Value::Array(items) => {
+            out.push('[');
+            for (i, it) in items.iter().enumerate() {
+                if i > 0 { out.push(','); }
+                write_value(it, out);
+            }
+            out.push(']');
+        }
+        Value::Object(map) => {
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort();
+            out.push('{');
+            for (i, k) in keys.iter().enumerate() {
+                if i > 0 { out.push(','); }
+                write_string(k, out);
+                out.push(':');
+                write_value(&map[*k], out);
+            }
+            out.push('}');
+        }
+    }
+}
+
+fn write_string(s: &str, out: &mut String) {
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\x08' => out.push_str("\\b"),
+            '\x0c' => out.push_str("\\f"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+}

--- a/crates/lex-ast/src/canon_print.rs
+++ b/crates/lex-ast/src/canon_print.rs
@@ -1,0 +1,384 @@
+//! Pretty-printer for canonical AST. Output is parseable Lex source.
+//!
+//! This is the inverse-ish of `canonicalize_program`: it does NOT recover
+//! `if` or `?` (those are folded away in the canonical form). All branching
+//! prints as `match`; `?` would print as its full match expansion.
+
+use crate::canonical::*;
+use std::fmt::Write;
+
+pub fn print_stages(stages: &[Stage]) -> String {
+    let mut p = Printer::new();
+    for (i, s) in stages.iter().enumerate() {
+        if i > 0 { p.out.push('\n'); }
+        p.stage(s);
+    }
+    p.out
+}
+
+struct Printer { out: String, indent: usize }
+
+impl Printer {
+    fn new() -> Self { Self { out: String::new(), indent: 0 } }
+    fn nl(&mut self) { self.out.push('\n'); }
+    fn pad(&mut self) { for _ in 0..self.indent { self.out.push_str("  "); } }
+
+    fn stage(&mut self, s: &Stage) {
+        match s {
+            Stage::Import(i) => {
+                writeln!(self.out, "import \"{}\" as {}", i.reference, i.alias).unwrap();
+            }
+            Stage::TypeDecl(td) => self.type_decl(td),
+            Stage::FnDecl(fd) => self.fn_decl(fd),
+        }
+    }
+
+    fn type_decl(&mut self, td: &TypeDecl) {
+        write!(self.out, "type {}", td.name).unwrap();
+        if !td.params.is_empty() {
+            write!(self.out, "[{}]", td.params.join(", ")).unwrap();
+        }
+        write!(self.out, " = ").unwrap();
+        self.ty(&td.definition);
+        self.nl();
+    }
+
+    fn fn_decl(&mut self, fd: &FnDecl) {
+        write!(self.out, "fn {}", fd.name).unwrap();
+        if !fd.type_params.is_empty() {
+            write!(self.out, "[{}]", fd.type_params.join(", ")).unwrap();
+        }
+        write!(self.out, "(").unwrap();
+        for (i, p) in fd.params.iter().enumerate() {
+            if i > 0 { write!(self.out, ", ").unwrap(); }
+            write!(self.out, "{} :: ", p.name).unwrap();
+            self.ty(&p.ty);
+        }
+        write!(self.out, ") -> ").unwrap();
+        self.effects(&fd.effects);
+        self.ty(&fd.return_type);
+        write!(self.out, " ").unwrap();
+        self.expr_as_block(&fd.body);
+        self.nl();
+    }
+
+    fn effects(&mut self, effects: &[Effect]) {
+        if effects.is_empty() { return; }
+        write!(self.out, "[").unwrap();
+        for (i, e) in effects.iter().enumerate() {
+            if i > 0 { write!(self.out, ", ").unwrap(); }
+            write!(self.out, "{}", e.name).unwrap();
+            if let Some(arg) = &e.arg {
+                match arg {
+                    EffectArg::Str { value } => write!(self.out, "(\"{}\")", value).unwrap(),
+                    EffectArg::Int { value } => write!(self.out, "({})", value).unwrap(),
+                    EffectArg::Ident { value } => write!(self.out, "({})", value).unwrap(),
+                }
+            }
+        }
+        write!(self.out, "] ").unwrap();
+    }
+
+    fn ty(&mut self, t: &TypeExpr) {
+        match t {
+            TypeExpr::Named { name, args } => {
+                write!(self.out, "{}", name).unwrap();
+                if !args.is_empty() {
+                    write!(self.out, "[").unwrap();
+                    for (i, a) in args.iter().enumerate() {
+                        if i > 0 { write!(self.out, ", ").unwrap(); }
+                        self.ty(a);
+                    }
+                    write!(self.out, "]").unwrap();
+                }
+            }
+            TypeExpr::Record { fields } => {
+                write!(self.out, "{{ ").unwrap();
+                for (i, f) in fields.iter().enumerate() {
+                    if i > 0 { write!(self.out, ", ").unwrap(); }
+                    write!(self.out, "{} :: ", f.name).unwrap();
+                    self.ty(&f.ty);
+                }
+                write!(self.out, " }}").unwrap();
+            }
+            TypeExpr::Tuple { items } => {
+                write!(self.out, "(").unwrap();
+                for (i, it) in items.iter().enumerate() {
+                    if i > 0 { write!(self.out, ", ").unwrap(); }
+                    self.ty(it);
+                }
+                write!(self.out, ")").unwrap();
+            }
+            TypeExpr::Function { params, effects, ret } => {
+                write!(self.out, "(").unwrap();
+                for (i, p) in params.iter().enumerate() {
+                    if i > 0 { write!(self.out, ", ").unwrap(); }
+                    self.ty(p);
+                }
+                write!(self.out, ") -> ").unwrap();
+                self.effects(effects);
+                self.ty(ret);
+            }
+            TypeExpr::Union { variants } => {
+                for (i, v) in variants.iter().enumerate() {
+                    if i > 0 { write!(self.out, " | ").unwrap(); }
+                    write!(self.out, "{}", v.name).unwrap();
+                    if let Some(p) = &v.payload {
+                        write!(self.out, "(").unwrap();
+                        self.ty(p);
+                        write!(self.out, ")").unwrap();
+                    }
+                }
+            }
+        }
+    }
+
+    /// Print a CExpr as a `{ ... }` block, even if it's not a Block — we wrap it.
+    fn expr_as_block(&mut self, e: &CExpr) {
+        write!(self.out, "{{").unwrap();
+        self.indent += 1;
+        self.print_block_contents(e);
+        self.indent -= 1;
+        self.nl();
+        self.pad();
+        write!(self.out, "}}").unwrap();
+    }
+
+    /// Emit the contents of a block — i.e. flatten Lets and Block.statements
+    /// onto separate lines, ending with the result expression.
+    fn print_block_contents(&mut self, e: &CExpr) {
+        match e {
+            CExpr::Let { name, ty, value, body } => {
+                self.nl();
+                self.pad();
+                write!(self.out, "let {}", name).unwrap();
+                if let Some(ty) = ty {
+                    write!(self.out, " :: ").unwrap();
+                    self.ty(ty);
+                }
+                write!(self.out, " := ").unwrap();
+                self.expr(value);
+                self.print_block_contents(body);
+            }
+            CExpr::Block { statements, result } => {
+                for s in statements {
+                    self.nl();
+                    self.pad();
+                    self.expr(s);
+                }
+                self.print_block_contents(result);
+            }
+            other => {
+                self.nl();
+                self.pad();
+                self.expr(other);
+            }
+        }
+    }
+
+    fn expr(&mut self, e: &CExpr) {
+        match e {
+            CExpr::Literal { value } => self.lit(value),
+            CExpr::Var { name } => { write!(self.out, "{}", name).unwrap(); }
+            CExpr::Call { callee, args } => {
+                self.expr(callee);
+                write!(self.out, "(").unwrap();
+                for (i, a) in args.iter().enumerate() {
+                    if i > 0 { write!(self.out, ", ").unwrap(); }
+                    self.expr(a);
+                }
+                write!(self.out, ")").unwrap();
+            }
+            CExpr::Let { .. } | CExpr::Block { .. } => {
+                self.expr_as_block(e);
+            }
+            CExpr::Match { scrutinee, arms } => {
+                write!(self.out, "match ").unwrap();
+                self.expr(scrutinee);
+                write!(self.out, " {{").unwrap();
+                self.indent += 1;
+                for arm in arms {
+                    self.nl();
+                    self.pad();
+                    self.pat(&arm.pattern);
+                    write!(self.out, " => ").unwrap();
+                    self.expr(&arm.body);
+                    write!(self.out, ",").unwrap();
+                }
+                self.indent -= 1;
+                self.nl();
+                self.pad();
+                write!(self.out, "}}").unwrap();
+            }
+            CExpr::Constructor { name, args } => {
+                write!(self.out, "{}", name).unwrap();
+                if !args.is_empty() {
+                    write!(self.out, "(").unwrap();
+                    for (i, a) in args.iter().enumerate() {
+                        if i > 0 { write!(self.out, ", ").unwrap(); }
+                        self.expr(a);
+                    }
+                    write!(self.out, ")").unwrap();
+                }
+            }
+            CExpr::RecordLit { fields } => {
+                write!(self.out, "{{ ").unwrap();
+                for (i, f) in fields.iter().enumerate() {
+                    if i > 0 { write!(self.out, ", ").unwrap(); }
+                    write!(self.out, "{}: ", f.name).unwrap();
+                    self.expr(&f.value);
+                }
+                write!(self.out, " }}").unwrap();
+            }
+            CExpr::TupleLit { items } => {
+                write!(self.out, "(").unwrap();
+                for (i, it) in items.iter().enumerate() {
+                    if i > 0 { write!(self.out, ", ").unwrap(); }
+                    self.expr(it);
+                }
+                write!(self.out, ")").unwrap();
+            }
+            CExpr::ListLit { items } => {
+                write!(self.out, "[").unwrap();
+                for (i, it) in items.iter().enumerate() {
+                    if i > 0 { write!(self.out, ", ").unwrap(); }
+                    self.expr(it);
+                }
+                write!(self.out, "]").unwrap();
+            }
+            CExpr::FieldAccess { value, field } => {
+                self.expr(value);
+                write!(self.out, ".{}", field).unwrap();
+            }
+            CExpr::Lambda { params, return_type, effects, body } => {
+                write!(self.out, "fn (").unwrap();
+                for (i, p) in params.iter().enumerate() {
+                    if i > 0 { write!(self.out, ", ").unwrap(); }
+                    write!(self.out, "{} :: ", p.name).unwrap();
+                    self.ty(&p.ty);
+                }
+                write!(self.out, ") -> ").unwrap();
+                self.effects(effects);
+                self.ty(return_type);
+                write!(self.out, " ").unwrap();
+                self.expr_as_block(body);
+            }
+            CExpr::BinOp { op, lhs, rhs } => {
+                write!(self.out, "(").unwrap();
+                self.expr(lhs);
+                write!(self.out, " {} ", op).unwrap();
+                self.expr(rhs);
+                write!(self.out, ")").unwrap();
+            }
+            CExpr::UnaryOp { op, expr } => {
+                if op == "not" {
+                    write!(self.out, "(not ").unwrap();
+                } else {
+                    write!(self.out, "({}", op).unwrap();
+                }
+                self.expr(expr);
+                write!(self.out, ")").unwrap();
+            }
+            CExpr::Return { value } => {
+                // No source-level form for an early return; we approximate by
+                // printing the value (M3+ rejects programs that need this).
+                self.expr(value);
+            }
+        }
+    }
+
+    fn lit(&mut self, l: &CLit) {
+        match l {
+            CLit::Int { value } => write!(self.out, "{}", value).unwrap(),
+            CLit::Float { value } => write!(self.out, "{}", value).unwrap(),
+            CLit::Str { value } => write!(self.out, "\"{}\"", escape(value)).unwrap(),
+            CLit::Bytes { value } => {
+                // Hex-encoded bytes; round-trip via raw byte string.
+                write!(self.out, "b\"").unwrap();
+                let bytes = decode_hex(value);
+                for b in bytes {
+                    if b.is_ascii() && (b as char).is_ascii_graphic() && b != b'"' && b != b'\\' {
+                        self.out.push(b as char);
+                    } else {
+                        write!(self.out, "\\x{:02x}", b).unwrap();
+                    }
+                }
+                write!(self.out, "\"").unwrap();
+            }
+            CLit::Bool { value } => write!(self.out, "{}", value).unwrap(),
+            CLit::Unit => write!(self.out, "()").unwrap(),
+        }
+    }
+
+    fn pat(&mut self, p: &Pattern) {
+        match p {
+            Pattern::PLiteral { value } => self.lit(value),
+            Pattern::PVar { name } => { write!(self.out, "{}", name).unwrap(); }
+            Pattern::PWild => { write!(self.out, "_").unwrap(); }
+            Pattern::PConstructor { name, args } => {
+                write!(self.out, "{}", name).unwrap();
+                if !args.is_empty() {
+                    write!(self.out, "(").unwrap();
+                    for (i, a) in args.iter().enumerate() {
+                        if i > 0 { write!(self.out, ", ").unwrap(); }
+                        self.pat(a);
+                    }
+                    write!(self.out, ")").unwrap();
+                }
+            }
+            Pattern::PRecord { fields } => {
+                write!(self.out, "{{ ").unwrap();
+                for (i, f) in fields.iter().enumerate() {
+                    if i > 0 { write!(self.out, ", ").unwrap(); }
+                    write!(self.out, "{}: ", f.name).unwrap();
+                    self.pat(&f.pattern);
+                }
+                write!(self.out, " }}").unwrap();
+            }
+            Pattern::PTuple { items } => {
+                write!(self.out, "(").unwrap();
+                for (i, it) in items.iter().enumerate() {
+                    if i > 0 { write!(self.out, ", ").unwrap(); }
+                    self.pat(it);
+                }
+                write!(self.out, ")").unwrap();
+            }
+        }
+    }
+}
+
+fn escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\t' => out.push_str("\\t"),
+            '\r' => out.push_str("\\r"),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+fn decode_hex(s: &str) -> Vec<u8> {
+    let mut out = Vec::with_capacity(s.len() / 2);
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i + 1 < bytes.len() {
+        let h = (parse_hex(bytes[i]) << 4) | parse_hex(bytes[i + 1]);
+        out.push(h);
+        i += 2;
+    }
+    out
+}
+
+fn parse_hex(b: u8) -> u8 {
+    match b {
+        b'0'..=b'9' => b - b'0',
+        b'a'..=b'f' => b - b'a' + 10,
+        b'A'..=b'F' => b - b'A' + 10,
+        _ => 0,
+    }
+}

--- a/crates/lex-ast/src/canonical.rs
+++ b/crates/lex-ast/src/canonical.rs
@@ -1,0 +1,176 @@
+//! Canonical AST per spec §5.1.
+//!
+//! Two views:
+//! - The data tree itself (this module).
+//! - Node-IDs computed from positions (§5.2; see [`node_id`]).
+//!
+//! The canonical AST has no `If`, no `?`, no parens, no comments. Record
+//! field orders are sorted alphabetically; union variants too. The
+//! canonicalizer (§5.3) is in `crate::canonicalize`.
+
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+
+/// A whole stage's canonical form. Lex source is a *projection* of a set of
+/// stages (§3.12); each `fn` and `type` declaration becomes one stage.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "node")]
+pub enum Stage {
+    FnDecl(FnDecl),
+    TypeDecl(TypeDecl),
+    Import(Import),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FnDecl {
+    pub name: String,
+    pub type_params: Vec<String>,
+    pub params: Vec<Param>,
+    pub effects: Vec<Effect>,
+    pub return_type: TypeExpr,
+    pub body: CExpr,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TypeDecl {
+    pub name: String,
+    pub params: Vec<String>,
+    pub definition: TypeExpr,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Import {
+    pub reference: String,
+    pub alias: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Param {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub ty: TypeExpr,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Effect {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arg: Option<EffectArg>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "kind")]
+pub enum EffectArg {
+    Str { value: String },
+    Int { value: i64 },
+    Ident { value: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "node")]
+pub enum TypeExpr {
+    Named { name: String, args: Vec<TypeExpr> },
+    Record { fields: Vec<TypeField> },
+    Tuple { items: Vec<TypeExpr> },
+    Function { params: Vec<TypeExpr>, effects: Vec<Effect>, ret: Box<TypeExpr> },
+    Union { variants: Vec<UnionVariant> },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TypeField {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub ty: TypeExpr,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct UnionVariant {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload: Option<TypeExpr>,
+}
+
+/// Canonical expression. No `If`, no `Try`. `Pipe` is normalized to `Call`
+/// (`x |> f` ≡ `Call f [x]`, `x |> f(a)` ≡ `Call f [x, a]`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "node")]
+pub enum CExpr {
+    Literal { value: CLit },
+    Var { name: String },
+    Call { callee: Box<CExpr>, args: Vec<CExpr> },
+    Let { name: String, ty: Option<TypeExpr>, value: Box<CExpr>, body: Box<CExpr> },
+    Match { scrutinee: Box<CExpr>, arms: Vec<Arm> },
+    Block { statements: Vec<CExpr>, result: Box<CExpr> },
+    Constructor { name: String, args: Vec<CExpr> },
+    RecordLit { fields: Vec<RecordField> },
+    TupleLit { items: Vec<CExpr> },
+    ListLit { items: Vec<CExpr> },
+    FieldAccess { value: Box<CExpr>, field: String },
+    Lambda { params: Vec<Param>, return_type: TypeExpr, effects: Vec<Effect>, body: Box<CExpr> },
+    BinOp { op: String, lhs: Box<CExpr>, rhs: Box<CExpr> },
+    UnaryOp { op: String, expr: Box<CExpr> },
+    /// Tail position only; used for `?` desugaring.
+    Return { value: Box<CExpr> },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RecordField {
+    pub name: String,
+    pub value: CExpr,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "kind")]
+pub enum CLit {
+    Int { value: i64 },
+    Float { value: String }, // Stringified for stable canonical encoding.
+    Str { value: String },
+    Bytes { value: String }, // Hex-encoded for stable JSON.
+    Bool { value: bool },
+    Unit,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Arm {
+    pub pattern: Pattern,
+    pub body: CExpr,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "node")]
+pub enum Pattern {
+    PLiteral { value: CLit },
+    PVar { name: String },
+    PWild,
+    PConstructor { name: String, args: Vec<Pattern> },
+    PRecord { fields: Vec<PatternRecordField> },
+    PTuple { items: Vec<Pattern> },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PatternRecordField {
+    pub name: String,
+    pub pattern: Pattern,
+}
+
+/// Indexed view (used by tools). Maps NodeId → reference into a stage.
+/// Computing this is `O(n)` walk of the tree; we keep IDs out of the data.
+pub struct WithIds<'a> {
+    #[allow(dead_code)]
+    pub root: &'a Stage,
+    pub map: IndexMap<String, NodePath>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NodePath(pub Vec<usize>);
+
+impl NodePath {
+    pub fn id(&self) -> String {
+        let mut s = String::from("n_0");
+        for &p in &self.0 {
+            s.push('.');
+            s.push_str(&p.to_string());
+        }
+        s
+    }
+}

--- a/crates/lex-ast/src/canonicalize.rs
+++ b/crates/lex-ast/src/canonicalize.rs
@@ -1,0 +1,375 @@
+//! Canonicalizer: `SyntaxTree` → `CanonicalAst` per spec §5.3.
+//!
+//! Rules:
+//! 1. Sort record-literal fields and record-type fields alphabetically.
+//! 2. Sort union variants alphabetically.
+//! 3. `if c { a } else { b }` → `Match(c, [Arm(true, a), Arm(false, b)])`.
+//! 4. `e?` → the canonical Match expansion from §3.10.
+//! 5. Identifiers starting with an uppercase letter are constructors
+//!    (in expressions and in patterns). Lowercase idents are vars/binders.
+//! 6. `Pipe(x, f)` → `Call(f, [x])`; `Pipe(x, Call(f, args))` → `Call(f, [x, args...])`.
+//! 7. Top-level: each `Item` becomes one `Stage`. Order is preserved (no
+//!    dependency reordering yet — TODO §5.3 rule 3).
+
+use crate::canonical::*;
+use lex_syntax::syntax as s;
+
+pub fn canonicalize_program(program: &s::Program) -> Vec<Stage> {
+    program.items.iter().map(canonicalize_item).collect()
+}
+
+pub fn canonicalize_item(item: &s::Item) -> Stage {
+    match item {
+        s::Item::Import(i) => Stage::Import(Import {
+            reference: i.reference.clone(),
+            alias: i.alias.clone(),
+        }),
+        s::Item::TypeDecl(td) => Stage::TypeDecl(canonicalize_type_decl(td)),
+        s::Item::FnDecl(fd) => Stage::FnDecl(canonicalize_fn_decl(fd)),
+    }
+}
+
+fn canonicalize_type_decl(td: &s::TypeDecl) -> TypeDecl {
+    TypeDecl {
+        name: td.name.clone(),
+        params: td.params.clone(),
+        definition: canonicalize_type(&td.definition),
+    }
+}
+
+fn canonicalize_fn_decl(fd: &s::FnDecl) -> FnDecl {
+    FnDecl {
+        name: fd.name.clone(),
+        type_params: fd.type_params.clone(),
+        params: fd
+            .params
+            .iter()
+            .map(|p| Param { name: p.name.clone(), ty: canonicalize_type(&p.ty) })
+            .collect(),
+        effects: fd.effects.iter().map(canonicalize_effect).collect(),
+        return_type: canonicalize_type(&fd.return_type),
+        body: canonicalize_block(&fd.body),
+    }
+}
+
+fn canonicalize_effect(e: &s::Effect) -> Effect {
+    Effect {
+        name: e.name.clone(),
+        arg: e.arg.as_ref().map(|a| match a {
+            s::EffectArg::Str(s) => EffectArg::Str { value: s.clone() },
+            s::EffectArg::Int(n) => EffectArg::Int { value: *n },
+            s::EffectArg::Ident(s) => EffectArg::Ident { value: s.clone() },
+        }),
+    }
+}
+
+fn canonicalize_type(t: &s::TypeExpr) -> TypeExpr {
+    match t {
+        s::TypeExpr::Named { name, args } => TypeExpr::Named {
+            name: name.clone(),
+            args: args.iter().map(canonicalize_type).collect(),
+        },
+        s::TypeExpr::Record(fs) => {
+            let mut fields: Vec<TypeField> = fs
+                .iter()
+                .map(|f| TypeField { name: f.name.clone(), ty: canonicalize_type(&f.ty) })
+                .collect();
+            fields.sort_by(|a, b| a.name.cmp(&b.name));
+            TypeExpr::Record { fields }
+        }
+        s::TypeExpr::Tuple(items) => TypeExpr::Tuple {
+            items: items.iter().map(canonicalize_type).collect(),
+        },
+        s::TypeExpr::Function { params, effects, ret } => TypeExpr::Function {
+            params: params.iter().map(canonicalize_type).collect(),
+            effects: {
+                let mut es: Vec<Effect> = effects.iter().map(canonicalize_effect).collect();
+                es.sort_by(|a, b| a.name.cmp(&b.name));
+                es
+            },
+            ret: Box::new(canonicalize_type(ret)),
+        },
+        s::TypeExpr::Union(variants) => {
+            let mut vs: Vec<UnionVariant> = variants
+                .iter()
+                .map(|v| UnionVariant {
+                    name: v.name.clone(),
+                    payload: v.payload.as_ref().map(canonicalize_type),
+                })
+                .collect();
+            vs.sort_by(|a, b| a.name.cmp(&b.name));
+            TypeExpr::Union { variants: vs }
+        }
+    }
+}
+
+fn canonicalize_block(b: &s::Block) -> CExpr {
+    // Convert `{ stmt1; stmt2; ...; result }` into nested Lets where possible
+    // so binders carry through to body. For pure expressions in statement
+    // position we keep them in `Block.statements` (this is a CExpr::Block).
+    let result = canonicalize_expr(&b.result);
+    fold_block(&b.statements[..], result)
+}
+
+/// Fold statements into nested `Let { body: ... }` chains. Bare `Statement::Expr`
+/// becomes a `Block { statements: [...], result: ... }` — but only if there
+/// are non-let statements in the chain. For all-let chains we collapse to a
+/// chain of `Let { body }` so type-checking and evaluation are linear.
+fn fold_block(stmts: &[s::Statement], result: CExpr) -> CExpr {
+    if stmts.is_empty() {
+        return result;
+    }
+    // Walk from the end, building nested Lets / blocks.
+    let mut acc = result;
+    let mut pending_exprs: Vec<CExpr> = Vec::new();
+    for stmt in stmts.iter().rev() {
+        match stmt {
+            s::Statement::Let { name, ty, value } => {
+                if !pending_exprs.is_empty() {
+                    pending_exprs.reverse();
+                    let body = std::mem::replace(&mut acc, CExpr::Literal { value: CLit::Unit });
+                    acc = CExpr::Block { statements: pending_exprs.clone(), result: Box::new(body) };
+                    pending_exprs.clear();
+                }
+                acc = CExpr::Let {
+                    name: name.clone(),
+                    ty: ty.as_ref().map(canonicalize_type),
+                    value: Box::new(canonicalize_expr(value)),
+                    body: Box::new(acc),
+                };
+            }
+            s::Statement::Expr(e) => {
+                pending_exprs.push(canonicalize_expr(e));
+            }
+        }
+    }
+    if !pending_exprs.is_empty() {
+        pending_exprs.reverse();
+        acc = CExpr::Block { statements: pending_exprs, result: Box::new(acc) };
+    }
+    acc
+}
+
+fn canonicalize_expr(e: &s::Expr) -> CExpr {
+    match e {
+        s::Expr::Lit(l) => CExpr::Literal { value: canonicalize_lit(l) },
+        s::Expr::Var(name) => {
+            if is_constructor_name(name) {
+                CExpr::Constructor { name: name.clone(), args: Vec::new() }
+            } else {
+                CExpr::Var { name: name.clone() }
+            }
+        }
+        s::Expr::Block(b) => canonicalize_block(b),
+        s::Expr::Call { callee, args } => {
+            // Special case: a Call whose callee is an uppercase-named Var is a constructor.
+            if let s::Expr::Var(name) = callee.as_ref() {
+                if is_constructor_name(name) {
+                    return CExpr::Constructor {
+                        name: name.clone(),
+                        args: args.iter().map(canonicalize_expr).collect(),
+                    };
+                }
+            }
+            CExpr::Call {
+                callee: Box::new(canonicalize_expr(callee)),
+                args: args.iter().map(canonicalize_expr).collect(),
+            }
+        }
+        s::Expr::Pipe { left, right } => {
+            let lc = canonicalize_expr(left);
+            // x |> f ≡ Call(f, [x]); x |> f(args) ≡ Call(f, [x, args...]).
+            match canonicalize_expr(right) {
+                CExpr::Call { callee, args } => {
+                    let mut new_args = Vec::with_capacity(args.len() + 1);
+                    new_args.push(lc);
+                    new_args.extend(args);
+                    CExpr::Call { callee, args: new_args }
+                }
+                CExpr::Constructor { name, args } => {
+                    let mut new_args = Vec::with_capacity(args.len() + 1);
+                    new_args.push(lc);
+                    new_args.extend(args);
+                    CExpr::Constructor { name, args: new_args }
+                }
+                other => CExpr::Call { callee: Box::new(other), args: vec![lc] },
+            }
+        }
+        s::Expr::Try(inner) => {
+            // §3.10 desugar
+            let v = canonicalize_expr(inner);
+            CExpr::Match {
+                scrutinee: Box::new(v),
+                arms: vec![
+                    Arm {
+                        pattern: Pattern::PConstructor {
+                            name: "Ok".into(),
+                            args: vec![Pattern::PVar { name: "v".into() }],
+                        },
+                        body: CExpr::Var { name: "v".into() },
+                    },
+                    Arm {
+                        pattern: Pattern::PConstructor {
+                            name: "Err".into(),
+                            args: vec![Pattern::PVar { name: "e".into() }],
+                        },
+                        body: CExpr::Return {
+                            value: Box::new(CExpr::Constructor {
+                                name: "Err".into(),
+                                args: vec![CExpr::Var { name: "e".into() }],
+                            }),
+                        },
+                    },
+                ],
+            }
+        }
+        s::Expr::Field { value, field } => CExpr::FieldAccess {
+            value: Box::new(canonicalize_expr(value)),
+            field: field.clone(),
+        },
+        s::Expr::BinOp { op, lhs, rhs } => CExpr::BinOp {
+            op: op.as_str().to_string(),
+            lhs: Box::new(canonicalize_expr(lhs)),
+            rhs: Box::new(canonicalize_expr(rhs)),
+        },
+        s::Expr::UnaryOp { op, expr } => CExpr::UnaryOp {
+            op: match op { s::UnaryOp::Neg => "-", s::UnaryOp::Not => "not" }.into(),
+            expr: Box::new(canonicalize_expr(expr)),
+        },
+        s::Expr::If { cond, then_block, else_block } => CExpr::Match {
+            scrutinee: Box::new(canonicalize_expr(cond)),
+            arms: vec![
+                Arm {
+                    pattern: Pattern::PLiteral { value: CLit::Bool { value: true } },
+                    body: canonicalize_block(then_block),
+                },
+                Arm {
+                    pattern: Pattern::PLiteral { value: CLit::Bool { value: false } },
+                    body: canonicalize_block(else_block),
+                },
+            ],
+        },
+        s::Expr::Match { scrutinee, arms } => CExpr::Match {
+            scrutinee: Box::new(canonicalize_expr(scrutinee)),
+            arms: arms.iter().map(canonicalize_arm).collect(),
+        },
+        s::Expr::RecordLit(fields) => {
+            let mut fs: Vec<RecordField> = fields
+                .iter()
+                .map(|f| RecordField {
+                    name: f.name.clone(),
+                    value: canonicalize_expr(&f.value),
+                })
+                .collect();
+            fs.sort_by(|a, b| a.name.cmp(&b.name));
+            CExpr::RecordLit { fields: fs }
+        }
+        s::Expr::TupleLit(items) => CExpr::TupleLit {
+            items: items.iter().map(canonicalize_expr).collect(),
+        },
+        s::Expr::ListLit(items) => CExpr::ListLit {
+            items: items.iter().map(canonicalize_expr).collect(),
+        },
+        s::Expr::Constructor { name, args } => CExpr::Constructor {
+            name: name.clone(),
+            args: args.iter().map(canonicalize_expr).collect(),
+        },
+        s::Expr::Lambda(l) => CExpr::Lambda {
+            params: l.params.iter().map(|p| Param {
+                name: p.name.clone(),
+                ty: canonicalize_type(&p.ty),
+            }).collect(),
+            return_type: canonicalize_type(&l.return_type),
+            effects: {
+                let mut es: Vec<Effect> = l.effects.iter().map(canonicalize_effect).collect();
+                es.sort_by(|a, b| a.name.cmp(&b.name));
+                es
+            },
+            body: Box::new(canonicalize_block(&l.body)),
+        },
+    }
+}
+
+fn canonicalize_arm(a: &s::Arm) -> Arm {
+    Arm { pattern: canonicalize_pattern(&a.pattern), body: canonicalize_expr(&a.body) }
+}
+
+fn canonicalize_pattern(p: &s::Pattern) -> Pattern {
+    match p {
+        s::Pattern::Lit(l) => Pattern::PLiteral { value: canonicalize_lit(l) },
+        s::Pattern::Var(name) => {
+            // Uppercase-named bare ident in pattern position is a tag-only constructor.
+            if is_constructor_name(name) {
+                Pattern::PConstructor { name: name.clone(), args: Vec::new() }
+            } else {
+                Pattern::PVar { name: name.clone() }
+            }
+        }
+        s::Pattern::Wild => Pattern::PWild,
+        s::Pattern::Constructor { name, args } => Pattern::PConstructor {
+            name: name.clone(),
+            args: args.iter().map(canonicalize_pattern).collect(),
+        },
+        s::Pattern::Record { fields, rest: _ } => {
+            let mut fs: Vec<PatternRecordField> = fields
+                .iter()
+                .map(|f| PatternRecordField {
+                    name: f.name.clone(),
+                    pattern: f
+                        .pattern
+                        .as_ref()
+                        .map(canonicalize_pattern)
+                        .unwrap_or(Pattern::PVar { name: f.name.clone() }),
+                })
+                .collect();
+            fs.sort_by(|a, b| a.name.cmp(&b.name));
+            Pattern::PRecord { fields: fs }
+        }
+        s::Pattern::Tuple(items) => Pattern::PTuple {
+            items: items.iter().map(canonicalize_pattern).collect(),
+        },
+    }
+}
+
+fn canonicalize_lit(l: &s::Literal) -> CLit {
+    match l {
+        s::Literal::Int(n) => CLit::Int { value: *n },
+        s::Literal::Float(f) => CLit::Float { value: format_canonical_float(*f) },
+        s::Literal::Str(s) => CLit::Str { value: s.clone() },
+        s::Literal::Bytes(b) => CLit::Bytes { value: hex(b) },
+        s::Literal::Bool(b) => CLit::Bool { value: *b },
+        s::Literal::Unit => CLit::Unit,
+    }
+}
+
+fn format_canonical_float(f: f64) -> String {
+    // RFC 8785-flavored: shortest round-trippable. We use Rust's default
+    // float formatting, which is already shortest-round-trip via Grisu/Ryu.
+    if f.is_finite() {
+        let s = format!("{}", f);
+        if !s.contains('.') && !s.contains('e') && !s.contains('E') {
+            // Ensure float-shape stays a float.
+            format!("{}.0", s)
+        } else {
+            s
+        }
+    } else if f.is_nan() {
+        "NaN".into()
+    } else if f.is_sign_positive() {
+        "Infinity".into()
+    } else {
+        "-Infinity".into()
+    }
+}
+
+fn hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{:02x}", b));
+    }
+    s
+}
+
+fn is_constructor_name(name: &str) -> bool {
+    name.chars().next().map(|c| c.is_ascii_uppercase()).unwrap_or(false)
+}

--- a/crates/lex-ast/src/ids.rs
+++ b/crates/lex-ast/src/ids.rs
@@ -1,0 +1,202 @@
+//! Node IDs (§5.2). A NodeId encodes the path from a stage root to a node
+//! as `n_0[.<i>]*`, where each `<i>` is the position in the parent's
+//! children array.
+
+use crate::canonical::*;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct NodeId(pub String);
+
+impl NodeId {
+    pub fn root() -> Self { NodeId("n_0".into()) }
+    pub fn child(&self, i: usize) -> Self { NodeId(format!("{}.{}", self.0, i)) }
+    pub fn as_str(&self) -> &str { &self.0 }
+}
+
+/// Walk a stage and emit all NodeIds with their underlying nodes (referenced).
+/// Order is depth-first, child-index ordered.
+pub fn collect_ids(stage: &Stage) -> Vec<(NodeId, NodeRef<'_>)> {
+    let mut out = Vec::new();
+    let root = NodeId::root();
+    out.push((root.clone(), NodeRef::Stage(stage)));
+    walk_stage(stage, &root, &mut out);
+    out
+}
+
+#[derive(Debug)]
+pub enum NodeRef<'a> {
+    Stage(&'a Stage),
+    CExpr(&'a CExpr),
+    Pattern(&'a Pattern),
+    TypeExpr(&'a TypeExpr),
+}
+
+fn walk_stage<'a>(s: &'a Stage, parent: &NodeId, out: &mut Vec<(NodeId, NodeRef<'a>)>) {
+    match s {
+        Stage::FnDecl(fd) => {
+            // children: params (0..n_params), return_type (n), body (n+1)
+            for (i, p) in fd.params.iter().enumerate() {
+                let id = parent.child(i);
+                out.push((id.clone(), NodeRef::TypeExpr(&p.ty)));
+                walk_type(&p.ty, &id, out);
+            }
+            let rid = parent.child(fd.params.len());
+            out.push((rid.clone(), NodeRef::TypeExpr(&fd.return_type)));
+            walk_type(&fd.return_type, &rid, out);
+            let bid = parent.child(fd.params.len() + 1);
+            out.push((bid.clone(), NodeRef::CExpr(&fd.body)));
+            walk_expr(&fd.body, &bid, out);
+        }
+        Stage::TypeDecl(td) => {
+            let id = parent.child(0);
+            out.push((id.clone(), NodeRef::TypeExpr(&td.definition)));
+            walk_type(&td.definition, &id, out);
+        }
+        Stage::Import(_) => {}
+    }
+}
+
+fn walk_expr<'a>(e: &'a CExpr, parent: &NodeId, out: &mut Vec<(NodeId, NodeRef<'a>)>) {
+    let mut idx = 0;
+    let emit_expr = |child: &'a CExpr, idx: &mut usize, out: &mut Vec<(NodeId, NodeRef<'a>)>| {
+        let id = parent.child(*idx);
+        out.push((id.clone(), NodeRef::CExpr(child)));
+        walk_expr(child, &id, out);
+        *idx += 1;
+    };
+    let emit_pat = |p: &'a Pattern, idx: &mut usize, out: &mut Vec<(NodeId, NodeRef<'a>)>| {
+        let id = parent.child(*idx);
+        out.push((id.clone(), NodeRef::Pattern(p)));
+        walk_pat(p, &id, out);
+        *idx += 1;
+    };
+    match e {
+        CExpr::Literal { .. } | CExpr::Var { .. } => {}
+        CExpr::Call { callee, args } => {
+            emit_expr(callee, &mut idx, out);
+            for a in args { emit_expr(a, &mut idx, out); }
+        }
+        CExpr::Let { value, body, .. } => {
+            emit_expr(value, &mut idx, out);
+            emit_expr(body, &mut idx, out);
+        }
+        CExpr::Match { scrutinee, arms } => {
+            emit_expr(scrutinee, &mut idx, out);
+            for arm in arms {
+                emit_pat(&arm.pattern, &mut idx, out);
+                emit_expr(&arm.body, &mut idx, out);
+            }
+        }
+        CExpr::Block { statements, result } => {
+            for s in statements { emit_expr(s, &mut idx, out); }
+            emit_expr(result, &mut idx, out);
+        }
+        CExpr::Constructor { args, .. } => {
+            for a in args { emit_expr(a, &mut idx, out); }
+        }
+        CExpr::RecordLit { fields } => {
+            for f in fields { emit_expr(&f.value, &mut idx, out); }
+        }
+        CExpr::TupleLit { items } | CExpr::ListLit { items } => {
+            for it in items { emit_expr(it, &mut idx, out); }
+        }
+        CExpr::FieldAccess { value, .. } => {
+            emit_expr(value, &mut idx, out);
+        }
+        CExpr::Lambda { body, .. } => {
+            emit_expr(body, &mut idx, out);
+        }
+        CExpr::BinOp { lhs, rhs, .. } => {
+            emit_expr(lhs, &mut idx, out);
+            emit_expr(rhs, &mut idx, out);
+        }
+        CExpr::UnaryOp { expr, .. } => {
+            emit_expr(expr, &mut idx, out);
+        }
+        CExpr::Return { value } => {
+            emit_expr(value, &mut idx, out);
+        }
+    }
+}
+
+fn walk_pat<'a>(p: &'a Pattern, parent: &NodeId, out: &mut Vec<(NodeId, NodeRef<'a>)>) {
+    let mut idx = 0;
+    match p {
+        Pattern::PLiteral { .. } | Pattern::PVar { .. } | Pattern::PWild => {}
+        Pattern::PConstructor { args, .. } => {
+            for a in args {
+                let id = parent.child(idx);
+                out.push((id.clone(), NodeRef::Pattern(a)));
+                walk_pat(a, &id, out);
+                idx += 1;
+            }
+        }
+        Pattern::PRecord { fields } => {
+            for f in fields {
+                let id = parent.child(idx);
+                out.push((id.clone(), NodeRef::Pattern(&f.pattern)));
+                walk_pat(&f.pattern, &id, out);
+                idx += 1;
+            }
+        }
+        Pattern::PTuple { items } => {
+            for it in items {
+                let id = parent.child(idx);
+                out.push((id.clone(), NodeRef::Pattern(it)));
+                walk_pat(it, &id, out);
+                idx += 1;
+            }
+        }
+    }
+}
+
+fn walk_type<'a>(t: &'a TypeExpr, parent: &NodeId, out: &mut Vec<(NodeId, NodeRef<'a>)>) {
+    let mut idx = 0;
+    match t {
+        TypeExpr::Named { args, .. } => {
+            for a in args {
+                let id = parent.child(idx);
+                out.push((id.clone(), NodeRef::TypeExpr(a)));
+                walk_type(a, &id, out);
+                idx += 1;
+            }
+        }
+        TypeExpr::Record { fields } => {
+            for f in fields {
+                let id = parent.child(idx);
+                out.push((id.clone(), NodeRef::TypeExpr(&f.ty)));
+                walk_type(&f.ty, &id, out);
+                idx += 1;
+            }
+        }
+        TypeExpr::Tuple { items } => {
+            for it in items {
+                let id = parent.child(idx);
+                out.push((id.clone(), NodeRef::TypeExpr(it)));
+                walk_type(it, &id, out);
+                idx += 1;
+            }
+        }
+        TypeExpr::Function { params, ret, .. } => {
+            for p in params {
+                let id = parent.child(idx);
+                out.push((id.clone(), NodeRef::TypeExpr(p)));
+                walk_type(p, &id, out);
+                idx += 1;
+            }
+            let id = parent.child(idx);
+            out.push((id.clone(), NodeRef::TypeExpr(ret)));
+            walk_type(ret, &id, out);
+        }
+        TypeExpr::Union { variants } => {
+            for v in variants {
+                if let Some(p) = &v.payload {
+                    let id = parent.child(idx);
+                    out.push((id.clone(), NodeRef::TypeExpr(p)));
+                    walk_type(p, &id, out);
+                }
+                idx += 1;
+            }
+        }
+    }
+}

--- a/crates/lex-ast/src/lib.rs
+++ b/crates/lex-ast/src/lib.rs
@@ -1,0 +1,59 @@
+//! M2: canonical AST, node IDs, canonicalizer, canonical-JSON, hashing.
+//!
+//! See spec §5.
+
+pub mod canonical;
+pub mod canonicalize;
+pub mod canon_json;
+pub mod canon_print;
+pub mod ids;
+
+pub use canonical::*;
+pub use canonicalize::{canonicalize_program, canonicalize_item};
+pub use canon_print::print_stages;
+pub use ids::{collect_ids, NodeId, NodeRef};
+
+/// SHA-256 over the canonical-JSON encoding of a stage. Excludes NodeIds
+/// (the canonical AST data does not carry IDs; they're derived).
+pub fn stage_canonical_hash(stage: &Stage) -> [u8; 32] {
+    let v = serde_json::to_value(stage).expect("stage is always serializable");
+    canon_json::hash_canonical(&v)
+}
+
+pub fn stage_canonical_hash_hex(stage: &Stage) -> String {
+    canon_json::hex(&stage_canonical_hash(stage))
+}
+
+/// SigId: §4.1. SHA-256 over canonical_json({name, input_types, output_type, effects}).
+pub fn sig_id(stage: &Stage) -> Option<String> {
+    let value = match stage {
+        Stage::FnDecl(fd) => serde_json::json!({
+            "effects": serde_json::to_value(&fd.effects).unwrap(),
+            "input_types": serde_json::to_value(
+                fd.params.iter().map(|p| &p.ty).collect::<Vec<_>>()
+            ).unwrap(),
+            "name": fd.name,
+            "output_type": serde_json::to_value(&fd.return_type).unwrap(),
+        }),
+        Stage::TypeDecl(td) => serde_json::json!({
+            "kind": "type",
+            "name": td.name,
+            "params": td.params,
+        }),
+        Stage::Import(_) => return None,
+    };
+    Some(canon_json::hex(&canon_json::hash_canonical(&value)))
+}
+
+/// StageId: §4.1. SHA-256 over (SigId || canonical_ast_hash). We don't yet
+/// have implementation_metadata, so it's omitted.
+pub fn stage_id(stage: &Stage) -> Option<String> {
+    let sig = sig_id(stage)?;
+    let ast_hash = stage_canonical_hash_hex(stage);
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(sig.as_bytes());
+    h.update(ast_hash.as_bytes());
+    let r = h.finalize();
+    Some(canon_json::hex(&r))
+}

--- a/crates/lex-ast/tests/canonical.rs
+++ b/crates/lex-ast/tests/canonical.rs
@@ -1,0 +1,114 @@
+//! M2 acceptance: §5.6.
+
+use lex_ast::*;
+use lex_syntax::parse_source;
+
+fn canon(src: &str) -> Vec<Stage> {
+    let p = parse_source(src).unwrap();
+    canonicalize_program(&p)
+}
+
+#[test]
+fn round_trip_canonical() {
+    // parse → canonicalize → print → parse → canonicalize is identity.
+    let src = include_str!("../../../examples/a_factorial.lex");
+    let s1 = canon(src);
+    let printed = print_stages(&s1);
+    let s2 = canon(&printed);
+    assert_eq!(s1, s2, "round-trip differs.\nprinted:\n{printed}");
+}
+
+#[test]
+fn round_trip_b_parse_int() {
+    let src = include_str!("../../../examples/b_parse_int.lex");
+    let s1 = canon(src);
+    let printed = print_stages(&s1);
+    let s2 = canon(&printed);
+    assert_eq!(s1, s2, "round-trip differs.\nprinted:\n{printed}");
+}
+
+#[test]
+fn round_trip_d_shape() {
+    let src = include_str!("../../../examples/d_shape.lex");
+    let s1 = canon(src);
+    let printed = print_stages(&s1);
+    let s2 = canon(&printed);
+    assert_eq!(s1, s2, "round-trip differs.\nprinted:\n{printed}");
+}
+
+#[test]
+fn record_field_order_is_normalized() {
+    // Different source field order, same canonical hash.
+    let a = canon("fn p() -> Int { let r := { x: 1, y: 2 }\n r.x }\n");
+    let b = canon("fn p() -> Int { let r := { y: 2, x: 1 }\n r.x }\n");
+    assert_eq!(stage_canonical_hash_hex(&a[0]), stage_canonical_hash_hex(&b[0]));
+}
+
+#[test]
+fn union_variant_order_is_normalized() {
+    let a = canon("type X = A | B | C\n");
+    let b = canon("type X = C | A | B\n");
+    assert_eq!(stage_canonical_hash_hex(&a[0]), stage_canonical_hash_hex(&b[0]));
+}
+
+#[test]
+fn if_canonicalizes_to_match() {
+    let src = "fn pick(b :: Bool) -> Int {\n  if b { 1 } else { 2 }\n}\n";
+    let s = canon(src);
+    if let Stage::FnDecl(fd) = &s[0] {
+        match &fd.body {
+            CExpr::Match { arms, .. } => {
+                assert_eq!(arms.len(), 2);
+                // First arm should be Bool(true).
+                match &arms[0].pattern {
+                    Pattern::PLiteral { value: CLit::Bool { value: true } } => {}
+                    other => panic!("expected first arm = true literal, got {other:?}"),
+                }
+            }
+            other => panic!("expected match, got {other:?}"),
+        }
+    } else {
+        panic!("expected fn decl");
+    }
+}
+
+#[test]
+fn try_canonicalizes_to_match() {
+    let src = r#"
+import "std.io" as io
+fn r(x :: Int) -> Result[Int, Str] {
+  io.read(x)?
+}
+"#;
+    let s = canon(src);
+    let fd = match &s[1] { Stage::FnDecl(fd) => fd, _ => panic!() };
+    let m = match &fd.body { CExpr::Match { arms, .. } => arms, other => panic!("got {other:?}") };
+    assert_eq!(m.len(), 2, "Try desugars to a 2-arm match");
+}
+
+#[test]
+fn node_ids_walk() {
+    let s = canon(include_str!("../../../examples/a_factorial.lex"));
+    let ids = collect_ids(&s[0]);
+    assert!(!ids.is_empty());
+    // Root id is n_0.
+    assert_eq!(ids[0].0.as_str(), "n_0");
+}
+
+#[test]
+fn stage_id_is_deterministic() {
+    let src = include_str!("../../../examples/a_factorial.lex");
+    let s1 = canon(src);
+    let s2 = canon(src);
+    assert_eq!(stage_id(&s1[0]), stage_id(&s2[0]));
+    // Same hash twice.
+    assert_eq!(stage_canonical_hash_hex(&s1[0]), stage_canonical_hash_hex(&s2[0]));
+}
+
+#[test]
+fn renaming_changes_sig_id() {
+    let s1 = canon("fn add(x :: Int, y :: Int) -> Int { x + y }\n");
+    let s2 = canon("fn plus(x :: Int, y :: Int) -> Int { x + y }\n");
+    // Per §4.6 default: name IS in SigId.
+    assert_ne!(sig_id(&s1[0]), sig_id(&s2[0]));
+}

--- a/crates/lex-bytecode/Cargo.toml
+++ b/crates/lex-bytecode/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "lex-bytecode"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+indexmap.workspace = true
+lex-ast = { path = "../lex-ast" }
+lex-types = { path = "../lex-types" }
+
+[dev-dependencies]
+lex-syntax = { path = "../lex-syntax" }

--- a/crates/lex-bytecode/src/compiler.rs
+++ b/crates/lex-bytecode/src/compiler.rs
@@ -1,0 +1,376 @@
+//! M4 compiler: canonical AST → bytecode.
+
+use crate::op::*;
+use crate::program::*;
+use indexmap::IndexMap;
+use lex_ast as a;
+
+#[derive(Default)]
+struct ConstPool {
+    pool: Vec<Const>,
+    fields: IndexMap<String, u32>,
+    variants: IndexMap<String, u32>,
+    ints: IndexMap<i64, u32>,
+    bools: IndexMap<u8, u32>,
+    strs: IndexMap<String, u32>,
+}
+
+impl ConstPool {
+    fn field(&mut self, name: &str) -> u32 {
+        if let Some(i) = self.fields.get(name) { return *i; }
+        let i = self.pool.len() as u32;
+        self.pool.push(Const::FieldName(name.into()));
+        self.fields.insert(name.into(), i);
+        i
+    }
+    fn variant(&mut self, name: &str) -> u32 {
+        if let Some(i) = self.variants.get(name) { return *i; }
+        let i = self.pool.len() as u32;
+        self.pool.push(Const::VariantName(name.into()));
+        self.variants.insert(name.into(), i);
+        i
+    }
+    fn int(&mut self, n: i64) -> u32 {
+        if let Some(i) = self.ints.get(&n) { return *i; }
+        let i = self.pool.len() as u32;
+        self.pool.push(Const::Int(n));
+        self.ints.insert(n, i);
+        i
+    }
+    fn bool(&mut self, b: bool) -> u32 {
+        let key = b as u8;
+        if let Some(i) = self.bools.get(&key) { return *i; }
+        let i = self.pool.len() as u32;
+        self.pool.push(Const::Bool(b));
+        self.bools.insert(key, i);
+        i
+    }
+    fn str(&mut self, s: &str) -> u32 {
+        if let Some(i) = self.strs.get(s) { return *i; }
+        let i = self.pool.len() as u32;
+        self.pool.push(Const::Str(s.into()));
+        self.strs.insert(s.into(), i);
+        i
+    }
+    fn float(&mut self, f: f64) -> u32 {
+        // Floats: not deduped (NaN issues).
+        let i = self.pool.len() as u32;
+        self.pool.push(Const::Float(f));
+        i
+    }
+    fn unit(&mut self) -> u32 {
+        let i = self.pool.len() as u32;
+        self.pool.push(Const::Unit);
+        i
+    }
+}
+
+pub fn compile_program(stages: &[a::Stage]) -> Program {
+    let mut p = Program {
+        constants: Vec::new(),
+        functions: Vec::new(),
+        function_names: IndexMap::new(),
+        entry: None,
+    };
+
+    for s in stages {
+        if let a::Stage::FnDecl(fd) = s {
+            let idx = p.functions.len() as u32;
+            p.function_names.insert(fd.name.clone(), idx);
+            p.functions.push(Function {
+                name: fd.name.clone(),
+                arity: fd.params.len() as u16,
+                locals_count: 0,
+                code: Vec::new(),
+            });
+        }
+    }
+
+    let mut pool = ConstPool::default();
+    let function_names = p.function_names.clone();
+
+    for s in stages {
+        if let a::Stage::FnDecl(fd) = s {
+            let mut fc = FnCompiler {
+                code: Vec::new(),
+                locals: IndexMap::new(),
+                next_local: 0,
+                peak_local: 0,
+                pool: &mut pool,
+                function_names: &function_names,
+            };
+            for param in &fd.params {
+                let i = fc.next_local;
+                fc.locals.insert(param.name.clone(), i);
+                fc.next_local += 1;
+                fc.peak_local = fc.next_local;
+            }
+            fc.compile_expr(&fd.body, true);
+            fc.code.push(Op::Return);
+            let idx = function_names[&fd.name];
+            p.functions[idx as usize].code = fc.code;
+            p.functions[idx as usize].locals_count = fc.peak_local;
+        }
+    }
+    p.constants = pool.pool;
+    p
+}
+
+struct FnCompiler<'a> {
+    code: Vec<Op>,
+    locals: IndexMap<String, u16>,
+    next_local: u16,
+    /// Peak local usage seen during compilation (for VM frame sizing).
+    peak_local: u16,
+    pool: &'a mut ConstPool,
+    function_names: &'a IndexMap<String, u32>,
+}
+
+impl<'a> FnCompiler<'a> {
+    fn alloc_local(&mut self, name: &str) -> u16 {
+        let i = self.next_local;
+        self.locals.insert(name.into(), i);
+        self.next_local += 1;
+        if self.next_local > self.peak_local { self.peak_local = self.next_local; }
+        i
+    }
+    fn emit(&mut self, op: Op) { self.code.push(op); }
+
+    fn compile_expr(&mut self, e: &a::CExpr, tail: bool) {
+        match e {
+            a::CExpr::Literal { value } => self.compile_lit(value),
+            a::CExpr::Var { name } => {
+                let i = *self.locals.get(name).unwrap_or_else(|| panic!("unknown local: {name}"));
+                self.emit(Op::LoadLocal(i));
+            }
+            a::CExpr::Let { name, ty: _, value, body } => {
+                self.compile_expr(value, false);
+                let slot = self.alloc_local(name);
+                self.emit(Op::StoreLocal(slot));
+                self.compile_expr(body, tail);
+            }
+            a::CExpr::Block { statements, result } => {
+                for s in statements {
+                    self.compile_expr(s, false);
+                    self.emit(Op::Pop);
+                }
+                self.compile_expr(result, tail);
+            }
+            a::CExpr::Call { callee, args } => self.compile_call(callee, args, tail),
+            a::CExpr::Constructor { name, args } => {
+                for a in args { self.compile_expr(a, false); }
+                let name_idx = self.pool.variant(name);
+                self.emit(Op::MakeVariant { name_idx, arity: args.len() as u16 });
+            }
+            a::CExpr::Match { scrutinee, arms } => self.compile_match(scrutinee, arms, tail),
+            a::CExpr::RecordLit { fields } => {
+                let mut idxs = Vec::with_capacity(fields.len());
+                for f in fields {
+                    self.compile_expr(&f.value, false);
+                    idxs.push(self.pool.field(&f.name));
+                }
+                self.emit(Op::MakeRecord { field_name_indices: idxs });
+            }
+            a::CExpr::TupleLit { items } => {
+                for it in items { self.compile_expr(it, false); }
+                self.emit(Op::MakeTuple(items.len() as u16));
+            }
+            a::CExpr::ListLit { items } => {
+                for it in items { self.compile_expr(it, false); }
+                self.emit(Op::MakeList(items.len() as u32));
+            }
+            a::CExpr::FieldAccess { value, field } => {
+                self.compile_expr(value, false);
+                let idx = self.pool.field(field);
+                self.emit(Op::GetField(idx));
+            }
+            a::CExpr::BinOp { op, lhs, rhs } => self.compile_binop(op, lhs, rhs),
+            a::CExpr::UnaryOp { op, expr } => {
+                self.compile_expr(expr, false);
+                match op.as_str() {
+                    "-" => self.emit(Op::NumNeg),
+                    "not" => self.emit(Op::BoolNot),
+                    other => panic!("unknown unary: {other}"),
+                }
+            }
+            a::CExpr::Lambda { .. } => panic!("lambda not supported in M4"),
+            a::CExpr::Return { value } => {
+                self.compile_expr(value, true);
+                self.emit(Op::Return);
+            }
+        }
+    }
+
+    fn compile_lit(&mut self, l: &a::CLit) {
+        let i = match l {
+            a::CLit::Int { value } => self.pool.int(*value),
+            a::CLit::Bool { value } => self.pool.bool(*value),
+            a::CLit::Float { value } => {
+                let f: f64 = value.parse().unwrap_or(0.0);
+                self.pool.float(f)
+            }
+            a::CLit::Str { value } => self.pool.str(value),
+            a::CLit::Bytes { value: _ } => {
+                // Stub: M4 doesn't use bytes literals in §3.13 examples.
+                let i = self.pool.pool.len() as u32;
+                self.pool.pool.push(Const::Bytes(Vec::new()));
+                i
+            }
+            a::CLit::Unit => self.pool.unit(),
+        };
+        self.emit(Op::PushConst(i));
+    }
+
+    fn compile_call(&mut self, callee: &a::CExpr, args: &[a::CExpr], tail: bool) {
+        match callee {
+            a::CExpr::Var { name } if self.function_names.contains_key(name) => {
+                for a in args { self.compile_expr(a, false); }
+                let fn_id = self.function_names[name];
+                if tail {
+                    self.emit(Op::TailCall { fn_id, arity: args.len() as u16 });
+                } else {
+                    self.emit(Op::Call { fn_id, arity: args.len() as u16 });
+                }
+            }
+            other => panic!("unsupported callee in M4: {other:?}"),
+        }
+    }
+
+    fn compile_binop(&mut self, op: &str, lhs: &a::CExpr, rhs: &a::CExpr) {
+        self.compile_expr(lhs, false);
+        self.compile_expr(rhs, false);
+        match op {
+            "+" => self.emit(Op::NumAdd),
+            "-" => self.emit(Op::NumSub),
+            "*" => self.emit(Op::NumMul),
+            "/" => self.emit(Op::NumDiv),
+            "%" => self.emit(Op::NumMod),
+            "==" => self.emit(Op::NumEq),
+            "!=" => { self.emit(Op::NumEq); self.emit(Op::BoolNot); }
+            "<" => self.emit(Op::NumLt),
+            "<=" => self.emit(Op::NumLe),
+            ">" => { self.emit_swap_top2(); self.emit(Op::NumLt); }
+            ">=" => { self.emit_swap_top2(); self.emit(Op::NumLe); }
+            "and" => self.emit(Op::BoolAnd),
+            "or" => self.emit(Op::BoolOr),
+            other => panic!("unknown binop: {other:?}"),
+        }
+    }
+
+    fn emit_swap_top2(&mut self) {
+        let a = self.alloc_local("__swap_a");
+        let b = self.alloc_local("__swap_b");
+        self.emit(Op::StoreLocal(b));
+        self.emit(Op::StoreLocal(a));
+        self.emit(Op::LoadLocal(b));
+        self.emit(Op::LoadLocal(a));
+    }
+
+    fn compile_match(&mut self, scrutinee: &a::CExpr, arms: &[a::Arm], tail: bool) {
+        self.compile_expr(scrutinee, false);
+        let scrut_slot = self.alloc_local("__scrut");
+        self.emit(Op::StoreLocal(scrut_slot));
+
+        let mut end_jumps: Vec<usize> = Vec::new();
+        for arm in arms {
+            let arm_start_locals = self.next_local;
+            let arm_start_locals_map = self.locals.clone();
+
+            self.emit(Op::LoadLocal(scrut_slot));
+            let mut bindings: Vec<(String, u16)> = Vec::new();
+            let fail_jumps: Vec<usize> = self.compile_pattern_test(&arm.pattern, &mut bindings);
+
+            self.compile_expr(&arm.body, tail);
+            let j_end = self.code.len();
+            self.emit(Op::Jump(0));
+            end_jumps.push(j_end);
+
+            let fail_target = self.code.len() as i32;
+            for j in fail_jumps {
+                if let Op::JumpIfNot(off) = &mut self.code[j] {
+                    *off = fail_target - (j as i32 + 1);
+                }
+            }
+            self.next_local = arm_start_locals;
+            self.locals = arm_start_locals_map;
+        }
+        let panic_msg_idx = self.pool.str("non-exhaustive match");
+        self.emit(Op::Panic(panic_msg_idx));
+
+        let end_target = self.code.len() as i32;
+        for j in end_jumps {
+            if let Op::Jump(off) = &mut self.code[j] {
+                *off = end_target - (j as i32 + 1);
+            }
+        }
+    }
+
+    fn compile_pattern_test(&mut self, p: &a::Pattern, bindings: &mut Vec<(String, u16)>) -> Vec<usize> {
+        let mut fails = Vec::new();
+        match p {
+            a::Pattern::PWild => { self.emit(Op::Pop); }
+            a::Pattern::PVar { name } => {
+                let slot = self.alloc_local(name);
+                self.emit(Op::StoreLocal(slot));
+                bindings.push((name.clone(), slot));
+            }
+            a::Pattern::PLiteral { value } => {
+                self.compile_lit(value);
+                match value {
+                    a::CLit::Str { .. } => self.emit(Op::StrEq),
+                    a::CLit::Bytes { .. } => self.emit(Op::BytesEq),
+                    _ => self.emit(Op::NumEq),
+                }
+                let j = self.code.len();
+                self.emit(Op::JumpIfNot(0));
+                fails.push(j);
+            }
+            a::Pattern::PConstructor { name, args } => {
+                let name_idx = self.pool.variant(name);
+                self.emit(Op::Dup);
+                self.emit(Op::TestVariant(name_idx));
+                let j = self.code.len();
+                self.emit(Op::JumpIfNot(0));
+                fails.push(j);
+                if args.is_empty() {
+                    self.emit(Op::Pop);
+                } else if args.len() == 1 {
+                    self.emit(Op::GetVariantArg(0));
+                    let sub_fails = self.compile_pattern_test(&args[0], bindings);
+                    fails.extend(sub_fails);
+                } else {
+                    let slot = self.alloc_local("__variant");
+                    self.emit(Op::StoreLocal(slot));
+                    for (i, arg) in args.iter().enumerate() {
+                        self.emit(Op::LoadLocal(slot));
+                        self.emit(Op::GetVariantArg(i as u16));
+                        let sub_fails = self.compile_pattern_test(arg, bindings);
+                        fails.extend(sub_fails);
+                    }
+                }
+            }
+            a::Pattern::PRecord { fields } => {
+                let slot = self.alloc_local("__record");
+                self.emit(Op::StoreLocal(slot));
+                for f in fields {
+                    self.emit(Op::LoadLocal(slot));
+                    let fi = self.pool.field(&f.name);
+                    self.emit(Op::GetField(fi));
+                    let sub_fails = self.compile_pattern_test(&f.pattern, bindings);
+                    fails.extend(sub_fails);
+                }
+            }
+            a::Pattern::PTuple { items } => {
+                let slot = self.alloc_local("__tuple");
+                self.emit(Op::StoreLocal(slot));
+                for (i, item) in items.iter().enumerate() {
+                    self.emit(Op::LoadLocal(slot));
+                    self.emit(Op::GetElem(i as u16));
+                    let sub_fails = self.compile_pattern_test(item, bindings);
+                    fails.extend(sub_fails);
+                }
+            }
+        }
+        fails
+    }
+}

--- a/crates/lex-bytecode/src/lib.rs
+++ b/crates/lex-bytecode/src/lib.rs
@@ -1,0 +1,13 @@
+//! M4: bytecode definition, compiler, VM (pure subset). See spec §8.
+
+pub mod op;
+pub mod program;
+pub mod value;
+pub mod compiler;
+pub mod vm;
+
+pub use compiler::compile_program;
+pub use op::{Const, Op};
+pub use program::{Function, Program};
+pub use value::Value;
+pub use vm::{Vm, VmError};

--- a/crates/lex-bytecode/src/op.rs
+++ b/crates/lex-bytecode/src/op.rs
@@ -1,0 +1,74 @@
+//! Bytecode instruction set per spec §8.2.
+//!
+//! Pure subset (M4). Effect opcodes come in M5.
+
+use serde::{Deserialize, Serialize};
+
+/// Constant pool entry.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum Const {
+    Int(i64),
+    Float(f64),
+    Bool(bool),
+    Str(String),
+    Bytes(Vec<u8>),
+    Unit,
+    /// A field name, used by MAKE_RECORD/GET_FIELD.
+    FieldName(String),
+    /// A variant tag, used by MAKE_VARIANT/TEST_VARIANT/GET_VARIANT.
+    VariantName(String),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum Op {
+    // stack manipulation
+    PushConst(u32),
+    Pop,
+    Dup,
+
+    // locals
+    LoadLocal(u16),
+    StoreLocal(u16),
+
+    // constructors / pattern matching
+    /// Builds a record from `count` (name_const_idx, value) pairs on the stack.
+    /// Stack: [name_idx_n, val_n, ..., name_idx_1, val_1] but encoded as
+    /// alternating `<name_idx_const_u32> <value popped from stack>` — for
+    /// simplicity we instead push `count` values and `count` field name
+    /// constants in the same op as a `Vec<u32>` of name indices.
+    MakeRecord { field_name_indices: Vec<u32> },
+    MakeTuple(u16),
+    MakeList(u32),
+    MakeVariant { name_idx: u32, arity: u16 },
+    GetField(u32),         // field name const idx
+    GetElem(u16),          // tuple element index
+    TestVariant(u32),      // pushes Bool: top-of-stack matches variant name?
+    GetVariant(u32),       // extracts payload (replaces variant on stack with its args list)
+    GetVariantArg(u16),    // pop variant, push its i'th arg
+    GetListLen,
+    GetListElem(u32),
+
+    // control flow
+    Jump(i32),
+    JumpIf(i32),     // pops Bool
+    JumpIfNot(i32),
+    Call { fn_id: u32, arity: u16 },
+    TailCall { fn_id: u32, arity: u16 },
+    Return,
+    Panic(u32),     // pushes constant message and aborts
+
+    // arithmetic — typed (per spec §8.2). `NumAdd`/etc. dispatch on operand
+    // type at runtime; emitted when the compiler doesn't have type info.
+    // The post-M5 plan is to lower NumAdd → IntAdd|FloatAdd in a typed pass.
+    IntAdd, IntSub, IntMul, IntDiv, IntMod, IntNeg,
+    IntEq, IntLt, IntLe,
+    FloatAdd, FloatSub, FloatMul, FloatDiv, FloatNeg,
+    FloatEq, FloatLt, FloatLe,
+    NumAdd, NumSub, NumMul, NumDiv, NumMod, NumNeg,
+    NumEq, NumLt, NumLe,
+    BoolAnd, BoolOr, BoolNot,
+
+    // strings
+    StrConcat, StrLen, StrEq,
+    BytesLen, BytesEq,
+}

--- a/crates/lex-bytecode/src/program.rs
+++ b/crates/lex-bytecode/src/program.rs
@@ -1,0 +1,30 @@
+//! Compiled program: a set of functions plus a constant pool.
+
+use crate::op::*;
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Program {
+    pub constants: Vec<Const>,
+    pub functions: Vec<Function>,
+    /// Global function names → function index in `functions`.
+    pub function_names: IndexMap<String, u32>,
+    /// Entry function (for `lex run`, set to whatever function the user
+    /// chose to invoke). Optional.
+    pub entry: Option<u32>,
+}
+
+impl Program {
+    pub fn lookup(&self, name: &str) -> Option<u32> {
+        self.function_names.get(name).copied()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Function {
+    pub name: String,
+    pub arity: u16,
+    pub locals_count: u16,
+    pub code: Vec<Op>,
+}

--- a/crates/lex-bytecode/src/value.rs
+++ b/crates/lex-bytecode/src/value.rs
@@ -1,0 +1,32 @@
+//! Runtime values.
+
+use indexmap::IndexMap;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Value {
+    Int(i64),
+    Float(f64),
+    Bool(bool),
+    Str(String),
+    Bytes(Vec<u8>),
+    Unit,
+    List(Vec<Value>),
+    Tuple(Vec<Value>),
+    Record(IndexMap<String, Value>),
+    Variant { name: String, args: Vec<Value> },
+}
+
+impl Value {
+    pub fn as_int(&self) -> i64 {
+        match self { Value::Int(n) => *n, other => panic!("expected Int, got {other:?}") }
+    }
+    pub fn as_float(&self) -> f64 {
+        match self { Value::Float(n) => *n, other => panic!("expected Float, got {other:?}") }
+    }
+    pub fn as_bool(&self) -> bool {
+        match self { Value::Bool(b) => *b, other => panic!("expected Bool, got {other:?}") }
+    }
+    pub fn as_str(&self) -> &str {
+        match self { Value::Str(s) => s, other => panic!("expected Str, got {other:?}") }
+    }
+}

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -1,0 +1,402 @@
+//! M4: bytecode VM. Stack machine, pure subset (no effects).
+
+use crate::op::*;
+use crate::program::*;
+use crate::value::Value;
+use indexmap::IndexMap;
+
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum VmError {
+    #[error("runtime panic: {0}")]
+    Panic(String),
+    #[error("type mismatch at runtime: {0}")]
+    TypeMismatch(String),
+    #[error("stack underflow")]
+    StackUnderflow,
+    #[error("unknown function id: {0}")]
+    UnknownFunction(u32),
+}
+
+pub struct Vm<'a> {
+    program: &'a Program,
+    /// Per-call frames. Each frame has its own locals array and pc.
+    frames: Vec<Frame>,
+    stack: Vec<Value>,
+    /// Soft cap to avoid runaway computations in tests.
+    pub step_limit: u64,
+    pub steps: u64,
+}
+
+struct Frame {
+    fn_id: u32,
+    pc: usize,
+    locals: Vec<Value>,
+    /// Stack base when this frame started (for cleanup on return).
+    stack_base: usize,
+}
+
+impl<'a> Vm<'a> {
+    pub fn new(program: &'a Program) -> Self {
+        Self { program, frames: Vec::new(), stack: Vec::new(), step_limit: 10_000_000, steps: 0 }
+    }
+
+    pub fn call(&mut self, name: &str, args: Vec<Value>) -> Result<Value, VmError> {
+        let fn_id = self.program.lookup(name).ok_or_else(|| VmError::Panic(format!("no function `{name}`")))?;
+        self.invoke(fn_id, args)
+    }
+
+    pub fn invoke(&mut self, fn_id: u32, args: Vec<Value>) -> Result<Value, VmError> {
+        let f = &self.program.functions[fn_id as usize];
+        if args.len() != f.arity as usize {
+            return Err(VmError::Panic(format!("arity mismatch calling {}", f.name)));
+        }
+        let mut locals = vec![Value::Unit; f.locals_count.max(f.arity) as usize];
+        for (i, v) in args.into_iter().enumerate() { locals[i] = v; }
+        self.frames.push(Frame { fn_id, pc: 0, locals, stack_base: self.stack.len() });
+        self.run()
+    }
+
+    fn run(&mut self) -> Result<Value, VmError> {
+        loop {
+            if self.steps > self.step_limit {
+                return Err(VmError::Panic("step limit exceeded".into()));
+            }
+            self.steps += 1;
+            let frame_idx = self.frames.len() - 1;
+            let pc = self.frames[frame_idx].pc;
+            let fn_id = self.frames[frame_idx].fn_id;
+            let code = &self.program.functions[fn_id as usize].code;
+            if pc >= code.len() {
+                return Err(VmError::Panic("ran past end of code".into()));
+            }
+            let op = code[pc].clone();
+            self.frames[frame_idx].pc = pc + 1;
+
+            match op {
+                Op::PushConst(i) => {
+                    let c = &self.program.constants[i as usize];
+                    self.stack.push(const_to_value(c));
+                }
+                Op::Pop => { self.pop()?; }
+                Op::Dup => {
+                    let v = self.peek()?.clone();
+                    self.stack.push(v);
+                }
+                Op::LoadLocal(i) => {
+                    let v = self.frames[frame_idx].locals[i as usize].clone();
+                    self.stack.push(v);
+                }
+                Op::StoreLocal(i) => {
+                    let v = self.pop()?;
+                    self.frames[frame_idx].locals[i as usize] = v;
+                }
+                Op::MakeRecord { field_name_indices } => {
+                    let n = field_name_indices.len();
+                    let mut values: Vec<Value> = (0..n).map(|_| Value::Unit).collect();
+                    for i in (0..n).rev() {
+                        values[i] = self.pop()?;
+                    }
+                    let mut rec = IndexMap::new();
+                    for (i, val) in values.into_iter().enumerate() {
+                        let name = match &self.program.constants[field_name_indices[i] as usize] {
+                            Const::FieldName(s) => s.clone(),
+                            _ => return Err(VmError::TypeMismatch("expected FieldName const".into())),
+                        };
+                        rec.insert(name, val);
+                    }
+                    self.stack.push(Value::Record(rec));
+                }
+                Op::MakeTuple(n) => {
+                    let mut items: Vec<Value> = (0..n).map(|_| Value::Unit).collect();
+                    for i in (0..n as usize).rev() { items[i] = self.pop()?; }
+                    self.stack.push(Value::Tuple(items));
+                }
+                Op::MakeList(n) => {
+                    let mut items: Vec<Value> = (0..n).map(|_| Value::Unit).collect();
+                    for i in (0..n as usize).rev() { items[i] = self.pop()?; }
+                    self.stack.push(Value::List(items));
+                }
+                Op::MakeVariant { name_idx, arity } => {
+                    let mut args: Vec<Value> = (0..arity).map(|_| Value::Unit).collect();
+                    for i in (0..arity as usize).rev() { args[i] = self.pop()?; }
+                    let name = match &self.program.constants[name_idx as usize] {
+                        Const::VariantName(s) => s.clone(),
+                        _ => return Err(VmError::TypeMismatch("expected VariantName const".into())),
+                    };
+                    self.stack.push(Value::Variant { name, args });
+                }
+                Op::GetField(i) => {
+                    let name = match &self.program.constants[i as usize] {
+                        Const::FieldName(s) => s.clone(),
+                        _ => return Err(VmError::TypeMismatch("expected FieldName const".into())),
+                    };
+                    let v = self.pop()?;
+                    match v {
+                        Value::Record(r) => {
+                            let v = r.get(&name).cloned()
+                                .ok_or_else(|| VmError::TypeMismatch(format!("missing field `{name}`")))?;
+                            self.stack.push(v);
+                        }
+                        other => return Err(VmError::TypeMismatch(format!("GetField on non-record: {other:?}"))),
+                    }
+                }
+                Op::GetElem(i) => {
+                    let v = self.pop()?;
+                    match v {
+                        Value::Tuple(items) => {
+                            let v = items.into_iter().nth(i as usize)
+                                .ok_or_else(|| VmError::TypeMismatch(format!("tuple index {i} out of range")))?;
+                            self.stack.push(v);
+                        }
+                        other => return Err(VmError::TypeMismatch(format!("GetElem on non-tuple: {other:?}"))),
+                    }
+                }
+                Op::TestVariant(i) => {
+                    let name = match &self.program.constants[i as usize] {
+                        Const::VariantName(s) => s.clone(),
+                        _ => return Err(VmError::TypeMismatch("expected VariantName const".into())),
+                    };
+                    let v = self.pop()?;
+                    match &v {
+                        Value::Variant { name: vname, .. } => {
+                            self.stack.push(Value::Bool(vname == &name));
+                        }
+                        // For tag-only enums of primitive type (e.g. ParseError = Empty | NotNumber)
+                        // the value is currently a Variant too, since constructors emit MakeVariant.
+                        other => return Err(VmError::TypeMismatch(format!("TestVariant on non-variant: {other:?}"))),
+                    }
+                }
+                Op::GetVariant(_i) => {
+                    let v = self.pop()?;
+                    match v {
+                        Value::Variant { args, .. } => {
+                            self.stack.push(Value::Tuple(args));
+                        }
+                        other => return Err(VmError::TypeMismatch(format!("GetVariant on non-variant: {other:?}"))),
+                    }
+                }
+                Op::GetVariantArg(i) => {
+                    let v = self.pop()?;
+                    match v {
+                        Value::Variant { mut args, .. } => {
+                            if (i as usize) >= args.len() {
+                                return Err(VmError::TypeMismatch("variant arg index oob".into()));
+                            }
+                            self.stack.push(args.swap_remove(i as usize));
+                        }
+                        other => return Err(VmError::TypeMismatch(format!("GetVariantArg on non-variant: {other:?}"))),
+                    }
+                }
+                Op::GetListLen => {
+                    let v = self.pop()?;
+                    match v {
+                        Value::List(items) => self.stack.push(Value::Int(items.len() as i64)),
+                        other => return Err(VmError::TypeMismatch(format!("GetListLen on non-list: {other:?}"))),
+                    }
+                }
+                Op::GetListElem(i) => {
+                    let v = self.pop()?;
+                    match v {
+                        Value::List(items) => {
+                            let v = items.into_iter().nth(i as usize)
+                                .ok_or_else(|| VmError::TypeMismatch("list index oob".into()))?;
+                            self.stack.push(v);
+                        }
+                        other => return Err(VmError::TypeMismatch(format!("GetListElem on non-list: {other:?}"))),
+                    }
+                }
+                Op::Jump(off) => {
+                    let new_pc = (self.frames[frame_idx].pc as i32 + off) as usize;
+                    self.frames[frame_idx].pc = new_pc;
+                }
+                Op::JumpIf(off) => {
+                    let v = self.pop()?;
+                    if v.as_bool() {
+                        let new_pc = (self.frames[frame_idx].pc as i32 + off) as usize;
+                        self.frames[frame_idx].pc = new_pc;
+                    }
+                }
+                Op::JumpIfNot(off) => {
+                    let v = self.pop()?;
+                    if !v.as_bool() {
+                        let new_pc = (self.frames[frame_idx].pc as i32 + off) as usize;
+                        self.frames[frame_idx].pc = new_pc;
+                    }
+                }
+                Op::Call { fn_id, arity } => {
+                    let mut args: Vec<Value> = (0..arity).map(|_| Value::Unit).collect();
+                    for i in (0..arity as usize).rev() { args[i] = self.pop()?; }
+                    let f = &self.program.functions[fn_id as usize];
+                    let mut locals = vec![Value::Unit; f.locals_count.max(f.arity) as usize];
+                    for (i, v) in args.into_iter().enumerate() { locals[i] = v; }
+                    self.frames.push(Frame { fn_id, pc: 0, locals, stack_base: self.stack.len() });
+                }
+                Op::TailCall { fn_id, arity } => {
+                    let mut args: Vec<Value> = (0..arity).map(|_| Value::Unit).collect();
+                    for i in (0..arity as usize).rev() { args[i] = self.pop()?; }
+                    // Reuse current frame.
+                    let f = &self.program.functions[fn_id as usize];
+                    let frame = self.frames.last_mut().unwrap();
+                    frame.fn_id = fn_id;
+                    frame.pc = 0;
+                    frame.locals = vec![Value::Unit; f.locals_count.max(f.arity) as usize];
+                    for (i, v) in args.into_iter().enumerate() { frame.locals[i] = v; }
+                    // Stack base stays the same.
+                }
+                Op::Return => {
+                    let v = self.pop()?;
+                    let frame = self.frames.pop().unwrap();
+                    // Trim any extra stuff that the function pushed but didn't pop.
+                    self.stack.truncate(frame.stack_base);
+                    if self.frames.is_empty() {
+                        return Ok(v);
+                    }
+                    self.stack.push(v);
+                }
+                Op::Panic(i) => {
+                    let msg = match &self.program.constants[i as usize] {
+                        Const::Str(s) => s.clone(),
+                        _ => "panic".into(),
+                    };
+                    return Err(VmError::Panic(msg));
+                }
+                // Arithmetic
+                Op::IntAdd => self.bin_int(|a, b| Value::Int(a + b))?,
+                Op::IntSub => self.bin_int(|a, b| Value::Int(a - b))?,
+                Op::IntMul => self.bin_int(|a, b| Value::Int(a * b))?,
+                Op::IntDiv => self.bin_int(|a, b| Value::Int(a / b))?,
+                Op::IntMod => self.bin_int(|a, b| Value::Int(a % b))?,
+                Op::IntNeg => {
+                    let a = self.pop()?.as_int();
+                    self.stack.push(Value::Int(-a));
+                }
+                Op::IntEq => self.bin_int(|a, b| Value::Bool(a == b))?,
+                Op::IntLt => self.bin_int(|a, b| Value::Bool(a < b))?,
+                Op::IntLe => self.bin_int(|a, b| Value::Bool(a <= b))?,
+                Op::FloatAdd => self.bin_float(|a, b| Value::Float(a + b))?,
+                Op::FloatSub => self.bin_float(|a, b| Value::Float(a - b))?,
+                Op::FloatMul => self.bin_float(|a, b| Value::Float(a * b))?,
+                Op::FloatDiv => self.bin_float(|a, b| Value::Float(a / b))?,
+                Op::FloatNeg => {
+                    let a = self.pop()?.as_float();
+                    self.stack.push(Value::Float(-a));
+                }
+                Op::FloatEq => self.bin_float(|a, b| Value::Bool(a == b))?,
+                Op::FloatLt => self.bin_float(|a, b| Value::Bool(a < b))?,
+                Op::FloatLe => self.bin_float(|a, b| Value::Bool(a <= b))?,
+                Op::NumAdd => self.bin_num(|a, b| Value::Int(a + b), |a, b| Value::Float(a + b))?,
+                Op::NumSub => self.bin_num(|a, b| Value::Int(a - b), |a, b| Value::Float(a - b))?,
+                Op::NumMul => self.bin_num(|a, b| Value::Int(a * b), |a, b| Value::Float(a * b))?,
+                Op::NumDiv => self.bin_num(|a, b| Value::Int(a / b), |a, b| Value::Float(a / b))?,
+                Op::NumMod => self.bin_int(|a, b| Value::Int(a % b))?,
+                Op::NumNeg => {
+                    let v = self.pop()?;
+                    match v {
+                        Value::Int(n) => self.stack.push(Value::Int(-n)),
+                        Value::Float(f) => self.stack.push(Value::Float(-f)),
+                        other => return Err(VmError::TypeMismatch(format!("NumNeg on {other:?}"))),
+                    }
+                }
+                Op::NumEq => self.bin_eq()?,
+                Op::NumLt => self.bin_num(|a, b| Value::Bool(a < b), |a, b| Value::Bool(a < b))?,
+                Op::NumLe => self.bin_num(|a, b| Value::Bool(a <= b), |a, b| Value::Bool(a <= b))?,
+                Op::BoolAnd => {
+                    let b = self.pop()?.as_bool();
+                    let a = self.pop()?.as_bool();
+                    self.stack.push(Value::Bool(a && b));
+                }
+                Op::BoolOr => {
+                    let b = self.pop()?.as_bool();
+                    let a = self.pop()?.as_bool();
+                    self.stack.push(Value::Bool(a || b));
+                }
+                Op::BoolNot => {
+                    let a = self.pop()?.as_bool();
+                    self.stack.push(Value::Bool(!a));
+                }
+                Op::StrConcat => {
+                    let b = self.pop()?;
+                    let a = self.pop()?;
+                    let s = format!("{}{}", a.as_str(), b.as_str());
+                    self.stack.push(Value::Str(s));
+                }
+                Op::StrLen => {
+                    let v = self.pop()?;
+                    self.stack.push(Value::Int(v.as_str().len() as i64));
+                }
+                Op::StrEq => {
+                    let b = self.pop()?;
+                    let a = self.pop()?;
+                    self.stack.push(Value::Bool(a.as_str() == b.as_str()));
+                }
+                Op::BytesLen => {
+                    let v = self.pop()?;
+                    match v {
+                        Value::Bytes(b) => self.stack.push(Value::Int(b.len() as i64)),
+                        other => return Err(VmError::TypeMismatch(format!("BytesLen on {other:?}"))),
+                    }
+                }
+                Op::BytesEq => {
+                    let b = self.pop()?;
+                    let a = self.pop()?;
+                    let eq = match (a, b) {
+                        (Value::Bytes(x), Value::Bytes(y)) => x == y,
+                        _ => return Err(VmError::TypeMismatch("BytesEq operands".into())),
+                    };
+                    self.stack.push(Value::Bool(eq));
+                }
+            }
+        }
+    }
+
+    fn pop(&mut self) -> Result<Value, VmError> {
+        self.stack.pop().ok_or(VmError::StackUnderflow)
+    }
+    fn peek(&self) -> Result<&Value, VmError> {
+        self.stack.last().ok_or(VmError::StackUnderflow)
+    }
+
+    fn bin_int(&mut self, f: impl Fn(i64, i64) -> Value) -> Result<(), VmError> {
+        let b = self.pop()?.as_int();
+        let a = self.pop()?.as_int();
+        self.stack.push(f(a, b));
+        Ok(())
+    }
+    fn bin_float(&mut self, f: impl Fn(f64, f64) -> Value) -> Result<(), VmError> {
+        let b = self.pop()?.as_float();
+        let a = self.pop()?.as_float();
+        self.stack.push(f(a, b));
+        Ok(())
+    }
+    fn bin_num(
+        &mut self,
+        i: impl Fn(i64, i64) -> Value,
+        f: impl Fn(f64, f64) -> Value,
+    ) -> Result<(), VmError> {
+        let b = self.pop()?;
+        let a = self.pop()?;
+        match (a, b) {
+            (Value::Int(x), Value::Int(y)) => { self.stack.push(i(x, y)); Ok(()) }
+            (Value::Float(x), Value::Float(y)) => { self.stack.push(f(x, y)); Ok(()) }
+            (a, b) => Err(VmError::TypeMismatch(format!("Num op: {a:?} {b:?}"))),
+        }
+    }
+    fn bin_eq(&mut self) -> Result<(), VmError> {
+        let b = self.pop()?;
+        let a = self.pop()?;
+        self.stack.push(Value::Bool(a == b));
+        Ok(())
+    }
+}
+
+fn const_to_value(c: &Const) -> Value {
+    match c {
+        Const::Int(n) => Value::Int(*n),
+        Const::Float(f) => Value::Float(*f),
+        Const::Bool(b) => Value::Bool(*b),
+        Const::Str(s) => Value::Str(s.clone()),
+        Const::Bytes(b) => Value::Bytes(b.clone()),
+        Const::Unit => Value::Unit,
+        Const::FieldName(s) | Const::VariantName(s) => Value::Str(s.clone()),
+    }
+}

--- a/crates/lex-bytecode/tests/run.rs
+++ b/crates/lex-bytecode/tests/run.rs
@@ -39,7 +39,10 @@ fn example_d_shape() {
     };
     let r = vm.call("area", vec![circle]).unwrap();
     let v = match r { Value::Float(f) => f, other => panic!("expected float, got {other:?}") };
-    assert!((v - 3.14159).abs() < 1e-6, "got {v}");
+    // Source uses 3.14159 directly (the spec's example, not std::f64::consts::PI).
+    #[allow(clippy::approx_constant)]
+    let expected_area = 3.14159_f64;
+    assert!((v - expected_area).abs() < 1e-6, "got {v}");
 
     let rect = Value::Variant {
         name: "Rect".into(),

--- a/crates/lex-bytecode/tests/run.rs
+++ b/crates/lex-bytecode/tests/run.rs
@@ -1,0 +1,87 @@
+//! M4 acceptance: pure §3.13 examples produce expected outputs.
+
+use indexmap::IndexMap;
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, Value, Vm};
+use lex_syntax::parse_source;
+
+fn compile(src: &str) -> lex_bytecode::Program {
+    let p = parse_source(src).unwrap();
+    let stages = canonicalize_program(&p);
+    compile_program(&stages)
+}
+
+#[test]
+fn example_a_factorial() {
+    let src = include_str!("../../../examples/a_factorial.lex");
+    let p = compile(src);
+    let mut vm = Vm::new(&p);
+    let r = vm.call("factorial", vec![Value::Int(5)]).unwrap();
+    assert_eq!(r, Value::Int(120));
+    let r = vm.call("factorial", vec![Value::Int(0)]).unwrap();
+    assert_eq!(r, Value::Int(1));
+    let r = vm.call("factorial", vec![Value::Int(10)]).unwrap();
+    assert_eq!(r, Value::Int(3628800));
+}
+
+#[test]
+fn example_d_shape() {
+    let src = include_str!("../../../examples/d_shape.lex");
+    let p = compile(src);
+    let mut vm = Vm::new(&p);
+    let circle = Value::Variant {
+        name: "Circle".into(),
+        args: vec![Value::Record({
+            let mut m = IndexMap::new();
+            m.insert("radius".into(), Value::Float(1.0));
+            m
+        })],
+    };
+    let r = vm.call("area", vec![circle]).unwrap();
+    let v = match r { Value::Float(f) => f, other => panic!("expected float, got {other:?}") };
+    assert!((v - 3.14159).abs() < 1e-6, "got {v}");
+
+    let rect = Value::Variant {
+        name: "Rect".into(),
+        args: vec![Value::Record({
+            let mut m = IndexMap::new();
+            m.insert("width".into(), Value::Float(2.0));
+            m.insert("height".into(), Value::Float(3.0));
+            m
+        })],
+    };
+    let r = vm.call("area", vec![rect]).unwrap();
+    assert_eq!(r, Value::Float(6.0));
+}
+
+#[test]
+fn bytecode_is_reproducible() {
+    let src = include_str!("../../../examples/a_factorial.lex");
+    let p1 = compile(src);
+    let p2 = compile(src);
+    assert_eq!(p1, p2);
+}
+
+#[test]
+fn match_with_literal_int() {
+    let src = "fn id_or_zero(n :: Int) -> Int {\n  match n {\n    0 => 0,\n    _ => n,\n  }\n}\n";
+    let p = compile(src);
+    let mut vm = Vm::new(&p);
+    assert_eq!(vm.call("id_or_zero", vec![Value::Int(0)]).unwrap(), Value::Int(0));
+    assert_eq!(vm.call("id_or_zero", vec![Value::Int(7)]).unwrap(), Value::Int(7));
+}
+
+#[test]
+fn record_field_access() {
+    let src = "fn xof(r :: Record) -> Int { r.x }\n".replace(
+        "Record",
+        "{ x :: Int, y :: Int }",
+    );
+    let p = compile(&src);
+    let mut vm = Vm::new(&p);
+    let mut m = IndexMap::new();
+    m.insert("x".into(), Value::Int(11));
+    m.insert("y".into(), Value::Int(22));
+    let r = vm.call("xof", vec![Value::Record(m)]).unwrap();
+    assert_eq!(r, Value::Int(11));
+}

--- a/crates/lex-cli/Cargo.toml
+++ b/crates/lex-cli/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "lex-cli"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "lex"
+path = "src/main.rs"
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+anyhow.workspace = true
+indexmap.workspace = true
+lex-syntax = { path = "../lex-syntax" }
+lex-ast = { path = "../lex-ast" }
+lex-types = { path = "../lex-types" }
+lex-bytecode = { path = "../lex-bytecode" }

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -7,7 +7,7 @@
 //!   lex hash <file>                    # canonical AST hash for each stage
 
 use anyhow::{anyhow, bail, Context, Result};
-use lex_ast::{canonicalize_program, print_stages, stage_canonical_hash_hex, stage_id, Stage};
+use lex_ast::{canonicalize_program, stage_canonical_hash_hex, stage_id, Stage};
 use lex_bytecode::{compile_program, Value, Vm};
 use lex_syntax::parse_source;
 use std::fs;
@@ -180,6 +180,3 @@ fn value_to_json(v: &Value) -> serde_json::Value {
         }
     }
 }
-
-#[allow(dead_code)]
-fn unused_print_stages(s: &[Stage]) -> String { print_stages(s) }

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -1,0 +1,185 @@
+//! Lex CLI per spec §12.1. M4-level subset: parse, check, run.
+//!
+//! Usage:
+//!   lex parse <file>
+//!   lex check <file>
+//!   lex run <file> <fn> [<arg>...]    # args parsed as JSON
+//!   lex hash <file>                    # canonical AST hash for each stage
+
+use anyhow::{anyhow, bail, Context, Result};
+use lex_ast::{canonicalize_program, print_stages, stage_canonical_hash_hex, stage_id, Stage};
+use lex_bytecode::{compile_program, Value, Vm};
+use lex_syntax::parse_source;
+use std::fs;
+use std::io::Read;
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if let Err(e) = run(&args) {
+        eprintln!("error: {e:#}");
+        std::process::exit(1);
+    }
+}
+
+fn run(args: &[String]) -> Result<()> {
+    let cmd = args.first().ok_or_else(|| anyhow!("usage: lex <command> ..."))?;
+    match cmd.as_str() {
+        "parse" => cmd_parse(&args[1..]),
+        "check" => cmd_check(&args[1..]),
+        "run" => cmd_run(&args[1..]),
+        "hash" => cmd_hash(&args[1..]),
+        "help" | "--help" | "-h" => { print_usage(); Ok(()) }
+        other => bail!("unknown command `{other}`. try `lex help`"),
+    }
+}
+
+fn print_usage() {
+    println!("lex — Lex toolchain (M0–M4 subset)\n");
+    println!("commands:");
+    println!("  parse <file>              print canonical AST as JSON");
+    println!("  check <file>              type-check; exit 0 or print errors");
+    println!("  run <file> <fn> [args]    execute fn (args parsed as JSON)");
+    println!("  hash <file>               print stage canonical hashes");
+}
+
+fn read_source(path: &str) -> Result<String> {
+    if path == "-" {
+        let mut s = String::new();
+        std::io::stdin().read_to_string(&mut s).context("reading stdin")?;
+        Ok(s)
+    } else {
+        fs::read_to_string(path).with_context(|| format!("reading {path}"))
+    }
+}
+
+fn cmd_parse(args: &[String]) -> Result<()> {
+    let path = args.first().ok_or_else(|| anyhow!("usage: lex parse <file>"))?;
+    let src = read_source(path)?;
+    let prog = parse_source(&src)?;
+    let stages = canonicalize_program(&prog);
+    let json = serde_json::to_string_pretty(&stages)?;
+    println!("{json}");
+    Ok(())
+}
+
+fn cmd_check(args: &[String]) -> Result<()> {
+    let path = args.first().ok_or_else(|| anyhow!("usage: lex check <file>"))?;
+    let src = read_source(path)?;
+    let prog = parse_source(&src)?;
+    let stages = canonicalize_program(&prog);
+    match lex_types::check_program(&stages) {
+        Ok(_) => {
+            println!("ok");
+            Ok(())
+        }
+        Err(errs) => {
+            for e in &errs {
+                let json = serde_json::to_string(e)?;
+                println!("{json}");
+            }
+            std::process::exit(2);
+        }
+    }
+}
+
+fn cmd_run(args: &[String]) -> Result<()> {
+    let path = args.first().ok_or_else(|| anyhow!("usage: lex run <file> <fn> [args]"))?;
+    let func = args.get(1).ok_or_else(|| anyhow!("missing function name"))?;
+    let src = read_source(path)?;
+    let prog = parse_source(&src)?;
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        for e in &errs {
+            let json = serde_json::to_string(e)?;
+            eprintln!("{json}");
+        }
+        std::process::exit(2);
+    }
+    let bc = compile_program(&stages);
+    let mut vm = Vm::new(&bc);
+    let vargs: Vec<Value> = args[2..]
+        .iter()
+        .map(|a| {
+            let v: serde_json::Value = serde_json::from_str(a)
+                .with_context(|| format!("arg `{a}` must be JSON"))?;
+            Ok(json_to_value(&v))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let r = vm.call(func, vargs).map_err(|e| anyhow!("runtime: {e}"))?;
+    println!("{}", value_to_json_string(&r));
+    Ok(())
+}
+
+fn cmd_hash(args: &[String]) -> Result<()> {
+    let path = args.first().ok_or_else(|| anyhow!("usage: lex hash <file>"))?;
+    let src = read_source(path)?;
+    let prog = parse_source(&src)?;
+    let stages = canonicalize_program(&prog);
+    for s in &stages {
+        let name = stage_name(s);
+        let h = stage_canonical_hash_hex(s);
+        let sid = stage_id(s).unwrap_or_else(|| "-".into());
+        println!("{name}\tcanonical_ast={h}\tstage_id={sid}");
+    }
+    Ok(())
+}
+
+fn stage_name(s: &Stage) -> &str {
+    match s {
+        Stage::FnDecl(fd) => &fd.name,
+        Stage::TypeDecl(td) => &td.name,
+        Stage::Import(i) => &i.alias,
+    }
+}
+
+fn json_to_value(v: &serde_json::Value) -> Value {
+    use serde_json::Value as J;
+    match v {
+        J::Null => Value::Unit,
+        J::Bool(b) => Value::Bool(*b),
+        J::Number(n) => {
+            if let Some(i) = n.as_i64() { Value::Int(i) }
+            else if let Some(f) = n.as_f64() { Value::Float(f) }
+            else { Value::Unit }
+        }
+        J::String(s) => Value::Str(s.clone()),
+        J::Array(items) => Value::List(items.iter().map(json_to_value).collect()),
+        J::Object(map) => {
+            let mut out = indexmap::IndexMap::new();
+            for (k, v) in map { out.insert(k.clone(), json_to_value(v)); }
+            Value::Record(out)
+        }
+    }
+}
+
+fn value_to_json_string(v: &Value) -> String {
+    serde_json::to_string(&value_to_json(v)).unwrap()
+}
+
+fn value_to_json(v: &Value) -> serde_json::Value {
+    use serde_json::Value as J;
+    match v {
+        Value::Int(n) => J::from(*n),
+        Value::Float(f) => J::from(*f),
+        Value::Bool(b) => J::Bool(*b),
+        Value::Str(s) => J::String(s.clone()),
+        Value::Bytes(b) => J::String(b.iter().map(|b| format!("{:02x}", b)).collect()),
+        Value::Unit => J::Null,
+        Value::List(items) => J::Array(items.iter().map(value_to_json).collect()),
+        Value::Tuple(items) => J::Array(items.iter().map(value_to_json).collect()),
+        Value::Record(fields) => {
+            let mut m = serde_json::Map::new();
+            for (k, v) in fields { m.insert(k.clone(), value_to_json(v)); }
+            J::Object(m)
+        }
+        Value::Variant { name, args } => {
+            let mut m = serde_json::Map::new();
+            m.insert("$variant".into(), J::String(name.clone()));
+            m.insert("args".into(), J::Array(args.iter().map(value_to_json).collect()));
+            J::Object(m)
+        }
+    }
+}
+
+#[allow(dead_code)]
+fn unused_print_stages(s: &[Stage]) -> String { print_stages(s) }

--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "lex-runtime"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true

--- a/crates/lex-runtime/src/lib.rs
+++ b/crates/lex-runtime/src/lib.rs
@@ -1,0 +1,1 @@
+//! M5: effect runtime and sandbox. Placeholder.

--- a/crates/lex-stdlib/Cargo.toml
+++ b/crates/lex-stdlib/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "lex-stdlib"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true

--- a/crates/lex-stdlib/src/lib.rs
+++ b/crates/lex-stdlib/src/lib.rs
@@ -1,0 +1,1 @@
+//! M11: standard library stages. Placeholder.

--- a/crates/lex-store/Cargo.toml
+++ b/crates/lex-store/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "lex-store"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+thiserror.workspace = true

--- a/crates/lex-store/src/lib.rs
+++ b/crates/lex-store/src/lib.rs
@@ -1,0 +1,1 @@
+//! M6: content-addressed store. Placeholder.

--- a/crates/lex-syntax/Cargo.toml
+++ b/crates/lex-syntax/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "lex-syntax"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+logos.workspace = true
+indexmap.workspace = true

--- a/crates/lex-syntax/src/lib.rs
+++ b/crates/lex-syntax/src/lib.rs
@@ -1,0 +1,27 @@
+//! M1: lexer, parser, syntax tree, pretty-printer for Lex.
+//!
+//! See spec §3 for the grammar.
+
+pub mod token;
+pub mod syntax;
+pub mod parser;
+pub mod printer;
+
+pub use parser::{parse, ParseError};
+pub use printer::print_program;
+pub use syntax::*;
+pub use token::{lex, LexError, Token, TokenKind};
+
+/// Convenience: lex + parse a source string.
+pub fn parse_source(src: &str) -> Result<Program, SyntaxError> {
+    let toks = lex(src).map_err(SyntaxError::Lex)?;
+    parse(toks).map_err(SyntaxError::Parse)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SyntaxError {
+    #[error(transparent)]
+    Lex(#[from] LexError),
+    #[error(transparent)]
+    Parse(#[from] ParseError),
+}

--- a/crates/lex-syntax/src/parser.rs
+++ b/crates/lex-syntax/src/parser.rs
@@ -1,0 +1,749 @@
+//! Recursive-descent parser for Lex. Pratt-style precedence climbing for
+//! binary operators; everything else is straightforward LL(1)-with-lookahead.
+
+use crate::syntax::*;
+use crate::token::{Token, TokenKind};
+
+pub fn parse(tokens: Vec<Token>) -> Result<Program, ParseError> {
+    let mut p = Parser::new(tokens);
+    let program = p.parse_program()?;
+    p.skip_newlines();
+    if !p.at_eof() {
+        return Err(p.error("unexpected token after program"));
+    }
+    Ok(program)
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("parse error at byte {pos}: {msg}")]
+pub struct ParseError {
+    pub pos: usize,
+    pub msg: String,
+}
+
+struct Parser {
+    tokens: Vec<Token>,
+    idx: usize,
+}
+
+impl Parser {
+    fn new(tokens: Vec<Token>) -> Self {
+        Self { tokens, idx: 0 }
+    }
+
+    fn at_eof(&self) -> bool {
+        self.idx >= self.tokens.len()
+    }
+
+    fn peek(&self) -> Option<&TokenKind> {
+        self.tokens.get(self.idx).map(|t| &t.kind)
+    }
+
+    fn bump(&mut self) -> Option<Token> {
+        let t = self.tokens.get(self.idx).cloned();
+        if t.is_some() {
+            self.idx += 1;
+        }
+        t
+    }
+
+    fn current_pos(&self) -> usize {
+        self.tokens
+            .get(self.idx)
+            .map(|t| t.span.start)
+            .unwrap_or_else(|| self.tokens.last().map(|t| t.span.end).unwrap_or(0))
+    }
+
+    fn error(&self, msg: impl Into<String>) -> ParseError {
+        ParseError { pos: self.current_pos(), msg: msg.into() }
+    }
+
+    fn skip_newlines(&mut self) {
+        while matches!(self.peek(), Some(TokenKind::Newline) | Some(TokenKind::Semi)) {
+            self.idx += 1;
+        }
+    }
+
+    fn expect(&mut self, expected: &TokenKind, ctx: &str) -> Result<Token, ParseError> {
+        self.skip_newlines();
+        match self.peek() {
+            Some(k) if std::mem::discriminant(k) == std::mem::discriminant(expected) => {
+                Ok(self.bump().unwrap())
+            }
+            Some(other) => Err(self.error(format!(
+                "expected {expected:?} {ctx}, got {other:?}"
+            ))),
+            None => Err(self.error(format!("expected {expected:?} {ctx}, got EOF"))),
+        }
+    }
+
+    fn eat(&mut self, k: &TokenKind) -> bool {
+        self.skip_newlines();
+        if let Some(cur) = self.peek() {
+            if std::mem::discriminant(cur) == std::mem::discriminant(k) {
+                self.bump();
+                return true;
+            }
+        }
+        false
+    }
+
+    fn expect_ident(&mut self, ctx: &str) -> Result<String, ParseError> {
+        self.skip_newlines();
+        match self.peek() {
+            Some(TokenKind::Ident(_)) => match self.bump().unwrap().kind {
+                TokenKind::Ident(name) => Ok(name),
+                _ => unreachable!(),
+            },
+            other => Err(self.error(format!("expected identifier {ctx}, got {other:?}"))),
+        }
+    }
+
+    // --- top level ---
+
+    fn parse_program(&mut self) -> Result<Program, ParseError> {
+        let mut items = Vec::new();
+        loop {
+            self.skip_newlines();
+            if self.at_eof() {
+                break;
+            }
+            items.push(self.parse_item()?);
+        }
+        Ok(Program { items })
+    }
+
+    fn parse_item(&mut self) -> Result<Item, ParseError> {
+        match self.peek() {
+            Some(TokenKind::Import) => self.parse_import().map(Item::Import),
+            Some(TokenKind::Type) => self.parse_type_decl().map(Item::TypeDecl),
+            Some(TokenKind::Fn) => self.parse_fn_decl().map(Item::FnDecl),
+            other => Err(self.error(format!(
+                "expected `import`, `type`, or `fn` at top level, got {other:?}"
+            ))),
+        }
+    }
+
+    fn parse_import(&mut self) -> Result<Import, ParseError> {
+        self.expect(&TokenKind::Import, "in import")?;
+        let reference = match self.bump().map(|t| t.kind) {
+            Some(TokenKind::Str(s)) => s,
+            other => return Err(self.error(format!("expected string after `import`, got {other:?}"))),
+        };
+        self.expect(&TokenKind::As, "in import")?;
+        let alias = self.expect_ident("for import alias")?;
+        Ok(Import { reference, alias })
+    }
+
+    fn parse_type_decl(&mut self) -> Result<TypeDecl, ParseError> {
+        self.expect(&TokenKind::Type, "in type decl")?;
+        let name = self.expect_ident("for type name")?;
+        let params = if self.eat(&TokenKind::LBracket) {
+            let ps = self.parse_ident_list()?;
+            self.expect(&TokenKind::RBracket, "after type params")?;
+            ps
+        } else {
+            Vec::new()
+        };
+        self.expect(&TokenKind::Eq, "in type decl")?;
+        let definition = self.parse_type_decl_rhs()?;
+        Ok(TypeDecl { name, params, definition })
+    }
+
+    fn parse_ident_list(&mut self) -> Result<Vec<String>, ParseError> {
+        let mut out = Vec::new();
+        out.push(self.expect_ident("in identifier list")?);
+        while self.eat(&TokenKind::Comma) {
+            out.push(self.expect_ident("in identifier list")?);
+        }
+        Ok(out)
+    }
+
+    /// `type Foo = Variant1 | Variant2(Payload)` is a union; otherwise a plain type expression.
+    fn parse_type_decl_rhs(&mut self) -> Result<TypeExpr, ParseError> {
+        let first = self.parse_type_expr()?;
+        // Detect union: PascalCase ident (or named type w/ optional payload) followed by `|`.
+        if matches!(self.peek_skip_newlines(), Some(TokenKind::Bar)) {
+            let mut variants = Vec::new();
+            variants.push(type_to_variant(first)?);
+            while self.eat(&TokenKind::Bar) {
+                let next = self.parse_type_expr()?;
+                variants.push(type_to_variant(next)?);
+            }
+            Ok(TypeExpr::Union(variants))
+        } else {
+            Ok(first)
+        }
+    }
+
+    fn peek_skip_newlines(&mut self) -> Option<TokenKind> {
+        let saved = self.idx;
+        self.skip_newlines();
+        let out = self.peek().cloned();
+        self.idx = saved;
+        out
+    }
+
+    fn parse_type_expr(&mut self) -> Result<TypeExpr, ParseError> {
+        self.skip_newlines();
+        match self.peek() {
+            Some(TokenKind::LBrace) => self.parse_record_type(),
+            Some(TokenKind::LParen) => self.parse_paren_type_or_function(),
+            Some(TokenKind::Ident(_)) => {
+                let name = self.expect_ident("in type expr")?;
+                let args = if matches!(self.peek(), Some(TokenKind::LBracket)) {
+                    self.bump();
+                    let mut args = Vec::new();
+                    args.push(self.parse_type_expr()?);
+                    while self.eat(&TokenKind::Comma) {
+                        args.push(self.parse_type_expr()?);
+                    }
+                    self.expect(&TokenKind::RBracket, "after type args")?;
+                    args
+                } else if matches!(self.peek(), Some(TokenKind::LParen)) {
+                    // Constructor type with payload: `Name(T)` or `Name(T1, T2)`.
+                    self.bump();
+                    let mut args = Vec::new();
+                    if !matches!(self.peek_skip_newlines(), Some(TokenKind::RParen)) {
+                        args.push(self.parse_type_expr()?);
+                        while self.eat(&TokenKind::Comma) {
+                            args.push(self.parse_type_expr()?);
+                        }
+                    }
+                    self.expect(&TokenKind::RParen, "after constructor payload")?;
+                    args
+                } else {
+                    Vec::new()
+                };
+                Ok(TypeExpr::Named { name, args })
+            }
+            other => Err(self.error(format!("expected type expression, got {other:?}"))),
+        }
+    }
+
+    fn parse_record_type(&mut self) -> Result<TypeExpr, ParseError> {
+        self.expect(&TokenKind::LBrace, "in record type")?;
+        let mut fields = Vec::new();
+        if !matches!(self.peek_skip_newlines(), Some(TokenKind::RBrace)) {
+            loop {
+                self.skip_newlines();
+                let name = self.expect_ident("in record field")?;
+                self.expect(&TokenKind::ColonColon, "after record field name")?;
+                let ty = self.parse_type_expr()?;
+                fields.push(TypeField { name, ty });
+                self.skip_newlines();
+                if !self.eat(&TokenKind::Comma) { break; }
+                if matches!(self.peek_skip_newlines(), Some(TokenKind::RBrace)) { break; }
+            }
+        }
+        self.expect(&TokenKind::RBrace, "in record type")?;
+        Ok(TypeExpr::Record(fields))
+    }
+
+    fn parse_paren_type_or_function(&mut self) -> Result<TypeExpr, ParseError> {
+        self.expect(&TokenKind::LParen, "in type")?;
+        let mut args = Vec::new();
+        if !matches!(self.peek_skip_newlines(), Some(TokenKind::RParen)) {
+            args.push(self.parse_type_expr()?);
+            while self.eat(&TokenKind::Comma) {
+                args.push(self.parse_type_expr()?);
+            }
+        }
+        self.expect(&TokenKind::RParen, "in type")?;
+        // Function type if followed by `->`.
+        if matches!(self.peek_skip_newlines(), Some(TokenKind::Arrow)) {
+            self.skip_newlines();
+            self.bump();
+            let effects = self.parse_effects()?;
+            let ret = self.parse_type_expr()?;
+            Ok(TypeExpr::Function {
+                params: args,
+                effects,
+                ret: Box::new(ret),
+            })
+        } else if args.len() == 1 {
+            // Parenthesized type expression.
+            Ok(args.into_iter().next().unwrap())
+        } else {
+            Ok(TypeExpr::Tuple(args))
+        }
+    }
+
+    fn parse_fn_decl(&mut self) -> Result<FnDecl, ParseError> {
+        self.expect(&TokenKind::Fn, "in fn decl")?;
+        let name = self.expect_ident("for function name")?;
+        let type_params = if self.eat(&TokenKind::LBracket) {
+            let ps = self.parse_ident_list()?;
+            self.expect(&TokenKind::RBracket, "after type params")?;
+            ps
+        } else {
+            Vec::new()
+        };
+        self.expect(&TokenKind::LParen, "before params")?;
+        let mut params = Vec::new();
+        if !matches!(self.peek_skip_newlines(), Some(TokenKind::RParen)) {
+            params.push(self.parse_param()?);
+            while self.eat(&TokenKind::Comma) {
+                params.push(self.parse_param()?);
+            }
+        }
+        self.expect(&TokenKind::RParen, "after params")?;
+        self.expect(&TokenKind::Arrow, "before return type")?;
+        let effects = self.parse_effects()?;
+        let return_type = self.parse_type_expr()?;
+        let body = self.parse_block()?;
+        Ok(FnDecl { name, type_params, params, effects, return_type, body })
+    }
+
+    fn parse_param(&mut self) -> Result<Param, ParseError> {
+        let name = self.expect_ident("for parameter name")?;
+        self.expect(&TokenKind::ColonColon, "after parameter name")?;
+        let ty = self.parse_type_expr()?;
+        Ok(Param { name, ty })
+    }
+
+    fn parse_effects(&mut self) -> Result<Vec<Effect>, ParseError> {
+        if !self.eat(&TokenKind::LBracket) {
+            return Ok(Vec::new());
+        }
+        let mut out = Vec::new();
+        if !matches!(self.peek_skip_newlines(), Some(TokenKind::RBracket)) {
+            out.push(self.parse_effect()?);
+            while self.eat(&TokenKind::Comma) {
+                out.push(self.parse_effect()?);
+            }
+        }
+        self.expect(&TokenKind::RBracket, "after effects")?;
+        Ok(out)
+    }
+
+    fn parse_effect(&mut self) -> Result<Effect, ParseError> {
+        let name = self.expect_ident("for effect name")?;
+        let arg = if self.eat(&TokenKind::LParen) {
+            let arg = match self.bump().map(|t| t.kind) {
+                Some(TokenKind::Str(s)) => EffectArg::Str(s),
+                Some(TokenKind::Int(n)) => EffectArg::Int(n),
+                Some(TokenKind::Ident(s)) => EffectArg::Ident(s),
+                other => return Err(self.error(format!("invalid effect arg: {other:?}"))),
+            };
+            self.expect(&TokenKind::RParen, "after effect arg")?;
+            Some(arg)
+        } else {
+            None
+        };
+        Ok(Effect { name, arg })
+    }
+
+    // --- blocks and statements ---
+
+    fn parse_block(&mut self) -> Result<Block, ParseError> {
+        self.expect(&TokenKind::LBrace, "before block")?;
+        let mut statements = Vec::new();
+        let result;
+        loop {
+            self.skip_newlines();
+            if matches!(self.peek(), Some(TokenKind::RBrace)) {
+                // Empty block: synthesize Unit literal.
+                result = Box::new(Expr::Lit(Literal::Unit));
+                break;
+            }
+            // Try parsing a let; otherwise an expression.
+            if matches!(self.peek(), Some(TokenKind::Let)) {
+                let stmt = self.parse_let_statement()?;
+                statements.push(stmt);
+                self.skip_newlines();
+                continue;
+            }
+            let expr = self.parse_expr()?;
+            self.skip_newlines();
+            // If the next token is `}`, this expression is the block's result.
+            if matches!(self.peek(), Some(TokenKind::RBrace)) {
+                result = Box::new(expr);
+                break;
+            }
+            statements.push(Statement::Expr(expr));
+        }
+        self.expect(&TokenKind::RBrace, "to close block")?;
+        Ok(Block { statements, result })
+    }
+
+    fn parse_let_statement(&mut self) -> Result<Statement, ParseError> {
+        self.expect(&TokenKind::Let, "in let")?;
+        let name = self.expect_ident("after `let`")?;
+        let ty = if self.eat(&TokenKind::ColonColon) {
+            Some(self.parse_type_expr()?)
+        } else {
+            None
+        };
+        self.expect(&TokenKind::ColonEq, "in let")?;
+        let value = self.parse_expr()?;
+        Ok(Statement::Let { name, ty, value })
+    }
+
+    // --- expressions ---
+
+    fn parse_expr(&mut self) -> Result<Expr, ParseError> {
+        // Pipes are left-associative and bind less tightly than binary ops.
+        let mut left = self.parse_binary_expr(0)?;
+        while matches!(self.peek_skip_newlines(), Some(TokenKind::Pipe)) {
+            self.skip_newlines();
+            self.bump();
+            let right = self.parse_binary_expr(0)?;
+            left = Expr::Pipe { left: Box::new(left), right: Box::new(right) };
+        }
+        Ok(left)
+    }
+
+    fn parse_binary_expr(&mut self, min_prec: u8) -> Result<Expr, ParseError> {
+        let mut lhs = self.parse_unary()?;
+        loop {
+            let op = match self.peek_binop() {
+                Some(op) if op.precedence() >= min_prec => op,
+                _ => break,
+            };
+            self.skip_newlines();
+            self.bump();
+            let rhs = self.parse_binary_expr(op.precedence() + 1)?;
+            lhs = Expr::BinOp { op, lhs: Box::new(lhs), rhs: Box::new(rhs) };
+        }
+        Ok(lhs)
+    }
+
+    fn peek_binop(&mut self) -> Option<BinOp> {
+        match self.peek_skip_newlines()? {
+            TokenKind::Plus => Some(BinOp::Add),
+            TokenKind::Minus => Some(BinOp::Sub),
+            TokenKind::Star => Some(BinOp::Mul),
+            TokenKind::Slash => Some(BinOp::Div),
+            TokenKind::Percent => Some(BinOp::Mod),
+            TokenKind::EqEq => Some(BinOp::Eq),
+            TokenKind::BangEq => Some(BinOp::Neq),
+            TokenKind::Lt => Some(BinOp::Lt),
+            TokenKind::LtEq => Some(BinOp::Lte),
+            TokenKind::Gt => Some(BinOp::Gt),
+            TokenKind::GtEq => Some(BinOp::Gte),
+            TokenKind::And => Some(BinOp::And),
+            TokenKind::Or => Some(BinOp::Or),
+            _ => None,
+        }
+    }
+
+    fn parse_unary(&mut self) -> Result<Expr, ParseError> {
+        self.skip_newlines();
+        match self.peek() {
+            Some(TokenKind::Not) => {
+                self.bump();
+                let inner = self.parse_unary()?;
+                Ok(Expr::UnaryOp { op: UnaryOp::Not, expr: Box::new(inner) })
+            }
+            Some(TokenKind::Minus) => {
+                self.bump();
+                let inner = self.parse_unary()?;
+                Ok(Expr::UnaryOp { op: UnaryOp::Neg, expr: Box::new(inner) })
+            }
+            _ => self.parse_postfix(),
+        }
+    }
+
+    fn parse_postfix(&mut self) -> Result<Expr, ParseError> {
+        let mut expr = self.parse_primary()?;
+        loop {
+            // Postfix operations don't cross newlines (they bind tightly).
+            match self.peek() {
+                Some(TokenKind::Dot) => {
+                    self.bump();
+                    let field = self.expect_ident("after `.`")?;
+                    expr = Expr::Field { value: Box::new(expr), field };
+                }
+                Some(TokenKind::LParen) => {
+                    self.bump();
+                    let mut args = Vec::new();
+                    if !matches!(self.peek_skip_newlines(), Some(TokenKind::RParen)) {
+                        args.push(self.parse_expr()?);
+                        while self.eat(&TokenKind::Comma) {
+                            args.push(self.parse_expr()?);
+                        }
+                    }
+                    self.expect(&TokenKind::RParen, "in call")?;
+                    expr = Expr::Call { callee: Box::new(expr), args };
+                }
+                Some(TokenKind::Question) => {
+                    self.bump();
+                    expr = Expr::Try(Box::new(expr));
+                }
+                _ => break,
+            }
+        }
+        Ok(expr)
+    }
+
+    fn parse_primary(&mut self) -> Result<Expr, ParseError> {
+        self.skip_newlines();
+        match self.peek() {
+            Some(TokenKind::Int(_)) => match self.bump().unwrap().kind {
+                TokenKind::Int(n) => Ok(Expr::Lit(Literal::Int(n))),
+                _ => unreachable!(),
+            },
+            Some(TokenKind::Float(_)) => match self.bump().unwrap().kind {
+                TokenKind::Float(n) => Ok(Expr::Lit(Literal::Float(n))),
+                _ => unreachable!(),
+            },
+            Some(TokenKind::Str(_)) => match self.bump().unwrap().kind {
+                TokenKind::Str(s) => Ok(Expr::Lit(Literal::Str(s))),
+                _ => unreachable!(),
+            },
+            Some(TokenKind::Bytes(_)) => match self.bump().unwrap().kind {
+                TokenKind::Bytes(b) => Ok(Expr::Lit(Literal::Bytes(b))),
+                _ => unreachable!(),
+            },
+            Some(TokenKind::True) => { self.bump(); Ok(Expr::Lit(Literal::Bool(true))) }
+            Some(TokenKind::False) => { self.bump(); Ok(Expr::Lit(Literal::Bool(false))) }
+            Some(TokenKind::If) => self.parse_if(),
+            Some(TokenKind::Match) => self.parse_match(),
+            Some(TokenKind::Fn) => self.parse_lambda(),
+            Some(TokenKind::LBrace) => self.parse_brace_expr(),
+            Some(TokenKind::LBracket) => self.parse_list_literal(),
+            Some(TokenKind::LParen) => self.parse_paren_or_tuple(),
+            Some(TokenKind::Ident(_)) => self.parse_ident_or_record(),
+            other => Err(self.error(format!("expected expression, got {other:?}"))),
+        }
+    }
+
+    /// Disambiguate `{` between record literal and block.
+    /// Lookahead: `{ Ident :` is a record literal; `{ }` is also a record
+    /// (empty block has no use). Anything else is a block.
+    fn parse_brace_expr(&mut self) -> Result<Expr, ParseError> {
+        // Save position; peek 2-3 tokens past `{` (skipping newlines).
+        let saved = self.idx;
+        self.bump(); // `{`
+        // Skip newlines.
+        while matches!(self.peek(), Some(TokenKind::Newline) | Some(TokenKind::Semi)) {
+            self.idx += 1;
+        }
+        let is_record = matches!(self.peek(), Some(TokenKind::RBrace))
+            || (matches!(self.peek(), Some(TokenKind::Ident(_)))
+                && matches!(self.tokens.get(self.idx + 1).map(|t| &t.kind), Some(TokenKind::Colon) | Some(TokenKind::Comma) | Some(TokenKind::RBrace)));
+        self.idx = saved;
+        if is_record {
+            self.parse_record_literal()
+        } else {
+            Ok(Expr::Block(self.parse_block()?))
+        }
+    }
+
+    fn parse_record_literal(&mut self) -> Result<Expr, ParseError> {
+        self.expect(&TokenKind::LBrace, "in record literal")?;
+        let mut fields = Vec::new();
+        if !matches!(self.peek_skip_newlines(), Some(TokenKind::RBrace)) {
+            loop {
+                self.skip_newlines();
+                let name = self.expect_ident("in record literal")?;
+                let value = if self.eat(&TokenKind::Colon) {
+                    self.parse_expr()?
+                } else {
+                    // shorthand: `{ name }` => `{ name: name }`
+                    Expr::Var(name.clone())
+                };
+                fields.push(RecordLitField { name, value });
+                self.skip_newlines();
+                if !self.eat(&TokenKind::Comma) { break; }
+                if matches!(self.peek_skip_newlines(), Some(TokenKind::RBrace)) { break; }
+            }
+        }
+        self.expect(&TokenKind::RBrace, "after record literal")?;
+        Ok(Expr::RecordLit(fields))
+    }
+
+    fn parse_if(&mut self) -> Result<Expr, ParseError> {
+        self.expect(&TokenKind::If, "in if")?;
+        let cond = self.parse_expr()?;
+        let then_block = self.parse_block()?;
+        self.expect(&TokenKind::Else, "expected `else`")?;
+        let else_block = self.parse_block()?;
+        Ok(Expr::If { cond: Box::new(cond), then_block, else_block })
+    }
+
+    fn parse_match(&mut self) -> Result<Expr, ParseError> {
+        self.expect(&TokenKind::Match, "in match")?;
+        let scrutinee = self.parse_expr()?;
+        self.expect(&TokenKind::LBrace, "before match arms")?;
+        let mut arms = Vec::new();
+        loop {
+            self.skip_newlines();
+            if matches!(self.peek(), Some(TokenKind::RBrace)) { break; }
+            let pattern = self.parse_pattern()?;
+            self.expect(&TokenKind::FatArrow, "in match arm")?;
+            let body = self.parse_expr()?;
+            arms.push(Arm { pattern, body });
+            self.skip_newlines();
+            if !self.eat(&TokenKind::Comma) { break; }
+        }
+        self.expect(&TokenKind::RBrace, "after match arms")?;
+        Ok(Expr::Match { scrutinee: Box::new(scrutinee), arms })
+    }
+
+    fn parse_lambda(&mut self) -> Result<Expr, ParseError> {
+        self.expect(&TokenKind::Fn, "in lambda")?;
+        self.expect(&TokenKind::LParen, "before lambda params")?;
+        let mut params = Vec::new();
+        if !matches!(self.peek_skip_newlines(), Some(TokenKind::RParen)) {
+            params.push(self.parse_param()?);
+            while self.eat(&TokenKind::Comma) {
+                params.push(self.parse_param()?);
+            }
+        }
+        self.expect(&TokenKind::RParen, "after lambda params")?;
+        self.expect(&TokenKind::Arrow, "before lambda return type")?;
+        let effects = self.parse_effects()?;
+        let return_type = self.parse_type_expr()?;
+        let body = self.parse_block()?;
+        Ok(Expr::Lambda(Box::new(Lambda { params, effects, return_type, body })))
+    }
+
+    fn parse_list_literal(&mut self) -> Result<Expr, ParseError> {
+        self.expect(&TokenKind::LBracket, "before list literal")?;
+        let mut items = Vec::new();
+        if !matches!(self.peek_skip_newlines(), Some(TokenKind::RBracket)) {
+            items.push(self.parse_expr()?);
+            while self.eat(&TokenKind::Comma) {
+                if matches!(self.peek_skip_newlines(), Some(TokenKind::RBracket)) { break; }
+                items.push(self.parse_expr()?);
+            }
+        }
+        self.expect(&TokenKind::RBracket, "after list literal")?;
+        Ok(Expr::ListLit(items))
+    }
+
+    fn parse_paren_or_tuple(&mut self) -> Result<Expr, ParseError> {
+        self.expect(&TokenKind::LParen, "")?;
+        if matches!(self.peek_skip_newlines(), Some(TokenKind::RParen)) {
+            self.bump();
+            return Ok(Expr::Lit(Literal::Unit));
+        }
+        let first = self.parse_expr()?;
+        if self.eat(&TokenKind::Comma) {
+            let mut items = vec![first];
+            if !matches!(self.peek_skip_newlines(), Some(TokenKind::RParen)) {
+                items.push(self.parse_expr()?);
+                while self.eat(&TokenKind::Comma) {
+                    if matches!(self.peek_skip_newlines(), Some(TokenKind::RParen)) { break; }
+                    items.push(self.parse_expr()?);
+                }
+            }
+            self.expect(&TokenKind::RParen, "after tuple")?;
+            Ok(Expr::TupleLit(items))
+        } else {
+            self.expect(&TokenKind::RParen, "after parenthesized expression")?;
+            Ok(first)
+        }
+    }
+
+    fn parse_ident_or_record(&mut self) -> Result<Expr, ParseError> {
+        // Ident is parsed as a Var; later postfix (`(`, `.`, `?`) attach.
+        let name = self.expect_ident("")?;
+        Ok(Expr::Var(name))
+    }
+
+    // --- patterns ---
+
+    fn parse_pattern(&mut self) -> Result<Pattern, ParseError> {
+        self.skip_newlines();
+        match self.peek() {
+            Some(TokenKind::Underscore) => { self.bump(); Ok(Pattern::Wild) }
+            Some(TokenKind::Int(_)) => match self.bump().unwrap().kind {
+                TokenKind::Int(n) => Ok(Pattern::Lit(Literal::Int(n))),
+                _ => unreachable!(),
+            },
+            Some(TokenKind::Float(_)) => match self.bump().unwrap().kind {
+                TokenKind::Float(n) => Ok(Pattern::Lit(Literal::Float(n))),
+                _ => unreachable!(),
+            },
+            Some(TokenKind::Str(_)) => match self.bump().unwrap().kind {
+                TokenKind::Str(s) => Ok(Pattern::Lit(Literal::Str(s))),
+                _ => unreachable!(),
+            },
+            Some(TokenKind::True) => { self.bump(); Ok(Pattern::Lit(Literal::Bool(true))) }
+            Some(TokenKind::False) => { self.bump(); Ok(Pattern::Lit(Literal::Bool(false))) }
+            Some(TokenKind::LBrace) => self.parse_record_pattern(),
+            Some(TokenKind::LParen) => self.parse_tuple_pattern(),
+            Some(TokenKind::Ident(_)) => {
+                let name = self.expect_ident("")?;
+                if matches!(self.peek(), Some(TokenKind::LParen)) {
+                    self.bump();
+                    let mut args = Vec::new();
+                    if !matches!(self.peek_skip_newlines(), Some(TokenKind::RParen)) {
+                        args.push(self.parse_pattern()?);
+                        while self.eat(&TokenKind::Comma) {
+                            args.push(self.parse_pattern()?);
+                        }
+                    }
+                    self.expect(&TokenKind::RParen, "after constructor pattern")?;
+                    Ok(Pattern::Constructor { name, args })
+                } else {
+                    Ok(Pattern::Var(name))
+                }
+            }
+            other => Err(self.error(format!("expected pattern, got {other:?}"))),
+        }
+    }
+
+    fn parse_record_pattern(&mut self) -> Result<Pattern, ParseError> {
+        self.expect(&TokenKind::LBrace, "")?;
+        let mut fields = Vec::new();
+        let rest = false;
+        if !matches!(self.peek_skip_newlines(), Some(TokenKind::RBrace)) {
+            loop {
+                self.skip_newlines();
+                let name = self.expect_ident("in record pattern")?;
+                let pattern = if self.eat(&TokenKind::Colon) {
+                    Some(self.parse_pattern()?)
+                } else {
+                    None
+                };
+                fields.push(RecordPatField { name, pattern });
+                self.skip_newlines();
+                if !self.eat(&TokenKind::Comma) { break; }
+                if matches!(self.peek_skip_newlines(), Some(TokenKind::RBrace)) { break; }
+            }
+        }
+        self.expect(&TokenKind::RBrace, "after record pattern")?;
+        Ok(Pattern::Record { fields, rest })
+    }
+
+    fn parse_tuple_pattern(&mut self) -> Result<Pattern, ParseError> {
+        self.expect(&TokenKind::LParen, "")?;
+        let mut items = Vec::new();
+        if !matches!(self.peek_skip_newlines(), Some(TokenKind::RParen)) {
+            items.push(self.parse_pattern()?);
+            while self.eat(&TokenKind::Comma) {
+                items.push(self.parse_pattern()?);
+            }
+        }
+        self.expect(&TokenKind::RParen, "after tuple pattern")?;
+        if items.len() == 1 {
+            Ok(items.into_iter().next().unwrap())
+        } else {
+            Ok(Pattern::Tuple(items))
+        }
+    }
+}
+
+/// In a union RHS, every leaf must be a `Named` type expression — that is, a
+/// PascalCase ident with optional payload via `Variant(payload_type)`.
+fn type_to_variant(t: TypeExpr) -> Result<UnionVariant, ParseError> {
+    match t {
+        TypeExpr::Named { name, args } => {
+            let payload = match args.len() {
+                0 => None,
+                1 => Some(args.into_iter().next().unwrap()),
+                _ => Some(TypeExpr::Tuple(args)),
+            };
+            Ok(UnionVariant { name, payload })
+        }
+        // `Foo({ field :: T })` parses as Named with one arg = Record. handled above.
+        _ => Err(ParseError {
+            pos: 0,
+            msg: "union variant must be a constructor name".into(),
+        }),
+    }
+}

--- a/crates/lex-syntax/src/printer.rs
+++ b/crates/lex-syntax/src/printer.rs
@@ -1,0 +1,389 @@
+//! Pretty-printer for the syntax tree. Designed so
+//! `parse(text) → print → parse` round-trips on the canonical AST.
+
+use crate::syntax::*;
+use std::fmt::Write;
+
+pub fn print_program(program: &Program) -> String {
+    let mut p = Printer::new();
+    p.program(program);
+    p.out
+}
+
+struct Printer {
+    out: String,
+    indent: usize,
+}
+
+impl Printer {
+    fn new() -> Self { Self { out: String::new(), indent: 0 } }
+
+    fn write_indent(&mut self) {
+        for _ in 0..self.indent {
+            self.out.push_str("  ");
+        }
+    }
+
+    fn nl(&mut self) {
+        self.out.push('\n');
+    }
+
+    fn program(&mut self, p: &Program) {
+        for (i, item) in p.items.iter().enumerate() {
+            if i > 0 { self.nl(); }
+            self.item(item);
+        }
+        if !p.items.is_empty() {
+            self.nl();
+        }
+    }
+
+    fn item(&mut self, item: &Item) {
+        match item {
+            Item::Import(i) => {
+                writeln!(self.out, "import \"{}\" as {}", i.reference, i.alias).unwrap();
+            }
+            Item::TypeDecl(td) => self.type_decl(td),
+            Item::FnDecl(fd) => self.fn_decl(fd),
+        }
+    }
+
+    fn type_decl(&mut self, td: &TypeDecl) {
+        write!(self.out, "type {}", td.name).unwrap();
+        if !td.params.is_empty() {
+            write!(self.out, "[{}]", td.params.join(", ")).unwrap();
+        }
+        write!(self.out, " = ").unwrap();
+        self.type_expr(&td.definition);
+        self.nl();
+    }
+
+    fn fn_decl(&mut self, fd: &FnDecl) {
+        write!(self.out, "fn {}", fd.name).unwrap();
+        if !fd.type_params.is_empty() {
+            write!(self.out, "[{}]", fd.type_params.join(", ")).unwrap();
+        }
+        write!(self.out, "(").unwrap();
+        for (i, p) in fd.params.iter().enumerate() {
+            if i > 0 { write!(self.out, ", ").unwrap(); }
+            write!(self.out, "{} :: ", p.name).unwrap();
+            self.type_expr(&p.ty);
+        }
+        write!(self.out, ") -> ").unwrap();
+        self.effects(&fd.effects);
+        self.type_expr(&fd.return_type);
+        write!(self.out, " ").unwrap();
+        self.block(&fd.body);
+        self.nl();
+    }
+
+    fn effects(&mut self, effects: &[Effect]) {
+        if effects.is_empty() { return; }
+        write!(self.out, "[").unwrap();
+        for (i, e) in effects.iter().enumerate() {
+            if i > 0 { write!(self.out, ", ").unwrap(); }
+            write!(self.out, "{}", e.name).unwrap();
+            if let Some(arg) = &e.arg {
+                match arg {
+                    EffectArg::Str(s) => write!(self.out, "(\"{}\")", s).unwrap(),
+                    EffectArg::Int(n) => write!(self.out, "({})", n).unwrap(),
+                    EffectArg::Ident(s) => write!(self.out, "({})", s).unwrap(),
+                }
+            }
+        }
+        write!(self.out, "] ").unwrap();
+    }
+
+    fn type_expr(&mut self, t: &TypeExpr) {
+        match t {
+            TypeExpr::Named { name, args } => {
+                write!(self.out, "{}", name).unwrap();
+                if !args.is_empty() {
+                    write!(self.out, "[").unwrap();
+                    for (i, a) in args.iter().enumerate() {
+                        if i > 0 { write!(self.out, ", ").unwrap(); }
+                        self.type_expr(a);
+                    }
+                    write!(self.out, "]").unwrap();
+                }
+            }
+            TypeExpr::Record(fs) => {
+                write!(self.out, "{{ ").unwrap();
+                for (i, f) in fs.iter().enumerate() {
+                    if i > 0 { write!(self.out, ", ").unwrap(); }
+                    write!(self.out, "{} :: ", f.name).unwrap();
+                    self.type_expr(&f.ty);
+                }
+                write!(self.out, " }}").unwrap();
+            }
+            TypeExpr::Tuple(items) => {
+                write!(self.out, "(").unwrap();
+                for (i, it) in items.iter().enumerate() {
+                    if i > 0 { write!(self.out, ", ").unwrap(); }
+                    self.type_expr(it);
+                }
+                write!(self.out, ")").unwrap();
+            }
+            TypeExpr::Function { params, effects, ret } => {
+                write!(self.out, "(").unwrap();
+                for (i, p) in params.iter().enumerate() {
+                    if i > 0 { write!(self.out, ", ").unwrap(); }
+                    self.type_expr(p);
+                }
+                write!(self.out, ") -> ").unwrap();
+                self.effects(effects);
+                self.type_expr(ret);
+            }
+            TypeExpr::Union(variants) => {
+                for (i, v) in variants.iter().enumerate() {
+                    if i > 0 { write!(self.out, " | ").unwrap(); }
+                    write!(self.out, "{}", v.name).unwrap();
+                    if let Some(payload) = &v.payload {
+                        write!(self.out, "(").unwrap();
+                        self.type_expr(payload);
+                        write!(self.out, ")").unwrap();
+                    }
+                }
+            }
+        }
+    }
+
+    fn block(&mut self, b: &Block) {
+        write!(self.out, "{{").unwrap();
+        self.indent += 1;
+        for stmt in &b.statements {
+            self.nl();
+            self.write_indent();
+            self.statement(stmt);
+        }
+        self.nl();
+        self.write_indent();
+        self.expr(&b.result);
+        self.indent -= 1;
+        self.nl();
+        self.write_indent();
+        write!(self.out, "}}").unwrap();
+    }
+
+    fn statement(&mut self, s: &Statement) {
+        match s {
+            Statement::Let { name, ty, value } => {
+                write!(self.out, "let {}", name).unwrap();
+                if let Some(ty) = ty {
+                    write!(self.out, " :: ").unwrap();
+                    self.type_expr(ty);
+                }
+                write!(self.out, " := ").unwrap();
+                self.expr(value);
+            }
+            Statement::Expr(e) => self.expr(e),
+        }
+    }
+
+    fn expr(&mut self, e: &Expr) {
+        self.expr_prec(e, 0);
+    }
+
+    fn expr_prec(&mut self, e: &Expr, parent_prec: u8) {
+        match e {
+            Expr::Lit(l) => self.literal(l),
+            Expr::Var(n) => { write!(self.out, "{}", n).unwrap(); }
+            Expr::Block(b) => self.block(b),
+            Expr::Call { callee, args } => {
+                self.expr_prec(callee, 100);
+                write!(self.out, "(").unwrap();
+                for (i, a) in args.iter().enumerate() {
+                    if i > 0 { write!(self.out, ", ").unwrap(); }
+                    self.expr(a);
+                }
+                write!(self.out, ")").unwrap();
+            }
+            Expr::Pipe { left, right } => {
+                if parent_prec > 0 { write!(self.out, "(").unwrap(); }
+                self.expr_prec(left, 1);
+                write!(self.out, " |> ").unwrap();
+                self.expr_prec(right, 1);
+                if parent_prec > 0 { write!(self.out, ")").unwrap(); }
+            }
+            Expr::Try(inner) => {
+                self.expr_prec(inner, 100);
+                write!(self.out, "?").unwrap();
+            }
+            Expr::Field { value, field } => {
+                self.expr_prec(value, 100);
+                write!(self.out, ".{}", field).unwrap();
+            }
+            Expr::BinOp { op, lhs, rhs } => {
+                let prec = op.precedence() + 10;
+                if parent_prec > prec { write!(self.out, "(").unwrap(); }
+                self.expr_prec(lhs, prec);
+                write!(self.out, " {} ", op.as_str()).unwrap();
+                self.expr_prec(rhs, prec + 1);
+                if parent_prec > prec { write!(self.out, ")").unwrap(); }
+            }
+            Expr::UnaryOp { op, expr } => {
+                let s = match op { UnaryOp::Neg => "-", UnaryOp::Not => "not " };
+                write!(self.out, "{}", s).unwrap();
+                self.expr_prec(expr, 100);
+            }
+            Expr::If { cond, then_block, else_block } => {
+                write!(self.out, "if ").unwrap();
+                self.expr(cond);
+                write!(self.out, " ").unwrap();
+                self.block(then_block);
+                write!(self.out, " else ").unwrap();
+                self.block(else_block);
+            }
+            Expr::Match { scrutinee, arms } => {
+                write!(self.out, "match ").unwrap();
+                self.expr(scrutinee);
+                write!(self.out, " {{").unwrap();
+                self.indent += 1;
+                for arm in arms {
+                    self.nl();
+                    self.write_indent();
+                    self.pattern(&arm.pattern);
+                    write!(self.out, " => ").unwrap();
+                    self.expr(&arm.body);
+                    write!(self.out, ",").unwrap();
+                }
+                self.indent -= 1;
+                self.nl();
+                self.write_indent();
+                write!(self.out, "}}").unwrap();
+            }
+            Expr::RecordLit(fields) => {
+                write!(self.out, "{{ ").unwrap();
+                for (i, f) in fields.iter().enumerate() {
+                    if i > 0 { write!(self.out, ", ").unwrap(); }
+                    write!(self.out, "{}: ", f.name).unwrap();
+                    self.expr(&f.value);
+                }
+                write!(self.out, " }}").unwrap();
+            }
+            Expr::TupleLit(items) => {
+                write!(self.out, "(").unwrap();
+                for (i, it) in items.iter().enumerate() {
+                    if i > 0 { write!(self.out, ", ").unwrap(); }
+                    self.expr(it);
+                }
+                write!(self.out, ")").unwrap();
+            }
+            Expr::ListLit(items) => {
+                write!(self.out, "[").unwrap();
+                for (i, it) in items.iter().enumerate() {
+                    if i > 0 { write!(self.out, ", ").unwrap(); }
+                    self.expr(it);
+                }
+                write!(self.out, "]").unwrap();
+            }
+            Expr::Constructor { name, args } => {
+                write!(self.out, "{}", name).unwrap();
+                if !args.is_empty() {
+                    write!(self.out, "(").unwrap();
+                    for (i, a) in args.iter().enumerate() {
+                        if i > 0 { write!(self.out, ", ").unwrap(); }
+                        self.expr(a);
+                    }
+                    write!(self.out, ")").unwrap();
+                }
+            }
+            Expr::Lambda(l) => {
+                write!(self.out, "fn (").unwrap();
+                for (i, p) in l.params.iter().enumerate() {
+                    if i > 0 { write!(self.out, ", ").unwrap(); }
+                    write!(self.out, "{} :: ", p.name).unwrap();
+                    self.type_expr(&p.ty);
+                }
+                write!(self.out, ") -> ").unwrap();
+                self.effects(&l.effects);
+                self.type_expr(&l.return_type);
+                write!(self.out, " ").unwrap();
+                self.block(&l.body);
+            }
+        }
+    }
+
+    fn literal(&mut self, l: &Literal) {
+        match l {
+            Literal::Int(n) => write!(self.out, "{}", n).unwrap(),
+            Literal::Float(n) => write!(self.out, "{}", format_float(*n)).unwrap(),
+            Literal::Str(s) => write!(self.out, "\"{}\"", escape(s)).unwrap(),
+            Literal::Bytes(b) => {
+                write!(self.out, "b\"").unwrap();
+                for &c in b {
+                    if c.is_ascii() && (c as char).is_ascii_graphic() && c != b'"' && c != b'\\' {
+                        self.out.push(c as char);
+                    } else {
+                        write!(self.out, "\\x{:02x}", c).unwrap();
+                    }
+                }
+                write!(self.out, "\"").unwrap();
+            }
+            Literal::Bool(b) => write!(self.out, "{}", b).unwrap(),
+            Literal::Unit => write!(self.out, "()").unwrap(),
+        }
+    }
+
+    fn pattern(&mut self, p: &Pattern) {
+        match p {
+            Pattern::Lit(l) => self.literal(l),
+            Pattern::Var(n) => { write!(self.out, "{}", n).unwrap(); }
+            Pattern::Wild => { write!(self.out, "_").unwrap(); }
+            Pattern::Constructor { name, args } => {
+                write!(self.out, "{}", name).unwrap();
+                if !args.is_empty() {
+                    write!(self.out, "(").unwrap();
+                    for (i, a) in args.iter().enumerate() {
+                        if i > 0 { write!(self.out, ", ").unwrap(); }
+                        self.pattern(a);
+                    }
+                    write!(self.out, ")").unwrap();
+                }
+            }
+            Pattern::Record { fields, rest: _ } => {
+                write!(self.out, "{{ ").unwrap();
+                for (i, f) in fields.iter().enumerate() {
+                    if i > 0 { write!(self.out, ", ").unwrap(); }
+                    write!(self.out, "{}", f.name).unwrap();
+                    if let Some(p) = &f.pattern {
+                        write!(self.out, ": ").unwrap();
+                        self.pattern(p);
+                    }
+                }
+                write!(self.out, " }}").unwrap();
+            }
+            Pattern::Tuple(items) => {
+                write!(self.out, "(").unwrap();
+                for (i, it) in items.iter().enumerate() {
+                    if i > 0 { write!(self.out, ", ").unwrap(); }
+                    self.pattern(it);
+                }
+                write!(self.out, ")").unwrap();
+            }
+        }
+    }
+}
+
+fn escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\t' => out.push_str("\\t"),
+            '\r' => out.push_str("\\r"),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+fn format_float(n: f64) -> String {
+    if n.is_finite() && n == n.trunc() {
+        format!("{:.1}", n)
+    } else {
+        format!("{}", n)
+    }
+}

--- a/crates/lex-syntax/src/syntax.rs
+++ b/crates/lex-syntax/src/syntax.rs
@@ -1,0 +1,207 @@
+//! Syntax tree (the parser's direct output, before canonicalization in §5).
+//!
+//! These nodes hew closely to source syntax; canonicalization (§5.3) folds
+//! `if` into `Match`, `?` into its match expansion, etc.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Program {
+    pub items: Vec<Item>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum Item {
+    Import(Import),
+    TypeDecl(TypeDecl),
+    FnDecl(FnDecl),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Import {
+    pub reference: String,
+    pub alias: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TypeDecl {
+    pub name: String,
+    pub params: Vec<String>,
+    pub definition: TypeExpr,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FnDecl {
+    pub name: String,
+    pub type_params: Vec<String>,
+    pub params: Vec<Param>,
+    pub effects: Vec<Effect>,
+    pub return_type: TypeExpr,
+    pub body: Block,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Param {
+    pub name: String,
+    pub ty: TypeExpr,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Effect {
+    pub name: String,
+    pub arg: Option<EffectArg>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum EffectArg {
+    Str(String),
+    Int(i64),
+    Ident(String),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum TypeExpr {
+    /// Named primitive or constructor application (`Int`, `Result[Int, Str]`, `T`).
+    /// We resolve which it is during type-checking, not parsing.
+    Named { name: String, args: Vec<TypeExpr> },
+    Record(Vec<TypeField>),
+    Tuple(Vec<TypeExpr>),
+    Function {
+        params: Vec<TypeExpr>,
+        effects: Vec<Effect>,
+        ret: Box<TypeExpr>,
+    },
+    Union(Vec<UnionVariant>),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TypeField {
+    pub name: String,
+    pub ty: TypeExpr,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct UnionVariant {
+    pub name: String,
+    /// `None` = tag-only (`Empty`); `Some(payload)` = constructor with payload.
+    pub payload: Option<TypeExpr>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Block {
+    pub statements: Vec<Statement>,
+    pub result: Box<Expr>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum Statement {
+    Let { name: String, ty: Option<TypeExpr>, value: Expr },
+    Expr(Expr),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum Expr {
+    Lit(Literal),
+    Var(String),
+    Block(Block),
+    Call { callee: Box<Expr>, args: Vec<Expr> },
+    Pipe { left: Box<Expr>, right: Box<Expr> },
+    /// `expr?` postfix.
+    Try(Box<Expr>),
+    /// `expr.field`
+    Field { value: Box<Expr>, field: String },
+    BinOp { op: BinOp, lhs: Box<Expr>, rhs: Box<Expr> },
+    UnaryOp { op: UnaryOp, expr: Box<Expr> },
+    If { cond: Box<Expr>, then_block: Block, else_block: Block },
+    Match { scrutinee: Box<Expr>, arms: Vec<Arm> },
+    RecordLit(Vec<RecordLitField>),
+    TupleLit(Vec<Expr>),
+    ListLit(Vec<Expr>),
+    /// A bare constructor name (`None`, `Empty`) or constructor call (`Ok(x)`).
+    /// Since we cannot distinguish a constructor from a variable at parse
+    /// time, the parser emits `Var`/`Call` and the type checker resolves it.
+    /// This variant is kept for the canonicalizer to lift detected
+    /// constructors into.
+    Constructor { name: String, args: Vec<Expr> },
+    Lambda(Box<Lambda>),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Lambda {
+    pub params: Vec<Param>,
+    pub return_type: TypeExpr,
+    pub effects: Vec<Effect>,
+    pub body: Block,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RecordLitField {
+    pub name: String,
+    pub value: Expr,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum BinOp {
+    Add, Sub, Mul, Div, Mod,
+    Eq, Neq, Lt, Lte, Gt, Gte,
+    And, Or,
+}
+
+impl BinOp {
+    pub fn precedence(self) -> u8 {
+        use BinOp::*;
+        match self {
+            Or => 1,
+            And => 2,
+            Eq | Neq | Lt | Lte | Gt | Gte => 3,
+            Add | Sub => 4,
+            Mul | Div | Mod => 5,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        use BinOp::*;
+        match self {
+            Add => "+", Sub => "-", Mul => "*", Div => "/", Mod => "%",
+            Eq => "==", Neq => "!=", Lt => "<", Lte => "<=", Gt => ">", Gte => ">=",
+            And => "and", Or => "or",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum UnaryOp { Neg, Not }
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Arm {
+    pub pattern: Pattern,
+    pub body: Expr,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum Pattern {
+    Lit(Literal),
+    /// Bare ident — either a binder or (during canonicalization) a tag-only constructor.
+    Var(String),
+    Wild,
+    Constructor { name: String, args: Vec<Pattern> },
+    Record { fields: Vec<RecordPatField>, rest: bool },
+    Tuple(Vec<Pattern>),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RecordPatField {
+    pub name: String,
+    /// `None` means shorthand `{ name }` => `{ name: name }`.
+    pub pattern: Option<Pattern>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum Literal {
+    Int(i64),
+    Float(f64),
+    Str(String),
+    Bytes(Vec<u8>),
+    Bool(bool),
+    Unit,
+}

--- a/crates/lex-syntax/src/token.rs
+++ b/crates/lex-syntax/src/token.rs
@@ -1,0 +1,125 @@
+use logos::Logos;
+use std::ops::Range;
+
+#[derive(Logos, Debug, Clone, PartialEq)]
+#[logos(skip r"[ \t\r\f]+")]
+#[logos(skip r"#[^\n]*")]
+pub enum TokenKind {
+    // keywords
+    #[token("fn")]      Fn,
+    #[token("let")]     Let,
+    #[token("type")]    Type,
+    #[token("match")]   Match,
+    #[token("if")]      If,
+    #[token("else")]    Else,
+    #[token("return")]  Return,
+    #[token("import")]  Import,
+    #[token("as")]      As,
+    #[token("true")]    True,
+    #[token("false")]   False,
+    #[token("and")]     And,
+    #[token("or")]      Or,
+    #[token("not")]     Not,
+
+    // multi-char operators (longer first to win the match race)
+    #[token("|>")] Pipe,
+    #[token("->")] Arrow,
+    #[token("=>")] FatArrow,
+    #[token(":=")] ColonEq,
+    #[token("::")] ColonColon,
+    #[token("==")] EqEq,
+    #[token("!=")] BangEq,
+    #[token("<=")] LtEq,
+    #[token(">=")] GtEq,
+
+    // single-char operators
+    #[token("+")] Plus,
+    #[token("-")] Minus,
+    #[token("*")] Star,
+    #[token("/")] Slash,
+    #[token("%")] Percent,
+    #[token("<")] Lt,
+    #[token(">")] Gt,
+    #[token(".")] Dot,
+    #[token(",")] Comma,
+    #[token(";")] Semi,
+    #[token(":")] Colon,
+    #[token("?")] Question,
+    #[token("(")] LParen,
+    #[token(")")] RParen,
+    #[token("{")] LBrace,
+    #[token("}")] RBrace,
+    #[token("[")] LBracket,
+    #[token("]")] RBracket,
+    #[token("=")] Eq,
+    #[token("|")] Bar,
+    #[token("_")] Underscore,
+    #[token("\n")] Newline,
+
+    // literals
+    #[regex(r"[0-9][0-9_]*\.[0-9][0-9_]*", |lex| lex.slice().replace('_', "").parse::<f64>().ok())]
+    Float(f64),
+
+    #[regex(r"[0-9][0-9_]*", |lex| lex.slice().replace('_', "").parse::<i64>().ok(), priority = 3)]
+    Int(i64),
+
+    #[regex(r#""([^"\\]|\\.)*""#, |lex| unescape(&lex.slice()[1..lex.slice().len()-1]))]
+    Str(String),
+
+    #[regex(r#"b"([^"\\]|\\.)*""#, |lex| unescape(&lex.slice()[2..lex.slice().len()-1]).map(|s| s.into_bytes()))]
+    Bytes(Vec<u8>),
+
+    #[regex(r"[a-zA-Z][a-zA-Z0-9_]*", |lex| lex.slice().to_string())]
+    Ident(String),
+}
+
+fn unescape(s: &str) -> Option<String> {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            match chars.next()? {
+                'n' => out.push('\n'),
+                't' => out.push('\t'),
+                'r' => out.push('\r'),
+                '\\' => out.push('\\'),
+                '"' => out.push('"'),
+                '0' => out.push('\0'),
+                _ => return None,
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    Some(out)
+}
+
+#[derive(Debug, Clone)]
+pub struct Token {
+    pub kind: TokenKind,
+    pub span: Range<usize>,
+}
+
+pub fn lex(src: &str) -> Result<Vec<Token>, LexError> {
+    let mut toks = Vec::new();
+    let mut lx = TokenKind::lexer(src);
+    while let Some(res) = lx.next() {
+        match res {
+            Ok(kind) => toks.push(Token { kind, span: lx.span() }),
+            Err(_) => {
+                return Err(LexError {
+                    span: lx.span(),
+                    snippet: lx.slice().to_string(),
+                });
+            }
+        }
+    }
+    Ok(toks)
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("unrecognized token `{snippet}` at {span:?}")]
+pub struct LexError {
+    pub span: Range<usize>,
+    pub snippet: String,
+}

--- a/crates/lex-syntax/tests/round_trip.rs
+++ b/crates/lex-syntax/tests/round_trip.rs
@@ -1,0 +1,47 @@
+//! M1 acceptance: round-trip parse → pretty-print → parse for §3.13 examples.
+
+use lex_syntax::{parse_source, print_program};
+
+fn round_trip(src: &str) {
+    let prog1 = parse_source(src).unwrap_or_else(|e| panic!("parse failed: {e}\nsource:\n{src}"));
+    let printed = print_program(&prog1);
+    let prog2 = parse_source(&printed).unwrap_or_else(|e| {
+        panic!("re-parse failed: {e}\nprinted:\n{printed}\noriginal:\n{src}")
+    });
+    assert_eq!(prog1, prog2, "round trip differs.\nprinted:\n{printed}");
+}
+
+#[test]
+fn example_a_factorial() {
+    round_trip(include_str!("../../../examples/a_factorial.lex"));
+}
+
+#[test]
+fn example_b_parse_int() {
+    round_trip(include_str!("../../../examples/b_parse_int.lex"));
+}
+
+#[test]
+fn example_c_echo() {
+    round_trip(include_str!("../../../examples/c_echo.lex"));
+}
+
+#[test]
+fn example_d_shape() {
+    round_trip(include_str!("../../../examples/d_shape.lex"));
+}
+
+#[test]
+fn parses_simple_let() {
+    round_trip("fn id(x :: Int) -> Int {\n  let y :: Int := x\n  y\n}\n");
+}
+
+#[test]
+fn parses_pipe() {
+    round_trip("fn f(x :: Int) -> Int { x |> g |> h }\n");
+}
+
+#[test]
+fn parses_record_literal() {
+    round_trip("fn p() -> Int { let r := { x: 1, y: 2 }\n r.x }\n");
+}

--- a/crates/lex-trace/Cargo.toml
+++ b/crates/lex-trace/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "lex-trace"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true

--- a/crates/lex-trace/src/lib.rs
+++ b/crates/lex-trace/src/lib.rs
@@ -1,0 +1,1 @@
+//! M7: trace tree and replay. Placeholder for future milestones.

--- a/crates/lex-types/Cargo.toml
+++ b/crates/lex-types/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "lex-types"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+indexmap.workspace = true
+lex-ast = { path = "../lex-ast" }
+
+[dev-dependencies]
+lex-syntax = { path = "../lex-syntax" }

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -1,0 +1,158 @@
+//! Built-in module signatures used by §3.13 examples and beyond.
+//!
+//! These are stub signatures that let the type-checker verify code that
+//! imports `std.io`, `std.str`, `std.list`, etc. They will be backed by
+//! real stages once the stdlib lands (M11).
+
+use crate::env::TypeEnv;
+use crate::types::*;
+use indexmap::IndexMap;
+
+/// Build the value-level scope of a module: a record of named functions.
+pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
+    match name {
+        "io" => {
+            let mut fields = IndexMap::new();
+            // io.print(line :: Str) -> [io] Nil
+            fields.insert("print".into(), Ty::function(
+                vec![Ty::str()],
+                EffectSet::singleton("io"),
+                Ty::Unit,
+            ));
+            // io.read(path :: Str) -> [io] Result[Str, Str]
+            fields.insert("read".into(), Ty::function(
+                vec![Ty::str()],
+                EffectSet::singleton("io"),
+                Ty::Con("Result".into(), vec![Ty::str(), Ty::str()]),
+            ));
+            // io.write(path :: Str, contents :: Str) -> [io] Result[Unit, Str]
+            fields.insert("write".into(), Ty::function(
+                vec![Ty::str(), Ty::str()],
+                EffectSet::singleton("io"),
+                Ty::Con("Result".into(), vec![Ty::Unit, Ty::str()]),
+            ));
+            Some(Ty::Record(fields))
+        }
+        "str" => {
+            let mut fields = IndexMap::new();
+            fields.insert("is_empty".into(), Ty::function(vec![Ty::str()], EffectSet::empty(), Ty::bool()));
+            fields.insert("to_int".into(), Ty::function(vec![Ty::str()], EffectSet::empty(),
+                Ty::Con("Option".into(), vec![Ty::int()])));
+            fields.insert("concat".into(), Ty::function(vec![Ty::str(), Ty::str()], EffectSet::empty(), Ty::str()));
+            fields.insert("len".into(), Ty::function(vec![Ty::str()], EffectSet::empty(), Ty::int()));
+            Some(Ty::Record(fields))
+        }
+        "int" => {
+            let mut fields = IndexMap::new();
+            fields.insert("to_str".into(), Ty::function(vec![Ty::int()], EffectSet::empty(), Ty::str()));
+            fields.insert("to_float".into(), Ty::function(vec![Ty::int()], EffectSet::empty(), Ty::float()));
+            Some(Ty::Record(fields))
+        }
+        "float" => {
+            let mut fields = IndexMap::new();
+            fields.insert("to_int".into(), Ty::function(vec![Ty::float()], EffectSet::empty(), Ty::int()));
+            fields.insert("to_str".into(), Ty::function(vec![Ty::float()], EffectSet::empty(), Ty::str()));
+            Some(Ty::Record(fields))
+        }
+        "list" => {
+            // list polymorphic functions need fresh vars at use sites; we
+            // encode them with placeholder Var ids that get instantiated.
+            let mut fields = IndexMap::new();
+            // map :: List[a], (a) -> b -> List[b]
+            fields.insert("map".into(), Ty::function(
+                vec![
+                    Ty::List(Box::new(Ty::Var(0))),
+                    Ty::function(vec![Ty::Var(0)], EffectSet::empty(), Ty::Var(1)),
+                ],
+                EffectSet::empty(),
+                Ty::List(Box::new(Ty::Var(1))),
+            ));
+            fields.insert("filter".into(), Ty::function(
+                vec![
+                    Ty::List(Box::new(Ty::Var(0))),
+                    Ty::function(vec![Ty::Var(0)], EffectSet::empty(), Ty::bool()),
+                ],
+                EffectSet::empty(),
+                Ty::List(Box::new(Ty::Var(0))),
+            ));
+            fields.insert("fold".into(), Ty::function(
+                vec![
+                    Ty::List(Box::new(Ty::Var(0))),
+                    Ty::Var(1),
+                    Ty::function(vec![Ty::Var(1), Ty::Var(0)], EffectSet::empty(), Ty::Var(1)),
+                ],
+                EffectSet::empty(),
+                Ty::Var(1),
+            ));
+            fields.insert("len".into(), Ty::function(
+                vec![Ty::List(Box::new(Ty::Var(0)))],
+                EffectSet::empty(),
+                Ty::int(),
+            ));
+            Some(Ty::Record(fields))
+        }
+        "result" => {
+            let mut fields = IndexMap::new();
+            // result.map :: Result[T, E], (T) -> U -> Result[U, E]
+            fields.insert("map".into(), Ty::function(
+                vec![
+                    Ty::Con("Result".into(), vec![Ty::Var(0), Ty::Var(1)]),
+                    Ty::function(vec![Ty::Var(0)], EffectSet::empty(), Ty::Var(2)),
+                ],
+                EffectSet::empty(),
+                Ty::Con("Result".into(), vec![Ty::Var(2), Ty::Var(1)]),
+            ));
+            fields.insert("and_then".into(), Ty::function(
+                vec![
+                    Ty::Con("Result".into(), vec![Ty::Var(0), Ty::Var(1)]),
+                    Ty::function(vec![Ty::Var(0)], EffectSet::empty(),
+                        Ty::Con("Result".into(), vec![Ty::Var(2), Ty::Var(1)])),
+                ],
+                EffectSet::empty(),
+                Ty::Con("Result".into(), vec![Ty::Var(2), Ty::Var(1)]),
+            ));
+            fields.insert("map_err".into(), Ty::function(
+                vec![
+                    Ty::Con("Result".into(), vec![Ty::Var(0), Ty::Var(1)]),
+                    Ty::function(vec![Ty::Var(1)], EffectSet::empty(), Ty::Var(2)),
+                ],
+                EffectSet::empty(),
+                Ty::Con("Result".into(), vec![Ty::Var(0), Ty::Var(2)]),
+            ));
+            Some(Ty::Record(fields))
+        }
+        "option" => {
+            let mut fields = IndexMap::new();
+            fields.insert("map".into(), Ty::function(
+                vec![
+                    Ty::Con("Option".into(), vec![Ty::Var(0)]),
+                    Ty::function(vec![Ty::Var(0)], EffectSet::empty(), Ty::Var(1)),
+                ],
+                EffectSet::empty(),
+                Ty::Con("Option".into(), vec![Ty::Var(1)]),
+            ));
+            fields.insert("unwrap_or".into(), Ty::function(
+                vec![Ty::Con("Option".into(), vec![Ty::Var(0)]), Ty::Var(0)],
+                EffectSet::empty(),
+                Ty::Var(0),
+            ));
+            Some(Ty::Record(fields))
+        }
+        _ => None,
+    }
+}
+
+/// Resolve `import "std.foo" as alias` to a module name (e.g. "io").
+pub fn module_for_import(reference: &str) -> Option<&'static str> {
+    let suffix = reference.strip_prefix("std.")?;
+    Some(match suffix {
+        "io" => "io",
+        "str" => "str",
+        "int" => "int",
+        "float" => "float",
+        "list" => "list",
+        "result" => "result",
+        "option" => "option",
+        _ => return None,
+    })
+}

--- a/crates/lex-types/src/checker.rs
+++ b/crates/lex-types/src/checker.rs
@@ -1,0 +1,660 @@
+//! M3: type checker. Walks the canonical AST, infers types via unification,
+//! and checks declared signatures and effects.
+
+use crate::builtins::{module_for_import, module_scope};
+use crate::env::{TypeDefKind, TypeEnv, ty_from_canon};
+use crate::error::TypeError;
+use crate::types::*;
+use crate::unifier::{UnifyError, Unifier};
+use indexmap::IndexMap;
+use lex_ast as a;
+
+/// Result of checking a whole program.
+pub struct ProgramTypes {
+    pub fn_signatures: IndexMap<String, Scheme>,
+    pub type_env: TypeEnv,
+}
+
+pub fn check_program(stages: &[a::Stage]) -> Result<ProgramTypes, Vec<TypeError>> {
+    let mut tcx = Checker::new();
+    let mut errors = Vec::new();
+
+    // Pass 1: gather imports → bring module values into scope.
+    for stage in stages {
+        if let a::Stage::Import(i) = stage {
+            if let Some(mod_name) = module_for_import(&i.reference) {
+                if let Some(ty) = module_scope(mod_name, &tcx.type_env) {
+                    tcx.globals.insert(i.alias.clone(), Scheme {
+                        // Module-level signatures use Var(0..n); generalize all.
+                        vars: collect_vars(&ty),
+                        ty,
+                    });
+                }
+            }
+        }
+    }
+
+    // Pass 2: register user-declared types.
+    for stage in stages {
+        if let a::Stage::TypeDecl(td) = stage {
+            if let Err(e) = tcx.type_env.add_user_type(&td.name, td.clone()) {
+                errors.push(TypeError::RecursiveTypeWithoutConstructor {
+                    at_node: "n_0".into(),
+                    name: e,
+                });
+            }
+        }
+    }
+
+    // Pass 3: register fn signatures (so mutual recursion works).
+    for stage in stages {
+        if let a::Stage::FnDecl(fd) = stage {
+            let scheme = function_scheme(fd);
+            tcx.globals.insert(fd.name.clone(), scheme);
+        }
+    }
+
+    // Pass 4: check each fn body.
+    let mut signatures = IndexMap::new();
+    for stage in stages {
+        if let a::Stage::FnDecl(fd) = stage {
+            match tcx.check_fn(fd) {
+                Ok(scheme) => { signatures.insert(fd.name.clone(), scheme); }
+                Err(es) => errors.extend(es),
+            }
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(ProgramTypes { fn_signatures: signatures, type_env: tcx.type_env })
+    } else {
+        Err(errors)
+    }
+}
+
+fn collect_vars(t: &Ty) -> Vec<TyVarId> {
+    let mut out = Vec::new();
+    fn walk(t: &Ty, out: &mut Vec<TyVarId>) {
+        match t {
+            Ty::Var(v) => { if !out.contains(v) { out.push(*v); } }
+            Ty::Prim(_) | Ty::Unit | Ty::Never => {}
+            Ty::List(inner) => walk(inner, out),
+            Ty::Tuple(items) => for it in items { walk(it, out); },
+            Ty::Record(fs) => for v in fs.values() { walk(v, out); },
+            Ty::Con(_, args) => for a in args { walk(a, out); },
+            Ty::Function { params, ret, .. } => {
+                for p in params { walk(p, out); }
+                walk(ret, out);
+            }
+        }
+    }
+    walk(t, &mut out);
+    out
+}
+
+fn function_scheme(fd: &a::FnDecl) -> Scheme {
+    // Collect type-param ids in order; map their names to fresh Var(idx).
+    let params: Vec<Ty> = fd.params.iter().map(|p| ty_from_canon(&p.ty, &fd.type_params)).collect();
+    let ret = ty_from_canon(&fd.return_type, &fd.type_params);
+    let effects = EffectSet({
+        let mut s = std::collections::BTreeSet::new();
+        for e in &fd.effects { s.insert(e.name.clone()); }
+        s
+    });
+    let ty = Ty::Function { params, effects, ret: Box::new(ret) };
+    let vars: Vec<TyVarId> = (0..fd.type_params.len() as u32).collect();
+    Scheme { vars, ty }
+}
+
+struct Checker {
+    u: Unifier,
+    type_env: TypeEnv,
+    globals: IndexMap<String, Scheme>,
+}
+
+impl Checker {
+    fn new() -> Self {
+        Self {
+            u: Unifier::new(),
+            type_env: TypeEnv::new_with_builtins(),
+            globals: IndexMap::new(),
+        }
+    }
+
+    fn check_fn(&mut self, fd: &a::FnDecl) -> Result<Scheme, Vec<TypeError>> {
+        // Instantiate fn's signature with fresh vars for its type params.
+        let scheme = function_scheme(fd);
+        let (param_tys, declared_effects, ret_ty) = match instantiate(&scheme, &mut self.u) {
+            Ty::Function { params, effects, ret } => (params, effects, *ret),
+            _ => unreachable!(),
+        };
+
+        let mut locals: IndexMap<String, Ty> = IndexMap::new();
+        for (p, t) in fd.params.iter().zip(param_tys.iter()) {
+            locals.insert(p.name.clone(), t.clone());
+        }
+
+        let mut inferred_effects = EffectSet::empty();
+        let body_ty = self.check_expr(&fd.body, "n_0", &mut locals, &mut inferred_effects)
+            .map_err(|e| vec![e])?;
+
+        if let Err(e) = self.u.unify(&body_ty, &ret_ty) {
+            return Err(vec![mismatch_err("n_0", e, &self.u, vec![format!("in function `{}`", fd.name)])]);
+        }
+
+        if !inferred_effects.is_subset(&declared_effects) {
+            // Pick the first undeclared effect for the error.
+            for e in inferred_effects.0.iter() {
+                if !declared_effects.0.contains(e) {
+                    return Err(vec![TypeError::EffectNotDeclared {
+                        at_node: "n_0".into(),
+                        effect: e.clone(),
+                    }]);
+                }
+            }
+        }
+
+        Ok(scheme)
+    }
+
+    fn check_expr(
+        &mut self,
+        e: &a::CExpr,
+        node_id: &str,
+        locals: &mut IndexMap<String, Ty>,
+        effs: &mut EffectSet,
+    ) -> Result<Ty, TypeError> {
+        match e {
+            a::CExpr::Literal { value } => Ok(lit_type(value)),
+            a::CExpr::Var { name } => {
+                if let Some(t) = locals.get(name) {
+                    return Ok(t.clone());
+                }
+                if let Some(scheme) = self.globals.get(name).cloned() {
+                    return Ok(instantiate(&scheme, &mut self.u));
+                }
+                Err(TypeError::UnknownIdentifier { at_node: node_id.into(), name: name.clone() })
+            }
+            a::CExpr::Constructor { name, args } => self.check_constructor(name, args, node_id, locals, effs),
+            a::CExpr::Call { callee, args } => self.check_call(callee, args, node_id, locals, effs),
+            a::CExpr::Let { name, ty, value, body } => {
+                let v_ty = self.check_expr(value, node_id, locals, effs)?;
+                if let Some(declared) = ty {
+                    let d = ty_from_canon(declared, &[]);
+                    if let Err(err) = self.u.unify(&v_ty, &d) {
+                        return Err(mismatch_err(node_id, err, &self.u, vec![format!("in let `{}`", name)]));
+                    }
+                }
+                let prev = locals.insert(name.clone(), v_ty);
+                let body_ty = self.check_expr(body, node_id, locals, effs)?;
+                match prev {
+                    Some(p) => { locals.insert(name.clone(), p); }
+                    None => { locals.shift_remove(name); }
+                }
+                Ok(body_ty)
+            }
+            a::CExpr::Match { scrutinee, arms } => {
+                let scrut_ty = self.check_expr(scrutinee, node_id, locals, effs)?;
+                if arms.is_empty() {
+                    return Err(TypeError::NonExhaustiveMatch {
+                        at_node: node_id.into(), missing: vec!["_".into()]
+                    });
+                }
+                let result_ty = self.u.fresh();
+                for arm in arms {
+                    let mut arm_locals = locals.clone();
+                    self.bind_pattern(&arm.pattern, &scrut_ty, &mut arm_locals, node_id)?;
+                    let arm_ty = self.check_expr(&arm.body, node_id, &mut arm_locals, effs)?;
+                    if let Err(err) = self.u.unify(&arm_ty, &result_ty) {
+                        return Err(mismatch_err(node_id, err, &self.u, vec!["in match arm".into()]));
+                    }
+                }
+                Ok(result_ty)
+            }
+            a::CExpr::Block { statements, result } => {
+                for s in statements {
+                    self.check_expr(s, node_id, locals, effs)?;
+                }
+                self.check_expr(result, node_id, locals, effs)
+            }
+            a::CExpr::RecordLit { fields } => {
+                let mut tys = IndexMap::new();
+                for f in fields {
+                    if tys.contains_key(&f.name) {
+                        return Err(TypeError::DuplicateField {
+                            at_node: node_id.into(), field: f.name.clone()
+                        });
+                    }
+                    let ft = self.check_expr(&f.value, node_id, locals, effs)?;
+                    tys.insert(f.name.clone(), ft);
+                }
+                Ok(Ty::Record(tys))
+            }
+            a::CExpr::TupleLit { items } => {
+                let mut ts = Vec::new();
+                for it in items { ts.push(self.check_expr(it, node_id, locals, effs)?); }
+                Ok(Ty::Tuple(ts))
+            }
+            a::CExpr::ListLit { items } => {
+                let elem = self.u.fresh();
+                for it in items {
+                    let t = self.check_expr(it, node_id, locals, effs)?;
+                    if let Err(err) = self.u.unify(&t, &elem) {
+                        return Err(mismatch_err(node_id, err, &self.u, vec!["in list literal".into()]));
+                    }
+                }
+                Ok(Ty::List(Box::new(elem)))
+            }
+            a::CExpr::FieldAccess { value, field } => {
+                let vt = self.check_expr(value, node_id, locals, effs)?;
+                let resolved = self.u.resolve(&vt);
+                match resolved {
+                    Ty::Record(fields) => fields.get(field).cloned()
+                        .ok_or_else(|| TypeError::UnknownField {
+                            at_node: node_id.into(),
+                            record_type: Ty::Record(fields.clone()).pretty(),
+                            field: field.clone(),
+                        }),
+                    other => Err(TypeError::TypeMismatch {
+                        at_node: node_id.into(),
+                        expected: "record".into(),
+                        got: other.pretty(),
+                        context: vec![format!("field access `.{}`", field)],
+                    }),
+                }
+            }
+            a::CExpr::Lambda { params, return_type, effects: l_effects, body } => {
+                let param_tys: Vec<Ty> = params.iter().map(|p| ty_from_canon(&p.ty, &[])).collect();
+                let ret_ty = ty_from_canon(return_type, &[]);
+                let declared = EffectSet({
+                    let mut s = std::collections::BTreeSet::new();
+                    for e in l_effects { s.insert(e.name.clone()); }
+                    s
+                });
+                let mut inner_locals = locals.clone();
+                for (p, t) in params.iter().zip(param_tys.iter()) {
+                    inner_locals.insert(p.name.clone(), t.clone());
+                }
+                let mut inner_effs = EffectSet::empty();
+                let body_ty = self.check_expr(body, node_id, &mut inner_locals, &mut inner_effs)?;
+                if let Err(err) = self.u.unify(&body_ty, &ret_ty) {
+                    return Err(mismatch_err(node_id, err, &self.u, vec!["in lambda body".into()]));
+                }
+                if !inner_effs.is_subset(&declared) {
+                    for e in inner_effs.0.iter() {
+                        if !declared.0.contains(e) {
+                            return Err(TypeError::EffectNotDeclared {
+                                at_node: node_id.into(),
+                                effect: e.clone(),
+                            });
+                        }
+                    }
+                }
+                Ok(Ty::function(param_tys, declared, ret_ty))
+            }
+            a::CExpr::BinOp { op, lhs, rhs } => self.check_binop(op, lhs, rhs, node_id, locals, effs),
+            a::CExpr::UnaryOp { op, expr } => {
+                let t = self.check_expr(expr, node_id, locals, effs)?;
+                match op.as_str() {
+                    "-" => {
+                        // Either Int or Float; we pick Int by default if unconstrained.
+                        let r = self.u.resolve(&t);
+                        match r {
+                            Ty::Prim(Prim::Int) | Ty::Prim(Prim::Float) => Ok(t),
+                            Ty::Var(_) => {
+                                // default to Int.
+                                self.u.unify(&t, &Ty::int()).map_err(|e| mismatch_err(node_id, e, &self.u, vec![]))?;
+                                Ok(Ty::int())
+                            }
+                            other => Err(TypeError::TypeMismatch {
+                                at_node: node_id.into(),
+                                expected: "Int or Float".into(),
+                                got: other.pretty(),
+                                context: vec!["unary `-`".into()],
+                            }),
+                        }
+                    }
+                    "not" => {
+                        self.u.unify(&t, &Ty::bool()).map_err(|e| mismatch_err(node_id, e, &self.u, vec!["unary `not`".into()]))?;
+                        Ok(Ty::bool())
+                    }
+                    other => panic!("unknown unary op: {other}"),
+                }
+            }
+            a::CExpr::Return { value } => {
+                // For now treat Return as having type Never; the surrounding
+                // context will unify with the actual return type.
+                self.check_expr(value, node_id, locals, effs)?;
+                Ok(Ty::Never)
+            }
+        }
+    }
+
+    fn check_binop(
+        &mut self,
+        op: &str,
+        lhs: &a::CExpr,
+        rhs: &a::CExpr,
+        node_id: &str,
+        locals: &mut IndexMap<String, Ty>,
+        effs: &mut EffectSet,
+    ) -> Result<Ty, TypeError> {
+        let lt = self.check_expr(lhs, node_id, locals, effs)?;
+        let rt = self.check_expr(rhs, node_id, locals, effs)?;
+        match op {
+            "+" | "-" | "*" | "/" | "%" => {
+                self.u.unify(&lt, &rt).map_err(|e| mismatch_err(node_id, e, &self.u, vec![format!("operator `{op}`")]))?;
+                let r = self.u.resolve(&lt);
+                match r {
+                    Ty::Prim(Prim::Int) | Ty::Prim(Prim::Float) => Ok(lt),
+                    Ty::Var(_) => {
+                        self.u.unify(&lt, &Ty::int()).map_err(|e| mismatch_err(node_id, e, &self.u, vec![format!("operator `{op}`")]))?;
+                        Ok(Ty::int())
+                    }
+                    other => Err(TypeError::TypeMismatch {
+                        at_node: node_id.into(),
+                        expected: "Int or Float".into(),
+                        got: other.pretty(),
+                        context: vec![format!("operator `{op}`")],
+                    }),
+                }
+            }
+            "==" | "!=" => {
+                self.u.unify(&lt, &rt).map_err(|e| mismatch_err(node_id, e, &self.u, vec![format!("operator `{op}`")]))?;
+                Ok(Ty::bool())
+            }
+            "<" | "<=" | ">" | ">=" => {
+                self.u.unify(&lt, &rt).map_err(|e| mismatch_err(node_id, e, &self.u, vec![format!("operator `{op}`")]))?;
+                let r = self.u.resolve(&lt);
+                match r {
+                    Ty::Prim(Prim::Int) | Ty::Prim(Prim::Float) | Ty::Prim(Prim::Str) => Ok(Ty::bool()),
+                    Ty::Var(_) => {
+                        self.u.unify(&lt, &Ty::int()).map_err(|e| mismatch_err(node_id, e, &self.u, vec![format!("operator `{op}`")]))?;
+                        Ok(Ty::bool())
+                    }
+                    other => Err(TypeError::TypeMismatch {
+                        at_node: node_id.into(),
+                        expected: "Int, Float, or Str".into(),
+                        got: other.pretty(),
+                        context: vec![format!("operator `{op}`")],
+                    }),
+                }
+            }
+            "and" | "or" => {
+                self.u.unify(&lt, &Ty::bool()).map_err(|e| mismatch_err(node_id, e, &self.u, vec![format!("operator `{op}`")]))?;
+                self.u.unify(&rt, &Ty::bool()).map_err(|e| mismatch_err(node_id, e, &self.u, vec![format!("operator `{op}`")]))?;
+                Ok(Ty::bool())
+            }
+            other => panic!("unknown binop: {other}"),
+        }
+    }
+
+    fn check_call(
+        &mut self,
+        callee: &a::CExpr,
+        args: &[a::CExpr],
+        node_id: &str,
+        locals: &mut IndexMap<String, Ty>,
+        effs: &mut EffectSet,
+    ) -> Result<Ty, TypeError> {
+        let callee_ty = self.check_expr(callee, node_id, locals, effs)?;
+        let resolved = self.u.resolve(&callee_ty);
+        match resolved {
+            Ty::Function { params, effects, ret } => {
+                if params.len() != args.len() {
+                    return Err(TypeError::ArityMismatch {
+                        at_node: node_id.into(),
+                        expected: params.len(),
+                        got: args.len(),
+                    });
+                }
+                for (i, (a, p)) in args.iter().zip(params.iter()).enumerate() {
+                    let at = self.check_expr(a, node_id, locals, effs)?;
+                    if let Err(err) = self.u.unify(&at, p) {
+                        return Err(mismatch_err(node_id, err, &self.u, vec![format!("argument {} of call", i + 1)]));
+                    }
+                }
+                effs.extend(&effects);
+                Ok(*ret)
+            }
+            Ty::Var(_) => {
+                // Build a function type and unify.
+                let mut p_tys = Vec::new();
+                for a in args { p_tys.push(self.check_expr(a, node_id, locals, effs)?); }
+                let r = self.u.fresh();
+                let f = Ty::function(p_tys, EffectSet::empty(), r.clone());
+                self.u.unify(&callee_ty, &f).map_err(|e| mismatch_err(node_id, e, &self.u, vec!["in call".into()]))?;
+                Ok(r)
+            }
+            other => Err(TypeError::TypeMismatch {
+                at_node: node_id.into(),
+                expected: "function".into(),
+                got: other.pretty(),
+                context: vec!["in call".into()],
+            }),
+        }
+    }
+
+    fn check_constructor(
+        &mut self,
+        name: &str,
+        args: &[a::CExpr],
+        node_id: &str,
+        locals: &mut IndexMap<String, Ty>,
+        effs: &mut EffectSet,
+    ) -> Result<Ty, TypeError> {
+        let owning = self.type_env.ctor_to_type.get(name).cloned()
+            .ok_or_else(|| TypeError::UnknownVariant {
+                at_node: node_id.into(),
+                constructor: name.to_string(),
+            })?;
+        let def = self.type_env.types.get(&owning).cloned()
+            .expect("ctor_to_type points to a real type");
+        let variants = match &def.kind {
+            TypeDefKind::Union(v) => v.clone(),
+            _ => return Err(TypeError::UnknownVariant {
+                at_node: node_id.into(),
+                constructor: name.to_string(),
+            }),
+        };
+        // Instantiate the type's params with fresh vars; substitute into
+        // both the variant's payload type and the resulting Con(...).
+        let mut subst = IndexMap::new();
+        let mut con_args = Vec::with_capacity(def.params.len());
+        for (i, _p) in def.params.iter().enumerate() {
+            let fresh = self.u.fresh();
+            subst.insert(i as u32, fresh.clone());
+            con_args.push(fresh);
+        }
+        let payload = variants.get(name).cloned().flatten();
+        match (payload, args) {
+            (None, []) => Ok(Ty::Con(owning, con_args)),
+            (Some(payload), args) => {
+                let inst_payload = subst_vars(&payload, &subst);
+                let arg_count = match &inst_payload {
+                    Ty::Tuple(items) => items.len(),
+                    _ => 1,
+                };
+                if arg_count != args.len() {
+                    return Err(TypeError::ArityMismatch {
+                        at_node: node_id.into(),
+                        expected: arg_count,
+                        got: args.len(),
+                    });
+                }
+                if args.len() == 1 {
+                    let at = self.check_expr(&args[0], node_id, locals, effs)?;
+                    self.u.unify(&at, &inst_payload).map_err(|e| mismatch_err(node_id, e, &self.u, vec![format!("constructor `{}`", name)]))?;
+                } else {
+                    if let Ty::Tuple(items) = inst_payload {
+                        for (i, (a, t)) in args.iter().zip(items.iter()).enumerate() {
+                            let at = self.check_expr(a, node_id, locals, effs)?;
+                            self.u.unify(&at, t).map_err(|e| mismatch_err(node_id, e, &self.u, vec![format!("constructor `{}` arg {}", name, i + 1)]))?;
+                        }
+                    }
+                }
+                Ok(Ty::Con(owning, con_args))
+            }
+            (None, _) => Err(TypeError::ArityMismatch {
+                at_node: node_id.into(), expected: 0, got: args.len(),
+            }),
+        }
+    }
+
+    fn bind_pattern(
+        &mut self,
+        pat: &a::Pattern,
+        ty: &Ty,
+        locals: &mut IndexMap<String, Ty>,
+        node_id: &str,
+    ) -> Result<(), TypeError> {
+        match pat {
+            a::Pattern::PWild => Ok(()),
+            a::Pattern::PVar { name } => {
+                locals.insert(name.clone(), ty.clone());
+                Ok(())
+            }
+            a::Pattern::PLiteral { value } => {
+                let lt = lit_type(value);
+                self.u.unify(&lt, ty).map_err(|e| mismatch_err(node_id, e, &self.u, vec!["in pattern".into()]))?;
+                Ok(())
+            }
+            a::Pattern::PConstructor { name, args } => {
+                // Re-use constructor logic but in pattern position.
+                let owning = self.type_env.ctor_to_type.get(name).cloned()
+                    .ok_or_else(|| TypeError::UnknownVariant {
+                        at_node: node_id.into(), constructor: name.clone(),
+                    })?;
+                let def = self.type_env.types.get(&owning).cloned().unwrap();
+                let mut subst = IndexMap::new();
+                let mut con_args = Vec::new();
+                for (i, _) in def.params.iter().enumerate() {
+                    let fresh = self.u.fresh();
+                    subst.insert(i as u32, fresh.clone());
+                    con_args.push(fresh);
+                }
+                let con_ty = Ty::Con(owning.clone(), con_args);
+                self.u.unify(&con_ty, ty).map_err(|e| mismatch_err(node_id, e, &self.u, vec![format!("constructor pattern `{}`", name)]))?;
+                let payload = match &def.kind {
+                    TypeDefKind::Union(v) => v.get(name).cloned().flatten(),
+                    _ => None,
+                };
+                match (payload, args.as_slice()) {
+                    (None, []) => Ok(()),
+                    (Some(payload), args) => {
+                        let inst = subst_vars(&payload, &subst);
+                        if args.len() == 1 {
+                            self.bind_pattern(&args[0], &inst, locals, node_id)?;
+                        } else if let Ty::Tuple(items) = inst {
+                            for (a, t) in args.iter().zip(items.iter()) {
+                                self.bind_pattern(a, t, locals, node_id)?;
+                            }
+                        }
+                        Ok(())
+                    }
+                    (None, _) => Err(TypeError::ArityMismatch {
+                        at_node: node_id.into(), expected: 0, got: args.len(),
+                    }),
+                }
+            }
+            a::Pattern::PRecord { fields } => {
+                let resolved = self.u.resolve(ty);
+                let rec = match resolved {
+                    Ty::Record(r) => r,
+                    _ => return Err(TypeError::TypeMismatch {
+                        at_node: node_id.into(),
+                        expected: "record".into(),
+                        got: ty.pretty(),
+                        context: vec!["in record pattern".into()],
+                    }),
+                };
+                for f in fields {
+                    let ft = rec.get(&f.name).cloned()
+                        .ok_or_else(|| TypeError::UnknownField {
+                            at_node: node_id.into(),
+                            record_type: Ty::Record(rec.clone()).pretty(),
+                            field: f.name.clone(),
+                        })?;
+                    self.bind_pattern(&f.pattern, &ft, locals, node_id)?;
+                }
+                Ok(())
+            }
+            a::Pattern::PTuple { items } => {
+                let resolved = self.u.resolve(ty);
+                let tup = match resolved {
+                    Ty::Tuple(t) => t,
+                    Ty::Var(_) => {
+                        let fresh: Vec<Ty> = items.iter().map(|_| self.u.fresh()).collect();
+                        let tup_ty = Ty::Tuple(fresh.clone());
+                        self.u.unify(&tup_ty, ty).map_err(|e| mismatch_err(node_id, e, &self.u, vec!["in tuple pattern".into()]))?;
+                        fresh
+                    }
+                    other => return Err(TypeError::TypeMismatch {
+                        at_node: node_id.into(),
+                        expected: "tuple".into(),
+                        got: other.pretty(),
+                        context: vec!["in tuple pattern".into()],
+                    }),
+                };
+                if tup.len() != items.len() {
+                    return Err(TypeError::ArityMismatch {
+                        at_node: node_id.into(), expected: tup.len(), got: items.len(),
+                    });
+                }
+                for (p, t) in items.iter().zip(tup.iter()) {
+                    self.bind_pattern(p, t, locals, node_id)?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+fn lit_type(l: &a::CLit) -> Ty {
+    match l {
+        a::CLit::Int { .. } => Ty::int(),
+        a::CLit::Float { .. } => Ty::float(),
+        a::CLit::Str { .. } => Ty::str(),
+        a::CLit::Bytes { .. } => Ty::bytes(),
+        a::CLit::Bool { .. } => Ty::bool(),
+        a::CLit::Unit => Ty::Unit,
+    }
+}
+
+fn instantiate(s: &Scheme, u: &mut Unifier) -> Ty {
+    let mut subst = IndexMap::new();
+    for v in &s.vars { subst.insert(*v, u.fresh()); }
+    subst_vars(&s.ty, &subst)
+}
+
+fn subst_vars(t: &Ty, subst: &IndexMap<TyVarId, Ty>) -> Ty {
+    match t {
+        Ty::Var(v) => subst.get(v).cloned().unwrap_or_else(|| Ty::Var(*v)),
+        Ty::Prim(_) | Ty::Unit | Ty::Never => t.clone(),
+        Ty::List(inner) => Ty::List(Box::new(subst_vars(inner, subst))),
+        Ty::Tuple(items) => Ty::Tuple(items.iter().map(|t| subst_vars(t, subst)).collect()),
+        Ty::Record(fs) => {
+            let mut out = IndexMap::new();
+            for (k, v) in fs { out.insert(k.clone(), subst_vars(v, subst)); }
+            Ty::Record(out)
+        }
+        Ty::Con(n, args) => Ty::Con(n.clone(), args.iter().map(|t| subst_vars(t, subst)).collect()),
+        Ty::Function { params, effects, ret } => Ty::Function {
+            params: params.iter().map(|t| subst_vars(t, subst)).collect(),
+            effects: effects.clone(),
+            ret: Box::new(subst_vars(ret, subst)),
+        },
+    }
+}
+
+fn mismatch_err(node_id: &str, e: UnifyError, u: &Unifier, context: Vec<String>) -> TypeError {
+    match e {
+        UnifyError::Mismatch { a, b } => TypeError::TypeMismatch {
+            at_node: node_id.into(),
+            expected: u.resolve(&b).pretty(),
+            got: u.resolve(&a).pretty(),
+            context,
+        },
+        UnifyError::Infinite { .. } => TypeError::InfiniteType { at_node: node_id.into() },
+    }
+}

--- a/crates/lex-types/src/env.rs
+++ b/crates/lex-types/src/env.rs
@@ -1,0 +1,145 @@
+//! Type environment: type-decl info and value-binding scopes.
+
+use crate::types::*;
+use indexmap::IndexMap;
+
+#[derive(Debug, Clone)]
+pub struct TypeDef {
+    pub params: Vec<String>,
+    pub kind: TypeDefKind,
+}
+
+#[derive(Debug, Clone)]
+pub enum TypeDefKind {
+    /// A union: variant name → optional payload.
+    Union(IndexMap<String, Option<Ty>>),
+    /// A record alias: `type Foo = { x :: Int }` etc.
+    Alias(Ty),
+    /// Built-in opaque (Map, Set, ...).
+    Opaque,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct TypeEnv {
+    /// Type-name → definition.
+    pub types: IndexMap<String, TypeDef>,
+    /// Constructor name → owning type-name.
+    pub ctor_to_type: IndexMap<String, String>,
+}
+
+impl TypeEnv {
+    pub fn new_with_builtins() -> Self {
+        let mut e = TypeEnv::default();
+        // Result[T, E] = Ok(T) | Err(E)
+        let mut r_variants = IndexMap::new();
+        r_variants.insert("Ok".into(), Some(Ty::Var(0))); // T
+        r_variants.insert("Err".into(), Some(Ty::Var(1))); // E
+        e.types.insert("Result".into(), TypeDef {
+            params: vec!["T".into(), "E".into()],
+            kind: TypeDefKind::Union(r_variants),
+        });
+        e.ctor_to_type.insert("Ok".into(), "Result".into());
+        e.ctor_to_type.insert("Err".into(), "Result".into());
+
+        // Option[T] = Some(T) | None
+        let mut o_variants = IndexMap::new();
+        o_variants.insert("Some".into(), Some(Ty::Var(0))); // T
+        o_variants.insert("None".into(), None);
+        e.types.insert("Option".into(), TypeDef {
+            params: vec!["T".into()],
+            kind: TypeDefKind::Union(o_variants),
+        });
+        e.ctor_to_type.insert("Some".into(), "Option".into());
+        e.ctor_to_type.insert("None".into(), "Option".into());
+
+        // Nil = Unit (alias)
+        e.types.insert("Nil".into(), TypeDef {
+            params: vec![],
+            kind: TypeDefKind::Alias(Ty::Unit),
+        });
+
+        // Map, Set: opaque-ish. We just register the names so they parse as Cons.
+        e.types.insert("Map".into(), TypeDef { params: vec!["K".into(), "V".into()], kind: TypeDefKind::Opaque });
+        e.types.insert("Set".into(), TypeDef { params: vec!["T".into()], kind: TypeDefKind::Opaque });
+
+        e
+    }
+
+    pub fn add_user_type(&mut self, name: &str, decl: lex_ast::TypeDecl) -> Result<(), String> {
+        match &decl.definition {
+            lex_ast::TypeExpr::Union { variants } => {
+                let mut vmap = IndexMap::new();
+                for v in variants {
+                    let payload = v.payload.as_ref().map(|p| ty_from_canon(p, &decl.params));
+                    vmap.insert(v.name.clone(), payload);
+                    self.ctor_to_type.insert(v.name.clone(), name.to_string());
+                }
+                self.types.insert(name.to_string(), TypeDef {
+                    params: decl.params.clone(),
+                    kind: TypeDefKind::Union(vmap),
+                });
+            }
+            other => {
+                let ty = ty_from_canon(other, &decl.params);
+                self.types.insert(name.to_string(), TypeDef {
+                    params: decl.params.clone(),
+                    kind: TypeDefKind::Alias(ty),
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Convert canonical TypeExpr to internal Ty, treating type params as
+/// fresh-numbered Vars (0..n in declaration order). When instantiating, we
+/// substitute these out.
+pub fn ty_from_canon(t: &lex_ast::TypeExpr, params: &[String]) -> Ty {
+    match t {
+        lex_ast::TypeExpr::Named { name, args } => {
+            // type param?
+            if let Some(idx) = params.iter().position(|p| p == name) {
+                if !args.is_empty() {
+                    // Type params don't take args.
+                    return Ty::Con(name.clone(), args.iter().map(|a| ty_from_canon(a, params)).collect());
+                }
+                return Ty::Var(idx as u32);
+            }
+            // Primitives.
+            match name.as_str() {
+                "Int" => return Ty::int(),
+                "Float" => return Ty::float(),
+                "Bool" => return Ty::bool(),
+                "Str" => return Ty::str(),
+                "Bytes" => return Ty::bytes(),
+                "Unit" | "Nil" => return Ty::Unit,
+                "Never" => return Ty::Never,
+                "List" if args.len() == 1 => return Ty::List(Box::new(ty_from_canon(&args[0], params))),
+                _ => {}
+            }
+            Ty::Con(name.clone(), args.iter().map(|a| ty_from_canon(a, params)).collect())
+        }
+        lex_ast::TypeExpr::Record { fields } => {
+            let mut m = IndexMap::new();
+            for f in fields { m.insert(f.name.clone(), ty_from_canon(&f.ty, params)); }
+            Ty::Record(m)
+        }
+        lex_ast::TypeExpr::Tuple { items } => Ty::Tuple(items.iter().map(|t| ty_from_canon(t, params)).collect()),
+        lex_ast::TypeExpr::Function { params: ps, effects, ret } => {
+            let effs = EffectSet({
+                let mut s = std::collections::BTreeSet::new();
+                for e in effects { s.insert(e.name.clone()); }
+                s
+            });
+            Ty::Function {
+                params: ps.iter().map(|t| ty_from_canon(t, params)).collect(),
+                effects: effs,
+                ret: Box::new(ty_from_canon(ret, params)),
+            }
+        }
+        lex_ast::TypeExpr::Union { .. } => {
+            // Unions on the RHS of type-decls; not in arbitrary positions.
+            Ty::Unit
+        }
+    }
+}

--- a/crates/lex-types/src/error.rs
+++ b/crates/lex-types/src/error.rs
@@ -1,0 +1,96 @@
+//! Structured type errors per spec §6.7.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TypeError {
+    TypeMismatch {
+        at_node: String,
+        expected: String,
+        got: String,
+        context: Vec<String>,
+    },
+    UnknownIdentifier {
+        at_node: String,
+        name: String,
+    },
+    ArityMismatch {
+        at_node: String,
+        expected: usize,
+        got: usize,
+    },
+    NonExhaustiveMatch {
+        at_node: String,
+        missing: Vec<String>,
+    },
+    UnknownField {
+        at_node: String,
+        record_type: String,
+        field: String,
+    },
+    DuplicateField {
+        at_node: String,
+        field: String,
+    },
+    UnknownVariant {
+        at_node: String,
+        constructor: String,
+    },
+    EffectNotDeclared {
+        at_node: String,
+        effect: String,
+    },
+    InfiniteType {
+        at_node: String,
+    },
+    AmbiguousType {
+        at_node: String,
+    },
+    RecursiveTypeWithoutConstructor {
+        at_node: String,
+        name: String,
+    },
+}
+
+impl TypeError {
+    pub fn node(&self) -> &str {
+        match self {
+            TypeError::TypeMismatch { at_node, .. }
+            | TypeError::UnknownIdentifier { at_node, .. }
+            | TypeError::ArityMismatch { at_node, .. }
+            | TypeError::NonExhaustiveMatch { at_node, .. }
+            | TypeError::UnknownField { at_node, .. }
+            | TypeError::DuplicateField { at_node, .. }
+            | TypeError::UnknownVariant { at_node, .. }
+            | TypeError::EffectNotDeclared { at_node, .. }
+            | TypeError::InfiniteType { at_node, .. }
+            | TypeError::AmbiguousType { at_node, .. }
+            | TypeError::RecursiveTypeWithoutConstructor { at_node, .. } => at_node,
+        }
+    }
+}
+
+impl std::fmt::Display for TypeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            TypeError::TypeMismatch { at_node, expected, got, context } => {
+                write!(f, "type mismatch at {at_node}: expected {expected}, got {got}")?;
+                if !context.is_empty() { write!(f, " ({})", context.join(" / "))?; }
+                Ok(())
+            }
+            TypeError::UnknownIdentifier { at_node, name } => write!(f, "unknown identifier `{name}` at {at_node}"),
+            TypeError::ArityMismatch { at_node, expected, got } => write!(f, "arity mismatch at {at_node}: expected {expected}, got {got}"),
+            TypeError::NonExhaustiveMatch { at_node, missing } => write!(f, "non-exhaustive match at {at_node}: missing {missing:?}"),
+            TypeError::UnknownField { at_node, record_type, field } => write!(f, "unknown field `{field}` on {record_type} at {at_node}"),
+            TypeError::DuplicateField { at_node, field } => write!(f, "duplicate field `{field}` at {at_node}"),
+            TypeError::UnknownVariant { at_node, constructor } => write!(f, "unknown constructor `{constructor}` at {at_node}"),
+            TypeError::EffectNotDeclared { at_node, effect } => write!(f, "effect `{effect}` not declared at {at_node}"),
+            TypeError::InfiniteType { at_node } => write!(f, "infinite type (occurs check) at {at_node}"),
+            TypeError::AmbiguousType { at_node } => write!(f, "ambiguous type at {at_node}"),
+            TypeError::RecursiveTypeWithoutConstructor { at_node, name } => write!(f, "recursive type {name} has no constructor at {at_node}"),
+        }
+    }
+}
+
+impl std::error::Error for TypeError {}

--- a/crates/lex-types/src/lib.rs
+++ b/crates/lex-types/src/lib.rs
@@ -1,5 +1,7 @@
 //! M3: type system, effect system. See spec §6, §7.
 
+#![allow(clippy::result_large_err)]
+
 pub mod types;
 pub mod unifier;
 pub mod env;

--- a/crates/lex-types/src/lib.rs
+++ b/crates/lex-types/src/lib.rs
@@ -1,0 +1,12 @@
+//! M3: type system, effect system. See spec §6, §7.
+
+pub mod types;
+pub mod unifier;
+pub mod env;
+pub mod error;
+pub mod builtins;
+pub mod checker;
+
+pub use checker::{check_program, ProgramTypes};
+pub use error::TypeError;
+pub use types::{EffectSet, Prim, Scheme, Ty, TyVarId};

--- a/crates/lex-types/src/types.rs
+++ b/crates/lex-types/src/types.rs
@@ -1,0 +1,102 @@
+//! Internal type representation used by the inferencer/checker.
+//!
+//! We model types as either ground constructors (Int, List[T], ...) or
+//! unification variables. The `unifier` module handles solving.
+
+use indexmap::IndexMap;
+use std::collections::BTreeSet;
+
+pub type TyVarId = u32;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Ty {
+    Var(TyVarId),
+    Prim(Prim),
+    Unit,
+    Never,
+    List(Box<Ty>),
+    Tuple(Vec<Ty>),
+    /// Sorted alphabetically by field name.
+    Record(IndexMap<String, Ty>),
+    /// e.g. `Result[Int, Str]` or `Option[T]`. Resolved against the type env.
+    Con(String, Vec<Ty>),
+    Function {
+        params: Vec<Ty>,
+        effects: EffectSet,
+        ret: Box<Ty>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Prim { Int, Float, Bool, Str, Bytes }
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct EffectSet(pub BTreeSet<String>);
+
+impl EffectSet {
+    pub fn empty() -> Self { Self(BTreeSet::new()) }
+    pub fn singleton(s: impl Into<String>) -> Self {
+        let mut bs = BTreeSet::new();
+        bs.insert(s.into());
+        Self(bs)
+    }
+    pub fn union(&self, other: &EffectSet) -> EffectSet {
+        EffectSet(self.0.union(&other.0).cloned().collect())
+    }
+    pub fn is_subset(&self, other: &EffectSet) -> bool { self.0.is_subset(&other.0) }
+    pub fn extend(&mut self, other: &EffectSet) { self.0.extend(other.0.iter().cloned()); }
+}
+
+impl Ty {
+    pub fn int() -> Self { Ty::Prim(Prim::Int) }
+    pub fn float() -> Self { Ty::Prim(Prim::Float) }
+    pub fn bool() -> Self { Ty::Prim(Prim::Bool) }
+    pub fn str() -> Self { Ty::Prim(Prim::Str) }
+    pub fn bytes() -> Self { Ty::Prim(Prim::Bytes) }
+    pub fn function(params: Vec<Ty>, effects: EffectSet, ret: Ty) -> Self {
+        Ty::Function { params, effects, ret: Box::new(ret) }
+    }
+    pub fn pretty(&self) -> String {
+        match self {
+            Ty::Var(v) => format!("?{}", v),
+            Ty::Prim(p) => match p {
+                Prim::Int => "Int", Prim::Float => "Float", Prim::Bool => "Bool",
+                Prim::Str => "Str", Prim::Bytes => "Bytes",
+            }.into(),
+            Ty::Unit => "Unit".into(),
+            Ty::Never => "Never".into(),
+            Ty::List(t) => format!("List[{}]", t.pretty()),
+            Ty::Tuple(items) => {
+                let parts: Vec<_> = items.iter().map(|t| t.pretty()).collect();
+                format!("({})", parts.join(", "))
+            }
+            Ty::Record(fields) => {
+                let parts: Vec<_> = fields.iter().map(|(k, t)| format!("{} :: {}", k, t.pretty())).collect();
+                format!("{{ {} }}", parts.join(", "))
+            }
+            Ty::Con(name, args) => {
+                if args.is_empty() {
+                    name.clone()
+                } else {
+                    let parts: Vec<_> = args.iter().map(|t| t.pretty()).collect();
+                    format!("{}[{}]", name, parts.join(", "))
+                }
+            }
+            Ty::Function { params, effects, ret } => {
+                let parts: Vec<_> = params.iter().map(|t| t.pretty()).collect();
+                let eff = if effects.0.is_empty() { String::new() } else {
+                    let es: Vec<_> = effects.0.iter().cloned().collect();
+                    format!("[{}] ", es.join(", "))
+                };
+                format!("({}) -> {}{}", parts.join(", "), eff, ret.pretty())
+            }
+        }
+    }
+}
+
+/// A polymorphic scheme: type with universally-quantified type variables.
+#[derive(Debug, Clone)]
+pub struct Scheme {
+    pub vars: Vec<TyVarId>,
+    pub ty: Ty,
+}

--- a/crates/lex-types/src/unifier.rs
+++ b/crates/lex-types/src/unifier.rs
@@ -1,0 +1,125 @@
+//! Union-find based unification for type variables.
+
+use crate::types::*;
+use indexmap::IndexMap;
+
+#[derive(Default)]
+pub struct Unifier {
+    next_var: TyVarId,
+    /// Substitutions: `subst[v] = t` means var `v` was bound to `t`.
+    subst: IndexMap<TyVarId, Ty>,
+}
+
+impl Unifier {
+    pub fn new() -> Self { Self::default() }
+
+    pub fn fresh(&mut self) -> Ty {
+        let v = self.next_var;
+        self.next_var += 1;
+        Ty::Var(v)
+    }
+
+    pub fn fresh_id(&mut self) -> TyVarId {
+        let v = self.next_var;
+        self.next_var += 1;
+        v
+    }
+
+    /// Resolve a type by following substitutions. Recursive; structural.
+    pub fn resolve(&self, t: &Ty) -> Ty {
+        match t {
+            Ty::Var(v) => match self.subst.get(v) {
+                Some(t2) => self.resolve(t2),
+                None => Ty::Var(*v),
+            },
+            Ty::Prim(_) | Ty::Unit | Ty::Never => t.clone(),
+            Ty::List(inner) => Ty::List(Box::new(self.resolve(inner))),
+            Ty::Tuple(items) => Ty::Tuple(items.iter().map(|t| self.resolve(t)).collect()),
+            Ty::Record(fs) => {
+                let mut out = IndexMap::new();
+                for (k, v) in fs { out.insert(k.clone(), self.resolve(v)); }
+                Ty::Record(out)
+            }
+            Ty::Con(n, args) => Ty::Con(n.clone(), args.iter().map(|t| self.resolve(t)).collect()),
+            Ty::Function { params, effects, ret } => Ty::Function {
+                params: params.iter().map(|t| self.resolve(t)).collect(),
+                effects: effects.clone(),
+                ret: Box::new(self.resolve(ret)),
+            },
+        }
+    }
+
+    pub fn unify(&mut self, a: &Ty, b: &Ty) -> Result<(), UnifyError> {
+        let a = self.resolve(a);
+        let b = self.resolve(b);
+        match (&a, &b) {
+            (Ty::Var(v), other) | (other, Ty::Var(v)) => {
+                if let Ty::Var(w) = other {
+                    if v == w { return Ok(()); }
+                }
+                if occurs(*v, other, self) {
+                    return Err(UnifyError::Infinite { var: *v, ty: other.clone() });
+                }
+                self.subst.insert(*v, other.clone());
+                Ok(())
+            }
+            (Ty::Prim(p1), Ty::Prim(p2)) if p1 == p2 => Ok(()),
+            (Ty::Unit, Ty::Unit) | (Ty::Never, Ty::Never) => Ok(()),
+            // Never is a subtype of everything (bottom). For unification we
+            // treat it as compatible with any type.
+            (Ty::Never, _) | (_, Ty::Never) => Ok(()),
+            (Ty::List(t1), Ty::List(t2)) => self.unify(t1, t2),
+            (Ty::Tuple(xs), Ty::Tuple(ys)) if xs.len() == ys.len() => {
+                for (x, y) in xs.iter().zip(ys.iter()) { self.unify(x, y)?; }
+                Ok(())
+            }
+            (Ty::Record(a), Ty::Record(b)) => {
+                if a.len() != b.len() {
+                    return Err(UnifyError::Mismatch { a: Ty::Record(a.clone()), b: Ty::Record(b.clone()) });
+                }
+                for (k, va) in a {
+                    match b.get(k) {
+                        Some(vb) => self.unify(va, vb)?,
+                        None => return Err(UnifyError::Mismatch {
+                            a: Ty::Record(a.clone()), b: Ty::Record(b.clone())
+                        }),
+                    }
+                }
+                Ok(())
+            }
+            (Ty::Con(n1, a1), Ty::Con(n2, a2)) if n1 == n2 && a1.len() == a2.len() => {
+                for (x, y) in a1.iter().zip(a2.iter()) { self.unify(x, y)?; }
+                Ok(())
+            }
+            (Ty::Function { params: p1, effects: e1, ret: r1 },
+             Ty::Function { params: p2, effects: e2, ret: r2 })
+                if p1.len() == p2.len() && e1 == e2 =>
+            {
+                for (x, y) in p1.iter().zip(p2.iter()) { self.unify(x, y)?; }
+                self.unify(r1, r2)
+            }
+            _ => Err(UnifyError::Mismatch { a, b }),
+        }
+    }
+}
+
+fn occurs(v: TyVarId, t: &Ty, u: &Unifier) -> bool {
+    let t = u.resolve(t);
+    match t {
+        Ty::Var(w) => v == w,
+        Ty::Prim(_) | Ty::Unit | Ty::Never => false,
+        Ty::List(inner) => occurs(v, &inner, u),
+        Ty::Tuple(items) => items.iter().any(|t| occurs(v, t, u)),
+        Ty::Record(fs) => fs.values().any(|t| occurs(v, t, u)),
+        Ty::Con(_, args) => args.iter().any(|t| occurs(v, t, u)),
+        Ty::Function { params, ret, .. } => {
+            params.iter().any(|t| occurs(v, t, u)) || occurs(v, &ret, u)
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum UnifyError {
+    Mismatch { a: Ty, b: Ty },
+    Infinite { var: TyVarId, ty: Ty },
+}

--- a/crates/lex-types/tests/check.rs
+++ b/crates/lex-types/tests/check.rs
@@ -1,0 +1,95 @@
+//! M3 acceptance: every example in §3.13 type-checks; structured errors fire.
+
+use lex_ast::canonicalize_program;
+use lex_syntax::parse_source;
+use lex_types::{check_program, TypeError};
+
+fn check(src: &str) -> Result<(), Vec<TypeError>> {
+    let p = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&p);
+    check_program(&stages).map(|_| ())
+}
+
+#[test]
+fn example_a_factorial_checks() {
+    let src = include_str!("../../../examples/a_factorial.lex");
+    check(src).unwrap_or_else(|errs| panic!("type errors: {errs:#?}"));
+}
+
+#[test]
+fn example_b_parse_int_checks() {
+    let src = include_str!("../../../examples/b_parse_int.lex");
+    check(src).unwrap_or_else(|errs| panic!("type errors: {errs:#?}"));
+}
+
+#[test]
+fn example_c_echo_checks() {
+    let src = include_str!("../../../examples/c_echo.lex");
+    check(src).unwrap_or_else(|errs| panic!("type errors: {errs:#?}"));
+}
+
+#[test]
+fn example_d_shape_checks() {
+    let src = include_str!("../../../examples/d_shape.lex");
+    check(src).unwrap_or_else(|errs| panic!("type errors: {errs:#?}"));
+}
+
+#[test]
+fn detects_type_mismatch() {
+    let src = "fn bad(x :: Int) -> Str { x }\n";
+    let errs = check(src).unwrap_err();
+    assert!(matches!(errs[0], TypeError::TypeMismatch { .. }));
+}
+
+#[test]
+fn detects_unknown_identifier() {
+    let src = "fn bad() -> Int { y }\n";
+    let errs = check(src).unwrap_err();
+    assert!(matches!(errs[0], TypeError::UnknownIdentifier { .. }));
+}
+
+#[test]
+fn detects_arity_mismatch() {
+    let src = "fn add(x :: Int, y :: Int) -> Int { x + y }\nfn bad() -> Int { add(1) }\n";
+    let errs = check(src).unwrap_err();
+    assert!(matches!(errs[0], TypeError::ArityMismatch { .. }));
+}
+
+#[test]
+fn detects_undeclared_effect() {
+    let src = r#"
+import "std.io" as io
+fn bad() -> Str {
+  match io.read("path") {
+    Ok(s) => s,
+    Err(e) => e,
+  }
+}
+"#;
+    let errs = check(src).unwrap_err();
+    assert!(errs.iter().any(|e| matches!(e, TypeError::EffectNotDeclared { .. })),
+        "expected effect_not_declared, got {errs:#?}");
+}
+
+#[test]
+fn detects_unknown_field() {
+    let src = "fn bad() -> Int { let r := { x: 1 }\n r.y }\n";
+    let errs = check(src).unwrap_err();
+    assert!(errs.iter().any(|e| matches!(e, TypeError::UnknownField { .. })),
+        "got {errs:#?}");
+}
+
+#[test]
+fn detects_unknown_variant() {
+    let src = "fn bad() -> Int { match 1 { Bogus(x) => x, _ => 0 } }\n";
+    let errs = check(src).unwrap_err();
+    assert!(errs.iter().any(|e| matches!(e, TypeError::UnknownVariant { .. })),
+        "got {errs:#?}");
+}
+
+#[test]
+fn every_error_has_node_id() {
+    let src = "fn bad(x :: Int) -> Str { x }\n";
+    let errs = check(src).unwrap_err();
+    for e in &errs { assert!(!e.node().is_empty(), "missing node id: {e:?}"); }
+}

--- a/crates/spec-checker/Cargo.toml
+++ b/crates/spec-checker/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "spec-checker"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+serde.workspace = true

--- a/crates/spec-checker/src/lib.rs
+++ b/crates/spec-checker/src/lib.rs
@@ -1,0 +1,1 @@
+//! M14: Spec proof checker. Placeholder.

--- a/examples/a_factorial.lex
+++ b/examples/a_factorial.lex
@@ -1,0 +1,6 @@
+fn factorial(n :: Int) -> Int {
+  match n {
+    0 => 1,
+    _ => n * factorial(n - 1),
+  }
+}

--- a/examples/b_parse_int.lex
+++ b/examples/b_parse_int.lex
@@ -1,0 +1,19 @@
+import "std.str" as str
+import "std.result" as result
+
+type ParseError = Empty | NotNumber
+
+fn parse_int(s :: Str) -> Result[Int, ParseError] {
+  if str.is_empty(s) {
+    Err(Empty)
+  } else {
+    match str.to_int(s) {
+      Some(n) => Ok(n),
+      None    => Err(NotNumber),
+    }
+  }
+}
+
+fn double_input(s :: Str) -> Result[Int, ParseError] {
+  parse_int(s) |> result.map(fn (n :: Int) -> Int { n * 2 })
+}

--- a/examples/c_echo.lex
+++ b/examples/c_echo.lex
@@ -1,0 +1,5 @@
+import "std.io" as io
+
+fn echo(line :: Str) -> [io] Nil {
+  io.print(line)
+}

--- a/examples/d_shape.lex
+++ b/examples/d_shape.lex
@@ -1,0 +1,10 @@
+type Shape =
+    Circle({ radius :: Float })
+  | Rect({ width :: Float, height :: Float })
+
+fn area(s :: Shape) -> Float {
+  match s {
+    Circle({ radius }) => 3.14159 * radius * radius,
+    Rect({ width, height }) => width * height,
+  }
+}


### PR DESCRIPTION
## Summary

Implements milestones **M0 → M4** of the Lex language family per `langspecv2.md`. Working pure-subset language end-to-end with a CLI that parses, type-checks, and runs §3.13 examples.

## What works

- **M0** — Cargo workspace with 14 crates per spec §2; full workspace compiles.
- **M1** — `logos`-based lexer + recursive-descent parser + pretty-printer (spec §3); §3.13 examples round-trip parse → print → parse.
- **M2** — Canonical AST with sorted record fields/union variants, `if`→Match and `?`→Match desugar, NodeId paths, RFC 8785-style canonical JSON, SHA-256 hashing for SigId/StageId (spec §5).
- **M3** — HM-style type checker with structural records, ADT constructors, effect inference and checking, structured JSON errors per spec §6.7.
- **M4** — Bytecode compiler + stack VM (spec §8) for the pure subset; recursion (with TCO), pattern matching via decision-tree compilation, ADT match/construct, record/tuple/list literals.
- **CLI** — `lex parse | check | run | hash <file>`, JSON in/out for agents.

## Demo

```
$ lex check examples/a_factorial.lex
ok
$ lex run examples/a_factorial.lex factorial 5
120
$ lex run examples/a_factorial.lex factorial 10
3628800
$ echo 'fn bad(x :: Int) -> Str { x }' | lex check -
{"kind":"type_mismatch","at_node":"n_0","expected":"Str","got":"Int","context":["in function `bad`"]}
```

## Stubbed (per the milestone plan)

Crate skeletons exist; implementations pending in follow-on PRs:
- M5 effect runtime + sandbox (effects are statically checked but not yet runtime-enforced)
- M6 store, M7 trace + replay, M8 agent API server
- M9 Core, M10 Spec, M11 stdlib stages

## Open spec calls made (flag if you want different)

- `Pipe` is canonicalized into `Call` (spec §5.3 rule 6).
- VM uses operand-dispatched `Num*` opcodes alongside the spec's typed `Int*`/`Float*`; typed lowering is a follow-on optimization.
- §3.13 example B was missing `import "std.result" as result` (uses `result.map`); added it.
- Lambdas are accepted by parser/canonicalizer/checker but not yet compiled to bytecode (M4 only needed top-level fns).

## Test plan

- [x] `cargo test --workspace` — 33 passing, 0 failing
  - 7 syntax round-trip tests
  - 10 canonical AST tests (round-trip, hash determinism, `if`/`?` desugar, NodeIds)
  - 11 type checker tests (every §3.13 example + each error kind)
  - 5 bytecode VM tests (factorial, shape area, reproducibility)
- [x] `lex run examples/a_factorial.lex factorial 5` → `120`
- [x] `lex run examples/d_shape.lex` Circle/Rect path produces correct float areas
- [x] Bad programs exit non-zero with structured JSON errors

https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh

---
_Generated by [Claude Code](https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh)_