### PR TITLE
Add net.serve effect + weather-app REST API example

### DIFF
--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -140,7 +140,8 @@ fn cmd_run(args: &[String]) -> Result<()> {
         std::process::exit(3);
     }
 
-    let handler = DefaultHandler::new(policy);
+    let bc = std::sync::Arc::new(bc);
+    let handler = DefaultHandler::new(policy).with_program(std::sync::Arc::clone(&bc));
     let mut vm = Vm::with_handler(&bc, Box::new(handler));
     let recorder = lex_trace::Recorder::new();
     let trace_handle = recorder.handle();
@@ -457,7 +458,8 @@ fn cmd_replay(args: &[String]) -> Result<()> {
 
     let recorder = lex_trace::Recorder::new().with_overrides(overrides);
     let handle = recorder.handle();
-    let handler = DefaultHandler::new(policy);
+    let bc = std::sync::Arc::new(bc);
+    let handler = DefaultHandler::new(policy).with_program(std::sync::Arc::clone(&bc));
     let mut vm = Vm::with_handler(&bc, Box::new(handler));
     vm.set_tracer(Box::new(recorder));
 

--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -9,6 +9,7 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
+tiny_http = "0.12"
 lex-bytecode = { path = "../lex-bytecode" }
 
 [dev-dependencies]

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -4,10 +4,11 @@
 //! declared `[fs_read("/data")]` that's allowed at startup still has to
 //! pass the path check at the point of dispatch).
 
-use lex_bytecode::vm::EffectHandler;
-use lex_bytecode::Value;
+use lex_bytecode::vm::{EffectHandler, Vm};
+use lex_bytecode::{Program, Value};
 use std::cell::RefCell;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::builtins::try_pure_builtin;
@@ -40,6 +41,10 @@ pub struct DefaultHandler {
     pub read_root: Option<PathBuf>,
     /// Captured budget consumption (post-static-check, observability only).
     pub budget_used: RefCell<u64>,
+    /// Shared reference to the program, needed by `net.serve` so the
+    /// handler can spin up fresh VMs to dispatch incoming requests.
+    /// `None` if the handler was constructed without a program.
+    pub program: Option<Arc<Program>>,
 }
 
 impl DefaultHandler {
@@ -49,7 +54,12 @@ impl DefaultHandler {
             sink: Box::new(StdoutSink),
             read_root: None,
             budget_used: RefCell::new(0),
+            program: None,
         }
+    }
+
+    pub fn with_program(mut self, program: Arc<Program>) -> Self {
+        self.program = Some(program); self
     }
 
     pub fn with_sink(mut self, sink: Box<dyn IoSink>) -> Self {
@@ -139,9 +149,85 @@ impl EffectHandler for DefaultHandler {
                 let body = expect_str(args.get(1))?.to_string();
                 Ok(http_request("POST", &url, Some(&body)))
             }
+            ("net", "serve") => {
+                let port = match args.first() {
+                    Some(Value::Int(n)) if (0..=65535).contains(n) => *n as u16,
+                    _ => return Err("net.serve(port, handler): port must be Int 0..=65535".into()),
+                };
+                let handler_name = expect_str(args.get(1))?.to_string();
+                let program = self.program.clone()
+                    .ok_or_else(|| "net.serve requires a Program reference; use DefaultHandler::with_program".to_string())?;
+                let policy = self.policy.clone();
+                serve_http(port, handler_name, program, policy)
+            }
             other => Err(format!("unsupported effect {}.{}", other.0, other.1)),
         }
     }
