### PR TITLE
Add WebSocket multi-user chat (net.serve_ws + std.chat)

### DIFF
--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -10,6 +10,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
 tiny_http = { version = "0.12", features = ["ssl-rustls"] }
+tungstenite = "0.21"
 lex-bytecode = { path = "../lex-bytecode" }
 
 [dev-dependencies]

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -45,6 +45,10 @@ pub struct DefaultHandler {
     /// handler can spin up fresh VMs to dispatch incoming requests.
     /// `None` if the handler was constructed without a program.
     pub program: Option<Arc<Program>>,
+    /// Chat registry; populated by `net.serve_ws`'s per-message
+    /// dispatch so `chat.broadcast` / `chat.send` work from inside
+    /// a handler invocation.
+    pub chat_registry: Option<Arc<crate::ws::ChatRegistry>>,
 }
 
 impl DefaultHandler {
@@ -55,11 +59,16 @@ impl DefaultHandler {
             read_root: None,
             budget_used: RefCell::new(0),
             program: None,
+            chat_registry: None,
         }
     }
 
     pub fn with_program(mut self, program: Arc<Program>) -> Self {
         self.program = Some(program); self
+    }
+
+    pub fn with_chat_registry(mut self, registry: Arc<crate::ws::ChatRegistry>) -> Self {
+        self.chat_registry = Some(registry); self
     }
 
     pub fn with_sink(mut self, sink: Box<dyn IoSink>) -> Self {
@@ -176,6 +185,36 @@ impl EffectHandler for DefaultHandler {
                 let key = std::fs::read(&key_path)
                     .map_err(|e| format!("net.serve_tls: read key {key_path}: {e}"))?;
                 serve_http(port, handler_name, program, policy, Some(TlsConfig { cert, key }))
+            }
+            ("net", "serve_ws") => {
+                let port = match args.first() {
+                    Some(Value::Int(n)) if (0..=65535).contains(n) => *n as u16,
+                    _ => return Err("net.serve_ws(port, on_message): port must be Int 0..=65535".into()),
+                };
+                let handler_name = expect_str(args.get(1))?.to_string();
+                let program = self.program.clone()
+                    .ok_or_else(|| "net.serve_ws requires a Program reference".to_string())?;
+                let policy = self.policy.clone();
+                let registry = Arc::new(crate::ws::ChatRegistry::default());
+                crate::ws::serve_ws(port, handler_name, program, policy, registry)
+            }
+            ("chat", "broadcast") => {
+                let registry = self.chat_registry.as_ref()
+                    .ok_or_else(|| "chat.broadcast called outside a net.serve_ws handler".to_string())?;
+                let room = expect_str(args.first())?;
+                let body = expect_str(args.get(1))?;
+                crate::ws::chat_broadcast(registry, room, body);
+                Ok(Value::Unit)
+            }
+            ("chat", "send") => {
+                let registry = self.chat_registry.as_ref()
+                    .ok_or_else(|| "chat.send called outside a net.serve_ws handler".to_string())?;
+                let conn_id = match args.first() {
+                    Some(Value::Int(n)) if *n >= 0 => *n as u64,
+                    _ => return Err("chat.send: conn_id must be non-negative Int".into()),
+                };
+                let body = expect_str(args.get(1))?;
+                Ok(Value::Bool(crate::ws::chat_send(registry, conn_id, body)))
             }
             other => Err(format!("unsupported effect {}.{}", other.0, other.1)),
         }

--- a/crates/lex-runtime/src/lib.rs
+++ b/crates/lex-runtime/src/lib.rs
@@ -16,6 +16,7 @@
 pub mod builtins;
 pub mod policy;
 pub mod handler;
+pub mod ws;
 
 pub use builtins::{is_pure_module, try_pure_builtin};
 pub use handler::{CapturedSink, DefaultHandler, IoSink, StdoutSink};

