### PR TITLE
Add std.bytes (pure) and std.net.get/post (effectful)

### DIFF
--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -143,7 +143,50 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             }
         }
 
+        // -- bytes --
+        ("bytes", "len") => {
+            let b = expect_bytes(args.first())?;
+            Ok(Value::Int(b.len() as i64))
+        }
+        ("bytes", "eq") => {
+            let a = expect_bytes(args.first())?;
+            let b = expect_bytes(args.get(1))?;
+            Ok(Value::Bool(a == b))
+        }
+        ("bytes", "from_str") => {
+            let s = expect_str(args.first())?;
+            Ok(Value::Bytes(s.into_bytes()))
+        }
+        ("bytes", "to_str") => {
+            let b = expect_bytes(args.first())?;
+            match String::from_utf8(b.to_vec()) {
+                Ok(s) => Ok(ok_v(Value::Str(s))),
+                Err(e) => Ok(err_v(Value::Str(format!("{e}")))),
+            }
+        }
+        ("bytes", "slice") => {
+            let b = expect_bytes(args.first())?;
+            let lo = expect_int(args.get(1))? as usize;
+            let hi = expect_int(args.get(2))? as usize;
+            if lo > hi || hi > b.len() {
+                return Err(format!("bytes.slice: out of range [{lo}..{hi}] of {}", b.len()));
+            }
+            Ok(Value::Bytes(b[lo..hi].to_vec()))
+        }
+        ("bytes", "is_empty") => {
+            let b = expect_bytes(args.first())?;
+            Ok(Value::Bool(b.is_empty()))
+        }
+
         _ => Err(format!("unknown pure builtin: {kind}.{op}")),
+    }
+}
+
+fn expect_bytes(v: Option<&Value>) -> Result<&Vec<u8>, String> {
+    match v {
+        Some(Value::Bytes(b)) => Ok(b),
+        Some(other) => Err(format!("expected Bytes, got {other:?}")),
+        None => Err("missing argument".into()),
     }
 }
 

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -130,9 +130,81 @@ impl EffectHandler for DefaultHandler {
                 // enforced statically in `policy::check_program`.
                 Ok(Value::Unit)
             }
+            ("net", "get") => {
+                let url = expect_str(args.first())?.to_string();
+                Ok(http_request("GET", &url, None))
+            }
+            ("net", "post") => {
+                let url = expect_str(args.first())?.to_string();
+                let body = expect_str(args.get(1))?.to_string();
+                Ok(http_request("POST", &url, Some(&body)))
+            }
             other => Err(format!("unsupported effect {}.{}", other.0, other.1)),
         }
     }
