### PR TITLE
Implement Lex M11: stdlib MVP + lambda compilation

### DIFF
--- a/crates/lex-api/src/handlers.rs
+++ b/crates/lex-api/src/handlers.rs
@@ -340,6 +340,7 @@ fn value_to_json(v: &Value) -> serde_json::Value {
             m.insert("args".into(), J::Array(args.iter().map(value_to_json).collect()));
             J::Object(m)
         }
+        Value::Closure { fn_id, .. } => J::String(format!("<closure fn_{fn_id}>")),
     }
 }
 

--- a/crates/lex-bytecode/src/compiler.rs
+++ b/crates/lex-bytecode/src/compiler.rs
@@ -115,6 +115,7 @@ pub fn compile_program(stages: &[a::Stage]) -> Program {
     let mut pool = ConstPool::default();
     let function_names = p.function_names.clone();
     let module_aliases = p.module_aliases.clone();
+    let mut pending_lambdas: Vec<PendingLambda> = Vec::new();
 
     for s in stages {
         if let a::Stage::FnDecl(_) = s {
@@ -131,6 +132,8 @@ pub fn compile_program(stages: &[a::Stage]) -> Program {
                 function_names: &function_names,
                 module_aliases: &module_aliases,
                 id_map: &id_map,
+                pending_lambdas: &mut pending_lambdas,
+                next_fn_id: &mut p.functions,
             };
             for param in &fd.params {
                 let i = fc.next_local;
@@ -140,13 +143,63 @@ pub fn compile_program(stages: &[a::Stage]) -> Program {
             }
             fc.compile_expr(&fd.body, true);
             fc.code.push(Op::Return);
+            let code = std::mem::take(&mut fc.code);
+            let peak = fc.peak_local;
+            drop(fc);
             let idx = function_names[&fd.name];
-            p.functions[idx as usize].code = fc.code;
-            p.functions[idx as usize].locals_count = fc.peak_local;
+            p.functions[idx as usize].code = code;
+            p.functions[idx as usize].locals_count = peak;
         }
     }
+
+    // Compile pending lambdas in FIFO order. Each lambda may emit further
+    // lambdas; loop until the queue drains.
+    while let Some(pl) = pending_lambdas.pop() {
+        let id_map = std::collections::HashMap::new();
+        let mut fc = FnCompiler {
+            code: Vec::new(),
+            locals: IndexMap::new(),
+            next_local: 0,
+            peak_local: 0,
+            pool: &mut pool,
+            function_names: &function_names,
+            module_aliases: &module_aliases,
+            id_map: &id_map,
+            pending_lambdas: &mut pending_lambdas,
+            next_fn_id: &mut p.functions,
+        };
+        for name in &pl.capture_names {
+            let i = fc.next_local;
+            fc.locals.insert(name.clone(), i);
+            fc.next_local += 1;
+            fc.peak_local = fc.next_local;
+        }
+        for p in &pl.params {
+            let i = fc.next_local;
+            fc.locals.insert(p.name.clone(), i);
+            fc.next_local += 1;
+            fc.peak_local = fc.next_local;
+        }
+        fc.compile_expr(&pl.body, true);
+        fc.code.push(Op::Return);
+        let code = std::mem::take(&mut fc.code);
+        let peak = fc.peak_local;
+        drop(fc);
+        p.functions[pl.fn_id as usize].code = code;
+        p.functions[pl.fn_id as usize].locals_count = peak;
+    }
+
     p.constants = pool.pool;
     p
+}
+
+#[derive(Debug, Clone)]
+struct PendingLambda {
+    fn_id: u32,
+    /// Names of captured outer-scope locals, in order.
+    capture_names: Vec<String>,
+    params: Vec<a::Param>,
+    body: a::CExpr,
 }
 
 struct FnCompiler<'a> {
@@ -160,6 +213,12 @@ struct FnCompiler<'a> {
     module_aliases: &'a IndexMap<String, String>,
     /// CExpr address → NodeId, populated per stage via `lex_ast::expr_ids`.
     id_map: &'a std::collections::HashMap<*const a::CExpr, lex_ast::NodeId>,
+    /// Queue of lambdas discovered during compilation; each gets a fresh
+    /// fn_id and is compiled in a later pass.
+    pending_lambdas: &'a mut Vec<PendingLambda>,
+    /// Mutable view of the function table — used to allocate fn_ids for
+    /// freshly-discovered lambdas.
+    next_fn_id: &'a mut Vec<Function>,
 }
 
 impl<'a> FnCompiler<'a> {
@@ -229,7 +288,7 @@ impl<'a> FnCompiler<'a> {
                     other => panic!("unknown unary: {other}"),
                 }
             }
