### PR TITLE
agent-tool: --examples FILE for behavioral verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ lex agent-tool --allow-effects net --input "x" \
 #   exit 2
 ```
 
-Flags: `--body '<src>'` / `--body-file <path>` skip the API call; `--request '<q>'` needs `ANTHROPIC_API_KEY`. `--max-steps N` (default 1M) caps op count as a runtime DoS guard. `--allow-fs-read PATH` and `--allow-net-host HOST` add per-path / per-host scopes on top of `--allow-effects`.
+Flags: `--body '<src>'` / `--body-file <path>` skip the API call; `--request '<q>'` needs `ANTHROPIC_API_KEY`. `--max-steps N` (default 1M) caps op count as a runtime DoS guard. `--allow-fs-read PATH` and `--allow-net-host HOST` add per-path / per-host scopes on top of `--allow-effects`. `--examples FILE` runs the tool against a JSON list of `{input, expected}` pairs and rejects on any mismatch (exit 5) — closes the well-typed-but-wrong-behavior gap.
 
 ### Adversarial benchmark
 

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -616,6 +616,12 @@ struct AgentToolOpts {
     /// tool needs to call api.openai.com but should not be able to
     /// POST to attacker.example.com.
     allow_net_host: Vec<String>,
+    /// Path to a JSON file of `[{"input": "...", "expected": "..."}, ...]`
+    /// pairs. When set, the tool runs once per case and is rejected
+    /// if any output mismatches `expected`. Closes the well-typed-but-
+    /// wrong-behavior gap: the type system says what code touches; the
+    /// examples say what it should return.
+    examples_file: Option<PathBuf>,
 }
 
 enum BodySource {
@@ -689,22 +695,82 @@ fn cmd_agent_tool(args: &[String]) -> Result<()> {
     // 5) Run with a step-limit cap. This is the runtime DoS guard:
     // type-check rejects effects, max_steps rejects runaway compute.
     let bc = std::sync::Arc::new(bc);
-    let handler = DefaultHandler::new(policy).with_program(std::sync::Arc::clone(&bc));
-    let mut vm = Vm::with_handler(&bc, Box::new(handler));
-    vm.set_step_limit(opts.max_steps);
-    let result = match vm.call("tool", vec![Value::Str(opts.user_input.clone())]) {
+
+    // 5a) If --examples is set, behavioral-verify before trusting the tool
+    // for live traffic. Catches the well-typed-but-wrong-behavior gap:
+    // the type system says what code touches; the examples say what it
+    // should return. On any mismatch, exit 5 (distinct from 2/3/4).
+    if let Some(path) = opts.examples_file.as_ref() {
+        let examples = load_examples(path)?;
+        if opts.show_source {
+            eprintln!("→ checking {} example(s)…", examples.len());
+        }
+        let mut failures: Vec<(usize, &Example, String)> = Vec::new();
+        for (idx, ex) in examples.iter().enumerate() {
+            let out = run_tool_once(&bc, &policy, opts.max_steps, &ex.input)?;
+            if out != ex.expected {
+                failures.push((idx, ex, out));
+            }
+        }
+        if !failures.is_empty() {
+            eprintln!("→ EXAMPLES FAILED — tool not trusted ({} of {} mismatched).",
+                failures.len(), examples.len());
+            for (i, ex, got) in &failures {
+                eprintln!("  [{i}] input={:?}", ex.input);
+                eprintln!("       expected={:?}", ex.expected);
+                eprintln!("       got     ={got:?}");
+            }
+            std::process::exit(5);
+        }
+        if opts.show_source {
+            eprintln!("→ examples passed: {}/{}", examples.len(), examples.len());
+        }
+    }
+
+    // 5b) Single-shot run with the user_input. With --examples this
+    // doubles as a sanity invocation; without examples it's the only run.
+    let result = run_tool_once(&bc, &policy, opts.max_steps, &opts.user_input)?;
+    println!("{result}");
+    Ok(())
+}
+
+#[derive(serde::Deserialize)]
+struct Example {
+    input: String,
+    expected: String,
+}
+
+fn load_examples(path: &std::path::Path) -> Result<Vec<Example>> {
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("read examples file {}", path.display()))?;
+    let cases: Vec<Example> = serde_json::from_str(&raw)
+        .with_context(|| format!("parse examples file {}; expected JSON array of {{input, expected}}", path.display()))?;
+    Ok(cases)
+}
+
+fn run_tool_once(
+    bc: &std::sync::Arc<lex_bytecode::Program>,
+    policy: &Policy,
+    max_steps: u64,
+    input: &str,
+) -> Result<String> {
+    let handler = DefaultHandler::new(policy.clone()).with_program(std::sync::Arc::clone(bc));
+    let mut vm = Vm::with_handler(bc, Box::new(handler));
+    vm.set_step_limit(max_steps);
+    let result = match vm.call("tool", vec![Value::Str(input.to_string())]) {
         Ok(v) => v,
         Err(e) => {
             let msg = format!("{e}");
             if msg.contains("step limit") {
-                eprintln!("→ STEP-LIMIT EXCEEDED — tool aborted at {} steps.", opts.max_steps);
+                eprintln!("→ STEP-LIMIT EXCEEDED — tool aborted at {max_steps} steps.");
                 eprintln!("  (raise with --max-steps; default {})", default_max_steps());
                 std::process::exit(4);
             }
             // Runtime scope rejections (--allow-fs-read / --allow-net-host
             // / --allow-fs-write) surface as effect-handler errors. Exit 3
             // matches the static-policy gate so callers can branch cleanly:
-            //   2 = type-check, 3 = policy (static or runtime), 4 = step-limit.
+            //   2 = type-check, 3 = policy (static or runtime), 4 = step-limit,
+            //   5 = examples failed.
             if msg.contains("outside --allow-fs-read")
                 || msg.contains("outside --allow-fs-write")
                 || msg.contains("not in --allow-net-host")
@@ -716,12 +782,10 @@ fn cmd_agent_tool(args: &[String]) -> Result<()> {
             return Err(anyhow!("runtime: {e}"));
         }
     };
-
-    match result {
-        Value::Str(s) => println!("{s}"),
-        other => println!("{}", value_to_json_string(&other)),
-    }
-    Ok(())
+    Ok(match result {
+        Value::Str(s) => s,
+        other => value_to_json_string(&other),
+    })
 }
 
 const fn default_max_steps() -> u64 { 1_000_000 }
@@ -736,6 +800,7 @@ fn parse_agent_tool_args(args: &[String]) -> Result<AgentToolOpts> {
     let mut max_steps: u64 = default_max_steps();
     let mut allow_fs_read: Vec<PathBuf> = Vec::new();
     let mut allow_net_host: Vec<String> = Vec::new();
+    let mut examples_file: Option<PathBuf> = None;
     let mut i = 0;
     while i < args.len() {
         match args[i].as_str() {
@@ -786,6 +851,11 @@ fn parse_agent_tool_args(args: &[String]) -> Result<AgentToolOpts> {
                     .parse().context("--max-steps must be an integer")?;
                 i += 2;
             }
+            "--examples" => {
+                let v = args.get(i + 1).ok_or_else(|| anyhow!("--examples needs a path"))?;
+                examples_file = Some(PathBuf::from(v));
+                i += 2;
+            }
             "--quiet" => { show_source = false; i += 1; }
             other => bail!("unknown agent-tool flag: {other}"),
         }
@@ -801,6 +871,7 @@ fn parse_agent_tool_args(args: &[String]) -> Result<AgentToolOpts> {
         max_steps,
         allow_fs_read,
         allow_net_host,
+        examples_file,
     })
 }
 

--- a/crates/lex-cli/tests/agent_tool.rs
+++ b/crates/lex-cli/tests/agent_tool.rs
@@ -136,3 +136,66 @@ fn benign_compute_runs_within_default_step_limit() {
     // sum 0..100 = 4950
     assert_eq!(stdout.trim(), "4950");
 }
+
+#[test]
+fn examples_pass_when_body_matches_expected() {
+    use std::io::Write;
+    let mut tmp = std::env::temp_dir();
+    tmp.push("lex_examples_pass.json");
+    let mut f = std::fs::File::create(&tmp).expect("create tmp");
+    f.write_all(br#"[{"input":"21","expected":"42"},{"input":"100","expected":"200"}]"#)
+        .expect("write tmp");
+
+    let (code, stdout, stderr) = run(&[
+        "agent-tool",
+        "--allow-effects", "",
+        "--quiet",
+        "--examples", tmp.to_str().unwrap(),
+        "--input", "5",
+        "--body",
+        "match str.to_int(input) { Some(n) => int.to_str(n * 2), None => \"err\" }",
+    ]);
+    assert_eq!(code, 0, "stderr:\n{stderr}");
+    // The single-shot --input run prints 10 (5 * 2) to stdout.
+    assert_eq!(stdout.trim(), "10");
+}
+
+#[test]
+fn examples_reject_wrong_behavior_with_exit_5() {
+    use std::io::Write;
+    let mut tmp = std::env::temp_dir();
+    tmp.push("lex_examples_fail.json");
+    let mut f = std::fs::File::create(&tmp).expect("create tmp");
+    f.write_all(br#"[{"input":"21","expected":"42"},{"input":"100","expected":"200"}]"#)
+        .expect("write tmp");
+
+    // Body triples instead of doubling — well-typed but wrong behavior.
+    // Type-check passes; --examples catches it before live use.
+    let (code, _stdout, stderr) = run(&[
+        "agent-tool",
+        "--allow-effects", "",
+        "--quiet",
+        "--examples", tmp.to_str().unwrap(),
+        "--input", "5",
+        "--body",
+        "match str.to_int(input) { Some(n) => int.to_str(n * 3), None => \"err\" }",
+    ]);
+    assert_eq!(code, 5, "expected exit 5; stderr:\n{stderr}");
+    assert!(stderr.contains("EXAMPLES FAILED"), "stderr:\n{stderr}");
+    assert!(stderr.contains("expected=\"42\""), "stderr:\n{stderr}");
+    assert!(stderr.contains("got     =\"63\""), "stderr:\n{stderr}");
+}
+
+#[test]
+fn examples_missing_file_errors_clearly() {
+    let (code, _stdout, stderr) = run(&[
+        "agent-tool",
+        "--allow-effects", "",
+        "--quiet",
+        "--examples", "/no/such/path/examples.json",
+        "--input", "x",
+        "--body", "input",
+    ]);
+    assert_ne!(code, 0);
+    assert!(stderr.contains("read examples file"), "stderr:\n{stderr}");
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -250,16 +250,18 @@
   </p>
   <ul class="tight">
     <li><strong>Spec proofs (§14 of <code>langspecs.md</code>).</strong> Attach a behavioral contract — <code>forall x :: Int, lo, hi where lo &lt;= hi: clamp(x, lo, hi) &gt;= lo and ... &lt;= hi</code> — and the checker discharges it via Z3 (or property-tests when SMT can't decide). Verdict travels with the stage in the store, so downstream agents can require <em>spec-proven</em> dependencies, not just well-typed ones.</li>
-    <li><strong>Examples-driven verification.</strong> The host hands the agent a small set of <code>{input → expected_output}</code> pairs. Lex runs the emitted body against each before trusting it for live traffic. Catches <em>wrong-but-consistent</em> behavior (the wrong-site scrape) at minimal cost; doesn't need SMT.</li>
+    <li><strong>Examples-driven verification.</strong> Pass <code>--examples FILE</code>; the host hands the agent a small set of <code>{input → expected}</code> pairs and Lex runs the emitted body against each before trusting it for live traffic. Any mismatch exits 5 with a per-case diff. Catches <em>wrong-but-consistent</em> behavior (the wrong-site scrape) at minimal cost; doesn't need SMT.</li>
     <li><strong>Differential evaluation.</strong> Run two agent-emitted bodies on the same inputs and flag divergence. Cheap regression detection across model upgrades.</li>
     <li><strong>Capability scoping.</strong> <code>--allow-net-host github.com</code> means the wrong-site scraping case can't even <em>reach</em> attacker.com — the blast radius of a behavioral bug is bounded.</li>
   </ul>
   <p>
-    Today Lex ships rungs 1 (effects) and 4 (scoping); rung 2 (Spec)
-    is implemented for explicit specs but not yet wired into
-    <code>agent-tool</code>; rungs 2–3 against agent-emitted code are
-    on the near roadmap. The point isn't that capability typing solves
-    correctness — it doesn't — it's that it's the only rung where the
+    Today Lex ships rungs 1 (effects), 2 (examples-driven, via
+    <code>--examples</code>), and 4 (scoping); rung 3 (differential
+    eval) and Spec proofs against agent-emitted bodies are on the
+    near roadmap (Spec works for explicit specs already, just not
+    yet wired into <code>agent-tool</code>). The point isn't that
+    capability typing solves correctness — it doesn't — it's that
+    it's the only rung where the
     contract is part of the language and free of inference cost.
   </p>
 </section>


### PR DESCRIPTION
## Summary

Closes the well-typed-but-wrong-behavior gap raised in the *Capability ≠ correctness* landing-page section. The host hands the tool a JSON list of `{input, expected}` pairs; `agent-tool` runs the emitted body against each input before trusting it for live traffic. Any mismatch exits **5** with a per-case diff.

```bash
$ lex agent-tool --allow-effects "" --examples bench/double.json \
    --input 5 --body '... triples instead of doubling ...'