+}
+
+/// Minimal hand-rolled HTTP/1.0 client. Supports `http://host:port/path`
+/// only (no TLS, no redirects). Returns `Result[Str, Str]` as a Lex
+/// `Value::Variant`.
+fn http_request(method: &str, url: &str, body: Option<&str>) -> Value {
+    let parsed = match parse_http_url(url) {
+        Ok(u) => u,
+        Err(e) => return err_value(format!("bad url: {e}")),
+    };
+    let body_bytes = body.unwrap_or("").as_bytes();
+    let req = format!(
+        "{method} {path} HTTP/1.0\r\nHost: {host}\r\nContent-Length: {clen}\r\nConnection: close\r\n\r\n",
+        path = parsed.path,
+        host = parsed.host,
+        clen = body_bytes.len(),
+    );
+    use std::io::{Read, Write};
+    use std::net::TcpStream;
+    use std::time::Duration;
+    let mut stream = match TcpStream::connect((parsed.host.as_str(), parsed.port)) {
+        Ok(s) => s,
+        Err(e) => return err_value(format!("connect: {e}")),
+    };
+    let _ = stream.set_read_timeout(Some(Duration::from_secs(10)));
+    let _ = stream.set_write_timeout(Some(Duration::from_secs(10)));
+    if let Err(e) = stream.write_all(req.as_bytes()) {
+        return err_value(format!("write: {e}"));
+    }
+    if !body_bytes.is_empty() {
+        if let Err(e) = stream.write_all(body_bytes) {
+            return err_value(format!("write body: {e}"));
+        }
+    }
+    let mut buf = String::new();
+    if let Err(e) = stream.read_to_string(&mut buf) {
+        return err_value(format!("read: {e}"));
+    }
+    // Split headers from body.
+    let body_text = match buf.split_once("\r\n\r\n") {
+        Some((_head, b)) => b.to_string(),
+        None => buf,
+    };
+    Value::Variant { name: "Ok".into(), args: vec![Value::Str(body_text)] }
+}
+
+struct ParsedUrl { host: String, port: u16, path: String }
+
+fn parse_http_url(url: &str) -> Result<ParsedUrl, String> {
+    let rest = url.strip_prefix("http://").ok_or_else(|| "must start with http://".to_string())?;
+    let (host_port, path) = match rest.find('/') {
+        Some(i) => (&rest[..i], &rest[i..]),
+        None => (rest, "/"),
+    };
+    let (host, port) = match host_port.rsplit_once(':') {
+        Some((h, p)) => (h.to_string(), p.parse::<u16>().map_err(|e| format!("port: {e}"))?),
+        None => (host_port.to_string(), 80),
+    };
+    Ok(ParsedUrl { host, port, path: path.to_string() })
+}
+
+fn err_value(msg: String) -> Value {
+    Value::Variant { name: "Err".into(), args: vec![Value::Str(msg)] }
 }
 
 fn expect_str(v: Option<&Value>) -> Result<&str, String> {

--- a/crates/lex-runtime/tests/bytes_and_net.rs
+++ b/crates/lex-runtime/tests/bytes_and_net.rs
@@ -1,0 +1,163 @@
+//! std.bytes (pure) + std.net.get/post (effectful).
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::collections::BTreeSet;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::thread;
+
+fn run(src: &str, func: &str, args: Vec<Value>, policy: Policy) -> Value {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors: {errs:#?}");
+    }
+    let bc = compile_program(&stages);
+    let handler = DefaultHandler::new(policy);
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(func, args).expect("vm")
+}
+
+fn allow(effects: &[&str]) -> Policy {
+    let mut p = Policy::pure();
+    p.allow_effects = effects.iter().map(|s| s.to_string()).collect::<BTreeSet<_>>();
+    p
+}
+
+// -- bytes --------------------------------------------------------------
+
+#[test]
+fn bytes_len_works() {
+    let src = r#"
+import "std.bytes" as bytes
+fn n(b :: Bytes) -> Int { bytes.len(b) }
+"#;
+    assert_eq!(run(src, "n", vec![Value::Bytes(b"hello".to_vec())], Policy::pure()), Value::Int(5));
+    assert_eq!(run(src, "n", vec![Value::Bytes(vec![])], Policy::pure()), Value::Int(0));
+}
+
+#[test]
+fn bytes_eq_compares_content() {
+    let src = r#"
+import "std.bytes" as bytes
+fn same(a :: Bytes, b :: Bytes) -> Bool { bytes.eq(a, b) }
+"#;
+    assert_eq!(run(src, "same", vec![
+        Value::Bytes(b"abc".to_vec()), Value::Bytes(b"abc".to_vec())
+    ], Policy::pure()), Value::Bool(true));
+    assert_eq!(run(src, "same", vec![
+        Value::Bytes(b"abc".to_vec()), Value::Bytes(b"abd".to_vec())
+    ], Policy::pure()), Value::Bool(false));
+}
+
+#[test]
+fn bytes_round_trip_through_str() {
+    let src = r#"
+import "std.bytes" as bytes
+fn round_trip(s :: Str) -> Result[Str, Str] {
+  bytes.to_str(bytes.from_str(s))
+}
+"#;
+    let r = run(src, "round_trip", vec![Value::Str("hello, lex".into())], Policy::pure());
+    assert_eq!(r, Value::Variant {
+        name: "Ok".into(),
+        args: vec![Value::Str("hello, lex".into())],
+    });
+}
+
+#[test]
+fn bytes_to_str_returns_err_on_invalid_utf8() {
+    let src = r#"
+import "std.bytes" as bytes
+fn decode(b :: Bytes) -> Result[Str, Str] { bytes.to_str(b) }
+"#;
+    let r = run(src, "decode", vec![Value::Bytes(vec![0xff, 0xfe, 0xfd])], Policy::pure());
+    let v = match r { Value::Variant { name, args } => (name, args), other => panic!("{other:?}") };
+    assert_eq!(v.0, "Err");
+}
+
+#[test]
+fn bytes_slice_works() {
+    let src = r#"
+import "std.bytes" as bytes
+fn middle(b :: Bytes, lo :: Int, hi :: Int) -> Bytes { bytes.slice(b, lo, hi) }
+"#;
+    let r = run(src, "middle", vec![
+        Value::Bytes(b"helloworld".to_vec()),
+        Value::Int(2),
+        Value::Int(7),
+    ], Policy::pure());
+    assert_eq!(r, Value::Bytes(b"llowo".to_vec()));
+}
+
+// -- net.get -----------------------------------------------------------
+
+/// Spawn a tiny HTTP server that responds with a fixed body to one
+/// request, then shuts down. Returns its port.
+fn spawn_one_shot_server(body: &'static str) -> (u16, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    let handle = thread::spawn(move || {
+        if let Ok((mut s, _)) = listener.accept() {
+            let mut buf = [0u8; 1024];
+            let _ = s.read(&mut buf);
+            let resp = format!(
+                "HTTP/1.0 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(), body,
+            );
+            let _ = s.write_all(resp.as_bytes());
+        }
+    });
+    (port, handle)
+}
+
+#[test]
+fn net_get_returns_response_body() {
+    let (port, handle) = spawn_one_shot_server("hello from server");
+    let url = format!("http://127.0.0.1:{port}/");
+    let src = r#"
+import "std.net" as net
+fn fetch(u :: Str) -> [net] Result[Str, Str] { net.get(u) }
+"#;
+    let r = run(src, "fetch", vec![Value::Str(url)], allow(&["net"]));
+    let _ = handle.join();
+    let (name, args) = match r {
+        Value::Variant { name, args } => (name, args),
+        other => panic!("expected Variant, got {other:?}"),
+    };
+    assert_eq!(name, "Ok");
+    let body = match &args[0] { Value::Str(s) => s.clone(), _ => panic!() };
+    assert!(body.contains("hello from server"), "body: {body}");
+}
+
+#[test]
+fn net_get_blocked_without_policy() {
+    // The policy walk rejects programs with [net] when net isn't allowed.
+    let src = r#"
+import "std.net" as net
+fn fetch(u :: Str) -> [net] Result[Str, Str] { net.get(u) }
+"#;
+    let prog = parse_source(src).unwrap();
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("typecheck: {errs:#?}");
+    }
+    let bc = compile_program(&stages);
+    let policy = Policy::pure();
+    let violations = lex_runtime::check_program(&bc, &policy).expect_err("must reject net");
+    assert!(violations.iter().any(|v| v.effect.as_deref() == Some("net")));
+}
+
+#[test]
+fn net_get_returns_err_for_bad_url() {
+    let src = r#"
+import "std.net" as net
+fn fetch(u :: Str) -> [net] Result[Str, Str] { net.get(u) }
+"#;
+    let r = run(src, "fetch", vec![Value::Str("not-a-url".into())], allow(&["net"]));
+    let (name, _) = match r { Value::Variant { name, args } => (name, args), other => panic!("{other:?}") };
+    assert_eq!(name, "Err");
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -116,6 +116,45 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
             ));
             Some(Ty::Record(fields))
         }