-            a::CExpr::Lambda { .. } => panic!("lambda not supported in M4"),
+            a::CExpr::Lambda { params, body, .. } => self.compile_lambda(params, body),
             a::CExpr::Return { value } => {
                 self.compile_expr(value, true);
                 self.emit(Op::Return);
@@ -266,10 +325,16 @@ impl<'a> FnCompiler<'a> {
         let node_id_idx = self.pool.node_id(&node_id);
 
         // Module function call: `alias.op(args)` where `alias` is an imported
-        // module ⇒ EffectCall(kind=module_name, op=field_name).
+        // module ⇒ EffectCall, except for higher-order pure ops where we
+        // emit inline bytecode using CallClosure (the closure-arg can't be
+        // serialized through the effect handler).
         if let a::CExpr::FieldAccess { value, field } = callee {
             if let a::CExpr::Var { name } = value.as_ref() {
                 if let Some(module) = self.module_aliases.get(name) {
+                    if self.try_emit_higher_order(module, field, args, node_id_idx) {
+                        let _ = tail;
+                        return;
+                    }
                     for a in args { self.compile_expr(a, false); }
                     let kind_idx = self.pool.str(module);
                     let op_idx = self.pool.str(field);
@@ -279,7 +344,7 @@ impl<'a> FnCompiler<'a> {
                         arity: args.len() as u16,
                         node_id_idx,
                     });
-                    let _ = tail; // EffectCall doesn't tail-optimize.
+                    let _ = tail;
                     return;
                 }
             }
@@ -294,7 +359,20 @@ impl<'a> FnCompiler<'a> {
                     self.emit(Op::Call { fn_id, arity: args.len() as u16, node_id_idx });
                 }
             }
-            other => panic!("unsupported callee: {other:?}"),
+            a::CExpr::Var { name } if self.locals.contains_key(name) => {
+                // First-class function value bound to a local. Push the
+                // closure, then args, then CallClosure.
+                let slot = self.locals[name];
+                self.emit(Op::LoadLocal(slot));
+                for a in args { self.compile_expr(a, false); }
+                self.emit(Op::CallClosure { arity: args.len() as u16, node_id_idx });
+            }
+            // Lambda directly applied — push closure + args + CallClosure.
+            other => {
+                self.compile_expr(other, false);
+                for a in args { self.compile_expr(a, false); }
+                self.emit(Op::CallClosure { arity: args.len() as u16, node_id_idx });
+            }
         }
     }
 
@@ -434,5 +512,204 @@ impl<'a> FnCompiler<'a> {
             }
         }
         fails
