### PR TITLE
Relicense from Apache-2.0 to EUPL-1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
-license = "Apache-2.0"
+license = "EUPL-1.2"
 
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,23 @@
+European Union Public Licence v. 1.2 (EUPL-1.2)
+
+Copyright (c) 2026 lex-lang contributors
+
+Licensed under the EUPL, Version 1.2 only (the "Licence"); you may not
+use this work except in compliance with the Licence.
+
+You may obtain a copy of the Licence at:
+
+    https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/eupl_v1.2_en.pdf
+    https://eupl.eu/1.2/en/                          (HTML, all 23 EU languages)
+    https://spdx.org/licenses/EUPL-1.2.html          (SPDX identifier: EUPL-1.2)
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the Licence is distributed on an "AS IS" basis,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the Licence for the specific language governing
+permissions and limitations under the Licence.
+
+The EUPL-1.2 is a copyleft licence approved by the European Commission
+and is compatible with several other open-source licences listed in
+its Appendix (including GPL-2.0, GPL-3.0, AGPL-3.0, LGPL-2.1, LGPL-3.0,
+MPL-2.0, EPL-1.0, CeCILL-2.0/2.1, OSL-2.1/3.0, and CC-BY-SA-3.0).

--- a/README.md
+++ b/README.md
@@ -311,4 +311,4 @@ cargo test --release -p core-compiler -- --ignored   # release-only matmul perf 
 
 ## License
 
-Apache-2.0.
+[EUPL-1.2](LICENSE) — the European Union Public Licence v. 1.2.


### PR DESCRIPTION
## Summary

Switches the workspace license from **Apache-2.0** to **EUPL-1.2** (European Union Public Licence v. 1.2; SPDX `EUPL-1.2`).

## What changed

- `Cargo.toml` (workspace): `license = "EUPL-1.2"`. Per-crate `Cargo.toml`s inherit via `license.workspace = true`, so no individual crate edits needed.
- `LICENSE`: new file with the standard EUPL-1.2 notice and pointers to the official EU text (joinup.ec.europa.eu, eupl.eu, spdx.org).
- `README.md`: license section updated.

The EUPL-1.2 is a copyleft license approved by the European Commission. Per its Appendix, it is compatibility-listed with GPL-2.0, GPL-3.0, AGPL-3.0, LGPL-2.1/3.0, MPL-2.0, EPL-1.0, CeCILL-2.0/2.1, OSL-2.1/3.0, and CC-BY-SA-3.0.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` — 125 passing, 0 failing
- [x] No code changes; only metadata + license file

https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh

---
_Generated by [Claude Code](https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh)_