+}
+
+/// Blocks the calling thread, accepts incoming HTTP requests on
+/// `127.0.0.1:port`, and dispatches each through the named Lex
+/// stage. Each request gets a fresh `Vm`; the program and policy
+/// are shared.
+///
+/// Handler signature in Lex (by convention):
+///   fn <name>(req :: Record { method :: Str, path :: Str, body :: Str })
+///        -> Record { status :: Int, body :: Str }
+fn serve_http(port: u16, handler_name: String, program: Arc<Program>, policy: Policy) -> Result<Value, String> {
+    let server = tiny_http::Server::http(("127.0.0.1", port))
+        .map_err(|e| format!("net.serve bind {port}: {e}"))?;
+    eprintln!("net.serve: listening on http://127.0.0.1:{port}");
+    for mut req in server.incoming_requests() {
+        let lex_req = build_request_value(&mut req);
+        let handler = DefaultHandler::new(policy.clone()).with_program(Arc::clone(&program));
+        let mut vm = Vm::with_handler(&program, Box::new(handler));
+        match vm.call(&handler_name, vec![lex_req]) {
+            Ok(resp) => {
+                let (status, body) = unpack_response(&resp);
+                let response = tiny_http::Response::from_string(body)
+                    .with_status_code(status);
+                let _ = req.respond(response);
+            }
+            Err(e) => {
+                let response = tiny_http::Response::from_string(format!("internal error: {e}"))
+                    .with_status_code(500);
+                let _ = req.respond(response);
+            }
+        }
+    }
+    Ok(Value::Unit)
+}
+
+fn build_request_value(req: &mut tiny_http::Request) -> Value {
+    let method = format!("{:?}", req.method()).to_uppercase();
+    let url = req.url().to_string();
+    let (path, query) = match url.split_once('?') {
+        Some((p, q)) => (p.to_string(), q.to_string()),
+        None => (url, String::new()),
+    };
+    let mut body = String::new();
+    let _ = req.as_reader().read_to_string(&mut body);
+    let mut rec = indexmap::IndexMap::new();
+    rec.insert("method".into(), Value::Str(method));
+    rec.insert("path".into(), Value::Str(path));
+    rec.insert("query".into(), Value::Str(query));
+    rec.insert("body".into(), Value::Str(body));
+    Value::Record(rec)
+}
+
+fn unpack_response(v: &Value) -> (u16, String) {
+    if let Value::Record(rec) = v {
+        let status = rec.get("status").and_then(|s| match s {
+            Value::Int(n) => Some(*n as u16),
+            _ => None,
+        }).unwrap_or(200);
+        let body = rec.get("body").and_then(|b| match b {
+            Value::Str(s) => Some(s.clone()),
+            _ => None,
+        }).unwrap_or_default();
+        return (status, body);
+    }
+    (500, format!("handler returned non-record: {v:?}"))
 }
 
 /// Minimal hand-rolled HTTP/1.0 client. Supports `http://host:port/path`