+    }
+
+    /// Compile a Lambda: collect free variables that resolve to outer-scope
+    /// locals, register a synthetic function, emit MakeClosure with the
+    /// captured values pushed in order.
+    fn compile_lambda(&mut self, params: &[a::Param], body: &a::CExpr) {
+        // Free vars = vars referenced in body that aren't bound locally.
+        let mut bound: std::collections::HashSet<String> = params.iter().map(|p| p.name.clone()).collect();
+        let mut frees: Vec<String> = Vec::new();
+        free_vars(body, &mut bound, &mut frees);
+
+        // Filter to those that are in the enclosing locals (captures) —
+        // skip globals (function names) which are referenced directly.
+        let captures: Vec<String> = frees.into_iter()
+            .filter(|n| self.locals.contains_key(n) && !self.function_names.contains_key(n))
+            .collect();
+
+        // Allocate a fresh fn_id by appending a placeholder Function.
+        let fn_id = self.next_fn_id.len() as u32;
+        self.next_fn_id.push(Function {
+            name: format!("__lambda_{fn_id}"),
+            arity: (captures.len() + params.len()) as u16,
+            locals_count: 0,
+            code: Vec::new(),
+            effects: Vec::new(),
+        });
+
+        // Emit code at the lambda site: load each captured local, then MakeClosure.
+        for c in &captures {
+            let slot = *self.locals.get(c).expect("free var must be in scope");
+            self.emit(Op::LoadLocal(slot));
+        }
+        self.emit(Op::MakeClosure { fn_id, capture_count: captures.len() as u16 });
+
+        // Queue the body for later compilation.
+        self.pending_lambdas.push(PendingLambda {
+            fn_id,
+            capture_names: captures,
+            params: params.to_vec(),
+            body: body.clone(),
+        });
+    }
+
+    /// Higher-order stdlib ops on Result/Option whose function arg is a
+    /// closure. Emit inline: pattern-match on the variant, invoke the
+    /// closure when applicable, return wrapped result.
+    fn try_emit_higher_order(
+        &mut self,
+        module: &str,
+        op: &str,
+        args: &[a::CExpr],
+        _node_id_idx: u32,
+    ) -> bool {
+        match (module, op) {
+            ("result", "map") => self.emit_variant_map(args, "Ok", true),
+            ("result", "and_then") => self.emit_variant_map(args, "Ok", false),
+            ("result", "map_err") => self.emit_variant_map(args, "Err", true),
+            ("option", "map") => self.emit_variant_map(args, "Some", true),
+            ("option", "and_then") => self.emit_variant_map(args, "Some", false),
+            _ => return false,
+        }
+        true
+    }
+
+    /// Inline pattern: `<module>.map(v, f)` and friends.
+    /// `wrap_with`: variant tag whose payload triggers the call (Ok / Some / Err).
+    /// `wrap_result`: if true, wrap the closure's result back in `wrap_with`
+    /// (map shape); if false, expect the closure to return a wrapped value
+    /// itself (and_then shape).
+    fn emit_variant_map(
+        &mut self,
+        args: &[a::CExpr],
+        wrap_with: &str,
+        wrap_result: bool,
+    ) {
+        // args[0] = the wrapped value (Result/Option), args[1] = closure
+        let wrap_idx = self.pool.variant(wrap_with);
+
+        // Compile and store the value into a local, evaluate closure on top of stack.
+        self.compile_expr(&args[0], false);
+        let val_slot = self.alloc_local("__hov");
+        self.emit(Op::StoreLocal(val_slot));
+
+        self.compile_expr(&args[1], false);
+        let f_slot = self.alloc_local("__hof");
+        self.emit(Op::StoreLocal(f_slot));
+
+        // Stack discipline:
+        //   load val ⇒ [v]
+        //   dup     ⇒ [v, v]
+        //   test    ⇒ [v, Bool]
+        //   jumpifnot ⇒ [v]
+        // Both branches end with [v] before the branch body.
+        self.emit(Op::LoadLocal(val_slot));
+        self.emit(Op::Dup);
+        self.emit(Op::TestVariant(wrap_idx));
+        let j_skip = self.code.len();
+        self.emit(Op::JumpIfNot(0));
+
+        // Matched arm: extract payload, call closure on it.
+        self.emit(Op::GetVariantArg(0));
+        let arg_slot = self.alloc_local("__hov_arg");
+        self.emit(Op::StoreLocal(arg_slot));
+        self.emit(Op::LoadLocal(f_slot));
+        self.emit(Op::LoadLocal(arg_slot));
+        let nid = self.pool.node_id("n_hov");
+        self.emit(Op::CallClosure { arity: 1, node_id_idx: nid });
+        if wrap_result {
+            self.emit(Op::MakeVariant { name_idx: wrap_idx, arity: 1 });
+        }
+        let j_end = self.code.len();
+        self.emit(Op::Jump(0));
+
+        // Skip arm: stack already has [v] from the failed Dup; nothing to do.
+        let skip_target = self.code.len() as i32;
+        if let Op::JumpIfNot(off) = &mut self.code[j_skip] {
+            *off = skip_target - (j_skip as i32 + 1);
+        }
+
+        let end_target = self.code.len() as i32;
+        if let Op::Jump(off) = &mut self.code[j_end] {
+            *off = end_target - (j_end as i32 + 1);
+        }
+    }
+}
+
+/// Collect free variables referenced in `e` that are not in `bound`.
+/// Mutates `bound` to track let/lambda introductions during the walk;
+/// the caller's set is preserved on return because Rust's borrow rules
+/// force us to clone for sub-scopes that rebind a name.
+fn free_vars(e: &a::CExpr, bound: &mut std::collections::HashSet<String>, out: &mut Vec<String>) {
+    match e {
+        a::CExpr::Literal { .. } => {}
+        a::CExpr::Var { name } => {
+            if !bound.contains(name) && !out.contains(name) {
+                out.push(name.clone());
+            }
+        }
+        a::CExpr::Call { callee, args } => {
+            free_vars(callee, bound, out);
+            for a in args { free_vars(a, bound, out); }
+        }
+        a::CExpr::Let { name, value, body, .. } => {
+            free_vars(value, bound, out);
+            let was_bound = bound.contains(name);
+            bound.insert(name.clone());
+            free_vars(body, bound, out);
+            if !was_bound { bound.remove(name); }
+        }
+        a::CExpr::Match { scrutinee, arms } => {
+            free_vars(scrutinee, bound, out);
+            for arm in arms {
+                let mut local_bound = bound.clone();
+                pattern_binders(&arm.pattern, &mut local_bound);
+                free_vars(&arm.body, &mut local_bound, out);
+            }
+        }
+        a::CExpr::Block { statements, result } => {
+            let mut local_bound = bound.clone();
+            for s in statements { free_vars(s, &mut local_bound, out); }
+            free_vars(result, &mut local_bound, out);
+        }
+        a::CExpr::Constructor { args, .. } => {
+            for a in args { free_vars(a, bound, out); }
+        }
+        a::CExpr::RecordLit { fields } => {
+            for f in fields { free_vars(&f.value, bound, out); }
+        }
+        a::CExpr::TupleLit { items } | a::CExpr::ListLit { items } => {
+            for it in items { free_vars(it, bound, out); }
+        }
+        a::CExpr::FieldAccess { value, .. } => free_vars(value, bound, out),
+        a::CExpr::Lambda { params, body, .. } => {
+            let mut inner = bound.clone();
+            for p in params { inner.insert(p.name.clone()); }
+            free_vars(body, &mut inner, out);
+        }
+        a::CExpr::BinOp { lhs, rhs, .. } => {
+            free_vars(lhs, bound, out);
+            free_vars(rhs, bound, out);
+        }
+        a::CExpr::UnaryOp { expr, .. } => free_vars(expr, bound, out),
+        a::CExpr::Return { value } => free_vars(value, bound, out),
+    }
+}
+
+fn pattern_binders(p: &a::Pattern, bound: &mut std::collections::HashSet<String>) {
+    match p {
+        a::Pattern::PWild | a::Pattern::PLiteral { .. } => {}
+        a::Pattern::PVar { name } => { bound.insert(name.clone()); }
+        a::Pattern::PConstructor { args, .. } => {
+            for a in args { pattern_binders(a, bound); }
+        }
+        a::Pattern::PRecord { fields } => {
+            for f in fields { pattern_binders(&f.pattern, bound); }
+        }
+        a::Pattern::PTuple { items } => {
+            for it in items { pattern_binders(it, bound); }
+        }
     }
 }

