### PR TITLE
std.flow.parallel — closes the §11.2 gap (sequential v1)

### DIFF
--- a/crates/lex-bytecode/src/compiler.rs
+++ b/crates/lex-bytecode/src/compiler.rs
@@ -577,6 +577,7 @@ impl<'a> FnCompiler<'a> {
             ("flow", "sequential") => self.emit_flow_sequential(args),
             ("flow", "branch") => self.emit_flow_branch(args),
             ("flow", "retry") => self.emit_flow_retry(args),
+            ("flow", "parallel") => self.emit_flow_parallel(args),
             _ => return false,
         }
         true
@@ -871,6 +872,31 @@ impl<'a> FnCompiler<'a> {
             Op::Return,
         ];
         let fn_id = self.install_trampoline("__flow_sequential", 3, 4, code);
+        self.emit(Op::MakeClosure { fn_id, capture_count: 2 });
+    }
+
+    /// `flow.parallel(fa, fb)` returns a closure `() -> (fa(), fb())`.
+    /// Implementation is sequential: each function is called in order
+    /// and the results are packed into a 2-tuple. The spec (§11.2)
+    /// allows the runtime to apply true parallelism here; that needs
+    /// a thread-safe handler split and is left to a follow-up. The
+    /// signature is what users program against — sequential vs threaded
+    /// is an implementation detail invisible to the type system.
+    fn emit_flow_parallel(&mut self, args: &[a::CExpr]) {
+        // Push fa, fb; build a 0-arg trampoline closure with 2 captures.
+        self.compile_expr(&args[0], false);
+        self.compile_expr(&args[1], false);
+        let nid = self.pool.node_id("n_flow_parallel");
+        let code = vec![
+            // Locals: [fa=0, fb=1]
+            Op::LoadLocal(0),                                  // push fa
+            Op::CallClosure { arity: 0, node_id_idx: nid },    // a = fa()
+            Op::LoadLocal(1),                                  // push fb
+            Op::CallClosure { arity: 0, node_id_idx: nid },    // b = fb()
+            Op::MakeTuple(2),                                  // (a, b)
+            Op::Return,
+        ];
+        let fn_id = self.install_trampoline("__flow_parallel", 2, 2, code);
         self.emit(Op::MakeClosure { fn_id, capture_count: 2 });
     }
 

--- a/crates/lex-runtime/tests/flow.rs
+++ b/crates/lex-runtime/tests/flow.rs
@@ -176,3 +176,41 @@ fn sign_and_double(x :: Int) -> Int {
     // minus: (-3) -> -(-3)*2 = 6
     assert_eq!(run(src, "sign_and_double", vec![Value::Int(-3)]), Value::Int(6));
 }
+
+// -- parallel ---------------------------------------------------------
+
+#[test]
+fn flow_parallel_returns_tuple_of_both_results() {
+    // Two 0-arg closures; flow.parallel returns a closure that returns
+    // their results as a 2-tuple.
+    let src = r#"
+import "std.flow" as flow
+fn run_pair() -> Tuple[Int, Int] {
+  let p := flow.parallel(
+    fn () -> Int { 7 },
+    fn () -> Int { 11 }
+  )
+  p()
+}
+"#;
+    let r = run(src, "run_pair", vec![]);
+    assert_eq!(r, Value::Tuple(vec![Value::Int(7), Value::Int(11)]));
+}
+
+#[test]
+fn flow_parallel_handles_heterogeneous_return_types() {
+    // Type variables A and B unify independently — first closure returns
+    // Int, second returns Str; the resulting tuple is Tuple[Int, Str].
+    let src = r#"
+import "std.flow" as flow
+fn pair() -> Tuple[Int, Str] {
+  let p := flow.parallel(
+    fn () -> Int { 42 },
+    fn () -> Str { "hello" }
+  )
+  p()
+}
+"#;
+    let r = run(src, "pair", vec![]);
+    assert_eq!(r, Value::Tuple(vec![Value::Int(42), Value::Str("hello".into())]));
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -416,6 +416,21 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 EffectSet::empty(),
                 Ty::function(vec![Ty::Var(0)], EffectSet::empty(), result_ty),
             ));
+            // parallel[A, B](fa: () -> A, fb: () -> B) -> () -> (A, B)
+            // Sequential implementation today; spec §11.2 reserves the
+            // option of a true-threaded scheduler. parallel_record is
+            // listed in the spec but not yet implemented — it needs row
+            // polymorphism over the input record's fields plus a
+            // record-iteration trampoline; tracked as follow-up.
+            fields.insert("parallel".into(), Ty::function(
+                vec![
+                    Ty::function(vec![], EffectSet::empty(), Ty::Var(0)),
+                    Ty::function(vec![], EffectSet::empty(), Ty::Var(1)),
+                ],
+                EffectSet::empty(),
+                Ty::function(vec![], EffectSet::empty(),
+                    Ty::Tuple(vec![Ty::Var(0), Ty::Var(1)])),
+            ));
             Some(Ty::Record(fields))
         }
         _ => None,


### PR DESCRIPTION
## Summary

Spec §11.2 lists five orchestration primitives (`sequential`, `branch`, `retry`, `parallel`, `parallel_record`). The first three were already wired as compile-time trampoline closures; `parallel` was missing both type signature and emit. `parallel_record` needs row polymorphism over the input record's fields plus a record-iteration trampoline — deferred with a code comment.

## What ships

`flow.parallel(fa, fb)` returns a 0-arg closure that, when called, invokes `fa()` then `fb()` and packs the results into a 2-tuple.

```lex
import "std.flow" as flow

fn pair() -> Tuple[Int, Str] {
  let p := flow.parallel(
    fn () -> Int { 42 },
    fn () -> Str { "hello" }
  )
  p()
}
// → (42, "hello")
```

Type signature uses independent type variables for `A` and `B` so heterogeneous return types unify cleanly.

## Implementation

Matches the existing `flow.sequential` pattern: `emit_flow_parallel` installs a trampoline with two captures, code loads each closure, calls it with arity 0, and emits `MakeTuple(2)` before returning.

## Caveat — sequential, not threaded

The spec reserves the option of a true-threaded scheduler at this SigId. Sequential implementation has the right *semantics*, just no speedup. Threading needs a thread-safe handler split (the current `DefaultHandler` isn't `Send` across threads in all configurations) and is left to a follow-up — the *signature* is what users program against, and that's now stable.

## Test plan

- [x] `flow_parallel_returns_tuple_of_both_results` — Int + Int → `(7, 11)`
- [x] `flow_parallel_handles_heterogeneous_return_types` — Int + Str → `(42, "hello")`
- [x] `cargo test --workspace` green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh

---
_Generated by [Claude Code](https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh)_