--- a/crates/lex-runtime/src/ws.rs
+++ b/crates/lex-runtime/src/ws.rs
@@ -1,0 +1,206 @@
+//! WebSocket server + chat-broadcast registry.
+//!
+//! `net.serve_ws(port, on_message)` blocks on a TCP listener, upgrades
+//! each incoming connection to WebSocket, and runs a per-connection
+//! worker thread that polls both inbound (calls Lex's `on_message`)
+//! and outbound (drains broadcasts from a channel into the socket).
+//!
+//! `chat.broadcast(room, body)` looks up every connection in `room`
+//! and pushes `body` onto its outbound channel. `chat.send(conn_id,
+//! body)` is the same but to a single connection.
+//!
+//! The registry is an `Arc<Mutex<…>>` because Lex's immutability means
+//! shared mutable state has to live in the host runtime. Lex code
+//! stays pure: it receives an event, returns Nil, and any side
+//! effects go through `chat.*` which is gated by the policy.
+
+// tungstenite's `accept_hdr` callback takes/returns a tungstenite
+// `ErrorResponse` which is large; we only ever return Ok so the
+// large-Err warning is noise.
+#![allow(clippy::result_large_err)]
+
+use crate::policy::Policy;
+use indexmap::IndexMap;
+use lex_bytecode::vm::Vm;
+use lex_bytecode::{Program, Value};
+use std::net::TcpListener;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+/// Per-connection state held in the global registry.
+struct Conn {
+    room: String,
+    /// Channel writer end. The connection's worker thread reads from
+    /// the corresponding Receiver and writes each message to the
+    /// WebSocket. Broadcasts push here.
+    outbound: mpsc::Sender<String>,
+}
+
+/// Global chat registry. One per `net.serve_ws` invocation.
+#[derive(Default)]
+pub struct ChatRegistry {
+    conns: Mutex<IndexMap<u64, Conn>>,
+}
+
+impl ChatRegistry {
+    fn register(&self, room: String, outbound: mpsc::Sender<String>) -> u64 {
+        static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+        let id = NEXT_ID.fetch_add(1, Ordering::SeqCst);
+        self.conns.lock().unwrap().insert(id, Conn { room, outbound });
+        id
+    }
+    fn unregister(&self, id: u64) {
+        self.conns.lock().unwrap().shift_remove(&id);
+    }
+    fn broadcast(&self, room: &str, body: &str) {
+        let conns = self.conns.lock().unwrap();
+        for c in conns.values() {
+            if c.room == room {
+                let _ = c.outbound.send(body.to_string());
+            }
+        }
+    }
+    fn send_to(&self, id: u64, body: &str) -> bool {
+        if let Some(c) = self.conns.lock().unwrap().get(&id) {
+            let _ = c.outbound.send(body.to_string());
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// `chat.broadcast(room, body)` — looked up at runtime by the
+/// effect handler; called from inside the Lex VM.
+pub fn chat_broadcast(reg: &Arc<ChatRegistry>, room: &str, body: &str) {
+    reg.broadcast(room, body);
+}
+
+pub fn chat_send(reg: &Arc<ChatRegistry>, conn_id: u64, body: &str) -> bool {
+    reg.send_to(conn_id, body)
+}
+
+/// Bind a WebSocket server. Blocks; returns Unit on shutdown (the
+/// process is normally killed before that).
+pub fn serve_ws(
+    port: u16,
+    handler_name: String,
+    program: Arc<Program>,
+    policy: Policy,
+    registry: Arc<ChatRegistry>,
+) -> Result<Value, String> {
+    let listener = TcpListener::bind(("127.0.0.1", port))
+        .map_err(|e| format!("net.serve_ws bind {port}: {e}"))?;
+    eprintln!("net.serve_ws: listening on ws://127.0.0.1:{port}");
+    for stream in listener.incoming() {
+        let stream = match stream {
+            Ok(s) => s,
+            Err(e) => { eprintln!("net.serve_ws accept: {e}"); continue; }
+        };
+        let program = Arc::clone(&program);
+        let policy = policy.clone();
+        let handler_name = handler_name.clone();
+        let registry = Arc::clone(&registry);
+        thread::spawn(move || {
+            if let Err(e) = handle_connection(stream, program, policy, handler_name, registry) {
+                eprintln!("net.serve_ws connection error: {e}");
+            }
+        });
+    }
+    Ok(Value::Unit)
+}
+
+fn handle_connection(
+    stream: std::net::TcpStream,
+    program: Arc<Program>,
+    policy: Policy,
+    handler_name: String,
+    registry: Arc<ChatRegistry>,
+) -> Result<(), String> {
+    use tungstenite::{accept_hdr, handshake::server::{Request, Response}};
+
+    // Capture the request path during the handshake — used as the room name.
+    let mut path = String::new();
+    let path_ref = &mut path;
+    let mut ws = accept_hdr(stream, |req: &Request, resp: Response| {
+        *path_ref = req.uri().path().to_string();
+        Ok(resp)
+    }).map_err(|e| format!("ws handshake: {e}"))?;
+
+    let room = path.trim_start_matches('/').to_string();
+
+    // Outbound channel: broadcast/send pushes here, this thread writes
+    // each message into the WebSocket.
+    let (tx, rx) = mpsc::channel::<String>();
+    let conn_id = registry.register(room.clone(), tx);
+
+    // Make WS reads non-blocking-ish so the same thread can also drain
+    // the outbound channel. tungstenite reads through the underlying
+    // TcpStream; setting a short read timeout lets us multiplex.
+    let _ = ws.get_mut().set_read_timeout(Some(Duration::from_millis(50)));
+
+    let result = run_loop(&mut ws, &rx, conn_id, &room, &program, &policy, &handler_name, &registry);
+    registry.unregister(conn_id);
+    let _ = ws.close(None);
+    result
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_loop(
+    ws: &mut tungstenite::WebSocket<std::net::TcpStream>,
+    rx: &mpsc::Receiver<String>,
+    conn_id: u64,
+    room: &str,
+    program: &Arc<Program>,
+    policy: &Policy,
+    handler_name: &str,
+    registry: &Arc<ChatRegistry>,
+) -> Result<(), String> {
+    use tungstenite::Message;
+    use std::io::ErrorKind;
+    loop {
+        // 1) Try to read one inbound message. WouldBlock = no data yet.
+        match ws.read() {
+            Ok(Message::Text(body)) => {
+                let ev = build_ws_event(conn_id, room, &body);
+                let handler = crate::handler::DefaultHandler::new(policy.clone())
+                    .with_program(Arc::clone(program))
+                    .with_chat_registry(Arc::clone(registry));
+                let mut vm = Vm::with_handler(program, Box::new(handler));
+                if let Err(e) = vm.call(handler_name, vec![ev]) {
+                    eprintln!("on_message {conn_id}: {e}");
+                }
+            }
+            Ok(Message::Binary(_)) => { /* binary frames ignored in v1 */ }
+            Ok(Message::Close(_)) | Err(tungstenite::Error::ConnectionClosed) => break,
+            Ok(_) => {} // ping/pong/frame
+            Err(tungstenite::Error::Io(ref e)) if e.kind() == ErrorKind::WouldBlock
+                || e.kind() == ErrorKind::TimedOut => {}
+            Err(e) => return Err(format!("ws read: {e}")),
+        }
+        // 2) Drain outbound channel. Doesn't block.
+        loop {
+            match rx.try_recv() {
+                Ok(msg) => {
+                    if let Err(e) = ws.send(Message::Text(msg)) {
+                        return Err(format!("ws send: {e}"));
+                    }
+                }
+                Err(mpsc::TryRecvError::Empty) => break,
+                Err(mpsc::TryRecvError::Disconnected) => return Ok(()),
+            }
+        }
+    }
+    Ok(())
+}
+
+fn build_ws_event(conn_id: u64, room: &str, body: &str) -> Value {
+    let mut rec = IndexMap::new();
+    rec.insert("body".into(), Value::Str(body.to_string()));
+    rec.insert("conn_id".into(), Value::Int(conn_id as i64));
+    rec.insert("room".into(), Value::Str(room.to_string()));
+    Value::Record(rec)
+}

--- a/crates/lex-runtime/tests/ws_chat.rs
+++ b/crates/lex-runtime/tests/ws_chat.rs
@@ -1,0 +1,155 @@
+//! Integration tests for WebSocket multi-user chat.
+//!
+//! Spawns the chat server in a background thread, connects N clients,
+//! has one send a message, asserts every other client in the same
+//! room receives it. Different rooms are isolated.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::collections::BTreeSet;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+use tungstenite::{connect, Message};
+
+fn spawn_chat_server(src: &str) {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors: {errs:#?}");
+    }
+    let bc = Arc::new(compile_program(&stages));
+    let mut policy = Policy::pure();
+    policy.allow_effects = ["net".to_string(), "chat".to_string()].into_iter().collect::<BTreeSet<_>>();
+    thread::spawn(move || {
+        let handler = DefaultHandler::new(policy.clone()).with_program(Arc::clone(&bc));
+        let mut vm = Vm::with_handler(&bc, Box::new(handler));
+        let _ = vm.call("main", vec![]);
+    });
+    thread::sleep(Duration::from_millis(200));
+}
+
+const CHAT_SRC_TEMPLATE: &str = r#"
+import "std.net" as net
+import "std.chat" as chat
+import "std.str" as str
+import "std.int" as int
+
+type Ev = { body :: Str, conn_id :: Int, room :: Str }
+
+fn on_message(ev :: Ev) -> [chat] Nil {
+  let prefix := str.concat("[", str.concat(int.to_str(ev.conn_id), "] "))
+  chat.broadcast(ev.room, str.concat(prefix, ev.body))
+}
+
+fn main() -> [chat, net] Nil { net.serve_ws(__PORT__, "on_message") }
+"#;
+
+fn chat_src(port: u16) -> String {
+    CHAT_SRC_TEMPLATE.replace("__PORT__", &port.to_string())
+}
+
+fn dial(port: u16, room: &str) -> tungstenite::WebSocket<tungstenite::stream::MaybeTlsStream<std::net::TcpStream>> {
+    let url = format!("ws://127.0.0.1:{port}/{room}");
+    let (ws, _resp) = connect(url).expect("ws connect");
+    ws
+}
+
+fn read_text(
+    ws: &mut tungstenite::WebSocket<tungstenite::stream::MaybeTlsStream<std::net::TcpStream>>,
+    timeout: Duration,
+) -> Option<String> {
+    // We can't change the timeout on an existing read; rely on the
+    // test calling with patience. tungstenite's `read` blocks; for
+    // bounded waits in tests we set the underlying TcpStream to a
+    // short read timeout once after connect.
+    let _ = timeout;
+    match ws.read() {
+        Ok(Message::Text(s)) => Some(s),
+        _ => None,
+    }
+}
+
+fn set_read_timeout(
+    ws: &mut tungstenite::WebSocket<tungstenite::stream::MaybeTlsStream<std::net::TcpStream>>,
+    d: Duration,
+) {
+    if let tungstenite::stream::MaybeTlsStream::Plain(ref mut tcp) = ws.get_mut() {
+        let _ = tcp.set_read_timeout(Some(d));
+    }
+}
+
+#[test]
+fn broadcast_reaches_other_clients_in_same_room() {
+    let port = 19101;
+    spawn_chat_server(&chat_src(port));
+
+    // Two clients join the same room.
+    let mut alice = dial(port, "lobby");
+    let mut bob = dial(port, "lobby");
+    set_read_timeout(&mut alice, Duration::from_secs(2));
+    set_read_timeout(&mut bob, Duration::from_secs(2));
+
+    // alice sends; both alice and bob should receive (server echoes
+    // to all in the room, including the sender).
+    alice.send(Message::Text("hello!".into())).unwrap();
+
+    let msg_a = read_text(&mut alice, Duration::from_secs(2)).expect("alice reads");
+    let msg_b = read_text(&mut bob, Duration::from_secs(2)).expect("bob reads");
+    assert!(msg_a.ends_with(" hello!"), "alice got: {msg_a}");
+    assert!(msg_b.ends_with(" hello!"), "bob got: {msg_b}");
+
+    // The two prefixes should match — same sender, same conn_id.
+    let prefix_a = msg_a.split_once(' ').unwrap().0;
+    let prefix_b = msg_b.split_once(' ').unwrap().0;
+    assert_eq!(prefix_a, prefix_b, "same sender → same prefix");
+}
+
+#[test]
+fn rooms_are_isolated() {
+    let port = 19102;
+    spawn_chat_server(&chat_src(port));
+
+    let mut a_lobby = dial(port, "lobby");
+    let mut a_general = dial(port, "general");
+    set_read_timeout(&mut a_lobby, Duration::from_millis(500));
+    set_read_timeout(&mut a_general, Duration::from_millis(500));
+
+    a_lobby.send(Message::Text("for-lobby-only".into())).unwrap();
+
+    // a_lobby should receive its own broadcast.
+    let lobby_msg = read_text(&mut a_lobby, Duration::from_secs(2)).expect("lobby reads");
+    assert!(lobby_msg.contains("for-lobby-only"), "lobby got: {lobby_msg}");
+
+    // a_general should time out (no broadcast crossed rooms).
+    let crossed = read_text(&mut a_general, Duration::from_millis(500));
+    assert!(crossed.is_none(), "general accidentally received: {crossed:?}");
+}
+
+#[test]
+fn many_clients_fan_out() {
+    let port = 19103;
+    spawn_chat_server(&chat_src(port));
+
+    const N: usize = 8;
+    let mut clients = Vec::with_capacity(N);
+    for _ in 0..N {
+        let mut ws = dial(port, "room1");
+        set_read_timeout(&mut ws, Duration::from_secs(2));
+        clients.push(ws);
+    }
+    // First client sends a message.
+    clients[0].send(Message::Text("ping".into())).unwrap();
+
+    // Every client should see the broadcast (sender included).
+    let mut ok = 0;
+    for (i, c) in clients.iter_mut().enumerate() {
+        match read_text(c, Duration::from_secs(2)) {
+            Some(s) if s.contains("ping") => ok += 1,
+            other => eprintln!("client {i} got {other:?}"),
+        }
+    }
+    assert_eq!(ok, N, "{ok}/{N} clients received the broadcast");
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -205,6 +205,28 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 EffectSet::singleton("net"),
                 Ty::Unit,
             ));
+            // serve_ws :: (Int, Str) -> [net] Unit
+            //             port  on_message_handler_name
+            // The handler is looked up by name at runtime.
+            fields.insert("serve_ws".into(), Ty::function(
+                vec![Ty::int(), Ty::str()],
+                EffectSet::singleton("net"),
+                Ty::Unit,
+            ));
+            Some(Ty::Record(fields))
+        }
+        "chat" => {
+            let mut fields = IndexMap::new();
+            fields.insert("broadcast".into(), Ty::function(
+                vec![Ty::str(), Ty::str()],
+                EffectSet::singleton("chat"),
+                Ty::Unit,
+            ));
+            fields.insert("send".into(), Ty::function(
+                vec![Ty::int(), Ty::str()],
+                EffectSet::singleton("chat"),
+                Ty::bool(),
+            ));
             Some(Ty::Record(fields))
         }
         "json" => {
@@ -321,6 +343,7 @@ pub fn module_for_import(reference: &str) -> Option<&'static str> {
         "flow" => "flow",
         "bytes" => "bytes",
         "net" => "net",
+        "chat" => "chat",
         _ => return None,
     })
 }

