### PR TITLE
agent-tool: --spec FILE for behavioral proofs

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ lex agent-tool --allow-effects net --input "x" \
 #   exit 2
 ```
 
-Flags: `--body '<src>'` / `--body-file <path>` skip the API call; `--request '<q>'` needs `ANTHROPIC_API_KEY`. `--max-steps N` (default 1M) caps op count as a runtime DoS guard. `--allow-fs-read PATH` and `--allow-net-host HOST` add per-path / per-host scopes on top of `--allow-effects`. `--examples FILE` runs the tool against a JSON list of `{input, expected}` pairs and rejects on any mismatch (exit 5) — closes the well-typed-but-wrong-behavior gap.
+Flags: `--body '<src>'` / `--body-file <path>` skip the API call; `--request '<q>'` needs `ANTHROPIC_API_KEY`. `--max-steps N` (default 1M) caps op count as a runtime DoS guard. `--allow-fs-read PATH` and `--allow-net-host HOST` add per-path / per-host scopes on top of `--allow-effects`. `--examples FILE` runs the tool against a JSON list of `{input, expected}` pairs (exit 5 on mismatch). `--spec FILE` proves a behavioral contract against the emitted body via the spec checker (exit 5 on counterexample, 6 on inconclusive — pass `--spec-allow-inconclusive` to ship anyway).
 
 ### Adversarial benchmark
 

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -622,6 +622,20 @@ struct AgentToolOpts {
     /// wrong-behavior gap: the type system says what code touches; the
     /// examples say what it should return.
     examples_file: Option<PathBuf>,
+    /// Path to a Spec file (`spec name { forall …: <bool expr> }`) to
+    /// prove against the emitted body before trusting it. Counterexamples
+    /// abort with exit 5 (same family as examples-failed); inconclusive
+    /// proofs abort with exit 6 unless `--spec-allow-inconclusive` is
+    /// set. This is the strongest behavioral check available — it lifts
+    /// rung 2 from "show me the answer for these N cases" to "show me
+    /// the answer for *all* cases the spec ranges over."
+    spec_file: Option<PathBuf>,
+    /// If true, an inconclusive Spec proof doesn't abort the run.
+    /// Useful when SMT can't decide a property but you still want
+    /// to ship; the spec's own evidence record stays in the trace.
+    spec_allow_inconclusive: bool,
+    /// Trials for randomized fallback when SMT can't decide.
+    spec_trials: u32,
 }
 
 enum BodySource {
@@ -690,6 +704,52 @@ fn cmd_agent_tool(args: &[String]) -> Result<()> {
             eprintln!("  {}", serde_json::to_string(v).unwrap_or_default());
         }
         std::process::exit(3);
+    }
+
+    // 4b) Spec proof. Strongest behavioral guarantee available pre-run:
+    // a quantified property attached to `tool` is checked against the
+    // emitted body before the tool ever executes on real inputs. SMT
+    // (via Z3, when available) handles structural+integer cases;
+    // randomized fallback covers the rest. Counterexamples abort with
+    // exit 5; inconclusive aborts with 6 unless --spec-allow-inconclusive.
+    if let Some(path) = opts.spec_file.as_ref() {
+        let spec_text = fs::read_to_string(path)
+            .with_context(|| format!("read spec file {}", path.display()))?;
+        let spec = spec_checker::parse_spec(&spec_text)
+            .map_err(|e| anyhow!("spec parse: {e}"))?;
+        if opts.show_source {
+            eprintln!("→ checking spec `{}`…", spec.name);
+        }
+        let report = spec_checker::check_spec(&spec, &src, opts.spec_trials);
+        match report.status {
+            spec_checker::ProofStatus::Proved => {
+                if opts.show_source {
+                    eprintln!("  spec proved ({} method, {} trials)",
+                        report.evidence.method, report.evidence.trials);
+                }
+            }
+            spec_checker::ProofStatus::Counterexample => {
+                eprintln!("→ SPEC COUNTEREXAMPLE — tool not run.");
+                if let Some(cx) = &report.evidence.counterexample {
+                    for (k, v) in cx { eprintln!("  {k} = {v}"); }
+                }
+                if let Some(note) = &report.evidence.note {
+                    eprintln!("  ({note})");
+                }
+                std::process::exit(5);
+            }
+            spec_checker::ProofStatus::Inconclusive => {
+                eprintln!("→ SPEC INCONCLUSIVE — could not decide property.");
+                if let Some(note) = &report.evidence.note {
+                    eprintln!("  ({note})");
+                }
+                if !opts.spec_allow_inconclusive {
+                    eprintln!("  (pass --spec-allow-inconclusive to ship anyway)");
+                    std::process::exit(6);
+                }
+                eprintln!("  (continuing because --spec-allow-inconclusive is set)");
+            }
+        }
     }
 
     // 5) Run with a step-limit cap. This is the runtime DoS guard:
@@ -801,6 +861,9 @@ fn parse_agent_tool_args(args: &[String]) -> Result<AgentToolOpts> {
     let mut allow_fs_read: Vec<PathBuf> = Vec::new();
     let mut allow_net_host: Vec<String> = Vec::new();
     let mut examples_file: Option<PathBuf> = None;
+    let mut spec_file: Option<PathBuf> = None;
+    let mut spec_allow_inconclusive = false;
+    let mut spec_trials: u32 = 1000;
     let mut i = 0;
     while i < args.len() {
         match args[i].as_str() {
@@ -856,6 +919,17 @@ fn parse_agent_tool_args(args: &[String]) -> Result<AgentToolOpts> {
                 examples_file = Some(PathBuf::from(v));
                 i += 2;
             }
+            "--spec" => {
+                let v = args.get(i + 1).ok_or_else(|| anyhow!("--spec needs a path"))?;
+                spec_file = Some(PathBuf::from(v));
+                i += 2;
+            }
+            "--spec-allow-inconclusive" => { spec_allow_inconclusive = true; i += 1; }
+            "--spec-trials" => {
+                spec_trials = args.get(i + 1).ok_or_else(|| anyhow!("--spec-trials needs an integer"))?
+                    .parse().context("--spec-trials must be a u32")?;
+                i += 2;
+            }
             "--quiet" => { show_source = false; i += 1; }
             other => bail!("unknown agent-tool flag: {other}"),
         }
@@ -872,6 +946,9 @@ fn parse_agent_tool_args(args: &[String]) -> Result<AgentToolOpts> {
         allow_fs_read,
         allow_net_host,
         examples_file,
+        spec_file,
+        spec_allow_inconclusive,
+        spec_trials,
     })
 }
 

--- a/crates/lex-cli/tests/agent_tool.rs
+++ b/crates/lex-cli/tests/agent_tool.rs
@@ -199,3 +199,61 @@ fn examples_missing_file_errors_clearly() {
     assert_ne!(code, 0);
     assert!(stderr.contains("read examples file"), "stderr:\n{stderr}");
 }
+
+#[test]
+fn spec_proved_against_correct_body() {
+    use std::io::Write;
+    let mut tmp = std::env::temp_dir();
+    tmp.push("lex_spec_ok.spec");
+    let mut f = std::fs::File::create(&tmp).expect("create spec");
+    f.write_all(br#"spec is_ok { forall s :: Str: tool(s) == "ok" }"#)
+        .expect("write spec");
+
+    let (code, stdout, stderr) = run(&[
+        "agent-tool",
+        "--allow-effects", "",
+        "--quiet",
+        "--spec", tmp.to_str().unwrap(),
+        "--input", "x",
+        "--body", r#""ok""#,
+    ]);
+    assert_eq!(code, 0, "stderr:\n{stderr}");
+    assert_eq!(stdout.trim(), "ok");
+}
+
+#[test]
+fn spec_counterexample_aborts_with_exit_5() {
+    use std::io::Write;
+    let mut tmp = std::env::temp_dir();
+    tmp.push("lex_spec_fail.spec");
+    let mut f = std::fs::File::create(&tmp).expect("create spec");
+    f.write_all(br#"spec is_ok { forall s :: Str: tool(s) == "ok" }"#)
+        .expect("write spec");
+
+    // Body always returns "oops" — spec asserts "ok"; randomized prover
+    // immediately finds a counterexample (any input string).
+    let (code, _stdout, stderr) = run(&[
+        "agent-tool",
+        "--allow-effects", "",
+        "--quiet",
+        "--spec", tmp.to_str().unwrap(),
+        "--input", "x",
+        "--body", r#""oops""#,
+    ]);
+    assert_eq!(code, 5, "expected exit 5; stderr:\n{stderr}");
+    assert!(stderr.contains("SPEC COUNTEREXAMPLE"), "stderr:\n{stderr}");
+}
+
+#[test]
+fn spec_missing_file_errors_clearly() {
+    let (code, _stdout, stderr) = run(&[
+        "agent-tool",
+        "--allow-effects", "",
+        "--quiet",
+        "--spec", "/no/such/path/some.spec",
+        "--input", "x",
+        "--body", r#""ok""#,
+    ]);
+    assert_ne!(code, 0);
+    assert!(stderr.contains("read spec file"), "stderr:\n{stderr}");
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -251,18 +251,17 @@
   <ul class="tight">
     <li><strong>Spec proofs (§14 of <code>langspecs.md</code>).</strong> Attach a behavioral contract — <code>forall x :: Int, lo, hi where lo &lt;= hi: clamp(x, lo, hi) &gt;= lo and ... &lt;= hi</code> — and the checker discharges it via Z3 (or property-tests when SMT can't decide). Verdict travels with the stage in the store, so downstream agents can require <em>spec-proven</em> dependencies, not just well-typed ones.</li>
     <li><strong>Examples-driven verification.</strong> Pass <code>--examples FILE</code>; the host hands the agent a small set of <code>{input → expected}</code> pairs and Lex runs the emitted body against each before trusting it for live traffic. Any mismatch exits 5 with a per-case diff. Catches <em>wrong-but-consistent</em> behavior (the wrong-site scrape) at minimal cost; doesn't need SMT.</li>
-    <li><strong>Differential evaluation.</strong> Run two agent-emitted bodies on the same inputs and flag divergence. Cheap regression detection across model upgrades.</li>
+    <li><strong>Spec proofs.</strong> Pass <code>--spec FILE</code>; the host attaches a behavioral contract — <code>forall x :: Int where x &gt;= 0: tool(x) == expected(x)</code> — and the spec checker discharges it via Z3 (or a randomized fallback). Counterexamples abort with exit 5; inconclusive proofs abort with 6 unless <code>--spec-allow-inconclusive</code> is set. Strongest available pre-execution check on behavior.</li>
     <li><strong>Capability scoping.</strong> <code>--allow-net-host github.com</code> means the wrong-site scraping case can't even <em>reach</em> attacker.com — the blast radius of a behavioral bug is bounded.</li>
+    <li><strong>Differential evaluation.</strong> Run two agent-emitted bodies on the same inputs and flag divergence. Cheap regression detection across model upgrades. (Roadmap.)</li>
   </ul>
   <p>
-    Today Lex ships rungs 1 (effects), 2 (examples-driven, via
-    <code>--examples</code>), and 4 (scoping); rung 3 (differential
-    eval) and Spec proofs against agent-emitted bodies are on the
-    near roadmap (Spec works for explicit specs already, just not
-    yet wired into <code>agent-tool</code>). The point isn't that
-    capability typing solves correctness — it doesn't — it's that
-    it's the only rung where the
-    contract is part of the language and free of inference cost.
+    Today Lex ships effects, capability scoping, examples-driven
+    verification, and Spec proofs against agent-emitted bodies.
+    Differential evaluation is the remaining roadmap item. The point
+    isn't that capability typing solves correctness — it doesn't — it's
+    that the contract lives in the language, free of inference cost,
+    and each higher rung composes on top of the previous one.
   </p>
 </section>
 


### PR DESCRIPTION
## Summary

Lifts the correctness ladder one rung past `--examples`: instead of *"show me the answer for these N cases"*, prove a quantified property holds across the spec's quantifier range. Same exit-code family as examples (5 for failure) plus 6 for SMT-inconclusive results.

```bash
$ lex agent-tool --allow-effects "" \
    --spec is_ok.spec --input x \
    --body '"oops"'
