### PR TITLE
agent-tool: --diff-body for differential evaluation (last correctness rung)

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ lex agent-tool --allow-effects net --input "x" \
 #   exit 2
 ```
 
-Flags: `--body '<src>'` / `--body-file <path>` skip the API call; `--request '<q>'` needs `ANTHROPIC_API_KEY`. `--max-steps N` (default 1M) caps op count as a runtime DoS guard. `--allow-fs-read PATH` and `--allow-net-host HOST` add per-path / per-host scopes on top of `--allow-effects`. `--examples FILE` runs the tool against a JSON list of `{input, expected}` pairs (exit 5 on mismatch). `--spec FILE` proves a behavioral contract against the emitted body via the spec checker (exit 5 on counterexample, 6 on inconclusive — pass `--spec-allow-inconclusive` to ship anyway).
+Flags: `--body '<src>'` / `--body-file <path>` skip the API call; `--request '<q>'` needs `ANTHROPIC_API_KEY`. `--max-steps N` (default 1M) caps op count as a runtime DoS guard. `--allow-fs-read PATH` and `--allow-net-host HOST` add per-path / per-host scopes on top of `--allow-effects`. `--examples FILE` runs the tool against a JSON list of `{input, expected}` pairs (exit 5 on mismatch). `--spec FILE` proves a behavioral contract against the emitted body via the spec checker (exit 5 on counterexample, 6 on inconclusive). `--diff-body 'src'` / `--diff-body-file FILE` runs a second body on the same inputs and exits 7 on output divergence — regression detection across model upgrades.
 
 ### Adversarial benchmark
 

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -636,6 +636,12 @@ struct AgentToolOpts {
     spec_allow_inconclusive: bool,
     /// Trials for randomized fallback when SMT can't decide.
     spec_trials: u32,
+    /// Optional second body to compare against. When set, both bodies
+    /// run on each input (single `--input` or every entry from
+    /// `--examples`); any output divergence aborts with exit 7.
+    /// Catches model-version regressions when v1's emission and v2's
+    /// emission disagree on at least one case the host cares about.
+    diff_body_source: Option<BodySource>,
 }
 
 enum BodySource {
@@ -756,6 +762,77 @@ fn cmd_agent_tool(args: &[String]) -> Result<()> {
     // type-check rejects effects, max_steps rejects runaway compute.
     let bc = std::sync::Arc::new(bc);
 
+    // 5-diff) Differential evaluation: if --diff-body is set, compile
+    // the second body through the same gates and run both on each input
+    // (single --input or every entry from --examples). Any output
+    // divergence aborts with exit 7. Use case: detect regressions when
+    // model v2's emission disagrees with v1's on inputs the host cares
+    // about, without needing a full Spec proof.
+    if let Some(diff_src) = opts.diff_body_source.as_ref() {
+        let diff_body_text = match diff_src {
+            BodySource::Literal(b) => b.clone(),
+            BodySource::File(p) => fs::read_to_string(p)
+                .with_context(|| format!("read diff body from {}", p.display()))?,
+            BodySource::Request(_) => bail!(
+                "--diff-body and --diff-body-file accept literal source; \
+                 invoke Claude separately and pass the body in"),
+        };
+        let diff_body_text = strip_code_fences(&diff_body_text);
+        let diff_src = build_tool_program(&diff_body_text, &opts.allowed_effects);
+        let prog_b = parse_source(&diff_src).context("parse diff body")?;
+        let stages_b = canonicalize_program(&prog_b);
+        if let Err(errs) = lex_types::check_program(&stages_b) {
+            eprintln!("→ DIFF BODY type-check rejected.");
+            for e in &errs { eprintln!("  {e}"); }
+            std::process::exit(2);
+        }
+        let bc_b = compile_program(&stages_b);
+        if let Err(violations) = check_policy(&bc_b, &policy) {
+            eprintln!("→ DIFF BODY policy rejected.");
+            for v in &violations {
+                eprintln!("  {}", serde_json::to_string(v).unwrap_or_default());
+            }
+            std::process::exit(3);
+        }
+        let bc_b = std::sync::Arc::new(bc_b);
+
+        // Inputs: --examples list or single --input.
+        let inputs: Vec<String> = match opts.examples_file.as_ref() {
+            Some(p) => load_examples(p)?.into_iter().map(|e| e.input).collect(),
+            None => vec![opts.user_input.clone()],
+        };
+
+        if opts.show_source {
+            eprintln!("→ comparing two bodies on {} input(s)…", inputs.len());
+        }
+        let mut diverged: Vec<(String, String, String)> = Vec::new();
+        for input in &inputs {
+            let out_a = run_tool_once(&bc, &policy, opts.max_steps, input)?;
+            let out_b = run_tool_once(&bc_b, &policy, opts.max_steps, input)?;
+            if out_a != out_b {
+                diverged.push((input.clone(), out_a, out_b));
+            }
+        }
+        if !diverged.is_empty() {
+            eprintln!("→ DIFFERENTIAL DIVERGENCE — {} of {} inputs differ.",
+                diverged.len(), inputs.len());
+            for (input, a, b) in &diverged {
+                eprintln!("  input={input:?}");
+                eprintln!("    body A → {a:?}");
+                eprintln!("    body B → {b:?}");
+            }
+            std::process::exit(7);
+        }
+        if opts.show_source {
+            eprintln!("→ no divergence on {} input(s)", inputs.len());
+        }
+        // Print body A's output on the first input — single-shot mode.
+        let chosen = inputs.first().cloned().unwrap_or_default();
+        let out = run_tool_once(&bc, &policy, opts.max_steps, &chosen)?;
+        println!("{out}");
+        return Ok(());
+    }
+
     // 5a) If --examples is set, behavioral-verify before trusting the tool
     // for live traffic. Catches the well-typed-but-wrong-behavior gap:
     // the type system says what code touches; the examples say what it
@@ -864,6 +941,7 @@ fn parse_agent_tool_args(args: &[String]) -> Result<AgentToolOpts> {
     let mut spec_file: Option<PathBuf> = None;
     let mut spec_allow_inconclusive = false;
     let mut spec_trials: u32 = 1000;
+    let mut diff_body: Option<BodySource> = None;
     let mut i = 0;
     while i < args.len() {
         match args[i].as_str() {
@@ -930,6 +1008,16 @@ fn parse_agent_tool_args(args: &[String]) -> Result<AgentToolOpts> {
                     .parse().context("--spec-trials must be a u32")?;
                 i += 2;
             }
+            "--diff-body" => {
+                diff_body = Some(BodySource::Literal(args.get(i + 1)
+                    .ok_or_else(|| anyhow!("--diff-body needs a value"))?.clone()));
+                i += 2;
+            }
+            "--diff-body-file" => {
+                diff_body = Some(BodySource::File(PathBuf::from(args.get(i + 1)
+                    .ok_or_else(|| anyhow!("--diff-body-file needs a path"))?)));
+                i += 2;
+            }
             "--quiet" => { show_source = false; i += 1; }
             other => bail!("unknown agent-tool flag: {other}"),
         }
@@ -949,6 +1037,7 @@ fn parse_agent_tool_args(args: &[String]) -> Result<AgentToolOpts> {
         spec_file,
         spec_allow_inconclusive,
         spec_trials,
+        diff_body_source: diff_body,
     })
 }
 

--- a/crates/lex-cli/tests/agent_tool.rs
+++ b/crates/lex-cli/tests/agent_tool.rs
@@ -257,3 +257,75 @@ fn spec_missing_file_errors_clearly() {
     assert_ne!(code, 0);
     assert!(stderr.contains("read spec file"), "stderr:\n{stderr}");
 }
+
+#[test]
+fn diff_two_matching_bodies_exit_zero() {
+    let (code, stdout, stderr) = run(&[
+        "agent-tool",
+        "--allow-effects", "",
+        "--quiet",
+        "--input", "world",
+        "--body", "str.concat(\"hi, \", input)",
+        "--diff-body", "str.concat(\"hi, \", input)",
+    ]);
+    assert_eq!(code, 0, "stderr:\n{stderr}");
+    assert_eq!(stdout.trim(), "hi, world");
+}
+
+#[test]
+fn diff_two_disagreeing_bodies_exit_7() {
+    let (code, _stdout, stderr) = run(&[
+        "agent-tool",
+        "--allow-effects", "",
+        "--quiet",
+        "--input", "world",
+        "--body", "str.concat(\"hi, \", input)",
+        "--diff-body", "str.concat(\"hello, \", input)",
+    ]);
+    assert_eq!(code, 7, "expected exit 7; stderr:\n{stderr}");
+    assert!(stderr.contains("DIFFERENTIAL DIVERGENCE"), "stderr:\n{stderr}");
+    assert!(stderr.contains("body A"), "stderr:\n{stderr}");
+    assert!(stderr.contains("body B"), "stderr:\n{stderr}");
+}
+
+#[test]
+fn diff_with_examples_runs_each_input() {
+    use std::io::Write;
+    let mut tmp = std::env::temp_dir();
+    tmp.push("lex_diff_examples.json");
+    let mut f = std::fs::File::create(&tmp).expect("create tmp");
+    f.write_all(br#"[{"input":"1","expected":""},{"input":"2","expected":""}]"#)
+        .expect("write tmp");
+
+    // Two algebraically-equivalent bodies (n*2 vs n+n). Per-case diff
+    // should pass on every input.
+    let (code, _stdout, stderr) = run(&[
+        "agent-tool",
+        "--allow-effects", "",
+        "--quiet",
+        "--examples", tmp.to_str().unwrap(),
+        "--input", "1",
+        "--body",
+        "match str.to_int(input) { Some(n) => int.to_str(n * 2), None => \"x\" }",
+        "--diff-body",
+        "match str.to_int(input) { Some(n) => int.to_str(n + n), None => \"x\" }",
+    ]);
+    assert_eq!(code, 0, "stderr:\n{stderr}");
+}
+
+#[test]
+fn diff_body_type_check_failure_exits_2() {
+    // Diff body uses io.read but the host only allows the empty effect
+    // set — the type checker rejects on the diff body.
+    let (code, _stdout, stderr) = run(&[
+        "agent-tool",
+        "--allow-effects", "",
+        "--quiet",
+        "--input", "x",
+        "--body", "input",
+        "--diff-body",
+        "match io.read(\"/etc/passwd\") { Ok(s) => s, Err(e) => e }",
+    ]);
+    assert_eq!(code, 2, "expected type-check rejection on diff body; stderr:\n{stderr}");
+    assert!(stderr.contains("DIFF BODY"), "stderr:\n{stderr}");
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -253,15 +253,15 @@
     <li><strong>Examples-driven verification.</strong> Pass <code>--examples FILE</code>; the host hands the agent a small set of <code>{input → expected}</code> pairs and Lex runs the emitted body against each before trusting it for live traffic. Any mismatch exits 5 with a per-case diff. Catches <em>wrong-but-consistent</em> behavior (the wrong-site scrape) at minimal cost; doesn't need SMT.</li>
     <li><strong>Spec proofs.</strong> Pass <code>--spec FILE</code>; the host attaches a behavioral contract — <code>forall x :: Int where x &gt;= 0: tool(x) == expected(x)</code> — and the spec checker discharges it via Z3 (or a randomized fallback). Counterexamples abort with exit 5; inconclusive proofs abort with 6 unless <code>--spec-allow-inconclusive</code> is set. Strongest available pre-execution check on behavior.</li>
     <li><strong>Capability scoping.</strong> <code>--allow-net-host github.com</code> means the wrong-site scraping case can't even <em>reach</em> attacker.com — the blast radius of a behavioral bug is bounded.</li>
-    <li><strong>Differential evaluation.</strong> Run two agent-emitted bodies on the same inputs and flag divergence. Cheap regression detection across model upgrades. (Roadmap.)</li>
+    <li><strong>Differential evaluation.</strong> Pass <code>--diff-body 'src'</code> (or <code>--diff-body-file</code>); both bodies run on each input (single <code>--input</code> or every entry from <code>--examples</code>); any output divergence aborts with exit 7. Cheap regression detection across model upgrades — no oracle needed.</li>
   </ul>
   <p>
-    Today Lex ships effects, capability scoping, examples-driven
-    verification, and Spec proofs against agent-emitted bodies.
-    Differential evaluation is the remaining roadmap item. The point
-    isn't that capability typing solves correctness — it doesn't — it's
-    that the contract lives in the language, free of inference cost,
-    and each higher rung composes on top of the previous one.
+    All four rungs ship today: effects, capability scoping,
+    examples-driven verification, Spec proofs, and differential
+    evaluation. The point isn't that capability typing solves
+    correctness — it doesn't — it's that the contract lives in the
+    language, free of inference cost, and each higher rung composes
+    on top of the previous one.
   </p>
 </section>
 


### PR DESCRIPTION
## Summary

Last rung of the correctness ladder. Two bodies, same inputs; divergence aborts before either is trusted. Use case: model v2's emission disagrees with v1's on at least one case the host cares about — catch it without an oracle and without writing a Spec proof.

```bash
$ lex agent-tool --allow-effects "" --quiet --input world \
    --body 'str.concat("hi, ", input)' \
    --diff-body 'str.concat("hello, ", input)'
