### PR TITLE
Add higher-order list ops: list.map / list.filter / list.fold

### DIFF
--- a/crates/lex-bytecode/src/compiler.rs
+++ b/crates/lex-bytecode/src/compiler.rs
@@ -571,9 +571,197 @@ impl<'a> FnCompiler<'a> {
             ("result", "map_err") => self.emit_variant_map(args, "Err", true),
             ("option", "map") => self.emit_variant_map(args, "Some", true),
             ("option", "and_then") => self.emit_variant_map(args, "Some", false),
+            ("list", "map") => self.emit_list_map(args),
+            ("list", "filter") => self.emit_list_filter(args),
+            ("list", "fold") => self.emit_list_fold(args),
             _ => return false,
         }
         true
+    }
+
+    /// `list.map(xs, f)` — inline loop applying `f` to each element.
+    /// Stack contract: pushes the resulting List.
+    fn emit_list_map(&mut self, args: &[a::CExpr]) {
+        // Compile xs and f, store both as locals.
+        self.compile_expr(&args[0], false);
+        let xs = self.alloc_local("__lm_xs");
+        self.emit(Op::StoreLocal(xs));
+        self.compile_expr(&args[1], false);
+        let f = self.alloc_local("__lm_f");
+        self.emit(Op::StoreLocal(f));
+
+        // out := []
+        self.emit(Op::MakeList(0));
+        let out = self.alloc_local("__lm_out");
+        self.emit(Op::StoreLocal(out));
+
+        // i := 0
+        let zero = self.pool.int(0);
+        self.emit(Op::PushConst(zero));
+        let i = self.alloc_local("__lm_i");
+        self.emit(Op::StoreLocal(i));
+
+        // loop_top: while i < len(xs) { ... }
+        let loop_top = self.code.len();
+        self.emit(Op::LoadLocal(i));
+        self.emit(Op::LoadLocal(xs));
+        self.emit(Op::GetListLen);
+        self.emit(Op::NumLt);
+        let j_exit = self.code.len();
+        self.emit(Op::JumpIfNot(0));
+
+        // body: out := out ++ [f(xs[i])]
+        let nid = self.pool.node_id("n_list_map");
+        self.emit(Op::LoadLocal(out));
+        self.emit(Op::LoadLocal(f));
+        self.emit(Op::LoadLocal(xs));
+        self.emit(Op::LoadLocal(i));
+        self.emit(Op::GetListElemDyn);
+        self.emit(Op::CallClosure { arity: 1, node_id_idx: nid });
+        self.emit(Op::ListAppend);
+        self.emit(Op::StoreLocal(out));
+
+        // i := i + 1
+        self.emit(Op::LoadLocal(i));
+        let one = self.pool.int(1);
+        self.emit(Op::PushConst(one));
+        self.emit(Op::NumAdd);
+        self.emit(Op::StoreLocal(i));
+
+        // jump back
+        let jump_back = self.code.len();
+        let back = (loop_top as i32) - (jump_back as i32 + 1);
+        self.emit(Op::Jump(back));
+
+        // exit: patch j_exit, push out
+        let exit_target = self.code.len() as i32;
+        if let Op::JumpIfNot(off) = &mut self.code[j_exit] {
+            *off = exit_target - (j_exit as i32 + 1);
+        }
+        self.emit(Op::LoadLocal(out));
+    }
+
+    /// `list.filter(xs, pred)` — keep elements where pred returns true.
+    fn emit_list_filter(&mut self, args: &[a::CExpr]) {
+        self.compile_expr(&args[0], false);
+        let xs = self.alloc_local("__lf_xs");
+        self.emit(Op::StoreLocal(xs));
+        self.compile_expr(&args[1], false);
+        let f = self.alloc_local("__lf_f");
+        self.emit(Op::StoreLocal(f));
+
+        self.emit(Op::MakeList(0));
+        let out = self.alloc_local("__lf_out");
+        self.emit(Op::StoreLocal(out));
+
+        let zero = self.pool.int(0);
+        self.emit(Op::PushConst(zero));
+        let i = self.alloc_local("__lf_i");
+        self.emit(Op::StoreLocal(i));
+
+        let loop_top = self.code.len();
+        self.emit(Op::LoadLocal(i));
+        self.emit(Op::LoadLocal(xs));
+        self.emit(Op::GetListLen);
+        self.emit(Op::NumLt);
+        let j_exit = self.code.len();
+        self.emit(Op::JumpIfNot(0));
+
+        // x := xs[i]
+        self.emit(Op::LoadLocal(xs));
+        self.emit(Op::LoadLocal(i));
+        self.emit(Op::GetListElemDyn);
+        let x = self.alloc_local("__lf_x");
+        self.emit(Op::StoreLocal(x));
+
+        // if pred(x) { out := out ++ [x] }
+        let nid = self.pool.node_id("n_list_filter");
+        self.emit(Op::LoadLocal(f));
+        self.emit(Op::LoadLocal(x));
+        self.emit(Op::CallClosure { arity: 1, node_id_idx: nid });
+        let j_skip = self.code.len();
+        self.emit(Op::JumpIfNot(0));
+
+        self.emit(Op::LoadLocal(out));
+        self.emit(Op::LoadLocal(x));
+        self.emit(Op::ListAppend);
+        self.emit(Op::StoreLocal(out));
+
+        let skip_target = self.code.len() as i32;
+        if let Op::JumpIfNot(off) = &mut self.code[j_skip] {
+            *off = skip_target - (j_skip as i32 + 1);
+        }
+
+        // i := i + 1
+        self.emit(Op::LoadLocal(i));
+        let one = self.pool.int(1);
+        self.emit(Op::PushConst(one));
+        self.emit(Op::NumAdd);
+        self.emit(Op::StoreLocal(i));
+
+        let jump_back = self.code.len();
+        let back = (loop_top as i32) - (jump_back as i32 + 1);
+        self.emit(Op::Jump(back));
+
+        let exit_target = self.code.len() as i32;
+        if let Op::JumpIfNot(off) = &mut self.code[j_exit] {
+            *off = exit_target - (j_exit as i32 + 1);
+        }
+        self.emit(Op::LoadLocal(out));
+    }
+
+    /// `list.fold(xs, init, f)` — left fold with two-arg combiner.
+    fn emit_list_fold(&mut self, args: &[a::CExpr]) {
+        // args: xs, init, f
+        self.compile_expr(&args[0], false);
+        let xs = self.alloc_local("__lo_xs");
+        self.emit(Op::StoreLocal(xs));
+        self.compile_expr(&args[1], false);
+        let acc = self.alloc_local("__lo_acc");
+        self.emit(Op::StoreLocal(acc));
+        self.compile_expr(&args[2], false);
+        let f = self.alloc_local("__lo_f");
+        self.emit(Op::StoreLocal(f));
+
+        let zero = self.pool.int(0);
+        self.emit(Op::PushConst(zero));
+        let i = self.alloc_local("__lo_i");
+        self.emit(Op::StoreLocal(i));
+
+        let loop_top = self.code.len();
+        self.emit(Op::LoadLocal(i));
+        self.emit(Op::LoadLocal(xs));
+        self.emit(Op::GetListLen);
+        self.emit(Op::NumLt);
+        let j_exit = self.code.len();
+        self.emit(Op::JumpIfNot(0));
+
+        // acc := f(acc, xs[i])
+        let nid = self.pool.node_id("n_list_fold");
+        self.emit(Op::LoadLocal(f));
+        self.emit(Op::LoadLocal(acc));
+        self.emit(Op::LoadLocal(xs));
+        self.emit(Op::LoadLocal(i));
+        self.emit(Op::GetListElemDyn);
+        self.emit(Op::CallClosure { arity: 2, node_id_idx: nid });
+        self.emit(Op::StoreLocal(acc));
+
+        // i := i + 1
+        self.emit(Op::LoadLocal(i));
+        let one = self.pool.int(1);
+        self.emit(Op::PushConst(one));
+        self.emit(Op::NumAdd);
+        self.emit(Op::StoreLocal(i));
+
+        let jump_back = self.code.len();
+        let back = (loop_top as i32) - (jump_back as i32 + 1);
+        self.emit(Op::Jump(back));
+
+        let exit_target = self.code.len() as i32;
+        if let Op::JumpIfNot(off) = &mut self.code[j_exit] {
+            *off = exit_target - (j_exit as i32 + 1);
+        }
+        self.emit(Op::LoadLocal(acc));
     }
 
     /// Inline pattern: `<module>.map(v, f)` and friends.

