### PR TITLE
Implement std.tuple; drop std.map/std.set stubs; trim README pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A language family designed for code no one will read. AI agents write more than 
 
 **Lex** is the general-purpose surface; **Core** covers performance-critical work (sized numerics, tensor shapes); **Spec** carries proof annotations. Implementation of `langspecs.md`; this README focuses on what currently runs.
 
-> Looking for the full pitch? See [`docs/index.html`](docs/index.html) — single static page, dark-mode-ready, self-contained. Once GitHub Pages is enabled (run `bash scripts/setup-pages.sh` or click through Settings → Pages → Source: `main` / `/docs`), it'll be live at `https://alpibrusl.github.io/lex-lang/`.
+Full pitch lives at [`docs/index.html`](docs/index.html) (also published via GitHub Pages — see the repo About panel for the live URL).
 
 ## Design rules at a glance
 

--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -15,7 +15,12 @@ pub fn try_pure_builtin(kind: &str, op: &str, args: &[Value]) -> Option<Result<V
 /// `kind` is one of the known pure module aliases — used by the policy
 /// walk to skip pure builtins that programs reference via imports.
 pub fn is_pure_module(kind: &str) -> bool {
-    matches!(kind, "str" | "int" | "float" | "bool" | "list" | "map" | "set"
+    // `map` and `set` are listed in the spec (§11.1) but defer to v1.1
+    // alongside refinement types — they need new `Value` variants for
+    // proper hashing semantics, which is a larger change. Until then,
+    // `import "std.map"` / `"std.set"` resolves to None so users get a
+    // clear "module not found" rather than silently-empty stubs.
+    matches!(kind, "str" | "int" | "float" | "bool" | "list"
         | "option" | "result" | "tuple" | "json" | "bytes" | "flow" | "math")
 }
 
@@ -138,6 +143,18 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             out.extend(expect_list(args.get(1))?.iter().cloned());
             Ok(Value::List(out))
         }