--- a/crates/lex-bytecode/src/op.rs
+++ b/crates/lex-bytecode/src/op.rs
@@ -54,6 +54,11 @@ pub enum Op {
     JumpIfNot(i32),
     Call { fn_id: u32, arity: u16, node_id_idx: u32 },
     TailCall { fn_id: u32, arity: u16, node_id_idx: u32 },
+    /// Build a Value::Closure: pop `capture_count` values (in order) and
+    /// pair them with `fn_id`.
+    MakeClosure { fn_id: u32, capture_count: u16 },
+    /// Call a closure: pop `arity` args + 1 closure (top of stack), invoke.
+    CallClosure { arity: u16, node_id_idx: u32 },
     /// EFFECT_CALL `<effect_kind_const_idx>` `<op_name_const_idx>` `<arity>`.
     /// Pops `arity` args, dispatches to a host effect handler, pushes result.
     /// `node_id_idx` points to a `Const::NodeId` for trace keying.

--- a/crates/lex-bytecode/src/value.rs
+++ b/crates/lex-bytecode/src/value.rs
@@ -14,6 +14,10 @@ pub enum Value {
     Tuple(Vec<Value>),
     Record(IndexMap<String, Value>),
     Variant { name: String, args: Vec<Value> },
+    /// First-class function value (a lambda + its captured locals). The
+    /// function's first `captures.len()` params bind to `captures`; the
+    /// remaining params are supplied at call time.
+    Closure { fn_id: u32, captures: Vec<Value> },
 }
 
 impl Value {

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -301,6 +301,33 @@ impl<'a> Vm<'a> {
                         self.frames[frame_idx].pc = new_pc;
                     }
                 }
+                Op::MakeClosure { fn_id, capture_count } => {
+                    let n = capture_count as usize;
+                    let mut captures: Vec<Value> = (0..n).map(|_| Value::Unit).collect();
+                    for i in (0..n).rev() { captures[i] = self.pop()?; }
+                    self.stack.push(Value::Closure { fn_id, captures });
+                }
+                Op::CallClosure { arity, node_id_idx } => {
+                    let mut args: Vec<Value> = (0..arity).map(|_| Value::Unit).collect();
+                    for i in (0..arity as usize).rev() { args[i] = self.pop()?; }
+                    let closure = self.pop()?;
+                    let (fn_id, captures) = match closure {
+                        Value::Closure { fn_id, captures } => (fn_id, captures),
+                        other => return Err(VmError::TypeMismatch(format!("CallClosure on non-closure: {other:?}"))),
+                    };
+                    let node_id = const_str(&self.program.constants, node_id_idx);
+                    let callee_name = self.program.functions[fn_id as usize].name.clone();
+                    let mut combined = captures;
+                    combined.extend(args);
+                    self.tracer.enter_call(&node_id, &callee_name, &combined);
+                    let f = &self.program.functions[fn_id as usize];
+                    let mut locals = vec![Value::Unit; f.locals_count.max(f.arity) as usize];
+                    for (i, v) in combined.into_iter().enumerate() { locals[i] = v; }
+                    self.frames.push(Frame {
+                        fn_id, pc: 0, locals, stack_base: self.stack.len(),
+                        trace_kind: FrameKind::Call(node_id),
+                    });
+                }
                 Op::Call { fn_id, arity, node_id_idx } => {
                     let mut args: Vec<Value> = (0..arity).map(|_| Value::Unit).collect();
                     for i in (0..arity as usize).rev() { args[i] = self.pop()?; }

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -297,6 +297,7 @@ fn value_to_json(v: &Value) -> serde_json::Value {
             m.insert("args".into(), J::Array(args.iter().map(value_to_json).collect()));
             J::Object(m)
         }
+        Value::Closure { fn_id, .. } => J::String(format!("<closure fn_{fn_id}>")),
     }
 }
 

--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -14,3 +14,4 @@ lex-bytecode = { path = "../lex-bytecode" }
 [dev-dependencies]
 lex-syntax = { path = "../lex-syntax" }
 lex-ast = { path = "../lex-ast" }
+lex-types = { path = "../lex-types" }