--- a/crates/lex-bytecode/src/op.rs
+++ b/crates/lex-bytecode/src/op.rs
@@ -47,6 +47,12 @@ pub enum Op {
     GetVariantArg(u16),    // pop variant, push its i'th arg
     GetListLen,
     GetListElem(u32),
+    /// Pop [list, value]; push list with `value` appended.
+    ListAppend,
+    /// Pop list; push it indexed by the integer on top.
+    /// Stack: [list, idx] → [list[idx]]. (Like GetListElem(u32) but
+    /// the index is dynamic.)
+    GetListElemDyn,
 
     // control flow
     Jump(i32),

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -283,6 +283,33 @@ impl<'a> Vm<'a> {
                         other => return Err(VmError::TypeMismatch(format!("GetListElem on non-list: {other:?}"))),
                     }
                 }
+                Op::GetListElemDyn => {
+                    // Stack: [list, idx]
+                    let idx = match self.pop()? {
+                        Value::Int(n) => n as usize,
+                        other => return Err(VmError::TypeMismatch(format!("GetListElemDyn idx: {other:?}"))),
+                    };
+                    let v = self.pop()?;
+                    match v {
+                        Value::List(items) => {
+                            let v = items.into_iter().nth(idx)
+                                .ok_or_else(|| VmError::TypeMismatch("list index oob".into()))?;
+                            self.stack.push(v);
+                        }
+                        other => return Err(VmError::TypeMismatch(format!("GetListElemDyn on non-list: {other:?}"))),
+                    }
+                }
+                Op::ListAppend => {
+                    let value = self.pop()?;
+                    let list = self.pop()?;
+                    match list {
+                        Value::List(mut items) => {
+                            items.push(value);
+                            self.stack.push(Value::List(items));
+                        }
+                        other => return Err(VmError::TypeMismatch(format!("ListAppend on non-list: {other:?}"))),
+                    }
+                }
                 Op::Jump(off) => {
                     let new_pc = (self.frames[frame_idx].pc as i32 + off) as usize;
                     self.frames[frame_idx].pc = new_pc;

--- a/crates/lex-runtime/tests/list_higher_order.rs
+++ b/crates/lex-runtime/tests/list_higher_order.rs
@@ -1,0 +1,137 @@
+//! Higher-order list operations: list.map, list.filter, list.fold.
+//!
+//! These compile to inline bytecode loops (not effect dispatch) so the
+//! closure arg can flow through the VM's CallClosure opcode.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+
+fn run(src: &str, func: &str, args: Vec<Value>) -> Value {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors: {errs:#?}");
+    }
+    let bc = compile_program(&stages);
+    let handler = DefaultHandler::new(Policy::permissive());
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(func, args).expect("vm")
+}
+
+fn ints(xs: &[i64]) -> Value {
+    Value::List(xs.iter().copied().map(Value::Int).collect())
+}
+
+#[test]
+fn list_map_doubles() {
+    let src = r#"
+import "std.list" as list
+fn doubled(xs :: List[Int]) -> List[Int] {
+  list.map(xs, fn (n :: Int) -> Int { n * 2 })
+}
+"#;
+    let r = run(src, "doubled", vec![ints(&[1, 2, 3, 4])]);
+    assert_eq!(r, ints(&[2, 4, 6, 8]));
+}
+
+#[test]
+fn list_map_on_empty_returns_empty() {
+    let src = r#"
+import "std.list" as list
+fn ident(xs :: List[Int]) -> List[Int] {
+  list.map(xs, fn (n :: Int) -> Int { n })
+}
+"#;
+    assert_eq!(run(src, "ident", vec![ints(&[])]), ints(&[]));
+}
+
+#[test]
+fn list_map_with_captured_local() {
+    let src = r#"
+import "std.list" as list
+fn add_each(xs :: List[Int], k :: Int) -> List[Int] {
+  list.map(xs, fn (n :: Int) -> Int { n + k })
+}
+"#;
+    let r = run(src, "add_each", vec![ints(&[10, 20, 30]), Value::Int(5)]);
+    assert_eq!(r, ints(&[15, 25, 35]));
+}
+
+#[test]
+fn list_filter_keeps_matching() {
+    let src = r#"
+import "std.list" as list
+fn evens(xs :: List[Int]) -> List[Int] {
+  list.filter(xs, fn (n :: Int) -> Bool { (n % 2) == 0 })
+}
+"#;
+    assert_eq!(run(src, "evens", vec![ints(&[1, 2, 3, 4, 5, 6])]), ints(&[2, 4, 6]));
+}
+
+#[test]
+fn list_filter_all_pass_or_all_fail() {
+    let src = r#"
+import "std.list" as list
+fn keep_pos(xs :: List[Int]) -> List[Int] {
+  list.filter(xs, fn (n :: Int) -> Bool { n > 0 })
+}
+"#;
+    assert_eq!(run(src, "keep_pos", vec![ints(&[1, 2, 3])]), ints(&[1, 2, 3]));
+    assert_eq!(run(src, "keep_pos", vec![ints(&[-1, -2, -3])]), ints(&[]));
+}
+
+#[test]
+fn list_fold_sums() {
+    let src = r#"
+import "std.list" as list
+fn sum(xs :: List[Int]) -> Int {
+  list.fold(xs, 0, fn (acc :: Int, x :: Int) -> Int { acc + x })
+}
+"#;
+    assert_eq!(run(src, "sum", vec![ints(&[])]), Value::Int(0));
+    assert_eq!(run(src, "sum", vec![ints(&[1, 2, 3, 4, 5])]), Value::Int(15));
+    assert_eq!(run(src, "sum", vec![ints(&[10])]), Value::Int(10));
+}
+
+#[test]
+fn list_fold_builds_a_string() {
+    let src = r#"
+import "std.list" as list
+import "std.str" as str
+fn join_with_dash(xs :: List[Str]) -> Str {
+  list.fold(xs, "", fn (acc :: Str, x :: Str) -> Str { str.concat(acc, x) })
+}
+"#;
+    let xs = Value::List(vec![Value::Str("a".into()), Value::Str("b".into()), Value::Str("c".into())]);
+    assert_eq!(run(src, "join_with_dash", vec![xs]), Value::Str("abc".into()));
+}
+
+#[test]
+fn list_map_filter_fold_pipeline() {
+    // pipeline: square evens, sum the squares
+    let src = r#"
+import "std.list" as list
+fn sum_even_squares(xs :: List[Int]) -> Int {
+  let evens := list.filter(xs, fn (n :: Int) -> Bool { (n % 2) == 0 })
+  let squared := list.map(evens, fn (n :: Int) -> Int { n * n })
+  list.fold(squared, 0, fn (acc :: Int, x :: Int) -> Int { acc + x })
+}
+"#;
+    // [1,2,3,4,5,6] → evens [2,4,6] → squared [4,16,36] → sum 56
+    assert_eq!(run(src, "sum_even_squares", vec![ints(&[1, 2, 3, 4, 5, 6])]), Value::Int(56));
+}
+
+#[test]
+fn list_map_then_fold_with_capture() {
+    let src = r#"
+import "std.list" as list
+fn weighted_sum(xs :: List[Int], k :: Int) -> Int {
+  let scaled := list.map(xs, fn (n :: Int) -> Int { n * k })
+  list.fold(scaled, 0, fn (acc :: Int, x :: Int) -> Int { acc + x })
+}
+"#;
+    // sum([3*10, 4*10, 5*10]) = 120
+    assert_eq!(run(src, "weighted_sum", vec![ints(&[3, 4, 5]), Value::Int(10)]), Value::Int(120));
+}


### PR DESCRIPTION
## Summary

Closes the M11 stdlib gap: lambdas now flow through list-shaped combinators end-to-end, completing the example-B-style functional pattern across collections.

## What landed

**Bytecode (`lex-bytecode`)**
- `Op::ListAppend` — pops `[list, value]`, pushes list with value appended.
- `Op::GetListElemDyn` — pops `[list, idx]`, pushes `list[idx]`; dynamic index for loop-controlled access.

**Compiler (`lex-bytecode::compiler`)**
- `emit_list_map(xs, f)` — inline bytecode loop. Stores `xs` and `f` as locals, accumulates an output list with `ListAppend`. Each iteration loads `f` as a closure and calls it on `xs[i]` via `CallClosure(arity=1)`.
- `emit_list_filter(xs, pred)` — same loop shape but conditionally appends based on the predicate's `Bool` result.
- `emit_list_fold(xs, init, f)` — two-arg combiner. `acc := f(acc, xs[i])` with `CallClosure(arity=2)`.
- Wired into the existing `try_emit_higher_order` dispatch in `compile_call`.

These ops can't go through the effect handler because the closure arg is a runtime `Value::Closure` that the host can't synchronously invoke. Inline compilation keeps the closure on the bytecode stack and uses `CallClosure` directly — the same pattern as `result.map`/`option.map` from M11.

## Demo

```
fn sum_even_squares(xs :: List[Int]) -> Int {
  let evens   := list.filter(xs, fn (n :: Int) -> Bool { (n % 2) == 0 })
  let squared := list.map(evens, fn (n :: Int) -> Int { n * n })
  list.fold(squared, 0, fn (acc :: Int, x :: Int) -> Int { acc + x })
}
// sum_even_squares([1..6]) == 56
```

## Test plan

- [x] `cargo test --workspace` — **117 passing** (108 prior + 9 new), 0 failing
- [x] `list.map` doubles a list, handles empty, captures outer locals (`add_each(xs, k)`)
- [x] `list.filter` keeps evens; covers all-pass and all-fail edge cases
- [x] `list.fold` sums (0, 15, 10), builds a string via `str.concat`
- [x] 3-stage `filter → map → fold` pipeline returns 56 for `[1..6]` (sum of squared evens)
- [x] Map+fold with captured outer local (`weighted_sum(xs, k)`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh

---
_Generated by [Claude Code](https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh)_