### PR TITLE
Add `lex ast-diff` — AST-native structural diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Flags: `--body '<src>'` / `--body-file <path>` skip the API call; `--request '<q
 | `lex agent-tool --allow-effects ks (--request 'q' \| --body 'src' \| --body-file F)` | Run an LLM-emitted tool body under declared effects |
 | `lex tool-registry serve [--port N]` | HTTP service to register Lex tools at runtime; `POST /tools` validates + stores, `POST /tools/{id}/invoke` runs |
 | `lex audit [paths...] [--effect K] [--calls FN] [--uses-host H] [--kind K]` | Structural code search by effect / call / hostname / AST kind. `--json` for agent-pipe output |
+| `lex ast-diff <file_a> <file_b> [--json] [--no-body]` | AST-native diff: added / removed / renamed / modified fns, plus body-level patches. Renames detected by body-hash with name normalized |
 
 ### Policy flags (run / replay)
 

--- a/crates/lex-cli/src/diff.rs
+++ b/crates/lex-cli/src/diff.rs
@@ -1,0 +1,445 @@
+//! `lex diff` — AST-native structural diff between two Lex sources.
+//!
+//! Pitch: Git diffs are line-based. Renaming a function or moving a
+//! match arm produces 50 "deleted" lines and 50 "inserted" lines that
+//! a reviewing agent has to re-parse. `lex diff` walks the canonical
+//! AST and reports *what changed in tree shape*: stages added,
+//! removed, modified — and inside a modified body, which expression
+//! kinds were replaced.
+//!
+//! Output is plain text by default and JSON via `--json` for piping
+//! into another agent's eval loop. Default JSON shape:
+//!
+//! ```json
+//! {
+//!   "added":   [{"name": "...", "signature": "..."}],
+//!   "removed": [{"name": "...", "signature": "..."}],
+//!   "renamed": [{"from": "...", "to": "...", "signature": "..."}],
+//!   "modified": [
+//!     {
+//!       "name": "...",
+//!       "signature_before": "...",
+//!       "signature_after":  "...",
+//!       "signature_changed": true|false,
+//!       "body_patches": [{"op": "Replace", "node_path": "...",
+//!                         "from_kind": "...", "to_kind": "..."}]
+//!     }
+//!   ]
+//! }
+//! ```
+
+use anyhow::{anyhow, Context, Result};
+use lex_ast::{
+    canonicalize_program, CExpr, Effect, FnDecl, Stage, TypeExpr,
+};
+use lex_syntax::parse_source;
+use serde::Serialize;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Default)]
+struct DiffOpts {
+    files: Vec<PathBuf>,
+    json: bool,
+    /// Also emit body-level patches for modified fns. On by default
+    /// because that's the wow; off via --no-body if the caller wants
+    /// just signature-level deltas.
+    body_patches: bool,
+}
+
+#[derive(Serialize)]
+struct AddRemove {
+    name: String,
+    signature: String,
+}
+
+#[derive(Serialize)]
+struct Renamed {
+    from: String,
+    to: String,
+    signature: String,
+}
+
+#[derive(Serialize)]
+struct Modified {
+    name: String,
+    signature_before: String,
+    signature_after: String,
+    signature_changed: bool,
+    body_patches: Vec<BodyPatch>,
+}
+
+#[derive(Serialize, Clone)]
+struct BodyPatch {
+    op: String,         // "Replace" | "Inserted" | "Deleted"
+    node_path: String,  // dotted path from fn body
+    from_kind: String,
+    to_kind: String,
+}
+
+#[derive(Serialize, Default)]
+struct DiffReport {
+    added: Vec<AddRemove>,
+    removed: Vec<AddRemove>,
+    renamed: Vec<Renamed>,
+    modified: Vec<Modified>,
+}
+
+pub fn cmd_diff(args: &[String]) -> Result<()> {
+    let opts = parse_diff_args(args)?;
+    if opts.files.len() != 2 {
+        return Err(anyhow!("usage: lex diff <file_a> <file_b> [--json] [--no-body]"));
+    }
+    let a = load_fns(&opts.files[0])?;
+    let b = load_fns(&opts.files[1])?;
+    let report = compute_diff(&a, &b, opts.body_patches);
+
+    if opts.json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        return Ok(());
+    }
+
+    if report.added.is_empty() && report.removed.is_empty()
+        && report.renamed.is_empty() && report.modified.is_empty()
+    {
+        println!("(no structural changes)");
+        return Ok(());
+    }
+
+    for a in &report.added   { println!("+ added    {}", a.signature); }
+    for r in &report.removed { println!("- removed  {}", r.signature); }
+    for r in &report.renamed {
+        println!("→ renamed  {} → {}", r.from, r.to);
+        println!("           {}", r.signature);
+    }
+    for m in &report.modified {
+        let sig = if m.signature_changed {
+            format!("{}\n             {} ", m.signature_before, "→")
+                + &m.signature_after
+        } else {
+            m.signature_after.clone()
+        };
+        println!("~ modified {sig}");
+        for p in &m.body_patches {
+            if p.from_kind == p.to_kind {
+                println!("             @ {}: {} edited", p.node_path, p.from_kind);
+            } else {
+                println!("             @ {}: {} → {}",
+                    p.node_path, p.from_kind, p.to_kind);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn parse_diff_args(args: &[String]) -> Result<DiffOpts> {
+    let mut o = DiffOpts { body_patches: true, ..Default::default() };
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json"    => { o.json = true;          i += 1; }
+            "--no-body" => { o.body_patches = false; i += 1; }
+            other => { o.files.push(PathBuf::from(other)); i += 1; }
+        }
+    }
+    Ok(o)
+}
+
+fn load_fns(path: &std::path::Path) -> Result<BTreeMap<String, FnDecl>> {
+    let src = fs::read_to_string(path)
+        .with_context(|| format!("read {}", path.display()))?;
+    let prog = parse_source(&src)
+        .map_err(|e| anyhow!("parse {}: {e}", path.display()))?;
+    let stages = canonicalize_program(&prog);
+    let mut out = BTreeMap::new();
+    for stage in stages {
+        if let Stage::FnDecl(fd) = stage {
+            out.insert(fd.name.clone(), fd);
+        }
+    }
+    Ok(out)
+}
+
+fn compute_diff(
+    a: &BTreeMap<String, FnDecl>,
+    b: &BTreeMap<String, FnDecl>,
+    body_patches: bool,
+) -> DiffReport {
+    let mut report = DiffReport::default();
+    let names_a: BTreeSet<&String> = a.keys().collect();
+    let names_b: BTreeSet<&String> = b.keys().collect();
+
+    let only_a: Vec<&String> = names_a.difference(&names_b).copied().collect();
+    let only_b: Vec<&String> = names_b.difference(&names_a).copied().collect();
+
+    // Detect renames: for each name only-in-A, check if any only-in-B
+    // has a body whose canonical-AST hash matches (modulo the fn
+    // name itself). sig_id over the FnDecl with name normalized
+    // serves as the structural-identity key.
+    let mut renamed_pairs: Vec<(String, String)> = Vec::new();
+    let mut consumed_a: BTreeSet<String> = BTreeSet::new();
+    let mut consumed_b: BTreeSet<String> = BTreeSet::new();
+    for &an in &only_a {
+        let fa = &a[an];
+        let fa_norm_id = body_hash(fa);
+        for &bn in &only_b {
+            if consumed_b.contains(bn) { continue; }
+            let fb = &b[bn];
+            if body_hash(fb) == fa_norm_id {
+                renamed_pairs.push((an.clone(), bn.clone()));
+                consumed_a.insert(an.clone());
+                consumed_b.insert(bn.clone());
+                break;
+            }
+        }
+    }
+
+    for &n in &only_a {
+        if consumed_a.contains(n) { continue; }
+        let fd = &a[n];
+        report.removed.push(AddRemove {
+            name: n.clone(),
+            signature: render_signature(fd),
+        });
+    }
+    for &n in &only_b {
+        if consumed_b.contains(n) { continue; }
+        let fd = &b[n];
+        report.added.push(AddRemove {
+            name: n.clone(),
+            signature: render_signature(fd),
+        });
+    }
+    for (an, bn) in &renamed_pairs {
+        let fd = &b[bn];
+        report.renamed.push(Renamed {
+            from: an.clone(),
+            to: bn.clone(),
+            signature: render_signature(fd),
+        });
+    }
+
+    // Modified: same name on both sides; compare bodies.
+    for n in names_a.intersection(&names_b) {
+        let fa = &a[*n];
+        let fb = &b[*n];
+        let sig_a = render_signature(fa);
+        let sig_b = render_signature(fb);
+        if body_hash(fa) == body_hash(fb) && sig_a == sig_b { continue; }
+
+        let body_patches = if body_patches {
+            let mut patches = Vec::new();
+            diff_expr(&fa.body, &fb.body, "body", &mut patches, 4);
+            patches
+        } else { Vec::new() };
+
+        report.modified.push(Modified {
+            name: (*n).clone(),
+            signature_before: sig_a.clone(),
+            signature_after: sig_b.clone(),
+            signature_changed: sig_a != sig_b,
+            body_patches,
+        });
+    }
+    report
+}
+
+/// Hash of the function's structural identity, used for rename
+/// detection. Excludes the function's name (so `fn foo -> Int { 1 }`
+/// and `fn bar -> Int { 1 }` share a hash) but includes everything
+/// else: params, effects, return type, body.
+///
+/// Uses `stage_canonical_hash_hex` (full AST) rather than `sig_id`
+/// (signature only) — otherwise two fns with the same signature but
+/// different bodies would falsely identify as renames.
+fn body_hash(fd: &FnDecl) -> String {
+    let mut anon = fd.clone();
+    anon.name = String::new();
+    let stage = Stage::FnDecl(anon);
+    lex_ast::stage_canonical_hash_hex(&stage)
+}
+
+/// Walk two CExprs in parallel; record the first divergence at each
+/// child position. `depth` caps recursion so a tiny per-fn diff
+/// doesn't degenerate into hundreds of micro-changes.
+fn diff_expr(a: &CExpr, b: &CExpr, path: &str, out: &mut Vec<BodyPatch>, depth: u32) {
+    if depth == 0 { return; }
+    let kind_a = node_kind(a);
+    let kind_b = node_kind(b);
+    if kind_a != kind_b {
+        out.push(BodyPatch {
+            op: "Replace".into(), node_path: path.into(),
+            from_kind: kind_a.into(), to_kind: kind_b.into(),
+        });
+        return;
+    }
+    // Same kind: recurse into structurally-equivalent children.
+    match (a, b) {
+        (CExpr::Literal { value: la }, CExpr::Literal { value: lb }) => {
+            if la != lb {
+                out.push(BodyPatch {
+                    op: "Replace".into(), node_path: path.into(),
+                    from_kind: "Literal".into(), to_kind: "Literal".into(),
+                });
+            }
+        }
+        (CExpr::Var { name: na }, CExpr::Var { name: nb }) => {
+            if na != nb {
+                out.push(BodyPatch {
+                    op: "Replace".into(), node_path: path.into(),
+                    from_kind: format!("Var({na})"), to_kind: format!("Var({nb})"),
+                });
+            }
+        }
+        (CExpr::Call { callee: ca, args: aa },
+         CExpr::Call { callee: cb, args: ab }) => {
+            diff_expr(ca, cb, &format!("{path}.callee"), out, depth - 1);
+            diff_args(aa, ab, &format!("{path}.args"), out, depth);
+        }
+        (CExpr::Let { name: na, value: va, body: ba, .. },
+         CExpr::Let { name: nb, value: vb, body: bb, .. }) => {
+            if na != nb {
+                out.push(BodyPatch {
+                    op: "Replace".into(),
+                    node_path: format!("{path}.name"),
+                    from_kind: format!("Let({na})"),
+                    to_kind:   format!("Let({nb})"),
+                });
+            }
+            diff_expr(va, vb, &format!("{path}.value"), out, depth - 1);
+            diff_expr(ba, bb, &format!("{path}.body"),  out, depth - 1);
+        }
+        (CExpr::Match { scrutinee: sa, arms: ams },
+         CExpr::Match { scrutinee: sb, arms: bms }) => {
+            diff_expr(sa, sb, &format!("{path}.scrutinee"), out, depth - 1);
+            let n = ams.len().max(bms.len());
+            for i in 0..n {
+                let p = format!("{path}.arms[{i}]");
+                match (ams.get(i), bms.get(i)) {
+                    (Some(a), Some(b)) =>
+                        diff_expr(&a.body, &b.body, &p, out, depth - 1),
+                    (Some(_), None) => out.push(BodyPatch {
+                        op: "Deleted".into(), node_path: p,
+                        from_kind: "MatchArm".into(), to_kind: "(removed)".into(),
+                    }),
+                    (None, Some(_)) => out.push(BodyPatch {
+                        op: "Inserted".into(), node_path: p,
+                        from_kind: "(none)".into(), to_kind: "MatchArm".into(),
+                    }),
+                    (None, None) => break,
+                }
+            }
+        }
+        (CExpr::Block { statements: sa, result: ra },
+         CExpr::Block { statements: sb, result: rb }) => {
+            diff_args(sa, sb, &format!("{path}.statements"), out, depth);
+            diff_expr(ra, rb, &format!("{path}.result"), out, depth - 1);
+        }
+        (CExpr::FieldAccess { value: va, field: fa },
+         CExpr::FieldAccess { value: vb, field: fb }) => {
+            diff_expr(va, vb, &format!("{path}.value"), out, depth - 1);
+            if fa != fb {
+                out.push(BodyPatch {
+                    op: "Replace".into(), node_path: format!("{path}.field"),
+                    from_kind: format!("Field({fa})"), to_kind: format!("Field({fb})"),
+                });
+            }
+        }
+        (CExpr::Lambda { body: ba, .. }, CExpr::Lambda { body: bb, .. }) => {
+            diff_expr(ba, bb, &format!("{path}.body"), out, depth - 1);
+        }
+        // For shapes we don't unfold further, mark the node itself
+        // as edited (same kind, content differs) — finer detail can
+        // come in a follow-up.
+        _ => {
+            out.push(BodyPatch {
+                op: "Replace".into(), node_path: path.into(),
+                from_kind: kind_a.into(), to_kind: kind_b.into(),
+            });
+        }
+    }
+}
+
+fn diff_args(a: &[CExpr], b: &[CExpr], path: &str, out: &mut Vec<BodyPatch>, depth: u32) {
+    let n = a.len().max(b.len());
+    for i in 0..n {
+        let p = format!("{path}[{i}]");
+        match (a.get(i), b.get(i)) {
+            (Some(x), Some(y)) => diff_expr(x, y, &p, out, depth - 1),
+            (Some(x), None) => out.push(BodyPatch {
+                op: "Deleted".into(), node_path: p,
+                from_kind: node_kind(x).into(), to_kind: "(removed)".into(),
+            }),
+            (None, Some(y)) => out.push(BodyPatch {
+                op: "Inserted".into(), node_path: p,
+                from_kind: "(none)".into(), to_kind: node_kind(y).into(),
+            }),
+            (None, None) => break,
+        }
+    }
+}
+
+fn node_kind(e: &CExpr) -> &'static str {
+    match e {
+        CExpr::Literal { .. }    => "Literal",
+        CExpr::Var { .. }        => "Var",
+        CExpr::Call { .. }       => "Call",
+        CExpr::Let { .. }        => "Let",
+        CExpr::Match { .. }      => "Match",
+        CExpr::Block { .. }      => "Block",
+        CExpr::Constructor { .. } => "Constructor",
+        CExpr::RecordLit { .. }  => "RecordLit",
+        CExpr::TupleLit { .. }   => "TupleLit",
+        CExpr::ListLit { .. }    => "ListLit",
+        CExpr::FieldAccess { .. } => "FieldAccess",
+        CExpr::Lambda { .. }     => "Lambda",
+        CExpr::BinOp { .. }      => "BinOp",
+        CExpr::UnaryOp { .. }    => "UnaryOp",
+        CExpr::Return { .. }     => "Return",
+    }
+}
+
+fn render_signature(fd: &FnDecl) -> String {
+    let params: Vec<String> = fd.params.iter()
+        .map(|p| format!("{} :: {}", p.name, render_type(&p.ty))).collect();
+    let eff = if fd.effects.is_empty() { String::new() } else {
+        let names: Vec<&str> = fd.effects.iter().map(|e: &Effect| e.name.as_str()).collect();
+        format!("[{}] ", names.join(", "))
+    };
+    format!("fn {}({}) -> {}{}", fd.name, params.join(", "),
+        eff, render_type(&fd.return_type))
+}
+
+fn render_type(t: &TypeExpr) -> String {
+    match t {
+        TypeExpr::Named { name, args } => {
+            if args.is_empty() { name.clone() }
+            else {
+                let parts: Vec<String> = args.iter().map(render_type).collect();
+                format!("{name}[{}]", parts.join(", "))
+            }
+        }
+        TypeExpr::Tuple { items } => {
+            let parts: Vec<String> = items.iter().map(render_type).collect();
+            format!("({})", parts.join(", "))
+        }
+        TypeExpr::Record { fields } => {
+            let parts: Vec<String> = fields.iter()
+                .map(|f| format!("{} :: {}", f.name, render_type(&f.ty))).collect();
+            format!("{{ {} }}", parts.join(", "))
+        }
+        TypeExpr::Function { params, effects, ret } => {
+            let parts: Vec<String> = params.iter().map(render_type).collect();
+            let eff = if effects.is_empty() { String::new() } else {
+                let names: Vec<&str> = effects.iter().map(|e| e.name.as_str()).collect();
+                format!("[{}] ", names.join(", "))
+            };
+            format!("({}) -> {}{}", parts.join(", "), eff, render_type(ret))
+        }
+        TypeExpr::Union { variants } => variants.iter().map(|v| match &v.payload {
+            Some(p) => format!("{}({})", v.name, render_type(p)),
+            None => v.name.clone(),
+        }).collect::<Vec<_>>().join(" | "),
+    }
+}

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -12,6 +12,7 @@
 
 mod tool_registry;
 mod audit;
