### PR TITLE
Implement Lex M8: CLI consolidation + agent API server

### DIFF
--- a/crates/lex-api/Cargo.toml
+++ b/crates/lex-api/Cargo.toml
@@ -7,3 +7,16 @@ license.workspace = true
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
+anyhow.workspace = true
+indexmap.workspace = true
+tiny_http = "0.12"
+lex-syntax = { path = "../lex-syntax" }
+lex-ast = { path = "../lex-ast" }
+lex-types = { path = "../lex-types" }
+lex-bytecode = { path = "../lex-bytecode" }
+lex-runtime = { path = "../lex-runtime" }
+lex-store = { path = "../lex-store" }
+lex-trace = { path = "../lex-trace" }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/lex-api/src/handlers.rs
+++ b/crates/lex-api/src/handlers.rs
@@ -1,0 +1,345 @@
+//! Request routing for the agent API.
+//!
+//! Each handler is a synchronous function that returns
+//! `Result<serde_json::Value, ApiError>`. The dispatcher wraps the result
+//! in an HTTP response — successes as 200 with the JSON body, structured
+//! errors as 4xx/5xx with a JSON envelope.
+
+use indexmap::IndexMap;
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{check_program as check_policy, DefaultHandler, Policy};
+use lex_store::Store;
+use lex_syntax::parse_source;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use tiny_http::{Header, Method, Request, Response};
+
+pub struct State {
+    pub store: Mutex<Store>,
+}
+
+impl State {
+    pub fn open(root: PathBuf) -> anyhow::Result<Self> {
+        Ok(Self { store: Mutex::new(Store::open(root)?) })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ErrorEnvelope {
+    error: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<serde_json::Value>,
+}
+
+fn json_response(status: u16, body: &serde_json::Value) -> Response<std::io::Cursor<Vec<u8>>> {
+    let bytes = serde_json::to_vec(body).unwrap_or_else(|_| b"{}".to_vec());
+    Response::from_data(bytes)
+        .with_status_code(status)
+        .with_header(Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..]).unwrap())
+}
+
+fn error_response(status: u16, msg: impl Into<String>) -> Response<std::io::Cursor<Vec<u8>>> {
+    json_response(status, &serde_json::to_value(ErrorEnvelope {
+        error: msg.into(), detail: None,
+    }).unwrap())
+}
+
+fn error_with_detail(status: u16, msg: impl Into<String>, detail: serde_json::Value)
+    -> Response<std::io::Cursor<Vec<u8>>>
+{
+    json_response(status, &serde_json::to_value(ErrorEnvelope {
+        error: msg.into(), detail: Some(detail),
+    }).unwrap())
+}
+
+pub fn handle(state: Arc<State>, mut req: Request) -> std::io::Result<()> {
+    let method = req.method().clone();
+    let url = req.url().to_string();
+    let path = url.split('?').next().unwrap_or("").to_string();
+    let query = url.split_once('?').map(|(_, q)| q.to_string()).unwrap_or_default();
+
+    let mut body = String::new();
+    let _ = req.as_reader().read_to_string(&mut body);
+
+    let resp = route(&state, &method, &path, &query, &body);
+    req.respond(resp)
+}
+
+fn route(
+    state: &State,
+    method: &Method,
+    path: &str,
+    query: &str,
+    body: &str,
+) -> Response<std::io::Cursor<Vec<u8>>> {
+    match (method, path) {
+        (Method::Get, "/v1/health") => json_response(200, &serde_json::json!({"ok": true})),
+        (Method::Post, "/v1/parse") => parse_handler(body),
+        (Method::Post, "/v1/check") => check_handler(body),
+        (Method::Post, "/v1/publish") => publish_handler(state, body),
+        (Method::Get, p) if p.starts_with("/v1/stage/") => {
+            let id = &p["/v1/stage/".len()..];
+            stage_handler(state, id)
+        }
+        (Method::Post, "/v1/run") => run_handler(state, body, false),
+        (Method::Post, "/v1/replay") => run_handler(state, body, true),
+        (Method::Get, p) if p.starts_with("/v1/trace/") => {
+            let id = &p["/v1/trace/".len()..];
+            trace_handler(state, id)
+        }
+        (Method::Get, "/v1/diff") => diff_handler(state, query),
+        _ => error_response(404, format!("unknown route: {method:?} {path}")),
+    }
+}
+
+#[derive(Deserialize)]
+struct ParseReq { source: String }
+
+fn parse_handler(body: &str) -> Response<std::io::Cursor<Vec<u8>>> {
+    let req: ParseReq = match serde_json::from_str(body) {
+        Ok(r) => r, Err(e) => return error_response(400, format!("bad request: {e}")),
+    };
+    match parse_source(&req.source) {
+        Ok(prog) => {
+            let stages = canonicalize_program(&prog);
+            json_response(200, &serde_json::to_value(&stages).unwrap())
+        }
+        Err(e) => error_response(400, format!("syntax error: {e}")),
+    }
+}
+
+fn check_handler(body: &str) -> Response<std::io::Cursor<Vec<u8>>> {
+    let req: ParseReq = match serde_json::from_str(body) {
+        Ok(r) => r, Err(e) => return error_response(400, format!("bad request: {e}")),
+    };
+    let prog = match parse_source(&req.source) {
+        Ok(p) => p, Err(e) => return error_response(400, format!("syntax error: {e}")),
+    };
+    let stages = canonicalize_program(&prog);
+    match lex_types::check_program(&stages) {
+        Ok(_) => json_response(200, &serde_json::json!({"ok": true})),
+        Err(errs) => json_response(422, &serde_json::to_value(&errs).unwrap()),
+    }
+}
+
+#[derive(Deserialize)]
+struct PublishReq { source: String, #[serde(default)] activate: bool }
+
+fn publish_handler(state: &State, body: &str) -> Response<std::io::Cursor<Vec<u8>>> {
+    let req: PublishReq = match serde_json::from_str(body) {
+        Ok(r) => r, Err(e) => return error_response(400, format!("bad request: {e}")),
+    };
+    let prog = match parse_source(&req.source) {
+        Ok(p) => p, Err(e) => return error_response(400, format!("syntax error: {e}")),
+    };
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        return error_with_detail(422, "type errors", serde_json::to_value(&errs).unwrap());
+    }
+    let store = state.store.lock().unwrap();
+    let mut out = Vec::new();
+    for s in &stages {
+        if matches!(s, lex_ast::Stage::Import(_)) { continue; }
+        match store.publish(s) {
+            Ok(id) => {
+                if req.activate {
+                    if let Err(e) = store.activate(&id) {
+                        return error_response(500, format!("activate: {e}"));
+                    }
+                }
+                let name = match s {
+                    lex_ast::Stage::FnDecl(fd) => fd.name.clone(),
+                    lex_ast::Stage::TypeDecl(td) => td.name.clone(),
+                    _ => "?".into(),
+                };
+                let sig = lex_ast::sig_id(s).unwrap_or_default();
+                let status = format!("{:?}", store.get_status(&id).unwrap_or(lex_store::StageStatus::Draft)).to_lowercase();
+                out.push(serde_json::json!({"name": name, "sig_id": sig, "stage_id": id, "status": status}));
+            }
+            Err(e) => return error_response(500, format!("publish: {e}")),
+        }
+    }
+    json_response(200, &serde_json::Value::Array(out))
+}
+
+fn stage_handler(state: &State, id: &str) -> Response<std::io::Cursor<Vec<u8>>> {
+    let store = state.store.lock().unwrap();
+    let meta = match store.get_metadata(id) {
+        Ok(m) => m, Err(e) => return error_response(404, format!("{e}")),
+    };
+    let ast = match store.get_ast(id) {
+        Ok(a) => a, Err(e) => return error_response(404, format!("{e}")),
+    };
+    let status = format!("{:?}", store.get_status(id).unwrap_or(lex_store::StageStatus::Draft)).to_lowercase();
+    json_response(200, &serde_json::json!({
+        "metadata": meta,
+        "ast": ast,
+        "status": status,
+    }))
+}
+
+#[derive(Deserialize, Default)]
+struct PolicyJson {
+    #[serde(default)] allow_effects: Vec<String>,
+    #[serde(default)] allow_fs_read: Vec<String>,
+    #[serde(default)] allow_fs_write: Vec<String>,
+    #[serde(default)] budget: Option<u64>,
+}
+
+impl PolicyJson {
+    fn into_policy(self) -> Policy {
+        Policy {
+            allow_effects: self.allow_effects.into_iter().collect::<BTreeSet<_>>(),
+            allow_fs_read: self.allow_fs_read.into_iter().map(PathBuf::from).collect(),
+            allow_fs_write: self.allow_fs_write.into_iter().map(PathBuf::from).collect(),
+            budget: self.budget,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct RunReq {
+    source: String,
+    #[serde(rename = "fn")] func: String,
+    #[serde(default)] args: Vec<serde_json::Value>,
+    #[serde(default)] policy: PolicyJson,
+    #[serde(default)] overrides: IndexMap<String, serde_json::Value>,
+}
+
+fn run_handler(state: &State, body: &str, with_overrides: bool) -> Response<std::io::Cursor<Vec<u8>>> {
+    let req: RunReq = match serde_json::from_str(body) {
+        Ok(r) => r, Err(e) => return error_response(400, format!("bad request: {e}")),
+    };
+    let prog = match parse_source(&req.source) {
+        Ok(p) => p, Err(e) => return error_response(400, format!("syntax error: {e}")),
+    };
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        return error_with_detail(422, "type errors", serde_json::to_value(&errs).unwrap());
+    }
+    let bc = compile_program(&stages);
+    let policy = req.policy.into_policy();
+    if let Err(violations) = check_policy(&bc, &policy) {
+        return error_with_detail(403, "policy violation", serde_json::to_value(&violations).unwrap());
+    }
+
+    let mut recorder = lex_trace::Recorder::new();
+    if with_overrides && !req.overrides.is_empty() {
+        recorder = recorder.with_overrides(req.overrides);
+    }
+    let handle = recorder.handle();
+    let handler = DefaultHandler::new(policy);
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.set_tracer(Box::new(recorder));
+
+    let vargs: Vec<Value> = req.args.iter().map(json_to_value).collect();
+    let started = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
+    let result = vm.call(&req.func, vargs);
+    let ended = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
+
+    let store = state.store.lock().unwrap();
+    let (root_out, root_err, status) = match &result {
+        Ok(v) => (Some(value_to_json(v)), None, 200u16),
+        Err(e) => (None, Some(format!("{e}")), 200u16),
+    };
+    let tree = handle.finalize(req.func.clone(), serde_json::Value::Null,
+        root_out.clone(), root_err.clone(), started, ended);
+    let run_id = match store.save_trace(&tree) {
+        Ok(id) => id,
+        Err(e) => return error_response(500, format!("save_trace: {e}")),
+    };
+
+    let mut body = serde_json::json!({
+        "run_id": run_id,
+        "output": root_out,
+    });
+    if let Some(err) = root_err {
+        body["error"] = serde_json::Value::String(err);
+    }
+    json_response(status, &body)
+}
+
+fn trace_handler(state: &State, id: &str) -> Response<std::io::Cursor<Vec<u8>>> {
+    let store = state.store.lock().unwrap();
+    match store.load_trace(id) {
+        Ok(t) => json_response(200, &serde_json::to_value(&t).unwrap()),
+        Err(e) => error_response(404, format!("{e}")),
+    }
+}
+
+fn diff_handler(state: &State, query: &str) -> Response<std::io::Cursor<Vec<u8>>> {
+    let mut a = None;
+    let mut b = None;
+    for kv in query.split('&') {
+        if let Some((k, v)) = kv.split_once('=') {
+            match k { "a" => a = Some(v.to_string()), "b" => b = Some(v.to_string()), _ => {} }
+        }
+    }
+    let (Some(a), Some(b)) = (a, b) else {
+        return error_response(400, "missing a or b query params");
+    };
+    let store = state.store.lock().unwrap();
+    let ta = match store.load_trace(&a) { Ok(t) => t, Err(e) => return error_response(404, format!("a: {e}")) };
+    let tb = match store.load_trace(&b) { Ok(t) => t, Err(e) => return error_response(404, format!("b: {e}")) };
+    match lex_trace::diff_runs(&ta, &tb) {
+        Some(d) => json_response(200, &serde_json::to_value(&d).unwrap()),
+        None => json_response(200, &serde_json::json!({"divergence": null})),
+    }
+}
+
+fn json_to_value(v: &serde_json::Value) -> Value {
+    use serde_json::Value as J;
+    match v {
+        J::Null => Value::Unit,
+        J::Bool(b) => Value::Bool(*b),
+        J::Number(n) => {
+            if let Some(i) = n.as_i64() { Value::Int(i) }
+            else if let Some(f) = n.as_f64() { Value::Float(f) }
+            else { Value::Unit }
+        }
+        J::String(s) => Value::Str(s.clone()),
+        J::Array(items) => Value::List(items.iter().map(json_to_value).collect()),
+        J::Object(map) => {
+            if let (Some(J::String(name)), Some(J::Array(args))) =
+                (map.get("$variant"), map.get("args"))
+            {
+                return Value::Variant {
+                    name: name.clone(),
+                    args: args.iter().map(json_to_value).collect(),
+                };
+            }
+            let mut out = IndexMap::new();
+            for (k, v) in map { out.insert(k.clone(), json_to_value(v)); }
+            Value::Record(out)
+        }
+    }
+}
+
+fn value_to_json(v: &Value) -> serde_json::Value {
+    use serde_json::Value as J;
+    match v {
+        Value::Int(n) => J::from(*n),
+        Value::Float(f) => J::from(*f),
+        Value::Bool(b) => J::Bool(*b),
+        Value::Str(s) => J::String(s.clone()),
+        Value::Bytes(b) => J::String(b.iter().map(|b| format!("{:02x}", b)).collect()),
+        Value::Unit => J::Null,
+        Value::List(items) => J::Array(items.iter().map(value_to_json).collect()),
+        Value::Tuple(items) => J::Array(items.iter().map(value_to_json).collect()),
+        Value::Record(fields) => {
+            let mut m = serde_json::Map::new();
+            for (k, v) in fields { m.insert(k.clone(), value_to_json(v)); }
+            J::Object(m)
+        }
+        Value::Variant { name, args } => {
+            let mut m = serde_json::Map::new();
+            m.insert("$variant".into(), J::String(name.clone()));
+            m.insert("args".into(), J::Array(args.iter().map(value_to_json).collect()));
+            J::Object(m)
+        }
+    }
+}
+

--- a/crates/lex-api/src/lib.rs
+++ b/crates/lex-api/src/lib.rs
@@ -1,1 +1,39 @@
-//! M12: agent API server. Placeholder.
+//! M8: agent API server. Spec §12.3.
+//!
+//! HTTP/JSON server exposing the same operations as the CLI. The server
+//! is stateful (it owns a `Store` instance) so agents don't pay sandbox
+//! startup cost per request.
+//!
+//! Endpoints:
+//!   POST /v1/parse           { source } → CanonicalAst | [SyntaxError]
+//!   POST /v1/check           { source } → { ok: true } | [TypeError]
+//!   POST /v1/publish         { source, activate? } → [{ stage_id, sig_id, status }]
+//!   GET  /v1/stage/<id>      → { metadata, ast, status }
+//!   POST /v1/run             { source, fn, args, policy } → { run_id, output | error }
+//!   GET  /v1/trace/<run_id>  → TraceTree
+//!   POST /v1/replay          { source, fn, args, policy, overrides } → { run_id, output | error }
+//!   GET  /v1/diff?a=&b=      → Divergence | { divergence: null }
+//!   GET  /v1/health          → { ok: true }
+
+pub mod handlers;
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+pub fn serve(port: u16, store_root: PathBuf) -> anyhow::Result<()> {
+    let server = tiny_http::Server::http(("127.0.0.1", port))
+        .map_err(|e| anyhow::anyhow!("bind failed: {e}"))?;
+    let state = Arc::new(handlers::State::open(store_root)?);
+    serve_on(server, state);
+    Ok(())
+}
+
+/// Test/embedded entry: takes an already-bound `Server` and runs until it
+/// stops accepting requests. Returns immediately when the `Server` is
+/// dropped on another thread.
+pub fn serve_on(server: tiny_http::Server, state: Arc<handlers::State>) {
+    for request in server.incoming_requests() {
+        let state = Arc::clone(&state);
+        let _ = handlers::handle(state, request);
+    }
+}

--- a/crates/lex-api/tests/m8.rs
+++ b/crates/lex-api/tests/m8.rs
@@ -1,0 +1,228 @@
+//! M8 acceptance per spec §12.4.
+//!
+//! - All CLI commands work end-to-end on §3.13 examples (covered by
+//!   crate-level tests across the workspace).
+//! - The agent API server starts, handles 100 sequential requests
+//!   without leaking memory, and returns the same results as the CLI.
+//! - A scripted agent loop (publish → run → trace → patch → run)
+//!   completes successfully. We exercise publish → run → trace → diff
+//!   here; patch lands in a follow-up.
+
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpStream};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use lex_api::handlers::State;
+use serde_json::json;
+use tempfile::TempDir;
+
+struct Server {
+    addr: SocketAddr,
+    _join: Option<thread::JoinHandle<()>>,
+    _server_holder: Arc<()>,
+}
+
+fn start_server() -> (Server, TempDir) {
+    let tmp = TempDir::new().unwrap();
+    let server = tiny_http::Server::http(("127.0.0.1", 0))
+        .expect("bind ephemeral port");
+    let addr: SocketAddr = match server.server_addr() {
+        tiny_http::ListenAddr::IP(addr) => addr,
+        _ => panic!("expected IP listener"),
+    };
+    let state = Arc::new(State::open(tmp.path().to_path_buf()).unwrap());
+    let join = thread::spawn(move || {
+        lex_api::serve_on(server, state);
+    });
+    // Give the OS a moment to actually start listening.
+    thread::sleep(Duration::from_millis(20));
+    (Server { addr, _join: Some(join), _server_holder: Arc::new(()) }, tmp)
+}
+
+fn http(addr: &SocketAddr, method: &str, path: &str, body: &str) -> (u16, String) {
+    let mut s = TcpStream::connect(addr).unwrap();
+    s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    let req = format!(
+        "{method} {path} HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(), body
+    );
+    s.write_all(req.as_bytes()).unwrap();
+    let mut buf = String::new();
+    s.read_to_string(&mut buf).unwrap();
+    let (head, body) = buf.split_once("\r\n\r\n").unwrap_or((&buf, ""));
+    let status = head.split_whitespace().nth(1).unwrap_or("0").parse().unwrap_or(0);
+    (status, body.to_string())
+}
+
+#[test]
+fn health_check() {
+    let (srv, _tmp) = start_server();
+    let (status, body) = http(&srv.addr, "GET", "/v1/health", "");
+    assert_eq!(status, 200);
+    assert!(body.contains("\"ok\":true"));
+}
+
+#[test]
+fn parse_then_check_pipeline() {
+    let (srv, _tmp) = start_server();
+    let src = "fn add(x :: Int, y :: Int) -> Int { x + y }\n";
+    let body = json!({"source": src}).to_string();
+    let (s1, b1) = http(&srv.addr, "POST", "/v1/parse", &body);
+    assert_eq!(s1, 200);
+    assert!(b1.contains("FnDecl"));
+    let (s2, b2) = http(&srv.addr, "POST", "/v1/check", &body);
+    assert_eq!(s2, 200);
+    assert!(b2.contains("\"ok\":true"));
+}
+
+#[test]
+fn parse_returns_4xx_on_syntax_error() {
+    let (srv, _tmp) = start_server();
+    let body = json!({"source": "fn"}).to_string();
+    let (s, _) = http(&srv.addr, "POST", "/v1/parse", &body);
+    assert!((400..500).contains(&s), "expected 4xx, got {s}");
+}
+
+#[test]
+fn check_returns_422_on_type_error() {
+    let (srv, _tmp) = start_server();
+    let src = "fn bad(x :: Int) -> Str { x }\n";
+    let body = json!({"source": src}).to_string();
+    let (s, b) = http(&srv.addr, "POST", "/v1/check", &body);
+    assert_eq!(s, 422);
+    assert!(b.contains("type_mismatch"), "expected type_mismatch, body: {b}");
+}
+
+#[test]
+fn agent_loop_publish_run_trace_diff() {
+    // §12.4: a scripted agent loop completes successfully.
+    let (srv, _tmp) = start_server();
+    let src = "fn factorial(n :: Int) -> Int { match n { 0 => 1, _ => n * factorial(n - 1) } }\n";
+
+    // 1) publish (and activate so resolve_sig works)
+    let pub_body = json!({"source": src, "activate": true}).to_string();
+    let (s, b) = http(&srv.addr, "POST", "/v1/publish", &pub_body);
+    assert_eq!(s, 200, "publish status: {b}");
+    let v: serde_json::Value = serde_json::from_str(&b).unwrap();
+    let stages = v.as_array().unwrap();
+    let first = &stages[0];
+    let stage_id = first["stage_id"].as_str().unwrap();
+    let _sig_id = first["sig_id"].as_str().unwrap();
+    assert_eq!(first["status"], "active");
+
+    // 2) get the published stage back
+    let (s, b) = http(&srv.addr, "GET", &format!("/v1/stage/{stage_id}"), "");
+    assert_eq!(s, 200, "stage GET: {b}");
+    assert!(b.contains("FnDecl"));
+
+    // 3) run the function
+    let run_body = json!({"source": src, "fn": "factorial", "args": [5]}).to_string();
+    let (s, b) = http(&srv.addr, "POST", "/v1/run", &run_body);
+    assert_eq!(s, 200);
+    let v: serde_json::Value = serde_json::from_str(&b).unwrap();
+    assert_eq!(v["output"], json!(120));
+    let run_id_a = v["run_id"].as_str().unwrap().to_string();
+
+    // 4) read the trace
+    let (s, b) = http(&srv.addr, "GET", &format!("/v1/trace/{run_id_a}"), "");
+    assert_eq!(s, 200);
+    assert!(b.contains("factorial"));
+
+    // 5) run again with a different argument and diff the two traces
+    let run_body2 = json!({"source": src, "fn": "factorial", "args": [4]}).to_string();
+    let (_, b2) = http(&srv.addr, "POST", "/v1/run", &run_body2);
+    let v2: serde_json::Value = serde_json::from_str(&b2).unwrap();
+    let run_id_b = v2["run_id"].as_str().unwrap().to_string();
+
+    let (s, body) = http(&srv.addr, "GET", &format!("/v1/diff?a={run_id_a}&b={run_id_b}"), "");
+    assert_eq!(s, 200);
+    // Different inputs ⇒ a divergence.
+    assert!(body.contains("node_id"), "expected divergence body: {body}");
+}
+
+#[test]
+fn handles_100_sequential_requests() {
+    // §12.4: server handles 100 sequential requests without crashing.
+    let (srv, _tmp) = start_server();
+    let body = json!({"source": "fn id(x :: Int) -> Int { x }\n"}).to_string();
+    for _ in 0..100 {
+        let (s, _) = http(&srv.addr, "POST", "/v1/check", &body);
+        assert_eq!(s, 200);
+    }
+}
+
+#[test]
+fn run_rejects_undeclared_effect() {
+    // §12.5: a program declaring [io] without policy is rejected at policy time.
+    let (srv, _tmp) = start_server();
+    let src = "import \"std.io\" as io\nfn say(line :: Str) -> [io] Nil { io.print(line) }\n";
+    let body = json!({"source": src, "fn": "say", "args": ["x"]}).to_string();
+    let (s, b) = http(&srv.addr, "POST", "/v1/run", &body);
+    assert_eq!(s, 403, "expected 403, got {s}: {b}");
+    assert!(b.contains("policy violation"));
+    assert!(b.contains("io"));
+}
+
+#[test]
+fn run_with_policy_succeeds() {
+    let (srv, _tmp) = start_server();
+    let src = "import \"std.io\" as io\nfn say(line :: Str) -> [io] Nil { io.print(line) }\n";
+    let body = json!({
+        "source": src, "fn": "say", "args": ["hello"],
+        "policy": {"allow_effects": ["io"]},
+    }).to_string();
+    let (s, b) = http(&srv.addr, "POST", "/v1/run", &body);
+    assert_eq!(s, 200, "expected 200, got {s}: {b}");
+}
+
+#[test]
+fn replay_with_overrides() {
+    let (srv, _tmp) = start_server();
+    let src = "import \"std.io\" as io\nfn read_one(p :: Str) -> [io] Result[Str, Str] { io.read(p) }\n";
+
+    // First run: io.read fails because path doesn't exist; result is Err(...) value-level.
+    let run = json!({
+        "source": src, "fn": "read_one", "args": ["/no/such"],
+        "policy": {"allow_effects": ["io"]},
+    }).to_string();
+    let (s, b) = http(&srv.addr, "POST", "/v1/run", &run);
+    assert_eq!(s, 200);
+    let v: serde_json::Value = serde_json::from_str(&b).unwrap();
+    let run_id = v["run_id"].as_str().unwrap().to_string();
+
+    // Pull the trace, find the io.read NodeId.
+    let (_, body) = http(&srv.addr, "GET", &format!("/v1/trace/{run_id}"), "");
+    let trace: serde_json::Value = serde_json::from_str(&body).unwrap();
+    let mut effect_node_id: Option<String> = None;
+    fn find(n: &serde_json::Value, out: &mut Option<String>) {
+        if let Some(arr) = n.as_array() {
+            for c in arr { find(c, out); }
+            return;
+        }
+        if let Some(kind) = n.get("kind").and_then(|k| k.as_str()) {
+            if kind == "effect" {
+                if let Some(nid) = n.get("node_id").and_then(|x| x.as_str()) {
+                    *out = Some(nid.to_string());
+                }
+            }
+        }
+        if let Some(children) = n.get("children") { find(children, out); }
+        if let Some(nodes) = n.get("nodes") { find(nodes, out); }
+    }
+    find(&trace, &mut effect_node_id);
+    let nid = effect_node_id.expect("trace has an effect node");
+
+    // Replay with override.
+    let injected = json!({"$variant": "Ok", "args": ["INJECTED"]});
+    let replay = json!({
+        "source": src, "fn": "read_one", "args": ["/no/such"],
+        "policy": {"allow_effects": ["io"]},
+        "overrides": { nid: injected },
+    }).to_string();
+    let (s, b) = http(&srv.addr, "POST", "/v1/replay", &replay);
+    assert_eq!(s, 200, "replay status: {s}, body: {b}");
+    let v: serde_json::Value = serde_json::from_str(&b).unwrap();
+    assert_eq!(v["output"], json!({"$variant": "Ok", "args": ["INJECTED"]}));
+}

--- a/crates/lex-cli/Cargo.toml
+++ b/crates/lex-cli/Cargo.toml
@@ -20,3 +20,4 @@ lex-bytecode = { path = "../lex-bytecode" }
 lex-runtime = { path = "../lex-runtime" }
 lex-store = { path = "../lex-store" }
 lex-trace = { path = "../lex-trace" }
+lex-api = { path = "../lex-api" }

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -39,7 +39,9 @@ fn run(args: &[String]) -> Result<()> {
         "publish" => cmd_publish(&args[1..]),
         "store" => cmd_store(&args[1..]),
         "trace" => cmd_trace(&args[1..]),
+        "replay" => cmd_replay(&args[1..]),
         "diff" => cmd_diff(&args[1..]),
+        "serve" => cmd_serve(&args[1..]),
         "help" | "--help" | "-h" => { print_usage(); Ok(()) }
         other => bail!("unknown command `{other}`. try `lex help`"),
     }
@@ -56,8 +58,13 @@ fn print_usage() {
     println!("                                     publish each stage to the store as Draft");
     println!("  store list [--store DIR]           list SigIds in the store");
     println!("  store get [--store DIR] <stage>    print metadata + canonical AST for a StageId");
+    println!("  trace <run_id>                     print a saved trace tree as JSON");
+    println!("  replay <run_id> <file> <fn> [args] [--override NODE=JSON]...");
+    println!("                                     re-execute with effect overrides keyed by NodeId");
+    println!("  diff <run_a> <run_b>               first NodeId where two traces diverge");
+    println!("  serve [--port N] [--store DIR]     start the agent API HTTP server");
     println!();
-    println!("policy flags (run):");
+    println!("policy flags (run, replay):");
     println!("  --allow-effects k1,k2,...   permit these effect kinds");
     println!("  --allow-fs-read PATH        (repeatable) permit fs_read under PATH");
     println!("  --allow-fs-write PATH       (repeatable) permit fs_write under PATH");
@@ -386,4 +393,103 @@ fn cmd_store(args: &[String]) -> Result<()> {
         }
         other => bail!("unknown `lex store` subcommand: {other}"),
     }
+}
+
+fn cmd_replay(args: &[String]) -> Result<()> {
+    // usage: lex replay <run_id> <file> <fn> [args] [--override NODE=JSON]
+    // Re-runs the function with overrides keyed by NodeId. Saves a fresh
+    // trace and prints its run_id. The original run_id is referenced for
+    // the user's bookkeeping; we don't currently load it (the function is
+    // re-executed from source).
+    let mut overrides: indexmap::IndexMap<String, serde_json::Value> = indexmap::IndexMap::new();
+    let mut policy = Policy::pure();
+    let mut positional: Vec<String> = Vec::new();
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--override" => {
+                let val = args.get(i + 1).ok_or_else(|| anyhow!("--override needs NODE=JSON"))?;
+                let (node, json) = val.split_once('=').ok_or_else(|| anyhow!("--override expects NODE=JSON"))?;
+                let v: serde_json::Value = serde_json::from_str(json)
+                    .with_context(|| format!("--override value must be JSON: {json}"))?;
+                overrides.insert(node.to_string(), v);
+                i += 2;
+            }
+            "--allow-effects" => {
+                let val = args.get(i + 1).ok_or_else(|| anyhow!("--allow-effects needs a value"))?;
+                policy.allow_effects = val.split(',').filter(|s| !s.is_empty())
+                    .map(|s| s.to_string()).collect::<BTreeSet<_>>();
+                i += 2;
+            }
+            _ => { positional.push(args[i].clone()); i += 1; }
+        }
+    }
+    let _orig_run_id = positional.first().ok_or_else(|| anyhow!("usage: lex replay <run_id> <file> <fn> [args]"))?;
+    let path = positional.get(1).ok_or_else(|| anyhow!("missing <file>"))?;
+    let func = positional.get(2).ok_or_else(|| anyhow!("missing <fn>"))?;
+
+    let src = read_source(path)?;
+    let prog = parse_source(&src)?;
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        for e in &errs { eprintln!("{}", serde_json::to_string(e)?); }
+        std::process::exit(2);
+    }
+    let bc = compile_program(&stages);
+    if let Err(violations) = check_policy(&bc, &policy) {
+        for v in &violations { eprintln!("{}", serde_json::to_string(v)?); }
+        std::process::exit(3);
+    }
+
+    let recorder = lex_trace::Recorder::new().with_overrides(overrides);
+    let handle = recorder.handle();
+    let handler = DefaultHandler::new(policy);
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.set_tracer(Box::new(recorder));
+
+    let vargs: Vec<Value> = positional[3..].iter().map(|a| {
+        let v: serde_json::Value = serde_json::from_str(a)
+            .with_context(|| format!("arg `{a}` must be JSON"))?;
+        Ok(json_to_value(&v))
+    }).collect::<Result<Vec<_>>>()?;
+
+    let started = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
+    let result = vm.call(func, vargs);
+    let ended = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
+
+    let store = lex_store::Store::open(default_store_root())?;
+    let (root_out, root_err) = match &result {
+        Ok(v) => (Some(value_to_json(v)), None),
+        Err(e) => (None, Some(format!("{e}"))),
+    };
+    let tree = handle.finalize(func.clone(), serde_json::Value::Null, root_out, root_err, started, ended);
+    let new_run_id = store.save_trace(&tree)?;
+    eprintln!("trace saved: {new_run_id}");
+    let r = result.map_err(|e| anyhow!("runtime: {e}"))?;
+    println!("{}", value_to_json_string(&r));
+    Ok(())
+}
+
+fn cmd_serve(args: &[String]) -> Result<()> {
+    let mut port: u16 = 4040;
+    let mut store_root = default_store_root();
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--port" => {
+                let v = args.get(i + 1).ok_or_else(|| anyhow!("--port needs value"))?;
+                port = v.parse().context("--port must be u16")?;
+                i += 2;
+            }
+            "--store" => {
+                let v = args.get(i + 1).ok_or_else(|| anyhow!("--store needs path"))?;
+                store_root = std::path::PathBuf::from(v);
+                i += 2;
+            }
+            _ => i += 1,
+        }
+    }
+    eprintln!("lex agent API listening on http://127.0.0.1:{port}");
+    eprintln!("store: {}", store_root.display());
+    lex_api::serve(port, store_root)
 }