--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -1,0 +1,243 @@
+//! Pure stdlib builtins — string, numeric, list, option, result, json
+//! ops dispatched via the same `EffectHandler` interface as effects, but
+//! without policy gates (they have no observable side effects).
+
+use indexmap::IndexMap;
+use lex_bytecode::Value;
+
+/// Returns Some(...) if `(kind, op)` names a known pure builtin.
+/// `None` means "not handled here; fall through to effect dispatch".
+pub fn try_pure_builtin(kind: &str, op: &str, args: &[Value]) -> Option<Result<Value, String>> {
+    if !is_pure_module(kind) { return None; }
+    Some(dispatch(kind, op, args))
+}
+
+/// `kind` is one of the known pure module aliases — used by the policy
+/// walk to skip pure builtins that programs reference via imports.
+pub fn is_pure_module(kind: &str) -> bool {
+    matches!(kind, "str" | "int" | "float" | "bool" | "list" | "map" | "set"
+        | "option" | "result" | "tuple" | "json" | "bytes")
+}
+
+fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
+    match (kind, op) {
+        // -- str --
+        ("str", "is_empty") => Ok(Value::Bool(expect_str(args.first())?.is_empty())),
+        ("str", "len") => Ok(Value::Int(expect_str(args.first())?.len() as i64)),
+        ("str", "concat") => {
+            let a = expect_str(args.first())?;
+            let b = expect_str(args.get(1))?;
+            Ok(Value::Str(format!("{a}{b}")))
+        }
+        ("str", "to_int") => {
+            let s = expect_str(args.first())?;
+            match s.parse::<i64>() {
+                Ok(n) => Ok(some(Value::Int(n))),
+                Err(_) => Ok(none()),
+            }
+        }
+        ("str", "split") => {
+            let s = expect_str(args.first())?;
+            let sep = expect_str(args.get(1))?;
+            let items: Vec<Value> = if sep.is_empty() {
+                s.chars().map(|c| Value::Str(c.to_string())).collect()
+            } else {
+                s.split(sep.as_str()).map(|p| Value::Str(p.to_string())).collect()
+            };
+            Ok(Value::List(items))
+        }
+        ("str", "join") => {
+            let parts = expect_list(args.first())?;
+            let sep = expect_str(args.get(1))?;
+            let mut out = String::new();
+            for (i, p) in parts.iter().enumerate() {
+                if i > 0 { out.push_str(&sep); }
+                match p {
+                    Value::Str(s) => out.push_str(s),
+                    other => return Err(format!("str.join element must be Str, got {other:?}")),
+                }
+            }
+            Ok(Value::Str(out))
+        }
+
+        // -- int / float --
+        ("int", "to_str") => Ok(Value::Str(expect_int(args.first())?.to_string())),
+        ("int", "to_float") => Ok(Value::Float(expect_int(args.first())? as f64)),
+        ("float", "to_int") => Ok(Value::Int(expect_float(args.first())? as i64)),
+        ("float", "to_str") => Ok(Value::Str(expect_float(args.first())?.to_string())),
+
+        // -- list --
+        ("list", "len") => Ok(Value::Int(expect_list(args.first())?.len() as i64)),
+        ("list", "is_empty") => Ok(Value::Bool(expect_list(args.first())?.is_empty())),
+        ("list", "head") => {
+            let xs = expect_list(args.first())?;
+            match xs.first() {
+                Some(v) => Ok(some(v.clone())),
+                None => Ok(none()),
+            }
+        }
+        ("list", "tail") => {
+            let xs = expect_list(args.first())?;
+            if xs.is_empty() { Ok(Value::List(Vec::new())) }
+            else { Ok(Value::List(xs[1..].to_vec())) }
+        }
+        ("list", "range") => {
+            let lo = expect_int(args.first())?;
+            let hi = expect_int(args.get(1))?;
+            Ok(Value::List((lo..hi).map(Value::Int).collect()))
+        }
+        ("list", "concat") => {
+            let mut out = expect_list(args.first())?.clone();
+            out.extend(expect_list(args.get(1))?.iter().cloned());
+            Ok(Value::List(out))
+        }
+
+        // -- option --
+        ("option", "unwrap_or") => {
+            let opt = first_arg(args)?;
+            let default = args.get(1).cloned().unwrap_or(Value::Unit);
+            match opt {
+                Value::Variant { name, args } if name == "Some" && !args.is_empty() => Ok(args[0].clone()),
+                Value::Variant { name, .. } if name == "None" => Ok(default),
+                other => Err(format!("option.unwrap_or expected Option, got {other:?}")),
+            }
+        }
+        ("option", "is_some") => match first_arg(args)? {
+            Value::Variant { name, .. } => Ok(Value::Bool(name == "Some")),
+            other => Err(format!("option.is_some expected Option, got {other:?}")),
+        },
+        ("option", "is_none") => match first_arg(args)? {
+            Value::Variant { name, .. } => Ok(Value::Bool(name == "None")),
+            other => Err(format!("option.is_none expected Option, got {other:?}")),
+        },
+
+        // -- result --
+        ("result", "is_ok") => match first_arg(args)? {
+            Value::Variant { name, .. } => Ok(Value::Bool(name == "Ok")),
+            other => Err(format!("result.is_ok expected Result, got {other:?}")),
+        },
+        ("result", "is_err") => match first_arg(args)? {
+            Value::Variant { name, .. } => Ok(Value::Bool(name == "Err")),
+            other => Err(format!("result.is_err expected Result, got {other:?}")),
+        },
+        ("result", "unwrap_or") => {
+            let res = first_arg(args)?;
+            let default = args.get(1).cloned().unwrap_or(Value::Unit);
+            match res {
+                Value::Variant { name, args } if name == "Ok" && !args.is_empty() => Ok(args[0].clone()),
+                Value::Variant { name, .. } if name == "Err" => Ok(default),
+                other => Err(format!("result.unwrap_or expected Result, got {other:?}")),
+            }
+        }
+
+        // -- json --
+        ("json", "stringify") => {
+            let v = first_arg(args)?;
+            Ok(Value::Str(serde_json::to_string(&value_to_json(v)).unwrap_or_default()))
+        }
+        ("json", "parse") => {
+            let s = expect_str(args.first())?;
+            match serde_json::from_str::<serde_json::Value>(&s) {
+                Ok(v) => Ok(ok_v(json_to_value(&v))),
+                Err(e) => Ok(err_v(Value::Str(format!("{e}")))),
+            }
+        }
+
+        _ => Err(format!("unknown pure builtin: {kind}.{op}")),
+    }
+}
+
+fn first_arg(args: &[Value]) -> Result<&Value, String> {
+    args.first().ok_or_else(|| "missing argument".into())
+}
+
+fn expect_str(v: Option<&Value>) -> Result<String, String> {
+    match v {
+        Some(Value::Str(s)) => Ok(s.clone()),
+        Some(other) => Err(format!("expected Str, got {other:?}")),
+        None => Err("missing argument".into()),
+    }
+}
+
+fn expect_int(v: Option<&Value>) -> Result<i64, String> {
+    match v {
+        Some(Value::Int(n)) => Ok(*n),
+        Some(other) => Err(format!("expected Int, got {other:?}")),
+        None => Err("missing argument".into()),
+    }
+}
+
+fn expect_float(v: Option<&Value>) -> Result<f64, String> {
+    match v {
+        Some(Value::Float(f)) => Ok(*f),
+        Some(other) => Err(format!("expected Float, got {other:?}")),
+        None => Err("missing argument".into()),
+    }
+}
+
+fn expect_list(v: Option<&Value>) -> Result<&Vec<Value>, String> {
+    match v {
+        Some(Value::List(xs)) => Ok(xs),
+        Some(other) => Err(format!("expected List, got {other:?}")),
+        None => Err("missing argument".into()),
+    }
+}
+
+fn some(v: Value) -> Value { Value::Variant { name: "Some".into(), args: vec![v] } }
+fn none() -> Value { Value::Variant { name: "None".into(), args: Vec::new() } }
+fn ok_v(v: Value) -> Value { Value::Variant { name: "Ok".into(), args: vec![v] } }
+fn err_v(v: Value) -> Value { Value::Variant { name: "Err".into(), args: vec![v] } }
+
+fn value_to_json(v: &Value) -> serde_json::Value {
+    use serde_json::Value as J;
+    match v {
+        Value::Int(n) => J::from(*n),
+        Value::Float(f) => J::from(*f),
+        Value::Bool(b) => J::Bool(*b),
+        Value::Str(s) => J::String(s.clone()),
+        Value::Bytes(b) => J::String(b.iter().map(|b| format!("{:02x}", b)).collect()),
+        Value::Unit => J::Null,
+        Value::List(items) => J::Array(items.iter().map(value_to_json).collect()),
+        Value::Tuple(items) => J::Array(items.iter().map(value_to_json).collect()),
+        Value::Record(fields) => {
+            let mut m = serde_json::Map::new();
+            for (k, v) in fields { m.insert(k.clone(), value_to_json(v)); }
+            J::Object(m)
+        }
+        Value::Variant { name, args } => {
+            let mut m = serde_json::Map::new();
+            m.insert("$variant".into(), J::String(name.clone()));
+            m.insert("args".into(), J::Array(args.iter().map(value_to_json).collect()));
+            J::Object(m)
+        }
+        Value::Closure { fn_id, .. } => J::String(format!("<closure fn_{fn_id}>")),
+    }
+}
+
+fn json_to_value(v: &serde_json::Value) -> Value {
+    use serde_json::Value as J;
+    match v {
+        J::Null => Value::Unit,
+        J::Bool(b) => Value::Bool(*b),
+        J::Number(n) => {
+            if let Some(i) = n.as_i64() { Value::Int(i) }
+            else if let Some(f) = n.as_f64() { Value::Float(f) }
+            else { Value::Unit }
+        }
+        J::String(s) => Value::Str(s.clone()),
+        J::Array(items) => Value::List(items.iter().map(json_to_value).collect()),
+        J::Object(map) => {
+            if let (Some(J::String(name)), Some(J::Array(args))) =
+                (map.get("$variant"), map.get("args"))
+            {
+                return Value::Variant {
+                    name: name.clone(),
+                    args: args.iter().map(json_to_value).collect(),
+                };
+            }
+            let mut out = IndexMap::new();
+            for (k, v) in map { out.insert(k.clone(), json_to_value(v)); }
+            Value::Record(out)
+        }
+    }
+}

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -10,6 +10,7 @@ use std::cell::RefCell;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::builtins::try_pure_builtin;
 use crate::policy::Policy;
 
 /// Output sink used by `io.print`. Tests inject a buffer; production prints