+mod diff;
 
 use anyhow::{anyhow, bail, Context, Result};
 use lex_ast::{canonicalize_program, sig_id, stage_canonical_hash_hex, stage_id, Stage};
@@ -50,6 +51,7 @@ fn run(args: &[String]) -> Result<()> {
         "agent-tool" => cmd_agent_tool(&args[1..]),
         "tool-registry" => tool_registry::cmd_tool_registry(&args[1..]),
         "audit" => audit::cmd_audit(&args[1..]),
+        "ast-diff" => diff::cmd_diff(&args[1..]),
         "help" | "--help" | "-h" => { print_usage(); Ok(()) }
         other => bail!("unknown command `{other}`. try `lex help`"),
     }
@@ -82,6 +84,8 @@ fn print_usage() {
     println!("                                     and invoke them via /tools/{{id}}/invoke");
     println!("  audit [paths...] [filters]        structural code search by effect / call /");
     println!("                                     hostname / AST kind. --json for machine-readable.");
+    println!("  ast-diff <file_a> <file_b>        AST-native diff: added/removed/renamed/modified");
+    println!("                                     fns, plus body-level patches per modified body.");
     println!();
     println!("policy flags (run, replay):");
     println!("  --allow-effects k1,k2,...   permit these effect kinds");

--- a/crates/lex-cli/tests/ast_diff.rs
+++ b/crates/lex-cli/tests/ast_diff.rs
@@ -1,0 +1,189 @@
+//! End-to-end tests for `lex ast-diff`. Builds two source files,
+//! runs the diff, asserts on the structured output. The shape:
+//!
+//!   { added, removed, renamed, modified[{body_patches: [...]}] }
+//!
+//! Renames are detected by hashing the FnDecl with the name field
+//! cleared — same body + same signature + different name = rename.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+fn lex_bin() -> &'static str { env!("CARGO_BIN_EXE_lex") }
+
+fn run(args: &[&str]) -> (i32, String, String) {
+    let out = Command::new(lex_bin())
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn lex");
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+/// Write `text` to a tempfile under `/tmp` and return its path.
+fn tmp(name: &str, text: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!("lex_diff_test_{name}.lex"));
+    let mut f = std::fs::File::create(&p).expect("create tmp");
+    f.write_all(text.as_bytes()).expect("write tmp");
+    p
+}
+
+#[test]
+fn no_changes_reports_clean() {
+    let a = tmp("identical_a", "fn id(x :: Int) -> Int { x }\n");
+    let b = tmp("identical_b", "fn id(x :: Int) -> Int { x }\n");
+    let (code, stdout, stderr) = run(&[
+        "ast-diff", a.to_str().unwrap(), b.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert!(stdout.contains("(no structural changes)"), "stdout: {stdout}");
+}
+
+#[test]
+fn added_function_surfaces_in_added_list() {
+    let a = tmp("a_only_one", "fn one() -> Int { 1 }\n");
+    let b = tmp("b_two", "fn one() -> Int { 1 }\nfn two() -> Int { 2 }\n");
+    let (code, stdout, _) = run(&[
+        "ast-diff", "--json", a.to_str().unwrap(), b.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    let added = v["added"].as_array().expect("added array");
+    assert_eq!(added.len(), 1);
+    assert_eq!(added[0]["name"], "two");
+    assert_eq!(v["removed"].as_array().unwrap().len(), 0);
+    assert_eq!(v["modified"].as_array().unwrap().len(), 0);
+}
+
+#[test]
+fn removed_function_surfaces_in_removed_list() {
+    let a = tmp("a_two", "fn one() -> Int { 1 }\nfn two() -> Int { 2 }\n");
+    let b = tmp("b_only_one", "fn one() -> Int { 1 }\n");
+    let (code, stdout, _) = run(&[
+        "ast-diff", "--json", a.to_str().unwrap(), b.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    let removed = v["removed"].as_array().expect("removed array");
+    assert_eq!(removed.len(), 1);
+    assert_eq!(removed[0]["name"], "two");
+}
+
+#[test]
+fn modified_body_with_same_signature_surfaces_with_body_patch() {
+    let a = tmp("a_double", "fn doubled(n :: Int) -> Int { n * 2 }\n");
+    let b = tmp("b_double", "fn doubled(n :: Int) -> Int { n + n }\n");
+    let (code, stdout, _) = run(&[
+        "ast-diff", "--json", a.to_str().unwrap(), b.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    let modified = v["modified"].as_array().expect("modified array");
+    assert_eq!(modified.len(), 1);
+    let m = &modified[0];
+    assert_eq!(m["name"], "doubled");
+    assert_eq!(m["signature_changed"], false);
+    let patches = m["body_patches"].as_array().expect("body_patches");
+    assert!(!patches.is_empty(), "expected at least one body patch");
+}
+
+#[test]
+fn modified_signature_records_before_after() {
+    let a = tmp("a_sig", "fn foo(n :: Int) -> Int { n }\n");
+    let b = tmp("b_sig", "fn foo(n :: Int) -> [io] Int { n }\n");
+    let (code, stdout, _) = run(&[
+        "ast-diff", "--json", a.to_str().unwrap(), b.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    let modified = v["modified"].as_array().expect("modified array");
+    assert_eq!(modified.len(), 1);
+    let m = &modified[0];
+    assert_eq!(m["signature_changed"], true);
+    assert!(m["signature_before"].as_str().unwrap().contains("-> Int"));
+    assert!(m["signature_after"].as_str().unwrap().contains("[io]"));
+}
+
+#[test]
+fn rename_detected_when_body_matches_modulo_name() {
+    // Identical body, same signature, different name → rename.
+    let a = tmp("a_rename", "fn shouted(s :: Str) -> Str { s }\n");
+    let b = tmp("b_rename", "fn say(s :: Str) -> Str { s }\n");
+    let (code, stdout, _) = run(&[
+        "ast-diff", "--json", a.to_str().unwrap(), b.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    let renamed = v["renamed"].as_array().expect("renamed array");
+    assert_eq!(renamed.len(), 1);
+    let r = &renamed[0];
+    assert_eq!(r["from"], "shouted");
+    assert_eq!(r["to"], "say");
+    // Pure renames don't show up in added/removed.
+    assert_eq!(v["added"].as_array().unwrap().len(), 0);
+    assert_eq!(v["removed"].as_array().unwrap().len(), 0);
+}
+
+#[test]
+fn different_bodies_with_different_names_are_add_remove_not_rename() {
+    // Bodies differ → not a rename even though the signatures match.
+    let a = tmp("a_add", "fn shouted(s :: Str) -> Str { s }\n");
+    let b = tmp("b_add", "fn greet(name :: Str) -> Str { match name { _ => name } }\n");
+    let (code, stdout, _) = run(&[
+        "ast-diff", "--json", a.to_str().unwrap(), b.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    assert_eq!(v["renamed"].as_array().unwrap().len(), 0,
+        "expected no false rename; got {v}");
+    assert_eq!(v["added"].as_array().unwrap().len(), 1);
+    assert_eq!(v["removed"].as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn text_output_is_human_readable() {
+    let a = tmp("a_text",
+        "fn doubled(n :: Int) -> Int { n * 2 }\nfn dropme() -> Int { 1 }\n");
+    let b = tmp("b_text",
+        "fn doubled(n :: Int) -> Int { n + n }\nfn newone() -> Int { 99 }\n");
+    let (code, stdout, _) = run(&[
+        "ast-diff", a.to_str().unwrap(), b.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("modified"), "stdout:\n{stdout}");
+    assert!(stdout.contains("added")  || stdout.contains("+"), "stdout:\n{stdout}");
+    assert!(stdout.contains("removed") || stdout.contains("-"), "stdout:\n{stdout}");
+}
+
+#[test]
+fn no_body_flag_skips_body_patches() {
+    let a = tmp("a_nobody", "fn doubled(n :: Int) -> Int { n * 2 }\n");
+    let b = tmp("b_nobody", "fn doubled(n :: Int) -> Int { n + n }\n");
+    let (code, stdout, _) = run(&[
+        "ast-diff", "--json", "--no-body",
+        a.to_str().unwrap(), b.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    let m = &v["modified"][0];
+    assert_eq!(m["body_patches"].as_array().unwrap().len(), 0,
+        "expected --no-body to suppress body patches");
+}
+
+#[test]
+fn parse_errors_surface_clearly() {
+    let a = tmp("a_bad", "fn ok() -> Int { 1 }\n");
+    let b = tmp("b_bad", "fn broken( - this is not valid lex\n");
+    let (code, _stdout, stderr) = run(&[
+        "ast-diff", a.to_str().unwrap(), b.to_str().unwrap(),
+    ]);
+    assert_ne!(code, 0);
+    assert!(stderr.contains("parse"), "stderr: {stderr}");
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -286,6 +286,50 @@ $ lex audit --uses-host attacker.com .   # check before you ship
 </section>
 
 <section>
+  <h2>Diffing what an agent changed: <code>lex ast-diff</code></h2>
+  <p class="lede">
+    Git diffs are line-based. When an agent renames a function or
+    moves a match arm, you get 50 deleted lines + 50 inserted lines
+    that a reviewing agent has to re-parse. <code>lex ast-diff</code>
+    walks the canonical AST and reports what *actually* changed in
+    tree shape: stages added, removed, renamed, modified — and inside
+    a modified body, which expression kinds were replaced.
+  </p>
+  <pre><code>$ lex ast-diff before.lex after.lex
++ added    fn greet(name :: Str) -> Str
+- removed  fn shouted(s :: Str) -> Str
+→ renamed  squared → cubed
+           fn cubed(n :: Int) -> Int
+~ modified fn doubled(n :: Int) -> Int
+             @ body: BinOp edited
+
+$ lex ast-diff --json before.lex after.lex
+{
+  "added":   [{"name": "greet",   "signature": "fn greet(...)"}],
+  "removed": [{"name": "shouted", "signature": "fn shouted(...)"}],
+  "renamed": [{"from": "squared", "to": "cubed",
+               "signature": "fn cubed(n :: Int) -> Int"}],
+  "modified": [{
+    "name": "doubled",
+    "signature_before": "fn doubled(n :: Int) -> Int",
+    "signature_after":  "fn doubled(n :: Int) -> Int",
+    "signature_changed": false,
+    "body_patches": [
+      {"op": "Replace", "node_path": "body",
+       "from_kind": "BinOp", "to_kind": "BinOp"}
+    ]
+  }]
+}</code></pre>
+  <p>
+    Renames are detected by hashing the FnDecl with the name field
+    cleared — same body + same signature + different name = rename,
+    not a delete-add. Two reviewing agents looking at the same change
+    no longer have to argue about whether <em>moved</em> or
+    <em>rewritten</em>.
+  </p>
+</section>
+
+<section>
   <h2>Capability ≠ correctness</h2>
   <p>
     Effect typing answers <em>what your code touches</em>, not


### PR DESCRIPTION
## Summary

Git diffs are line-based. When an agent renames a function or moves a match arm, you get 50 deleted lines + 50 inserted lines that a reviewing agent has to re-parse. `lex ast-diff` walks the canonical AST and reports what *actually* changed in tree shape.

```bash
$ lex ast-diff before.lex after.lex
+ added    fn greet(name :: Str) -> Str
- removed  fn shouted(s :: Str) -> Str
→ renamed  squared → cubed
           fn cubed(n :: Int) -> Int
~ modified fn doubled(n :: Int) -> Int
             @ body: BinOp edited
```

## Output classifications

| Class | When |
|---|---|
| `added` | name in B but not in A |
| `removed` | name in A but not in B (after pulling out renames) |
| `renamed` | name differs but body+signature hash match (with name normalized) |
| `modified` | same name, different body or signature; includes body_patches |

**Renames are detected** by hashing the `FnDecl` with the name field cleared — caught by `stage_canonical_hash_hex` (full AST), not `sig_id` (signature-only). That's why `shouted → say` registers as a rename but `shouted → greet` (different body) registers as an add+remove.

**Body patches** record AST-path-keyed structural edits down to a bounded depth (default 4). Schema: `{op: Replace|Inserted|Deleted, node_path, from_kind, to_kind}`.

## JSON shape (`--json`)

```json
{
  "added":   [{"name": "...", "signature": "..."}],
  "removed": [{"name": "...", "signature": "..."}],
  "renamed": [{"from": "...", "to": "...", "signature": "..."}],
  "modified": [{
    "name": "...",
    "signature_before": "...",
    "signature_after":  "...",
    "signature_changed": true|false,
    "body_patches": [{"op": "...", "node_path": "...",
                      "from_kind": "...", "to_kind": "..."}]
  }]
}
```

## Why this completes the pitch

Pairs with `lex audit` shipped in #45:

- **`audit` answers "what's in this codebase?"** — query by effect, call, host, kind
- **`ast-diff` answers "what changed?"** — structural deltas, not text deltas

Together they're code-review primitives agents can use *without parsing text*. Two reviewing agents looking at the same change no longer have to argue about whether *moved* or *rewritten*.

## Naming

Subcommand is `ast-diff`, not `diff` — `lex diff` already exists for trace divergence (§10.3 of the spec).

## Test plan

- [x] 10 integration tests in `crates/lex-cli/tests/ast_diff.rs`:
  - no-change → clean output
  - add / remove / modified-body / modified-signature
  - rename detected when bodies match modulo name
  - false-rename prevented when bodies differ
  - `--json` shape
  - `--no-body` suppresses patches
  - text output is human-readable
  - parse errors surface
- [x] `cargo test --workspace` green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

## Doc updates

- `docs/index.html` — new section *"Diffing what an agent changed: `lex ast-diff`"* placed alongside the audit section
- README toolchain table — one row added

https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh

---
_Generated by [Claude Code](https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh)_