→ SPEC COUNTEREXAMPLE — tool not run.
  s = ""
exit 5
```

Where `is_ok.spec` is:

```
spec is_ok {
  forall s :: Str:
    tool(s) == "ok"
}
```

## How it slots in

The spec check fires between the policy gate (step 4) and the run (step 5). The spec checker (already shipped per §14) runs SMT (Z3 when available) and falls back to randomized property testing for quantifiers it can't decide. Specs reference `tool` by name; the synthesized Lex source already declares it, so `check_spec` receives a complete program.

## New flags

| Flag | Purpose |
|---|---|
| `--spec FILE` | path to a spec file |
| `--spec-allow-inconclusive` | ship even if SMT can't decide (still aborts on counterexample) |
| `--spec-trials N` | trials for randomized fallback (default 1000) |

## Exit code map (now)

| Code | Meaning |
|---|---|
| 0 | ran |
| 2 | type-check rejected |
| 3 | policy rejected (static or runtime) |
| 4 | step-limit exceeded |
| **5** | examples failed **OR** spec counterexample |
| **6** | spec inconclusive (without `--spec-allow-inconclusive`) |

## Test plan

- [x] `spec_proved_against_correct_body` — body returns `"ok"`, spec asserts `tool(s) == "ok"` → exit 0, single-shot run prints `ok`
- [x] `spec_counterexample_aborts_with_exit_5` — body returns `"oops"`, same spec → exit 5 with counterexample dump
- [x] `spec_missing_file_errors_clearly` — bad path → non-zero exit, clear `read spec file` error
- [x] `cargo test --workspace` green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

## Doc updates

- README: one-sentence pointer to `--spec` alongside the other agent-tool flags
- `docs/index.html`: *Spec proofs* moves from "near roadmap" to a shipped rung; only differential evaluation remains roadmap on the correctness ladder

## Note on `flow.parallel_record`

Deferred this round. The spec signature `Record<{ k: () -> [E] T_k }> -> () -> Record<{ k: T_k }>` needs row polymorphism that Lex's `Ty::Record` doesn't yet implement (flat `IndexMap`, no rest variable). Real type-system extension — its own milestone, not a session-worth task. Tracked as a follow-up.

https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh

---
_Generated by [Claude Code](https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh)_