### PR TITLE
Add `lex tool-registry serve` — runtime tool registration over HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Flags: `--body '<src>'` / `--body-file <path>` skip the API call; `--request '<q
 | `lex spec smt <spec>` | Emit SMT-LIB 2 for external Z3 |
 | `lex serve [--port N] [--store DIR]` | Run the agent HTTP/JSON API |
 | `lex agent-tool --allow-effects ks (--request 'q' \| --body 'src' \| --body-file F)` | Run an LLM-emitted tool body under declared effects |
+| `lex tool-registry serve [--port N]` | HTTP service to register Lex tools at runtime; `POST /tools` validates + stores, `POST /tools/{id}/invoke` runs |
 
 ### Policy flags (run / replay)
 

--- a/crates/lex-cli/Cargo.toml
+++ b/crates/lex-cli/Cargo.toml
@@ -14,6 +14,7 @@ serde_json.workspace = true
 anyhow.workspace = true
 indexmap.workspace = true
 ureq = { version = "2.10", default-features = false, features = ["tls", "json"] }
+tiny_http = "0.12"
 lex-syntax = { path = "../lex-syntax" }
 lex-ast = { path = "../lex-ast" }
 lex-types = { path = "../lex-types" }

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -10,6 +10,8 @@
 //!   lex store list [--store DIR]
 //!   lex store get [--store DIR] <stage_id>
 
+mod tool_registry;
+
 use anyhow::{anyhow, bail, Context, Result};
 use lex_ast::{canonicalize_program, sig_id, stage_canonical_hash_hex, stage_id, Stage};
 use lex_bytecode::{compile_program, vm::Vm, Value};
@@ -45,6 +47,7 @@ fn run(args: &[String]) -> Result<()> {
         "conformance" => cmd_conformance(&args[1..]),
         "spec" => cmd_spec(&args[1..]),
         "agent-tool" => cmd_agent_tool(&args[1..]),
+        "tool-registry" => tool_registry::cmd_tool_registry(&args[1..]),
         "help" | "--help" | "-h" => { print_usage(); Ok(()) }
         other => bail!("unknown command `{other}`. try `lex help`"),
     }
@@ -73,6 +76,8 @@ fn print_usage() {
     println!("                                     have an LLM emit a Lex tool body, run it");
     println!("                                     under the declared effects (rejected at");
     println!("                                     type-check if it tries anything else)");
+    println!("  tool-registry serve [--port N]    HTTP service to register Lex tools at runtime");
+    println!("                                     and invoke them via /tools/{{id}}/invoke");
     println!();
     println!("policy flags (run, replay):");
     println!("  --allow-effects k1,k2,...   permit these effect kinds");

--- a/crates/lex-cli/src/tool_registry.rs
+++ b/crates/lex-cli/src/tool_registry.rs
@@ -1,0 +1,328 @@
+//! `lex tool-registry serve` — runtime tool registration over HTTP.
+//!
+//! The headline pitch of agent-tool says: "the function signature IS
+//! the security policy." The tool registry puts that on a network.
+//! Anyone can POST a Lex body + an effect declaration and get back a
+//! stable `/tools/{id}/invoke` endpoint. Each tool's effect manifest
+//! is published at `/tools/{id}` — the contract is auditable by any
+//! caller, not buried in the host's source.
+//!
+//! Endpoints:
+//!
+//!   POST /tools              register a tool; body is JSON:
+//!                              { name, body, allowed_effects?, allow_fs_read?,
+//!                                allow_net_host? }
+//!                            -> 201 { id, manifest }
+//!                            -> 400 { error_kind, detail }   (type-check / policy)
+//!
+//!   GET  /tools              list registered tools
+//!                            -> 200 [ { id, name, allowed_effects } ]
+//!
+//!   GET  /tools/{id}         tool manifest
+//!                            -> 200 { id, name, allowed_effects, ... }
+//!                            -> 404
+//!
+//!   POST /tools/{id}/invoke  run a tool. body is JSON: { input }
+//!                            -> 200 { output }
+//!                            -> 404  / 5xx { error_kind, detail }
+//!
+//! Storage is in-memory. The registry is single-process; persistence
+//! across restarts is a v1.1 follow-up.
+
+use anyhow::{anyhow, Result};
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Program, Value};
+use lex_runtime::{check_program as check_policy, DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use tiny_http::{Header, Method, Response, Server};
+
+/// One registered tool. We hold the compiled bytecode (`Arc<Program>`)
+/// so that invokes don't recompile per request.
+struct ToolEntry {
+    id: String,
+    name: String,
+    body: String,
+    allowed_effects: Vec<String>,
+    allow_fs_read: Vec<PathBuf>,
+    allow_net_host: Vec<String>,
+    program: Arc<Program>,
+}
+
+#[derive(Default)]
+struct Registry {
+    tools: Mutex<Vec<ToolEntry>>,
+    next_id: Mutex<u64>,
+}
+
+impl Registry {
+    fn alloc_id(&self) -> String {
+        let mut n = self.next_id.lock().unwrap();
+        *n += 1;
+        format!("t{:08x}", *n)
+    }
+    fn insert(&self, entry: ToolEntry) {
+        self.tools.lock().unwrap().push(entry);
+    }
+    fn get<F, R>(&self, id: &str, f: F) -> Option<R>
+    where F: FnOnce(&ToolEntry) -> R
+    {
+        let g = self.tools.lock().unwrap();
+        g.iter().find(|t| t.id == id).map(f)
+    }
+    fn list(&self) -> Vec<serde_json::Value> {
+        self.tools.lock().unwrap().iter().map(|t| json!({
+            "id": t.id,
+            "name": t.name,
+            "allowed_effects": t.allowed_effects,
+            "allow_fs_read": t.allow_fs_read.iter().map(|p| p.display().to_string()).collect::<Vec<_>>(),
+            "allow_net_host": t.allow_net_host,
+        })).collect()
+    }
+}
+
+#[derive(Deserialize)]
+struct RegisterReq {
+    name: String,
+    body: String,
+    #[serde(default)] allowed_effects: Vec<String>,
+    #[serde(default)] allow_fs_read: Vec<String>,
+    #[serde(default)] allow_net_host: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct InvokeReq {
+    #[serde(default)] input: String,
+}
+
+#[derive(Serialize)]
+struct ManifestOut<'a> {
+    id: &'a str,
+    name: &'a str,
+    allowed_effects: &'a [String],
+    allow_fs_read: Vec<String>,
+    allow_net_host: &'a [String],
+}
+
+/// Subcommand entry point: `lex tool-registry serve --port N`.
+pub fn cmd_tool_registry(args: &[String]) -> Result<()> {
+    let sub = args.first().ok_or_else(|| anyhow!("usage: lex tool-registry serve [--port N]"))?;
+    if sub != "serve" {
+        return Err(anyhow!("unknown subcommand `{sub}`; only `serve` is supported"));
+    }
+    let mut port: u16 = 8300;
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--port" => {
+                port = args.get(i + 1).ok_or_else(|| anyhow!("--port needs a value"))?
+                    .parse().map_err(|e| anyhow!("--port: {e}"))?;
+                i += 2;
+            }
+            other => return Err(anyhow!("unknown flag `{other}`")),
+        }
+    }
+    let registry = Arc::new(Registry::default());
+    serve(port, registry)
+}
+
+fn serve(port: u16, registry: Arc<Registry>) -> Result<()> {
+    let server = Server::http(("127.0.0.1", port))
+        .map_err(|e| anyhow!("bind {port}: {e}"))?;
+    eprintln!("lex tool-registry: listening on http://127.0.0.1:{port}");
+    for req in server.incoming_requests() {
+        let registry = Arc::clone(&registry);
+        std::thread::spawn(move || handle(req, registry));
+    }
+    Ok(())
+}
+
+fn json_response(status: u16, body: serde_json::Value) -> Response<std::io::Cursor<Vec<u8>>> {
+    let body_str = body.to_string();
+    let header = Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..]).unwrap();
+    Response::from_string(body_str).with_status_code(status).with_header(header)
+}
+
+fn handle(mut req: tiny_http::Request, registry: Arc<Registry>) {
+    let method = req.method().clone();
+    let url = req.url().to_string();
+    let path = url.split('?').next().unwrap_or(&url).to_string();
+
+    let mut body_str = String::new();
+    use std::io::Read;
+    let _ = Read::read_to_string(req.as_reader(), &mut body_str);
+
+    let resp = match (&method, path.as_str()) {
+        (Method::Post, "/tools") => post_tools(&body_str, &registry),
+        (Method::Get, "/tools")  => json_response(200, json!(registry.list())),
+        (Method::Get, p) if p.starts_with("/tools/") => {
+            let rest = &p["/tools/".len()..];
+            if let Some(id) = rest.strip_suffix("/invoke") {
+                json_response(405, json!({ "error": "use POST", "id": id }))
+            } else {
+                get_tool(rest, &registry)
+            }
+        }
+        (Method::Post, p) if p.starts_with("/tools/") && p.ends_with("/invoke") => {
+            let id = &p["/tools/".len()..p.len() - "/invoke".len()];
+            invoke_tool(id, &body_str, &registry)
+        }
+        _ => json_response(404, json!({ "error": "not found", "path": path })),
+    };
+    let _ = req.respond(resp);
+}
+
+fn post_tools(body_str: &str, registry: &Registry) -> Response<std::io::Cursor<Vec<u8>>> {
+    let parsed: RegisterReq = match serde_json::from_str(body_str) {
+        Ok(p) => p,
+        Err(e) => return json_response(400, json!({
+            "error_kind": "bad_json", "detail": e.to_string(),
+        })),
+    };
+
+    // 1) Build the same tool program agent-tool builds, splice the
+    // body into a fixed signature with the declared effects.
+    let src = build_tool_program(&parsed.body, &parsed.allowed_effects);
+
+    // 2) Parse + type-check.
+    let prog = match parse_source(&src) {
+        Ok(p) => p,
+        Err(e) => return json_response(400, json!({
+            "error_kind": "parse", "detail": e.to_string(),
+        })),
+    };
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        let detail: Vec<String> = errs.iter().map(|e| e.to_string()).collect();
+        return json_response(400, json!({
+            "error_kind": "type_check", "detail": detail,
+        }));
+    }
+
+    // 3) Compile + policy gate.
+    let bc = compile_program(&stages);
+    let policy = build_policy(&parsed);
+    if let Err(violations) = check_policy(&bc, &policy) {
+        let detail: Vec<String> = violations.iter().map(|v| v.to_string()).collect();
+        return json_response(400, json!({
+            "error_kind": "policy", "detail": detail,
+        }));
+    }
+
+    let entry = ToolEntry {
+        id: registry.alloc_id(),
+        name: parsed.name.clone(),
+        body: parsed.body.clone(),
+        allowed_effects: parsed.allowed_effects.clone(),
+        allow_fs_read: parsed.allow_fs_read.iter().map(PathBuf::from).collect(),
+        allow_net_host: parsed.allow_net_host.clone(),
+        program: Arc::new(bc),
+    };
+    let id = entry.id.clone();
+    let manifest = ManifestOut {
+        id: &entry.id,
+        name: &entry.name,
+        allowed_effects: &entry.allowed_effects,
+        allow_fs_read: entry.allow_fs_read.iter().map(|p| p.display().to_string()).collect(),
+        allow_net_host: &entry.allow_net_host,
+    };
+    let manifest_json = serde_json::to_value(&manifest).unwrap_or(json!({}));
+    registry.insert(entry);
+    json_response(201, json!({
+        "id": id,
+        "manifest": manifest_json,
+        "endpoint": format!("/tools/{id}/invoke"),
+    }))
+}
+
+fn get_tool(id: &str, registry: &Registry) -> Response<std::io::Cursor<Vec<u8>>> {
+    match registry.get(id, |t| json!({
+        "id": t.id,
+        "name": t.name,
+        "body": t.body,
+        "allowed_effects": t.allowed_effects,
+        "allow_fs_read": t.allow_fs_read.iter().map(|p| p.display().to_string()).collect::<Vec<_>>(),
+        "allow_net_host": t.allow_net_host,
+    })) {
+        Some(v) => json_response(200, v),
+        None => json_response(404, json!({ "error": "not found", "id": id })),
+    }
+}
+
+fn invoke_tool(id: &str, body_str: &str, registry: &Registry) -> Response<std::io::Cursor<Vec<u8>>> {
+    let parsed: InvokeReq = match serde_json::from_str(body_str) {
+        Ok(p) => p,
+        Err(e) => return json_response(400, json!({
+            "error_kind": "bad_json", "detail": e.to_string(),
+        })),
+    };
+    // Pull out the program + policy under the lock; release before
+    // running so the VM doesn't hold the registry mutex.
+    let setup = registry.get(id, |t| (
+        Arc::clone(&t.program),
+        build_policy_from_entry(t),
+    ));
+    let (prog, policy) = match setup {
+        Some(x) => x,
+        None => return json_response(404, json!({ "error": "not found", "id": id })),
+    };
+    let handler = DefaultHandler::new(policy).with_program(Arc::clone(&prog));
+    let mut vm = Vm::with_handler(&prog, Box::new(handler));
+    vm.set_step_limit(1_000_000);
+    match vm.call("tool", vec![Value::Str(parsed.input)]) {
+        Ok(Value::Str(s)) => json_response(200, json!({ "output": s })),
+        Ok(other) => json_response(200, json!({ "output": format!("{other:?}") })),
+        Err(e) => {
+            let msg = format!("{e}");
+            let kind = if msg.contains("step limit") { "step_limit" }
+                else if msg.contains("outside --allow-fs-read")
+                    || msg.contains("not in --allow-net-host") { "policy_runtime" }
+                else { "runtime" };
+            json_response(500, json!({ "error_kind": kind, "detail": msg }))
+        }
+    }
+}
+
+fn build_policy(req: &RegisterReq) -> Policy {
+    let mut policy = Policy::pure();
+    policy.allow_effects = req.allowed_effects.iter().cloned().collect::<BTreeSet<_>>();
+    policy.allow_fs_read = req.allow_fs_read.iter().map(PathBuf::from).collect();
+    policy.allow_net_host = req.allow_net_host.clone();
+    policy
+}
+
+fn build_policy_from_entry(t: &ToolEntry) -> Policy {
+    let mut policy = Policy::pure();
+    policy.allow_effects = t.allowed_effects.iter().cloned().collect::<BTreeSet<_>>();
+    policy.allow_fs_read = t.allow_fs_read.clone();
+    policy.allow_net_host = t.allow_net_host.clone();
+    policy
+}
+
+/// Build the same fixed-signature program the agent-tool flow uses.
+/// Kept here rather than cross-imported from main.rs because the
+/// registry needs it via a stable public-ish path; if main.rs's
+/// version drifts, this becomes the canonical one.
+fn build_tool_program(body: &str, allowed_effects: &[String]) -> String {
+    let imports = [
+        "import \"std.io\"    as io",
+        "import \"std.net\"   as net",
+        "import \"std.str\"   as str",
+        "import \"std.int\"   as int",
+        "import \"std.float\" as float",
+        "import \"std.list\"  as list",
+        "import \"std.json\"  as json",
+        "import \"std.bytes\" as bytes",
+        "import \"std.time\"  as time",
+    ].join("\n");
+    let effects = if allowed_effects.is_empty() {
+        String::new()
+    } else {
+        format!("[{}] ", allowed_effects.join(", "))
+    };
+    format!("{imports}\n\nfn tool(input :: Str) -> {effects}Str {{\n{body}\n}}\n")
+}

--- a/crates/lex-cli/tests/tool_registry.rs
+++ b/crates/lex-cli/tests/tool_registry.rs
@@ -1,0 +1,139 @@
+//! End-to-end tests for `lex tool-registry serve`.
+//!
+//! Spawns the binary, registers tools via HTTP, invokes them, and
+//! asserts on the manifest + runtime behavior. Each test uses its
+//! own port so they can run in parallel.
+
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+
+fn lex_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_lex")
+}
+
+struct Server {
+    child: Child,
+    port: u16,
+}
+impl Drop for Server {
+    fn drop(&mut self) { let _ = self.child.kill(); let _ = self.child.wait(); }
+}
+
+#[allow(clippy::zombie_processes)] // Drop handler kills + waits.
+fn start_server(port: u16) -> Server {
+    let child = Command::new(lex_bin())
+        .args(["tool-registry", "serve", "--port", &port.to_string()])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn server");
+    // Wait for the bind. Polling is more reliable than a sleep.
+    for _ in 0..40 {
+        if TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            return Server { child, port };
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("server didn't bind on {port}");
+}
+
+fn http(port: u16, method: &str, path: &str, body: &str) -> (u16, String) {
+    let mut s = TcpStream::connect(("127.0.0.1", port)).expect("connect");
+    s.set_read_timeout(Some(Duration::from_secs(10))).unwrap();
+    let req = format!(
+        "{method} {path} HTTP/1.1\r\nHost: 127.0.0.1\r\n\
+         Content-Type: application/json\r\nContent-Length: {}\r\n\
+         Connection: close\r\n\r\n{body}",
+        body.len(),
+    );
+    s.write_all(req.as_bytes()).unwrap();
+    let mut buf = String::new();
+    s.read_to_string(&mut buf).unwrap();
+    let (head, body) = buf.split_once("\r\n\r\n").unwrap_or((&buf, ""));
+    let status = head.split_whitespace().nth(1).unwrap_or("0").parse().unwrap_or(0);
+    (status, body.to_string())
+}
+
+#[test]
+fn register_pure_tool_then_invoke_returns_output() {
+    let s = start_server(18601);
+    let (status, body) = http(s.port, "POST", "/tools",
+        r#"{"name":"greeter","body":"str.concat(\"hi, \", input)","allowed_effects":[]}"#);
+    assert_eq!(status, 201, "register: {body}");
+    assert!(body.contains("\"id\""), "body: {body}");
+    assert!(body.contains("\"endpoint\""), "body: {body}");
+
+    let (status, body) = http(s.port, "POST", "/tools/t00000001/invoke",
+        r#"{"input":"world"}"#);
+    assert_eq!(status, 200, "invoke: {body}");
+    assert!(body.contains("\"output\":\"hi, world\""), "body: {body}");
+}
+
+#[test]
+fn malicious_tool_rejected_at_registration_with_type_check_error() {
+    let s = start_server(18602);
+    // Body uses io.read but allowed_effects is [net]. Type checker
+    // rejects at register-time; tool never gets stored.
+    let (status, body) = http(s.port, "POST", "/tools",
+        r#"{"name":"bad","body":"match io.read(\"/etc/passwd\") { Ok(s) => s, Err(e) => e }","allowed_effects":["net"]}"#);
+    assert_eq!(status, 400, "expected 400; body: {body}");
+    assert!(body.contains("type_check"), "body: {body}");
+    assert!(body.contains("effect `io`"), "body: {body}");
+
+    // Confirm nothing was stored.
+    let (status, body) = http(s.port, "GET", "/tools", "");
+    assert_eq!(status, 200);
+    assert_eq!(body, "[]", "tools list should be empty: {body}");
+}
+
+#[test]
+fn manifest_endpoint_returns_tool_record() {
+    let s = start_server(18603);
+    let (status, _) = http(s.port, "POST", "/tools",
+        r#"{"name":"echo","body":"input","allowed_effects":[]}"#);
+    assert_eq!(status, 201);
+
+    let (status, body) = http(s.port, "GET", "/tools/t00000001", "");
+    assert_eq!(status, 200, "body: {body}");
+    assert!(body.contains("\"name\":\"echo\""), "body: {body}");
+    assert!(body.contains("\"allowed_effects\":[]"), "body: {body}");
+}
+
+#[test]
+fn unknown_tool_id_returns_404() {
+    let s = start_server(18604);
+    let (status, body) = http(s.port, "GET", "/tools/t99999999", "");
+    assert_eq!(status, 404, "body: {body}");
+    let (status, _) = http(s.port, "POST", "/tools/t99999999/invoke", r#"{"input":"x"}"#);
+    assert_eq!(status, 404);
+}
+
+#[test]
+fn unknown_path_returns_404() {
+    let s = start_server(18605);
+    let (status, _) = http(s.port, "GET", "/no/such/path", "");
+    assert_eq!(status, 404);
+}
+
+#[test]
+fn list_tools_after_two_registrations() {
+    let s = start_server(18606);
+    // Two tools, both pure. We pre-build the JSON via an escaped
+    // body string — otherwise inner `"` from str.concat literals
+    // collide with JSON delimiters.
+    let cases: &[(&str, &str)] = &[
+        ("a", "input"),
+        ("b", r#"str.concat(\"x\", input)"#),
+    ];
+    for (name, body_lex) in cases {
+        let body = format!(r#"{{"name":"{name}","body":"{body_lex}","allowed_effects":[]}}"#);
+        let (status, resp) = http(s.port, "POST", "/tools", &body);
+        assert_eq!(status, 201, "register {name}: {resp}");
+    }
+    let (status, body) = http(s.port, "GET", "/tools", "");
+    assert_eq!(status, 200);
+    assert!(body.contains("\"name\":\"a\""), "body: {body}");
+    assert!(body.contains("\"name\":\"b\""), "body: {body}");
+}


### PR DESCRIPTION
## Summary

Puts the `agent-tool` flow on a network. Anyone can POST a Lex body + an effect declaration and get back a stable `/tools/{id}/invoke` endpoint. Each tool's effect manifest is published at `/tools/{id}` — the contract is auditable by any caller, not buried in the host's source.

```bash
$ lex tool-registry serve --port 8390
$ curl -X POST :8390/tools -d '
    {"name":"greeter","body":"str.concat(\"hi, \", input)",
     "allowed_effects":[]}'
→ 201 { "id": "t00000001",
        "manifest": { ..., "allowed_effects": [] },
        "endpoint": "/tools/t00000001/invoke" }

$ curl -X POST :8390/tools/t00000001/invoke -d '{"input":"world"}'
→ 200 { "output": "hi, world" }

$ curl -X POST :8390/tools -d '
    {"name":"bad",
     "body":"match io.read(\"/etc/passwd\") {...}",
     "allowed_effects":["net"]}'
→ 400 { "error_kind": "type_check",
        "detail": ["effect `io` not declared at n_0"] }
```

## Endpoints

| Method | Path | Purpose |
|---|---|---|
| `POST` | `/tools` | register; 201 on success, 400 with structured `error_kind` on rejection |
| `GET` | `/tools` | list registered tools |
| `GET` | `/tools/{id}` | tool manifest (includes the body) |
| `POST` | `/tools/{id}/invoke` | run a tool with `{"input": "..."}` |

The validation pipeline mirrors `agent-tool`: parse → canonicalize → type-check → policy gate. Tools that fail any gate never enter the registry, so `/invoke` can always trust what's stored.

## Architecture

`tool_registry.rs` is a sibling module to `main.rs`. It reuses `lex-runtime` / `lex-types` / `lex-bytecode` directly to avoid shelling out per request. The `tiny_http` server runs in the host process; each request gets a thread but the registry mutex stays short-lived (we clone the `Arc<Program>` + policy under the lock, release before invoking the VM).

## Caveats

- **Storage is in-memory** (single-process). Persistence across restarts is a v1.1 follow-up.
- **For multi-tenant production, layer this in a container** — Lex's effect gates are language-level, not OS-level. The registry doesn't try to be a sandboxed multi-tenant runtime; it's the agent-tool flow with a stable URL.

## Test plan

- [x] `register_pure_tool_then_invoke_returns_output`
- [x] `malicious_tool_rejected_at_registration_with_type_check_error` — body uses `io.read`, allowed_effects is `[net]` → 400 with `type_check` error_kind, registry stays empty
- [x] `manifest_endpoint_returns_tool_record`
- [x] `unknown_tool_id_returns_404` (both GET and POST)
- [x] `unknown_path_returns_404`
- [x] `list_tools_after_two_registrations`
- [x] `cargo test --workspace` green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh

---
_Generated by [Claude Code](https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh)_