→ checking 2 example(s)…
→ EXAMPLES FAILED — tool not trusted (2 of 2 mismatched).
  [0] input="21"
       expected="42"
       got     ="63"
exit 5
```

## Implementation

- Extracted `run_tool_once()` helper that captures the existing per-run setup (fresh `Vm`, step-limit cap, scope-error classification → exit 3/4)
- `cmd_agent_tool` now branches: with `--examples` it loops the helper before the final `--input` run; without it, the original single-shot path
- Type-check + policy-gate still fire first — examples only run if the body would otherwise have executed

## Exit code map (now)

| Code | Meaning |
|---|---|
| 0 | tool ran |
| 2 | type-check rejected |
| 3 | policy rejected (static or runtime scope) |
| 4 | step-limit exceeded |
| 5 | examples failed |

Distinct codes let the host loop branch cleanly on what failed.

## Test plan

- [x] `examples_pass_when_body_matches_expected` — body doubles, examples expect doubling → exit 0, single-shot run prints `10`
- [x] `examples_reject_wrong_behavior_with_exit_5` — body triples, examples expect doubling → exit 5, stderr contains the per-case diff
- [x] `examples_missing_file_errors_clearly` — `--examples /no/such/path` → non-zero exit, clear "read examples file" error
- [x] `cargo test --workspace` green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

## Doc updates

- README: one-sentence pointer to `--examples` alongside the other agent-tool flags
- `docs/index.html`: *Examples-driven verification* moves from "roadmap" to "shipped rung 2"

https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh

---
_Generated by [Claude Code](https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh)_