→ DIFFERENTIAL DIVERGENCE — 1 of 1 inputs differ.
  input="world"
    body A → "hi, world"
    body B → "hello, world"
exit 7
```

The second body goes through the same gates as the first (type-check, policy, scope), so a malicious diff body is rejected exactly as a malicious primary body would be. Combines with `--examples`: per-case diff across all input cases.

## New flags

| Flag | Purpose |
|---|---|
| `--diff-body 'src'` | literal second body |
| `--diff-body-file <path>` | second body from disk |

## Exit code map (now complete)

| Code | Meaning |
|---|---|
| 0 | ran |
| 2 | type-check rejected |
| 3 | policy rejected |
| 4 | step-limit exceeded |
| 5 | examples failed **OR** spec counterexample |
| 6 | spec inconclusive |
| **7** | differential divergence |

## Test plan

- [x] `diff_two_matching_bodies_exit_zero` — same body twice → exit 0, prints body A's output
- [x] `diff_two_disagreeing_bodies_exit_7` — different prefixes → exit 7 with both outputs in stderr
- [x] `diff_with_examples_runs_each_input` — algebraically-equivalent bodies (`n*2` vs `n+n`) over 2 examples → exit 0
- [x] `diff_body_type_check_failure_exits_2` — diff body uses `io.read` outside allowed effects → exit 2 with `DIFF BODY` label
- [x] `cargo test --workspace` green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

## Doc updates

- README: one-sentence pointer to `--diff-body` alongside the other agent-tool flags
- `docs/index.html`: *Differential evaluation* moves from "Roadmap" to a shipped rung. **All four behavioral-correctness rungs now exist on top of the effect-typing base.**

https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh

---
_Generated by [Claude Code](https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh)_