### PR DESCRIPTION
## Summary

Implements **M8 — CLI consolidation + agent API server** per spec §12. Adds the missing CLI commands (`replay`, `serve`) and an HTTP server exposing the same operations as the CLI for stateful agent loops.

## What landed

**CLI**
- `lex replay <run_id> <file> <fn> [args] [--override NODE=JSON]...` — re-executes with effect-output overrides keyed by NodeId; saves a fresh trace and prints its `run_id`.
- `lex serve [--port N] [--store DIR]` — starts the agent API HTTP server. Default port 4040; default store `$LEX_STORE` or `$HOME/.lex/store`.

**Agent API server (`lex-api`)**
- `tiny_http`-backed sync HTTP server. Stateful: it owns one `Store` instance protected by `Mutex`, so agents don't pay setup cost per request.
- Endpoints (spec §12.3):
  - `GET  /v1/health` → `{ok: true}`
  - `POST /v1/parse` → CanonicalAst | 4xx with syntax error
  - `POST /v1/check` → `{ok: true}` | 422 with structured `TypeError` list
  - `POST /v1/publish` → `[{name, sig_id, stage_id, status}, ...]`
  - `GET  /v1/stage/<id>` → `{metadata, ast, status}`
  - `POST /v1/run` → `{run_id, output | error}`; 403 with structured policy violation if effects aren't allowed
  - `GET  /v1/trace/<run_id>` → TraceTree
  - `POST /v1/replay` → `{run_id, output | error}` (with NodeId-keyed effect overrides)
  - `GET  /v1/diff?a=&b=` → Divergence | `{divergence: null}`