--- a/examples/chat_app.lex
+++ b/examples/chat_app.lex
@@ -1,0 +1,30 @@
+# Multi-user WebSocket chat in Lex.
+#
+# Each connection joins a room derived from its URL path:
+#   ws://127.0.0.1:9090/lobby      → room "lobby"
+#   ws://127.0.0.1:9090/general    → room "general"
+#
+# Run:
+#   lex run --allow-effects net,chat examples/chat_app.lex main
+# Open examples/chat_client.html in two tabs to see the broadcast.
+
+import "std.net" as net
+import "std.chat" as chat
+import "std.str" as str
+import "std.int" as int
+
+type WsEvent = { body :: Str, conn_id :: Int, room :: Str }
+
+# Each incoming text frame becomes a Lex call. We prefix the message
+# with the sender's connection id so other users can see who said what,
+# then broadcast to everyone in the same room (sender included — a
+# real client filters its own echoes).
+fn on_message(ev :: WsEvent) -> [chat] Nil {
+  let prefix := str.concat("[", str.concat(int.to_str(ev.conn_id), "] "))
+  let line   := str.concat(prefix, ev.body)
+  chat.broadcast(ev.room, line)
+}
+
+fn main() -> [chat, net] Nil {
+  net.serve_ws(9090, "on_message")
+}