+        "bytes" => {
+            let mut fields = IndexMap::new();
+            fields.insert("len".into(), Ty::function(
+                vec![Ty::bytes()], EffectSet::empty(), Ty::int(),
+            ));
+            fields.insert("is_empty".into(), Ty::function(
+                vec![Ty::bytes()], EffectSet::empty(), Ty::bool(),
+            ));
+            fields.insert("eq".into(), Ty::function(
+                vec![Ty::bytes(), Ty::bytes()], EffectSet::empty(), Ty::bool(),
+            ));
+            fields.insert("from_str".into(), Ty::function(
+                vec![Ty::str()], EffectSet::empty(), Ty::bytes(),
+            ));
+            fields.insert("to_str".into(), Ty::function(
+                vec![Ty::bytes()], EffectSet::empty(),
+                Ty::Con("Result".into(), vec![Ty::str(), Ty::str()]),
+            ));
+            fields.insert("slice".into(), Ty::function(
+                vec![Ty::bytes(), Ty::int(), Ty::int()],
+                EffectSet::empty(), Ty::bytes(),
+            ));
+            Some(Ty::Record(fields))
+        }
+        "net" => {
+            let mut fields = IndexMap::new();
+            // get :: Str -> [net] Result[Str, Str]
+            fields.insert("get".into(), Ty::function(
+                vec![Ty::str()],
+                EffectSet::singleton("net"),
+                Ty::Con("Result".into(), vec![Ty::str(), Ty::str()]),
+            ));
+            fields.insert("post".into(), Ty::function(
+                vec![Ty::str(), Ty::str()],
+                EffectSet::singleton("net"),
+                Ty::Con("Result".into(), vec![Ty::str(), Ty::str()]),
+            ));
+            Some(Ty::Record(fields))
+        }
         "json" => {
             let mut fields = IndexMap::new();
             // stringify :: T -> Str  (polymorphic on input)
@@ -228,6 +267,8 @@ pub fn module_for_import(reference: &str) -> Option<&'static str> {
         "option" => "option",
         "json" => "json",
         "flow" => "flow",
+        "bytes" => "bytes",
+        "net" => "net",
         _ => return None,
     })
 }


