### PR TITLE
Rename langspecv2.md → langspecs.md (drop the brainstorm-era v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A small family of programming languages designed for LLMs as primary writers, readers, and debuggers. **Lex** is the general-purpose surface; **Core** covers performance-critical work (sized numerics, tensor shapes); **Spec** carries proof annotations.
 
-Implementation of `langspecv2.md`. The design rules and milestone definitions all come from that document; this README focuses on what currently runs.
+Implementation of `langspecs.md`. The design rules and milestone definitions all come from that document; this README focuses on what currently runs.
 
 > Looking for the pitch? See [`docs/index.html`](docs/index.html) — single static page, dark-mode-ready, self-contained. Once GitHub Pages is enabled (run `bash scripts/setup-pages.sh` or click through Settings → Pages → Source: `main` / `/docs`), it'll be live at `https://alpibrusl.github.io/lex-lang/`.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -259,7 +259,7 @@ lex agent-tool --allow-effects net \
   <div class="wrap">
     Lex is implemented in Rust under <a href="https://github.com/alpibrusl/lex-lang/blob/main/LICENSE">EUPL-1.2</a>.
     Status: experimental. Agent integration ships in <code>lex agent-tool</code>; full spec lives in
-    <code>langspecv2.md</code>.
+    <code>langspecs.md</code>.
   </div>
 </footer>
 


### PR DESCRIPTION
## Summary

The `v2` was brainstorming-stage scaffolding and never the canonical name. Drops both references to `langspecs.md`:

- `README.md` opening line
- `docs/index.html` footer

## Note (worth flagging separately)

The spec file itself isn't checked into the repo. Both references are now structurally correct (*"the spec this implements is called langspecs.md"*) but the implied link will 404 if anyone tries to open it. That's a content-creation task — write/import the actual spec — not a rename.

https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh

---
_Generated by [Claude Code](https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh)_