+
+        // -- tuple --
+        // Per §11.1: fst, snd, third for 2- and 3-tuples. Index out of
+        // range is an error rather than a panic so calling `tuple.third`
+        // on a 2-tuple is a clean failure instead of a host crash.
+        ("tuple", "fst")   => tuple_index(first_arg(args)?, 0),
+        ("tuple", "snd")   => tuple_index(first_arg(args)?, 1),
+        ("tuple", "third") => tuple_index(first_arg(args)?, 2),
+        ("tuple", "len") => match first_arg(args)? {
+            Value::Tuple(items) => Ok(Value::Int(items.len() as i64)),
+            other => Err(format!("tuple.len: expected Tuple, got {other:?}")),
+        },
 
         // -- option --
         ("option", "unwrap_or") => {
@@ -434,6 +451,14 @@ fn expect_bytes(v: Option<&Value>) -> Result<&Vec<u8>, String> {
 
 fn first_arg(args: &[Value]) -> Result<&Value, String> {
     args.first().ok_or_else(|| "missing argument".into())
+}
+
+fn tuple_index(v: &Value, i: usize) -> Result<Value, String> {
+    match v {
+        Value::Tuple(items) => items.get(i).cloned()
+            .ok_or_else(|| format!("tuple index {i} out of range (len={})", items.len())),
+        other => Err(format!("expected Tuple, got {other:?}")),
+    }
 }
 
 fn expect_str(v: Option<&Value>) -> Result<String, String> {

--- a/crates/lex-runtime/tests/tuple_ops.rs
+++ b/crates/lex-runtime/tests/tuple_ops.rs
@@ -1,0 +1,76 @@
+//! std.tuple — fst, snd, third, len. Per spec §11.1.
+//!
+//! `Value::Tuple` already exists in the VM; these are pure builtins
+//! that index into it. Tests both that the type signatures unify
+//! cleanly across heterogeneous element types and that the runtime
+//! returns the right value.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+
+fn run(src: &str, func: &str, args: Vec<Value>) -> Value {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors: {errs:#?}");
+    }
+    let bc = compile_program(&stages);
+    let handler = DefaultHandler::new(Policy::permissive());
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(func, args).expect("vm")
+}
+
+#[test]
+fn tuple_fst_returns_first_element() {
+    let src = r#"
+import "std.tuple" as tuple
+fn first(p :: Tuple[Int, Str]) -> Int { tuple.fst(p) }
+"#;
+    let r = run(src, "first", vec![Value::Tuple(vec![
+        Value::Int(7),
+        Value::Str("ignored".into()),
+    ])]);
+    assert_eq!(r, Value::Int(7));
+}
+
+#[test]
+fn tuple_snd_returns_second_element() {
+    let src = r#"
+import "std.tuple" as tuple
+fn second(p :: Tuple[Int, Str]) -> Str { tuple.snd(p) }
+"#;
+    let r = run(src, "second", vec![Value::Tuple(vec![
+        Value::Int(0),
+        Value::Str("hello".into()),
+    ])]);
+    assert_eq!(r, Value::Str("hello".into()));
+}
+
+#[test]
+fn tuple_third_returns_third_element() {
+    let src = r#"
+import "std.tuple" as tuple
+fn third(p :: Tuple[Int, Str, Bool]) -> Bool { tuple.third(p) }
+"#;
+    let r = run(src, "third", vec![Value::Tuple(vec![
+        Value::Int(1),
+        Value::Str("two".into()),
+        Value::Bool(true),
+    ])]);
+    assert_eq!(r, Value::Bool(true));
+}
+
+#[test]
+fn tuple_len_counts_pair() {
+    let src = r#"
+import "std.tuple" as tuple
+fn n(p :: Tuple[Int, Str]) -> Int { tuple.len(p) }
+"#;
+    let r = run(src, "n", vec![Value::Tuple(vec![
+        Value::Int(1),
+        Value::Str("two".into()),
+    ])]);
+    assert_eq!(r, Value::Int(2));
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -350,6 +350,39 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
             ));
             Some(Ty::Record(fields))
         }
+        "tuple" => {
+            // Tuple accessors per §11.1. Polymorphic in the tuple's
+            // element types; we use the same row-variable shape used
+            // by list helpers. Tuples are heterogeneous, so each
+            // accessor is statically typed via independent type
+            // variables for each position.
+            let mut fields = IndexMap::new();
+            // fst :: (T0, T1) -> T0
+            fields.insert("fst".into(), Ty::function(
+                vec![Ty::Tuple(vec![Ty::Var(0), Ty::Var(1)])],
+                EffectSet::empty(),
+                Ty::Var(0),
+            ));
+            // snd :: (T0, T1) -> T1
+            fields.insert("snd".into(), Ty::function(
+                vec![Ty::Tuple(vec![Ty::Var(0), Ty::Var(1)])],
+                EffectSet::empty(),
+                Ty::Var(1),
+            ));
+            // third :: (T0, T1, T2) -> T2
+            fields.insert("third".into(), Ty::function(
+                vec![Ty::Tuple(vec![Ty::Var(0), Ty::Var(1), Ty::Var(2)])],
+                EffectSet::empty(),
+                Ty::Var(2),
+            ));
+            // len :: (T0, T1) -> Int  (covers any pair shape; Int back)
+            fields.insert("len".into(), Ty::function(
+                vec![Ty::Tuple(vec![Ty::Var(0), Ty::Var(1)])],
+                EffectSet::empty(),
+                Ty::int(),
+            ));
+            Some(Ty::Record(fields))
+        }
         "flow" => {
             // Orchestration primitives (spec §11.2). Each takes one or
             // more closures and returns a closure with a derived shape.
@@ -402,6 +435,7 @@ pub fn module_for_import(reference: &str) -> Option<&'static str> {
         "option" => "option",
         "json" => "json",
         "flow" => "flow",
+        "tuple" => "tuple",
         "bytes" => "bytes",
         "net" => "net",
         "chat" => "chat",

--- a/crates/lex-types/src/env.rs
+++ b/crates/lex-types/src/env.rs
@@ -130,6 +130,11 @@ pub fn ty_from_canon(t: &lex_ast::TypeExpr, params: &[String]) -> Ty {
                 "Unit" | "Nil" => return Ty::Unit,
                 "Never" => return Ty::Never,
                 "List" if args.len() == 1 => return Ty::List(Box::new(ty_from_canon(&args[0], params))),
+                // `Tuple[T0, T1, ...]` is the constructor surface for
+                // tuples; canonicalize to the structural Ty::Tuple so
+                // it unifies with `(T0, T1)` literal-tuple syntax and
+                // with std.tuple's signatures.
+                "Tuple" => return Ty::Tuple(args.iter().map(|a| ty_from_canon(a, params)).collect()),
                 _ => {}
             }
             Ty::Con(name.clone(), args.iter().map(|a| ty_from_canon(a, params)).collect())


### PR DESCRIPTION
## Summary

Two stdlib gaps from the spec audit + a README cleanup the user flagged.

### `std.tuple` (§11.1) — implemented

- `fst`, `snd`, `third` — accessors for 2- and 3-tuples
- `len` — element count
- All four pure builtins on top of the existing `Value::Tuple`; no new VM machinery
- 4 integration tests in `crates/lex-runtime/tests/tuple_ops.rs`
- Type signatures land in `lex-types::builtins`; resolver entry in `module_for_import`

**Type-system fix needed** to make this work: `Tuple[T0, T1]` parses to `TypeExpr::Named { name: "Tuple", args: [...] }`, which became `Ty::Con("Tuple", ...)` and didn't unify with `Ty::Tuple`. Added a `"Tuple"` special case in `ty_from_canon` parallel to the existing `"List"` one — now `Tuple[Int, Str]` and `(Int, Str)` are the same type for unification.

### `std.map` / `std.set` — honestly deferred

Were listed in `is_pure_module` but never registered in `module_for_import` (so `import "std.map"` was silently broken) and had no method signatures or runtime arms. Per the "rather an honest `not found` than a silent stub" principle, removed from `is_pure_module` entirely with a comment pointing to v1.1 alongside refinement types. Both deferred until a proper `Value::Map` / `Value::Set` lands with hashing support.

### README

Dropped the GitHub Pages setup-pointer line. That was scaffolding for the maintainer; the public README shouldn't host setup instructions. Replaced with a one-liner pointing at `docs/index.html` + the repo About panel for the live URL.

## Test plan

- [x] `cargo test -p lex-runtime --test tuple_ops` — 4/4
- [x] `cargo test --workspace` green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh

---
_Generated by [Claude Code](https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh)_