--- a/crates/lex-runtime/tests/net_serve.rs
+++ b/crates/lex-runtime/tests/net_serve.rs
@@ -1,0 +1,122 @@
+//! Integration tests for `net.serve`: spawn a Lex VM running an HTTP
+//! handler in a background thread, then drive it with raw HTTP
+//! requests over a TcpStream. The server thread is detached and
+//! killed when the test process exits.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::collections::BTreeSet;
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+/// Spawn the Lex source's `entry` function on a background thread.
+/// Returns the bound port (0 means "let OS choose"; we use a fixed
+/// port chosen by the test).
+fn spawn_lex_server(src: &str, entry: &str) {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors: {errs:#?}");
+    }
+    let bc = Arc::new(compile_program(&stages));
+    let mut policy = Policy::pure();
+    policy.allow_effects = ["net".to_string()].into_iter().collect::<BTreeSet<_>>();
+    let entry = entry.to_string();
+    thread::spawn(move || {
+        let handler = DefaultHandler::new(policy.clone()).with_program(Arc::clone(&bc));
+        let mut vm = Vm::with_handler(&bc, Box::new(handler));
+        let _ = vm.call(&entry, vec![]);
+    });
+    // Give the server a moment to bind.
+    thread::sleep(Duration::from_millis(150));
+}
+
+fn http(port: u16, method: &str, path: &str, body: &str) -> (u16, String) {
+    let mut s = TcpStream::connect(("127.0.0.1", port)).expect("connect");
+    s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    let req = format!(
+        "{method} {path} HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(), body,
+    );
+    s.write_all(req.as_bytes()).unwrap();
+    let mut buf = String::new();
+    s.read_to_string(&mut buf).unwrap();
+    let (head, body) = buf.split_once("\r\n\r\n").unwrap_or((&buf, ""));
+    let status = head.split_whitespace().nth(1).unwrap_or("0").parse().unwrap_or(0);
+    (status, body.to_string())
+}
+
+/// Tiny echo handler — repeats the request method and path in the
+/// response body. Useful for verifying the request marshaling layer.
+const ECHO_SRC: &str = r#"
+import "std.net" as net
+import "std.str" as str
+
+fn handle(req :: { body :: Str, method :: Str, path :: Str, query :: Str }) -> { body :: Str, status :: Int } {
+  let line := str.concat(req.method, " ")
+  let line2 := str.concat(line, req.path)
+  { status: 200, body: line2 }
+}
+
+fn main() -> [net] Nil { net.serve(18091, "handle") }
+"#;
+
+#[test]
+fn net_serve_dispatches_request_and_returns_response() {
+    spawn_lex_server(ECHO_SRC, "main");
+    let (status, body) = http(18091, "GET", "/hello", "");
+    assert_eq!(status, 200);
+    assert_eq!(body, "GET /hello");
+}
+
+#[test]
+fn net_serve_handles_post_with_body() {
+    // Reuse the same port → start a server on a different one.
+    let src = r#"
+import "std.net" as net
+import "std.str" as str
+fn handle(req :: { body :: Str, method :: Str, path :: Str, query :: Str }) -> { body :: Str, status :: Int } {
+  { status: 201, body: str.concat("got: ", req.body) }
+}
+fn main() -> [net] Nil { net.serve(18092, "handle") }
+"#;
+    spawn_lex_server(src, "main");
+    let (status, body) = http(18092, "POST", "/widgets", "hello-payload");
+    assert_eq!(status, 201);
+    assert_eq!(body, "got: hello-payload");
+}
+
+#[test]
+fn weather_app_responds_to_routes() {
+    let src = include_str!("../../../examples/weather_app.lex");
+    // Patch the example's port so the test owns its own.
+    let src = src.replace("net.serve(8080,", "net.serve(18093,");
+    spawn_lex_server(&src, "main");
+
+    let (status, body) = http(18093, "GET", "/weather/SF", "");
+    assert_eq!(status, 200);
+    assert!(body.contains("\"city\":\"SF\""), "body: {body}");
+    assert!(body.contains("\"temp_c\":18"));
+
+    let (status, body) = http(18093, "GET", "/forecast/Paris", "");
+    assert_eq!(status, 200);
+    assert!(body.contains("\"city\":\"Paris\""));
+    assert!(body.contains("day1"));
+
+    let (status, body) = http(18093, "GET", "/health", "");
+    assert_eq!(status, 200);
+    assert!(body.contains("\"ok\":true"));
+
+    let (status, body) = http(18093, "GET", "/missing", "");
+    assert_eq!(status, 404);
+    assert!(body.contains("not found"));
+
+    let (status, body) = http(18093, "POST", "/weather/SF", "");
+    assert_eq!(status, 405);
+    assert!(body.contains("method not allowed"));
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -40,6 +40,16 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 Ty::Con("Option".into(), vec![Ty::int()])));
             fields.insert("concat".into(), Ty::function(vec![Ty::str(), Ty::str()], EffectSet::empty(), Ty::str()));
             fields.insert("len".into(), Ty::function(vec![Ty::str()], EffectSet::empty(), Ty::int()));
+            fields.insert("split".into(), Ty::function(
+                vec![Ty::str(), Ty::str()],
+                EffectSet::empty(),
+                Ty::List(Box::new(Ty::str())),
+            ));
+            fields.insert("join".into(), Ty::function(
+                vec![Ty::List(Box::new(Ty::str())), Ty::str()],
+                EffectSet::empty(),
+                Ty::str(),
+            ));
             Some(Ty::Record(fields))
         }
         "int" => {
@@ -152,6 +162,14 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 vec![Ty::str(), Ty::str()],
                 EffectSet::singleton("net"),
                 Ty::Con("Result".into(), vec![Ty::str(), Ty::str()]),
+            ));
+            // serve :: (Int, Str) -> [net] Unit  (blocks; never returns
+            // under normal use). Handler's signature isn't carried in
+            // the type system here — looked up by name at runtime.
+            fields.insert("serve".into(), Ty::function(
+                vec![Ty::int(), Ty::str()],
+                EffectSet::singleton("net"),
+                Ty::Unit,
             ));
             Some(Ty::Record(fields))
         }

--- a/crates/lex-types/src/checker.rs
+++ b/crates/lex-types/src/checker.rs
@@ -121,6 +121,20 @@ impl Checker {
         }
     }
 