- All structured errors carry an envelope `{error, detail?}` — type errors and policy violations come back in `detail` so agents can parse them.

## Test plan

- [x] `cargo test --workspace` — **62 passing** (53 prior + 9 M8), 0 failing
- [x] §12.4 health-check round-trip via raw HTTP
- [x] §12.4 parse → check pipeline on a valid program
- [x] `/v1/parse` returns 4xx on syntax error
- [x] `/v1/check` returns 422 with `type_mismatch` on bad code
- [x] §12.4 agent loop: publish (activate=true) → `GET /v1/stage/<id>` → `/v1/run` → `/v1/trace/<id>` → `/v1/diff` against a second run with different args returns a non-null divergence
- [x] §12.4 server handles 100 sequential `/v1/check` requests
- [x] §12.5 program declaring `[io]` without policy returns 403 with structured policy violation; allowing `io` makes it run
- [x] Replay with NodeId-keyed effect override re-executes and the injected value flows through pattern matches
- [x] CLI smoke: `lex run --trace`, `lex replay`, `lex diff` all round-trip
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

## Deferred

- `/v1/patch` endpoint — canonical-AST patching lands with §5.4 patch ops in a follow-up.
- Async runtime (tokio/axum) — keeping the dep surface light. A future perf pass can swap in async.

https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh

---
_Generated by [Claude Code](https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh)_