### PR DESCRIPTION
## Summary

Stdlib breadth: `std.bytes` (pure) and `std.net.get`/`post` (effectful), both spec'd in §11.1 and previously stubbed.

## What landed

**`std.bytes` — pure, no policy gate**
- `bytes.len`, `bytes.is_empty`, `bytes.eq`
- `bytes.from_str` (UTF-8 encode), `bytes.to_str` (UTF-8 decode → `Result[Str, Str]`)
- `bytes.slice(b, lo, hi)`

**`std.net.get` / `std.net.post` — effectful**
- `net.get  :: (Str) -> [net] Result[Str, Str]`
- `net.post :: (Str, Str) -> [net] Result[Str, Str]`
- Requires `[net]` in the fn signature and `--allow-effects net` at runtime.
- Implementation: minimal hand-rolled HTTP/1.0 over `TcpStream` with 10s timeouts. HTTP only (no TLS), no redirects, single-shot connection.

This is intentionally a small, dep-free implementation suitable for the stdlib MVP. Production HTTPS / streaming / connection pooling belongs in a follow-up that picks an HTTP client crate (ureq, hyper, ...) under a feature flag.

## Test plan

- [x] `cargo test --workspace` — **145 passing** (137 prior + 8 new), 0 failing
- [x] `bytes.len` on `hello` and on empty
- [x] `bytes.eq` on equal vs differing inputs
- [x] `bytes.from_str` → `bytes.to_str` round-trip preserves a UTF-8 string
- [x] `bytes.to_str` on invalid UTF-8 returns `Err`
- [x] `bytes.slice` extracts the middle of `"helloworld"`
- [x] `net.get` against a one-shot local `TcpListener` returns `Ok(body)`
- [x] `net.get` without `--allow-effects net` rejected at policy time
- [x] `net.get` on a malformed URL returns `Err`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh

---
_Generated by [Claude Code](https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh)_