### PR TITLE
Add examples/inbox_app.lex — typed-handler event router

### DIFF
--- a/crates/lex-runtime/tests/inbox_app.rs
+++ b/crates/lex-runtime/tests/inbox_app.rs
@@ -1,0 +1,112 @@
+//! Integration tests for examples/inbox_app.lex — the typed-handler
+//! event router. Verifies that classification dispatches to the right
+//! handler and that each handler honors its declared effect scope.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::collections::BTreeSet;
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+fn spawn_inbox_server(port: u16) {
+    let src = include_str!("../../../examples/inbox_app.lex")
+        .replace("net.serve(8200,", &format!("net.serve({port},"));
+    let prog = parse_source(&src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors: {errs:#?}");
+    }
+    let bc = Arc::new(compile_program(&stages));
+    let mut policy = Policy::pure();
+    policy.allow_effects = ["io".into(), "net".into(), "time".into()]
+        .into_iter().collect::<BTreeSet<_>>();
+    policy.allow_fs_write = vec![PathBuf::from("/tmp")];
+    thread::spawn(move || {
+        let handler = DefaultHandler::new(policy).with_program(Arc::clone(&bc));
+        let mut vm = Vm::with_handler(&bc, Box::new(handler));
+        let _ = vm.call("main", vec![]);
+    });
+    thread::sleep(Duration::from_millis(200));
+}
+
+fn post(port: u16, path: &str, body: &str) -> (u16, String) {
+    let mut s = TcpStream::connect(("127.0.0.1", port)).expect("connect");
+    s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    let req = format!(
+        "POST {path} HTTP/1.1\r\nHost: 127.0.0.1\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len(),
+    );
+    s.write_all(req.as_bytes()).unwrap();
+    let mut buf = String::new();
+    s.read_to_string(&mut buf).unwrap();
+    let (head, body) = buf.split_once("\r\n\r\n").unwrap_or((&buf, ""));
+    let status = head.split_whitespace().nth(1).unwrap_or("0").parse().unwrap_or(0);
+    (status, body.to_string())
+}
+
+fn cleanup() {
+    let _ = std::fs::remove_file("/tmp/lex_inbox_spam.log");
+    let _ = std::fs::remove_file("/tmp/lex_inbox_followups.log");
+}
+
+#[test]
+fn spam_subject_routes_to_spam_handler_and_writes_log() {
+    cleanup();
+    let port = 18401;
+    spawn_inbox_server(port);
+    let (status, body) = post(port, "/hook",
+        r#"{"from":"a@b","subject":"win a prize today","body":"x"}"#);
+    assert_eq!(status, 200, "body: {body}");
+    assert!(body.contains("\"logged\""), "body: {body}");
+    let log = std::fs::read_to_string("/tmp/lex_inbox_spam.log")
+        .expect("spam log written");
+    assert!(log.contains("a@b"), "log content: {log}");
+    assert!(log.contains("win a prize"), "log content: {log}");
+}
+
+#[test]
+fn followup_subject_writes_followup_log_with_timestamp() {
+    cleanup();
+    let port = 18402;
+    spawn_inbox_server(port);
+    let (status, body) = post(port, "/hook",
+        r#"{"from":"a@b","subject":"please follow up next week","body":"x"}"#);
+    assert_eq!(status, 200, "body: {body}");
+    assert!(body.contains("scheduled at"), "body: {body}");
+    let log = std::fs::read_to_string("/tmp/lex_inbox_followups.log")
+        .expect("followup log written");
+    assert!(log.contains("follow-up"), "log content: {log}");
+    // timestamp is a unix-epoch integer, so the line starts with digits.
+    let first = log.chars().next().unwrap_or(' ');
+    assert!(first.is_ascii_digit(), "expected leading timestamp; got: {log}");
+}
+
+#[test]
+fn other_subject_returns_pure_ignored_response() {
+    cleanup();
+    let port = 18403;
+    spawn_inbox_server(port);
+    let (status, body) = post(port, "/hook",
+        r#"{"from":"a@b","subject":"weekly newsletter","body":"x"}"#);
+    assert_eq!(status, 200);
+    assert!(body.contains("ignored"), "body: {body}");
+    // No side effects on disk.
+    assert!(!PathBuf::from("/tmp/lex_inbox_spam.log").exists());
+    assert!(!PathBuf::from("/tmp/lex_inbox_followups.log").exists());
+}
+
+#[test]
+fn unknown_path_returns_404() {
+    let port = 18404;
+    spawn_inbox_server(port);
+    let (status, _body) = post(port, "/nope", "{}");
+    assert_eq!(status, 404);
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -237,6 +237,31 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
             ));
             Some(Ty::Record(fields))
         }
+        "time" => {
+            // time.now() -> [time] Int — unix timestamp seconds.
+            // Reading the clock is an effect for two reasons: it's
+            // non-deterministic (replay needs the captured value) and
+            // it's a side-channel surface (see "Capability ≠
+            // correctness" on the landing page).
+            let mut fields = IndexMap::new();
+            fields.insert("now".into(), Ty::function(
+                vec![],
+                EffectSet::singleton("time"),
+                Ty::int(),
+            ));
+            Some(Ty::Record(fields))
+        }
+        "rand" => {
+            // rand.int_in(lo, hi) -> [rand] Int — currently a deterministic
+            // stub (midpoint) per spec §13; replaced when randomness lands.
+            let mut fields = IndexMap::new();
+            fields.insert("int_in".into(), Ty::function(
+                vec![Ty::int(), Ty::int()],
+                EffectSet::singleton("rand"),
+                Ty::int(),
+            ));
+            Some(Ty::Record(fields))
+        }
         "net" => {
             let mut fields = IndexMap::new();
             // get :: Str -> [net] Result[Str, Str]
@@ -451,6 +476,8 @@ pub fn module_for_import(reference: &str) -> Option<&'static str> {
         "json" => "json",
         "flow" => "flow",
         "tuple" => "tuple",
+        "time" => "time",
+        "rand" => "rand",
         "bytes" => "bytes",
         "net" => "net",
         "chat" => "chat",

--- a/examples/inbox_app.lex
+++ b/examples/inbox_app.lex
@@ -1,0 +1,140 @@
+# An inbox processor that ROUTES events by classification and lets the
+# *function signatures* carry the security policy. Reader sees at a
+# glance:
+#
+#   classify         — pure (no effects)
+#   handle_important — [net]      can post to webhooks, can't touch fs
+#   handle_spam      — [io]       can write logs, can't make net calls
+#   handle_followup  — [time, io] can read clock + write reminders
+#
+# Adding a network call to handle_spam is a TYPE ERROR, not a code-review
+# bug. Granting [io] to the whole process and trusting that handle_spam
+# won't do something else is exactly what RestrictedPython / sandboxes
+# can't promise.
+#
+# Run:
+#   lex run --allow-effects io,net,time \
+#           --allow-fs-write /tmp \
+#           examples/inbox_app.lex main
+#
+# Send an event:
+#   curl -X POST http://127.0.0.1:8200/hook \
+#     -H 'content-type: application/json' \
+#     -d '{"from":"a@b","subject":"URGENT: down","body":"prod is on fire"}'
+
+import "std.net"  as net
+import "std.io"   as io
+import "std.str"  as str
+import "std.int"  as int
+import "std.json" as json
+import "std.time" as time
+
+type Email   = { body :: Str, from :: Str, subject :: Str }
+type Request = { body :: Str, method :: Str, path :: Str, query :: Str }
+type Response = { body :: Str, status :: Int }
+
+# ---- classification (pure) -----------------------------------------
+# No effects. The reader can tell at a glance that classify can't write
+# files, can't call APIs, can't read the clock — the type system says so.
+
+type Action = Important | Spam | FollowUp | Other
+
+fn classify(e :: Email) -> Action {
+  match str.contains(str.to_lower(e.subject), "urgent") {
+    true  => Important,
+    false => match str.contains(str.to_lower(e.subject), "follow up") {
+      true  => FollowUp,
+      false => match str.contains(str.to_lower(e.subject), "win a prize") {
+        true  => Spam,
+        false => Other,
+      },
+    },
+  }
+}
+
+# ---- handlers (each with its own narrow effect set) ----------------
+
+# handle_important can hit the network. It cannot write files. If you
+# accidentally added `io.write(...)` here, the type checker would
+# reject the whole program.
+fn handle_important(e :: Email) -> [net] Str {
+  let url := "http://example.com/slack-mock"
+  match net.post(url, str.concat("alert: ", e.subject)) {
+    Ok(_)  => "posted",
+    Err(m) => str.concat("post-failed: ", m),
+  }
+}
+
+# handle_spam can write to a log file. It cannot make network calls.
+fn handle_spam(e :: Email) -> [io] Str {
+  let line := str.concat(str.concat(e.from, " | "), e.subject)
+  match io.write("/tmp/lex_inbox_spam.log", line) {
+    Ok(_)  => "logged",
+    Err(m) => str.concat("log-failed: ", m),
+  }
+}
+
+# handle_followup needs *both* the clock (to stamp the reminder) and
+# the filesystem (to persist it). Any other capability is rejected.
+fn handle_followup(e :: Email) -> [time, io] Str {
+  let now  := time.now()
+  let stamp := int.to_str(now)
+  let entry := str.concat(stamp, str.concat(" | follow-up: ", e.subject))
+  match io.write("/tmp/lex_inbox_followups.log", entry) {
+    Ok(_)  => str.concat("scheduled at ", stamp),
+    Err(m) => str.concat("schedule-failed: ", m),
+  }
+}
+
+# Catch-all. Pure: returns a string, touches nothing.
+fn handle_other(e :: Email) -> Str {
+  str.concat("ignored: ", e.subject)
+}
+
+# ---- routing -------------------------------------------------------
+# Route's effect set is the *union* of the handlers it can call.
+# `[net, time, io]` here means: any code path through route may
+# touch any of those three. If a future contributor adds a new
+# variant whose handler uses [proc], the inferred set on route
+# changes and the type checker forces the signature update.
+
+fn route(e :: Email) -> [net, time, io] Str {
+  match classify(e) {
+    Important => handle_important(e),
+    Spam      => handle_spam(e),
+    FollowUp  => handle_followup(e),
+    Other     => handle_other(e),
+  }
+}
+
+# ---- HTTP glue -----------------------------------------------------
+
+fn parse_email(body :: Str) -> Email {
+  match json.parse(body) {
+    Ok(e)  => e,
+    Err(_) => { body: "", from: "", subject: "" },
+  }
+}
+
+fn handle(req :: Request) -> [net, time, io] Response {
+  match req.method {
+    "POST" => match req.path {
+      "/hook" => {
+        let email := parse_email(req.body)
+        let result := route(email)
+        let resp := str.concat("{\"result\":\"", str.concat(result, "\"}"))
+        { body: resp, status: 200 }
+      },
+      _ => { body: "{\"error\":\"not found\"}", status: 404 },
+    },
+    "GET" => match req.path {
+      "/" => { body: "{\"endpoints\":[\"POST /hook\"]}", status: 200 },
+      _   => { body: "{\"error\":\"not found\"}", status: 404 },
+    },
+    _ => { body: "{\"error\":\"method not allowed\"}", status: 405 },
+  }
+}
+
+fn main() -> [net, time, io] Nil {
+  net.serve(8200, "handle")
+}


### PR DESCRIPTION
## Summary

A webhook-driven inbox processor where the function signatures carry the security policy. Reader sees at a glance which handler can do what:

```lex
classify         — pure (no effects)
handle_important — [net]            can post to webhooks; cannot touch fs
handle_spam      — [io]             can write logs; cannot make net calls
handle_followup  — [time, io]       can read clock + write reminders
route            — [net, time, io]  union of branches
```

Adding a network call to `handle_spam` is a **type error**, not a code-review bug. That's the differentiator: in Python you grant io+net to the whole process and trust each function not to misuse what it has; in Lex you grant the union, but each function's signature pins what *that* function can use.

## Side-effect: registered std.time + std.rand in the type system

Both had runtime arms (`DefaultHandler` dispatches `("time","now")` and `("rand","int_in")`) but no module signatures — `import "std.time"` failed with `UnknownIdentifier`. Same silent-stub problem we cleaned up for std.map/std.set. Now resolved.

## Run

```bash
lex run --allow-effects io,net,time --allow-fs-write /tmp \
        examples/inbox_app.lex main

curl -X POST http://127.0.0.1:8200/hook \
  -H 'content-type: application/json' \
  -d '{"from":"a@b","subject":"URGENT: down","body":"prod is on fire"}'
```

## Test plan

- [x] `spam_subject_routes_to_spam_handler_and_writes_log` — `[io]`-only path
- [x] `followup_subject_writes_followup_log_with_timestamp` — `[time, io]` composition
- [x] `other_subject_returns_pure_ignored_response` — pure path, no side effects on disk
- [x] `unknown_path_returns_404`
- [x] `cargo test --workspace` green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh

---
_Generated by [Claude Code](https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh)_