@@ -77,6 +78,12 @@ impl DefaultHandler {
 
 impl EffectHandler for DefaultHandler {
     fn dispatch(&mut self, kind: &str, op: &str, args: Vec<Value>) -> Result<Value, String> {
+        // Pure stdlib builtins (str, list, json, ...) bypass the policy
+        // gate — they have no observable side effects and aren't tracked
+        // by the type system as effects.
+        if let Some(r) = try_pure_builtin(kind, op, &args) {
+            return r;
+        }
         self.ensure_kind_allowed(kind)?;
         match (kind, op) {
             ("io", "print") => {

--- a/crates/lex-runtime/src/lib.rs
+++ b/crates/lex-runtime/src/lib.rs
@@ -13,8 +13,10 @@
 //!   only. We ship the policy/dispatch layer, which is the user-visible
 //!   half of §7.4 and what the §7.6 acceptance tests exercise.
 
+pub mod builtins;
 pub mod policy;
 pub mod handler;
 
+pub use builtins::{is_pure_module, try_pure_builtin};
 pub use handler::{CapturedSink, DefaultHandler, IoSink, StdoutSink};
 pub use policy::{check_program, Policy, PolicyReport, PolicyViolation};

--- a/crates/lex-runtime/tests/m11.rs
+++ b/crates/lex-runtime/tests/m11.rs
@@ -1,0 +1,173 @@
+//! M11 stdlib acceptance: §3.13 example B end-to-end + per-module checks.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+
+fn compile(src: &str) -> lex_bytecode::Program {
+    let prog = parse_source(src).unwrap();
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors: {errs:#?}");
+    }
+    compile_program(&stages)
+}
+
+fn run(src: &str, func: &str, args: Vec<Value>) -> Value {
+    let prog = compile(src);
+    let handler = DefaultHandler::new(Policy::permissive());
+    let mut vm = Vm::with_handler(&prog, Box::new(handler));
+    vm.call(func, args).expect("vm error")
+}
+
+#[test]
+fn str_concat_split_join_round_trip() {
+    let src = r#"
+import "std.str" as str
+fn join_split(a :: Str, b :: Str) -> Str {
+  str.concat(a, b)
+}
+"#;
+    let v = run(src, "join_split", vec![Value::Str("foo".into()), Value::Str("bar".into())]);
+    assert_eq!(v, Value::Str("foobar".into()));
+}
+
+#[test]
+fn str_to_int_returns_option() {
+    let src = r#"
+import "std.str" as str
+fn parse(s :: Str) -> Option[Int] { str.to_int(s) }
+"#;
+    let ok = run(src, "parse", vec![Value::Str("42".into())]);
+    assert_eq!(ok, Value::Variant { name: "Some".into(), args: vec![Value::Int(42)] });
+    let none = run(src, "parse", vec![Value::Str("nope".into())]);
+    assert_eq!(none, Value::Variant { name: "None".into(), args: vec![] });
+}
+
+#[test]
+fn int_to_str_works() {
+    let src = r#"
+import "std.int" as int
+fn show(n :: Int) -> Str { int.to_str(n) }
+"#;
+    assert_eq!(run(src, "show", vec![Value::Int(42)]), Value::Str("42".into()));
+}
+
+#[test]
+fn list_basics() {
+    let src = r#"
+import "std.list" as list
+fn count(xs :: List[Int]) -> Int { list.len(xs) }
+"#;
+    let xs = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)]);
+    assert_eq!(run(src, "count", vec![xs]), Value::Int(3));
+}
+
+#[test]
+fn list_range_and_concat() {
+    let src = r#"
+import "std.list" as list
+fn r(lo :: Int, hi :: Int) -> List[Int] { list.range(lo, hi) }
+"#;
+    let v = run(src, "r", vec![Value::Int(0), Value::Int(3)]);
+    assert_eq!(v, Value::List(vec![Value::Int(0), Value::Int(1), Value::Int(2)]));
+}
+
+#[test]
+fn option_unwrap_or() {
+    let src = r#"
+import "std.option" as option
+fn pick(o :: Option[Int]) -> Int { option.unwrap_or(o, 99) }
+"#;
+    let some = Value::Variant { name: "Some".into(), args: vec![Value::Int(5)] };
+    let none = Value::Variant { name: "None".into(), args: vec![] };
+    assert_eq!(run(src, "pick", vec![some]), Value::Int(5));
+    assert_eq!(run(src, "pick", vec![none]), Value::Int(99));
+}
+
+#[test]
+fn json_round_trip() {
+    let src = r#"
+import "std.json" as json
+fn encode(v :: Int) -> Str { json.stringify(v) }
+"#;
+    assert_eq!(run(src, "encode", vec![Value::Int(7)]), Value::Str("7".into()));
+}
+
+#[test]
+fn closure_captures_outer_local() {
+    // Lambda captures `n` and applies it to its argument.
+    let src = r#"
+fn make_adder(n :: Int) -> (Int) -> Int {
+  fn (x :: Int) -> Int { x + n }
+}
+fn driver(n :: Int, x :: Int) -> Int {
+  let f := make_adder(n)
+  f(x)
+}
+"#;
+    assert_eq!(run(src, "driver", vec![Value::Int(10), Value::Int(5)]), Value::Int(15));
+}
+
+#[test]
+fn result_map_applies_closure_on_ok() {
+    let src = r#"
+import "std.result" as result
+fn double_ok(r :: Result[Int, Str]) -> Result[Int, Str] {
+  result.map(r, fn (n :: Int) -> Int { n * 2 })
+}
+"#;
+    let ok = Value::Variant { name: "Ok".into(), args: vec![Value::Int(21)] };
+    assert_eq!(run(src, "double_ok", vec![ok]),
+        Value::Variant { name: "Ok".into(), args: vec![Value::Int(42)] });
+    let err = Value::Variant { name: "Err".into(), args: vec![Value::Str("nope".into())] };
+    assert_eq!(run(src, "double_ok", vec![err.clone()]), err);
+}
+
+#[test]
+fn option_map_applies_closure_on_some() {
+    let src = r#"
+import "std.option" as option
+fn double_some(o :: Option[Int]) -> Option[Int] {
+  option.map(o, fn (n :: Int) -> Int { n * 2 })
+}
+"#;
+    let some = Value::Variant { name: "Some".into(), args: vec![Value::Int(7)] };
+    assert_eq!(run(src, "double_some", vec![some]),
+        Value::Variant { name: "Some".into(), args: vec![Value::Int(14)] });
+    let none = Value::Variant { name: "None".into(), args: vec![] };
+    assert_eq!(run(src, "double_some", vec![none.clone()]), none);
+}
+
+#[test]
+fn example_b_double_input_runs_end_to_end() {
+    // §3.13 example B: parse_int then result.map with a doubling lambda.
+    let src = r#"
+import "std.str" as str
+import "std.result" as result
+
+type ParseError = Empty | NotNumber
+
+fn parse_int(s :: Str) -> Result[Int, ParseError] {
+  if str.is_empty(s) {
+    Err(Empty)
+  } else {
+    match str.to_int(s) {
+      Some(n) => Ok(n),
+      None    => Err(NotNumber),
+    }
+  }
+}
+
+fn double_input(s :: Str) -> Result[Int, ParseError] {
+  parse_int(s) |> result.map(fn (n :: Int) -> Int { n * 2 })
+}
+"#;
+    assert_eq!(run(src, "double_input", vec![Value::Str("21".into())]),
+        Value::Variant { name: "Ok".into(), args: vec![Value::Int(42)] });
+    assert_eq!(run(src, "double_input", vec![Value::Str("".into())]),
+        Value::Variant { name: "Err".into(), args: vec![Value::Variant { name: "Empty".into(), args: vec![] }] });
+    assert_eq!(run(src, "double_input", vec![Value::Str("xx".into())]),
+        Value::Variant { name: "Err".into(), args: vec![Value::Variant { name: "NotNumber".into(), args: vec![] }] });
+}

--- a/crates/lex-trace/src/recorder.rs
+++ b/crates/lex-trace/src/recorder.rs
@@ -188,6 +188,7 @@ fn value_to_json(v: &Value) -> serde_json::Value {
             m.insert("args".into(), J::Array(args.iter().map(value_to_json).collect()));
             J::Object(m)
         }
+        Value::Closure { fn_id, .. } => J::String(format!("<closure fn_{fn_id}>")),
     }
 }
 