--- a/examples/chat_client.html
+++ b/examples/chat_client.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>lex chat</title>
+<style>
+  body { font-family: system-ui, sans-serif; max-width: 720px; margin: 2em auto; padding: 0 1em; }
+  #log { border: 1px solid #ccc; padding: 0.5em; height: 320px; overflow-y: auto;
+         font-family: ui-monospace, monospace; font-size: 13px; background: #fafafa; }
+  #log div { padding: 2px 0; border-bottom: 1px dotted #eee; }
+  form { display: flex; gap: 0.5em; margin-top: 1em; }
+  input[type=text] { flex: 1; padding: 0.4em; }
+  label { font-size: 14px; }
+  .meta { color: #999; }
+</style>
+</head>
+<body>
+  <h2>lex chat</h2>
+  <p>
+    <label>room: <input id="room" value="lobby" size="10" /></label>
+    &nbsp;
+    <label>server: <input id="server" value="ws://127.0.0.1:9090" size="22" /></label>
+    &nbsp;
+    <button id="connect">connect</button>
+    <span id="status" class="meta">disconnected</span>
+  </p>
+  <div id="log"></div>
+  <form id="send-form">
+    <input id="msg" type="text" placeholder="say something…" autocomplete="off" />
+    <button type="submit">send</button>
+  </form>
+
+<script>
+const log = document.getElementById('log');
+const status = document.getElementById('status');
+const roomEl = document.getElementById('room');
+const serverEl = document.getElementById('server');
+const msgEl = document.getElementById('msg');
+let ws = null;
+
+function append(text, cls) {
+  const d = document.createElement('div');
+  if (cls) d.className = cls;
+  d.textContent = text;
+  log.appendChild(d);
+  log.scrollTop = log.scrollHeight;
+}
+
+document.getElementById('connect').onclick = () => {
+  if (ws) ws.close();
+  const url = `${serverEl.value}/${roomEl.value}`;
+  append(`→ connecting to ${url}`, 'meta');
+  ws = new WebSocket(url);
+  ws.onopen    = () => { status.textContent = 'connected'; append('→ open', 'meta'); };
+  ws.onmessage = ev => append(ev.data);
+  ws.onclose   = () => { status.textContent = 'disconnected'; append('→ closed', 'meta'); ws = null; };
+  ws.onerror   = e  => append(`→ error: ${e.message || 'unknown'}`, 'meta');
+};
+
+document.getElementById('send-form').onsubmit = e => {
+  e.preventDefault();
+  if (!ws || ws.readyState !== WebSocket.OPEN) return;
+  ws.send(msgEl.value);
+  msgEl.value = '';
+};
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Lex can now host concurrent state-bearing services. `net.serve_ws(port, "on_message")` accepts WebSocket connections and dispatches each text frame to a Lex handler with `{ body, conn_id, room }`. Rooms are derived from the URL path (`/lobby` → `"lobby"`).

- `chat.broadcast(room, body)` pushes a message to every connection in `room`
- `chat.send(conn_id, body)` pushes to a single connection
- Both effects are gated by the existing `--allow-effects chat` policy

Shared mutable state lives in the host runtime via `Arc<Mutex<IndexMap<...>>>` so Lex code stays pure: it receives an event, returns Nil, and any side effects go through `chat.*`.

Each connection runs in its own thread that multiplexes inbound WS reads (50ms read timeout) with outbound mpsc broadcasts — sync tungstenite doesn't have a `split`, so we poll both ends from the same thread.

## What's included

- `net.serve_ws(Int, Str) -> [net] Unit` — bind a WebSocket server, dispatch frames to a Lex handler
- `std.chat`: `broadcast(Str, Str) -> [chat] Unit`, `send(Int, Str) -> [chat] Bool`
- `examples/chat_app.lex` — ~25 lines: each room is independent, message prefixed with sender's `conn_id`
- `examples/chat_client.html` — vanilla JS WebSocket client (room/server inputs, log, send form)
- 3 integration tests:
  - same-room broadcast reaches every member (sender included)
  - rooms are isolated (`/lobby` traffic doesn't cross to `/general`)
  - 8-client fan-out — first sends, all 8 receive

## Test plan

- [x] `cargo test -p lex-runtime --test ws_chat` — 3/3 passing
- [x] `cargo test --workspace` — 163 tests passing
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Live smoke: 2 Python WS clients on `/lobby` both receive `[1] hello from a python client` with matching `conn_id` prefix

https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh

---
_Generated by [Claude Code](https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh)_