+    /// If `ty` is a `Ty::Con(name, _)` whose definition is a record
+    /// alias (`type Foo = { ... }`), return the inner record type.
+    /// Otherwise return `ty` unchanged.
+    fn unfold_record_alias(&self, ty: Ty) -> Ty {
+        if let Ty::Con(ref n, _) = ty {
+            if let Some(td) = self.type_env.types.get(n) {
+                if let TypeDefKind::Alias(inner @ Ty::Record(_)) = &td.kind {
+                    return inner.clone();
+                }
+            }
+        }
+        ty
+    }
+
     fn check_fn(&mut self, fd: &a::FnDecl) -> Result<Scheme, Vec<TypeError>> {
         // Instantiate fn's signature with fresh vars for its type params.
         let scheme = function_scheme(fd);
@@ -138,7 +152,11 @@ impl Checker {
         let body_ty = self.check_expr(&fd.body, "n_0", &mut locals, &mut inferred_effects)
             .map_err(|e| vec![e])?;
 
-        if let Err(e) = self.u.unify(&body_ty, &ret_ty) {
+        // Unfold record-aliased return types so users can declare
+        //   `type Response = { ... }`
+        // and return a record literal directly.
+        let ret_ty_unfolded = self.unfold_record_alias(ret_ty.clone());
+        if let Err(e) = self.u.unify(&body_ty, &ret_ty_unfolded) {
             return Err(vec![mismatch_err("n_0", e, &self.u, vec![format!("in function `{}`", fd.name)])]);
         }
 
@@ -248,6 +266,17 @@ impl Checker {
             a::CExpr::FieldAccess { value, field } => {
                 let vt = self.check_expr(value, node_id, locals, effs)?;
                 let resolved = self.u.resolve(&vt);
+                // Unfold a Record-aliased Con (e.g. `type Request = { ... }`).
+                let resolved = match resolved {
+                    Ty::Con(ref n, _) => match self.type_env.types.get(n) {
+                        Some(td) => match &td.kind {
+                            TypeDefKind::Alias(inner @ Ty::Record(_)) => inner.clone(),
+                            _ => resolved,
+                        },
+                        None => resolved,
+                    },
+                    other => other,
+                };
                 match resolved {
                     Ty::Record(fields) => fields.get(field).cloned()
                         .ok_or_else(|| TypeError::UnknownField {

--- a/examples/weather_app.lex
+++ b/examples/weather_app.lex
@@ -1,0 +1,85 @@
+# A REST API written in Lex.
+#
+# Run:
+#   lex run --allow-effects net examples/weather_app.lex main
+# Then in another terminal:
+#   curl http://127.0.0.1:8080/weather/SF
+#   curl http://127.0.0.1:8080/forecast/Paris
+#   curl -XPOST http://127.0.0.1:8080/weather/Berlin   # 405
+#
+# Handler logic is one typed Lex function; routing is `match` on
+# req.path and req.method. Weather data is mocked to keep the example
+# dependency-free.
+
+import "std.net" as net
+import "std.str" as str
+import "std.int" as int
+import "std.list" as list
+import "std.option" as option
+
+type Request  = { body :: Str, method :: Str, path :: Str, query :: Str }
+type Response = { body :: Str, status :: Int }
+
+fn current_weather(city :: Str) -> Str {
+  let temp_c := match city {
+    "SF"     => 18,
+    "Paris"  => 14,
+    "Berlin" => 12,
+    "Tokyo"  => 22,
+    _        => 20,
+  }
+  let conditions := match city {
+    "SF"     => "foggy",
+    "Paris"  => "cloudy",
+    "Berlin" => "rainy",
+    "Tokyo"  => "clear",
+    _        => "unknown",
+  }
+  let head := str.concat("{\"city\":\"", city)
+  let head2 := str.concat(head, "\",\"temp_c\":")
+  let head3 := str.concat(head2, int.to_str(temp_c))
+  let head4 := str.concat(head3, ",\"conditions\":\"")
+  let head5 := str.concat(head4, conditions)
+  str.concat(head5, "\"}")
+}
+
+fn forecast(city :: Str) -> Str {
+  let head := str.concat("{\"city\":\"", city)
+  str.concat(head, "\",\"days\":[\"day1\",\"day2\",\"day3\"]}")
+}
+
+# Returns Some(rest) iff `path` starts with `prefix`. Lex stdlib doesn't
+# ship str.starts_with yet, so we use str.split + a pair of list ops.
+fn strip_prefix(path :: Str, prefix :: Str) -> Option[Str] {
+  let parts := str.split(path, prefix)
+  match list.head(parts) {
+    Some(first) => match str.is_empty(first) {
+      true  => match list.head(list.tail(parts)) {
+        Some(rest) => Some(rest),
+        None       => None,
+      },
+      false => None,
+    },
+    None => None,
+  }
+}
+
+fn handle(req :: Request) -> Response {
+  match req.method {
+    "GET" => match strip_prefix(req.path, "/weather/") {
+      Some(city) => { status: 200, body: current_weather(city) },
+      None       => match strip_prefix(req.path, "/forecast/") {
+        Some(city) => { status: 200, body: forecast(city) },
+        None       => match req.path {
+          "/health" => { status: 200, body: "{\"ok\":true}" },
+          _         => { status: 404, body: "{\"error\":\"not found\"}" },
+        },
+      },
+    },
+    _ => { status: 405, body: "{\"error\":\"method not allowed\"}" },
+  }
+}
+
+fn main() -> [net] Nil {
+  net.serve(8080, "handle")
+}


### PR DESCRIPTION
## Summary

A REST API can now be written in Lex source. The handler is **one typed Lex function**; routing is `match` on `req.path` and `req.method`; the policy gate enforces the `[net]` grant.

## Demo

```bash
$ lex run --allow-effects net examples/weather_app.lex main
net.serve: listening on http://127.0.0.1:8080

$ curl http://127.0.0.1:8080/weather/SF
{"city":"SF","temp_c":18,"conditions":"foggy"}

$ curl http://127.0.0.1:8080/forecast/Tokyo
{"city":"Tokyo","days":["day1","day2","day3"]}

$ curl -XPOST http://127.0.0.1:8080/weather/Berlin
{"error":"method not allowed"}        # status 405
```

## What landed

**`net.serve` effect (`lex-runtime`)**
- `DefaultHandler` grows an optional `Arc<Program>` via `with_program()` so the handler can spin up fresh VMs for incoming requests.
- New dispatch: `net.serve(port :: Int, handler_name :: Str) -> [net] Unit`
  - binds `tiny_http` on `127.0.0.1:port`, blocks accepting requests
  - for each request builds a Lex `Record { method, path, query, body }`
  - spawns a fresh `Vm` with the same Program + policy, calls the named handler, unpacks `Record { status, body }` and writes it back
  - 500 on errors

**Type system**
- `net.serve` signature added.
- `str.split` / `str.join` now have full signatures (split was already in the runtime).
- **Field access through a record-aliased `type T = { ... }` works** in both directions: the checker unfolds the alias when reading `req.field` and when matching a record literal against a record-aliased declared return type.

**Example (`examples/weather_app.lex`)**
- Complete REST service: `GET /weather/<city>`, `GET /forecast/<city>`, `GET /health`, structured 404 and 405. ~75 lines of Lex source.

**CLI**
- `lex run` and `lex replay` wrap the compiled `Program` in an `Arc` and pass it to `DefaultHandler::with_program` so `net.serve` can re-enter cleanly.

## Test plan

- [x] `cargo test --workspace` — **148 passing** (145 prior + 3 net.serve), 0 failing
- [x] `net_serve_dispatches_request_and_returns_response` — tiny echo handler returns `"GET /hello"`
- [x] `net_serve_handles_post_with_body` — 201 + echoed payload
- [x] `weather_app_responds_to_routes` — drives the example through all 5 routes (200 SF, 200 forecast, 200 health, 404, 405)
- [x] CLI smoke: `curl http://127.0.0.1:8080/weather/SF` returns the expected JSON
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

## Deferred

- HTTPS / TLS — the kernel is HTTP/1.0 plaintext.
- Concurrency — requests are processed sequentially. A thread-pool or async variant is the natural next step.
- Routing helpers / middleware as stdlib stages.
- `str.starts_with` / `str.ends_with` as proper stdlib ops (the example simulates with `str.split` + `list.head`).

## Answer to "how hard is a REST API in Lex?"

Now: **about as hard as writing the handler logic itself**. ~75 lines of Lex for a 5-route service with type-checked request/response, structured errors, and capability-gated network. Adding more routes is `match` arms.

https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh

---
_Generated by [Claude Code](https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh)_