--- a/crates/lex-trace/tests/m7.rs
+++ b/crates/lex-trace/tests/m7.rs
@@ -69,6 +69,7 @@ fn value_to_json(v: &Value) -> serde_json::Value {
             m.insert("args".into(), J::Array(args.iter().map(value_to_json).collect()));
             J::Object(m)
         }
+        Value::Closure { fn_id, .. } => J::String(format!("<closure fn_{fn_id}>")),
     }
 }
 

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -89,6 +89,44 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 EffectSet::empty(),
                 Ty::int(),
             ));
+            fields.insert("is_empty".into(), Ty::function(
+                vec![Ty::List(Box::new(Ty::Var(0)))],
+                EffectSet::empty(),
+                Ty::bool(),
+            ));
+            fields.insert("range".into(), Ty::function(
+                vec![Ty::int(), Ty::int()],
+                EffectSet::empty(),
+                Ty::List(Box::new(Ty::int())),
+            ));
+            fields.insert("head".into(), Ty::function(
+                vec![Ty::List(Box::new(Ty::Var(0)))],
+                EffectSet::empty(),
+                Ty::Con("Option".into(), vec![Ty::Var(0)]),
+            ));
+            fields.insert("tail".into(), Ty::function(
+                vec![Ty::List(Box::new(Ty::Var(0)))],
+                EffectSet::empty(),
+                Ty::List(Box::new(Ty::Var(0))),
+            ));
+            fields.insert("concat".into(), Ty::function(
+                vec![Ty::List(Box::new(Ty::Var(0))), Ty::List(Box::new(Ty::Var(0)))],
+                EffectSet::empty(),
+                Ty::List(Box::new(Ty::Var(0))),
+            ));
+            Some(Ty::Record(fields))
+        }
+        "json" => {
+            let mut fields = IndexMap::new();
+            // stringify :: T -> Str  (polymorphic on input)
+            fields.insert("stringify".into(), Ty::function(
+                vec![Ty::Var(0)], EffectSet::empty(), Ty::str(),
+            ));
+            // parse :: Str -> Result[T, Str]
+            fields.insert("parse".into(), Ty::function(
+                vec![Ty::str()], EffectSet::empty(),
+                Ty::Con("Result".into(), vec![Ty::Var(0), Ty::str()]),
+            ));
             Some(Ty::Record(fields))
         }
         "result" => {
@@ -153,6 +191,7 @@ pub fn module_for_import(reference: &str) -> Option<&'static str> {
         "list" => "list",
         "result" => "result",
         "option" => "option",
+        "json" => "json",
         _ => return None,
     })
 }


### PR DESCRIPTION
## Summary

Implements **M11 — stdlib MVP + lambda compilation** per spec §11. Pure stdlib functions (`str`, `int`, `float`, `list`, `option`, `result`, `json`) and the higher-order Result/Option ops now run end-to-end. **§3.13 example B** (`parse_int |> result.map`) executes correctly from source through the CLI; `double_input("21")` returns `Ok(42)`.

## Demo

```
$ lex run examples/b_parse_int.lex double_input '"21"'
{"$variant":"Ok","args":[42]}

$ lex run examples/b_parse_int.lex double_input '""'
{"$variant":"Err","args":[{"$variant":"Empty","args":[]}]}

$ lex run examples/b_parse_int.lex double_input '"xx"'
{"$variant":"Err","args":[{"$variant":"NotNumber","args":[]}]}
```

## What landed

**Closures (foundational)**
- New `Value::Closure { fn_id, captures }` and matching `Op::MakeClosure` / `Op::CallClosure` opcodes.
- Compiler does free-variable analysis on lambdas, registers a synthetic function whose first N params are captures, emits `LoadLocal` for each capture + `MakeClosure` at the lambda site.
- Pending-lambda queue compiled in a follow-up pass; nested lambdas handled.

**Pure stdlib (`lex-runtime/src/builtins.rs`)**
- `str`: `is_empty`, `len`, `concat`, `to_int`, `split`, `join`.
- `int` / `float`: `to_str`, `to_float`, `to_int`.
- `list`: `len`, `is_empty`, `head`, `tail`, `range`, `concat`.
- `option`: `unwrap_or`, `is_some`, `is_none`.
- `result`: `is_ok`, `is_err`, `unwrap_or`.
- `json`: `parse`, `stringify`.
- All bypass the effect-policy gate (no observable side effects).
- `DefaultHandler` tries pure builtins first, falls through to real effects.

**Higher-order pure ops (compiler-emitted inline bytecode)**
- `result.map` / `result.and_then` / `result.map_err`
- `option.map` / `option.and_then`
- These can't dispatch through the effect handler because their function arg is a runtime closure. The compiler recognizes them and emits inline pattern-match + `CallClosure` per spec §11.2.

**Type-system signatures extended (`lex-types`)**
- `json` module recognized as an importable.
- `list.range`, `list.head`, `list.tail`, `list.concat`, `list.is_empty`.

## Test plan

- [x] `cargo test --workspace` — **73 passing** (62 prior + 11 M11), 0 failing
- [x] §3.13 example B end-to-end: `double_input("21") => Ok(42)`, `double_input("") => Err(Empty)`, `double_input("xx") => Err(NotNumber)`
- [x] Closure captures outer locals (`make_adder` test)
- [x] `result.map` applies on `Ok`, passes through on `Err`
- [x] `option.map` applies on `Some`, passes through on `None`
- [x] Per-module smokes: `str.concat`, `str.to_int`, `int.to_str`, `list.len`, `list.range`, `option.unwrap_or`, `json.stringify`
- [x] CLI: `lex run examples/b_parse_int.lex double_input '"21"'` → `{"$variant":"Ok","args":[42]}`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

## Deferred

- `list.map` / `list.filter` / `list.fold` — need closure-call inside a loop; cleanest done with VM-internal step support, lands later.
- `std.flow` orchestration primitives (`parallel`, `retry`, `branch`).
- Full ~120-function stdlib catalog. The MVP here covers what §3.13 examples actually need.

https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh

---
_Generated by [Claude Code](https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh)_