### PR TITLE
Add `lex ast-merge` — three-way structural merge with JSON conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Flags: `--body '<src>'` / `--body-file <path>` skip the API call; `--request '<q
 | `lex tool-registry serve [--port N]` | HTTP service to register Lex tools at runtime; `POST /tools` validates + stores, `POST /tools/{id}/invoke` runs |
 | `lex audit [paths...] [--effect K] [--calls FN] [--uses-host H] [--kind K]` | Structural code search by effect / call / hostname / AST kind. `--json` for agent-pipe output |
 | `lex ast-diff <file_a> <file_b> [--json] [--no-body]` | AST-native diff: added / removed / renamed / modified fns, plus body-level patches. Renames detected by body-hash with name normalized |
+| `lex ast-merge <base> <ours> <theirs> [--json] [--output PATH]` | Three-way structural merge. Conflicts surface as JSON (4 kinds: modify-modify, modify-delete, delete-modify, add-add). Exit 2 on any conflict; `--output` writes merged source when clean |
 
 ### Policy flags (run / replay)
 

--- a/crates/lex-cli/src/ast_merge.rs
+++ b/crates/lex-cli/src/ast_merge.rs
@@ -1,0 +1,304 @@
+//! `lex ast-merge` — three-way structural merge of two divergent
+//! Lex sources against a common base.
+//!
+//! Pitch (from the agent-native VC sketch the user shared): when two
+//! agents disagree, you get *structured JSON*, not corrupted source
+//! with `<<<<<<< HEAD` markers. The receiving agent reads the
+//! conflict, resolves the logic programmatically, submits the unified
+//! AST. No re-parse of broken text.
+//!
+//! V1 scope: top-level FnDecl-by-name three-way merge. Body-level
+//! merge (overlapping changes inside a fn) is conservative — if the
+//! same fn was modified on both sides, it's flagged as a conflict
+//! and both bodies are returned in the JSON. Refining body-level
+//! patches into structural-merge is a follow-up.
+
+use anyhow::{anyhow, Context, Result};
+use lex_ast::{
+    canon_print::print_stages, canonicalize_program, FnDecl, Stage,
+    stage_canonical_hash_hex,
+};
+use lex_syntax::parse_source;
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Default)]
+struct MergeOpts {
+    files: Vec<PathBuf>, // [base, ours, theirs]
+    json: bool,
+    output: Option<PathBuf>,
+}
+
+#[derive(Serialize)]
+struct MergedFn {
+    name: String,
+    /// Where the merged version came from: "base" (unchanged on
+    /// both sides), "ours", "theirs", "both" (both sides made the
+    /// same edit), or "added-ours" / "added-theirs" / "added-both".
+    from: &'static str,
+}
+
+#[derive(Serialize)]
+struct Conflict {
+    /// The conflict kind; lets agent code branch cleanly.
+    /// One of: "modify-modify", "modify-delete", "delete-modify",
+    /// "add-add".
+    kind: &'static str,
+    name: String,
+    /// The function as it was on the merge base. None for add-add.
+    base: Option<String>,
+    /// Ours / theirs are the function pretty-printed as Lex source.
+    /// Agents resolving the conflict typically want the source they
+    /// can re-parse, not just an AST-JSON blob.
+    ours:   Option<String>,
+    theirs: Option<String>,
+}
+
+#[derive(Serialize)]
+struct MergeReport {
+    summary: MergeSummary,
+    merged: Vec<MergedFn>,
+    conflicts: Vec<Conflict>,
+}
+
+#[derive(Serialize, Default)]
+struct MergeSummary {
+    total_fns: usize,
+    clean: usize,
+    conflicts: usize,
+}
+
+pub fn cmd_ast_merge(args: &[String]) -> Result<()> {
+    let opts = parse_args(args)?;
+    if opts.files.len() != 3 {
+        return Err(anyhow!(
+            "usage: lex ast-merge <base.lex> <ours.lex> <theirs.lex> \
+             [--json] [--output PATH]"));
+    }
+    let base   = load_fns(&opts.files[0])?;
+    let ours   = load_fns(&opts.files[1])?;
+    let theirs = load_fns(&opts.files[2])?;
+    let report = compute_merge(&base, &ours, &theirs);
+
+    if let Some(out) = &opts.output {
+        if !report.conflicts.is_empty() {
+            return Err(anyhow!(
+                "{} conflicts; refusing to write merged source. \
+                 Re-run without --output to see structured JSON.",
+                report.conflicts.len()));
+        }
+        // Re-emit the merged set as Lex source via the canon printer.
+        let stages: Vec<Stage> = report.merged.iter()
+            .map(|m| pick_fn(&m.name, &base, &ours, &theirs, m.from))
+            .map(Stage::FnDecl)
+            .collect();
+        let src = print_stages(&stages);
+        fs::write(out, src).with_context(|| format!("write {}", out.display()))?;
+        if !opts.json {
+            eprintln!("→ wrote merged source to {} ({} fns)",
+                out.display(), report.merged.len());
+        }
+    }
+
+    if opts.json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        if report.conflicts.is_empty() {
+            println!("→ clean merge: {} fn(s)", report.summary.clean);
+        } else {
+            println!("→ {} conflict(s), {} clean merge(s)",
+                report.summary.conflicts, report.summary.clean);
+        }
+        for m in &report.merged {
+            println!("  ✓ {:<10} {}", m.from, m.name);
+        }
+        for c in &report.conflicts {
+            println!("  ✗ {:<10} {} ({})", c.kind, c.name,
+                short_kind_message(c.kind));
+        }
+    }
+    // Exit 2 on conflicts regardless of output format — lets agent
+    // loops branch on the exit code without re-parsing the report.
+    if !report.conflicts.is_empty() {
+        std::process::exit(2);
+    }
+    Ok(())
+}
+
+fn parse_args(args: &[String]) -> Result<MergeOpts> {
+    let mut o = MergeOpts::default();
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--json"   => { o.json = true; i += 1; }
+            "--output" => {
+                let v = args.get(i + 1).ok_or_else(|| anyhow!("--output needs a path"))?;
+                o.output = Some(PathBuf::from(v));
+                i += 2;
+            }
+            other => { o.files.push(PathBuf::from(other)); i += 1; }
+        }
+    }
+    Ok(o)
+}
+
+fn load_fns(path: &std::path::Path) -> Result<BTreeMap<String, FnDecl>> {
+    let src = fs::read_to_string(path)
+        .with_context(|| format!("read {}", path.display()))?;
+    let prog = parse_source(&src)
+        .map_err(|e| anyhow!("parse {}: {e}", path.display()))?;
+    let stages = canonicalize_program(&prog);
+    let mut out = BTreeMap::new();
+    for stage in stages {
+        if let Stage::FnDecl(fd) = stage {
+            out.insert(fd.name.clone(), fd);
+        }
+    }
+    Ok(out)
+}
+
+/// Hash a fn's full structural identity (canonical AST), name normalized.
+/// Used to detect "did this fn change?" — if the hash is the same on
+/// both sides, the fn is byte-identical AST-wise.
+fn fn_hash(fd: &FnDecl) -> String {
+    let mut anon = fd.clone();
+    anon.name = String::new();
+    stage_canonical_hash_hex(&Stage::FnDecl(anon))
+}
+
+fn compute_merge(
+    base:   &BTreeMap<String, FnDecl>,
+    ours:   &BTreeMap<String, FnDecl>,
+    theirs: &BTreeMap<String, FnDecl>,
+) -> MergeReport {
+    let mut report = MergeReport {
+        summary: MergeSummary::default(),
+        merged: Vec::new(),
+        conflicts: Vec::new(),
+    };
+    let names: std::collections::BTreeSet<&String> = base.keys()
+        .chain(ours.keys()).chain(theirs.keys()).collect();
+
+    for name in &names {
+        let in_base   = base.contains_key(*name);
+        let in_ours   = ours.contains_key(*name);
+        let in_theirs = theirs.contains_key(*name);
+        match (in_base, in_ours, in_theirs) {
+            (true, true, true) => {
+                let h_b = fn_hash(&base[*name]);
+                let h_o = fn_hash(&ours[*name]);
+                let h_t = fn_hash(&theirs[*name]);
+                let from = if h_o == h_t {
+                    if h_b == h_o { "base" } else { "both" }
+                } else if h_b == h_o {
+                    "theirs"
+                } else if h_b == h_t {
+                    "ours"
+                } else {
+                    report.conflicts.push(Conflict {
+                        kind: "modify-modify",
+                        name: (*name).clone(),
+                        base:   Some(render_fn(&base[*name])),
+                        ours:   Some(render_fn(&ours[*name])),
+                        theirs: Some(render_fn(&theirs[*name])),
+                    });
+                    continue;
+                };
+                report.merged.push(MergedFn { name: (*name).clone(), from });
+            }
+            (true, true, false) => {
+                // Theirs deleted. Conflict only if ours modified.
+                if fn_hash(&base[*name]) == fn_hash(&ours[*name]) {
+                    // ours unchanged → take theirs' delete (omit).
+                } else {
+                    report.conflicts.push(Conflict {
+                        kind: "modify-delete",
+                        name: (*name).clone(),
+                        base:   Some(render_fn(&base[*name])),
+                        ours:   Some(render_fn(&ours[*name])),
+                        theirs: None,
+                    });
+                }
+            }
+            (true, false, true) => {
+                if fn_hash(&base[*name]) == fn_hash(&theirs[*name]) {
+                    // theirs unchanged → take ours' delete.
+                } else {
+                    report.conflicts.push(Conflict {
+                        kind: "delete-modify",
+                        name: (*name).clone(),
+                        base:   Some(render_fn(&base[*name])),
+                        ours:   None,
+                        theirs: Some(render_fn(&theirs[*name])),
+                    });
+                }
+            }
+            (false, true, true) => {
+                // Both added independently. Same body → take either; else add-add conflict.
+                if fn_hash(&ours[*name]) == fn_hash(&theirs[*name]) {
+                    report.merged.push(MergedFn {
+                        name: (*name).clone(), from: "added-both",
+                    });
+                } else {
+                    report.conflicts.push(Conflict {
+                        kind: "add-add",
+                        name: (*name).clone(),
+                        base:   None,
+                        ours:   Some(render_fn(&ours[*name])),
+                        theirs: Some(render_fn(&theirs[*name])),
+                    });
+                }
+            }
+            (false, true, false) => {
+                report.merged.push(MergedFn {
+                    name: (*name).clone(), from: "added-ours",
+                });
+            }
+            (false, false, true) => {
+                report.merged.push(MergedFn {
+                    name: (*name).clone(), from: "added-theirs",
+                });
+            }
+            (true, false, false) => {
+                // Both branches deleted; clean removal, nothing to merge.
+            }
+            (false, false, false) => unreachable!(),
+        }
+    }
+
+    report.summary.clean     = report.merged.len();
+    report.summary.conflicts = report.conflicts.len();
+    report.summary.total_fns = report.merged.len() + report.conflicts.len();
+    report
+}
+
+fn pick_fn(
+    name: &str,
+    base: &BTreeMap<String, FnDecl>,
+    ours: &BTreeMap<String, FnDecl>,
+    theirs: &BTreeMap<String, FnDecl>,
+    from: &str,
+) -> FnDecl {
+    match from {
+        "base"        | "both"          => base[name].clone(),
+        "ours"        | "added-ours"    | "added-both" => ours[name].clone(),
+        "theirs"      | "added-theirs"  => theirs[name].clone(),
+        _ => ours.get(name).or(theirs.get(name)).or(base.get(name)).cloned().unwrap(),
+    }
+}
+
+fn render_fn(fd: &FnDecl) -> String {
+    print_stages(&[Stage::FnDecl(fd.clone())])
+}
+
+fn short_kind_message(kind: &str) -> &'static str {
+    match kind {
+        "modify-modify" => "both sides modified",
+        "modify-delete" => "ours modified, theirs deleted",
+        "delete-modify" => "ours deleted, theirs modified",
+        "add-add"       => "both added with different bodies",
+        _ => "",
+    }
+}

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -13,6 +13,7 @@
 mod tool_registry;
 mod audit;
 mod diff;
+mod ast_merge;
 
 use anyhow::{anyhow, bail, Context, Result};
 use lex_ast::{canonicalize_program, sig_id, stage_canonical_hash_hex, stage_id, Stage};
@@ -52,6 +53,7 @@ fn run(args: &[String]) -> Result<()> {
         "tool-registry" => tool_registry::cmd_tool_registry(&args[1..]),
         "audit" => audit::cmd_audit(&args[1..]),
         "ast-diff" => diff::cmd_diff(&args[1..]),
+        "ast-merge" => ast_merge::cmd_ast_merge(&args[1..]),
         "help" | "--help" | "-h" => { print_usage(); Ok(()) }
         other => bail!("unknown command `{other}`. try `lex help`"),
     }
@@ -86,6 +88,8 @@ fn print_usage() {
     println!("                                     hostname / AST kind. --json for machine-readable.");
     println!("  ast-diff <file_a> <file_b>        AST-native diff: added/removed/renamed/modified");
     println!("                                     fns, plus body-level patches per modified body.");
+    println!("  ast-merge <base> <ours> <theirs>  three-way structural merge; structured-JSON");
+    println!("                                     conflicts via --json; --output writes merged source.");
     println!();
     println!("policy flags (run, replay):");
     println!("  --allow-effects k1,k2,...   permit these effect kinds");

--- a/crates/lex-cli/tests/ast_merge.rs
+++ b/crates/lex-cli/tests/ast_merge.rs
@@ -1,0 +1,236 @@
+//! End-to-end tests for `lex ast-merge`. Builds three source files
+//! (base, ours, theirs), runs the merge, asserts on the structured
+//! output. Covers the four conflict kinds (modify-modify,
+//! modify-delete, delete-modify, add-add) and the clean-merge paths.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+fn lex_bin() -> &'static str { env!("CARGO_BIN_EXE_lex") }
+
+fn run(args: &[&str]) -> (i32, String, String) {
+    let out = Command::new(lex_bin())
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn lex");
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+fn tmp(name: &str, text: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!("lex_merge_test_{name}.lex"));
+    let mut f = std::fs::File::create(&p).expect("create tmp");
+    f.write_all(text.as_bytes()).expect("write tmp");
+    p
+}
+
+#[test]
+fn identical_inputs_merge_cleanly_with_zero_changes() {
+    let body = "fn id(x :: Int) -> Int { x }\n";
+    let b = tmp("identical_base", body);
+    let o = tmp("identical_ours", body);
+    let t = tmp("identical_theirs", body);
+    let (code, stdout, stderr) = run(&[
+        "ast-merge", "--json",
+        b.to_str().unwrap(), o.to_str().unwrap(), t.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0, "stderr: {stderr}");
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    assert_eq!(v["summary"]["clean"], 1);
+    assert_eq!(v["summary"]["conflicts"], 0);
+    // Source unchanged on both sides → "base" provenance.
+    assert_eq!(v["merged"][0]["from"], "base");
+}
+
+#[test]
+fn ours_modified_only_takes_ours() {
+    let b = tmp("oo_base",   "fn f() -> Int { 1 }\n");
+    let o = tmp("oo_ours",   "fn f() -> Int { 2 }\n");
+    let t = tmp("oo_theirs", "fn f() -> Int { 1 }\n");
+    let (code, stdout, _) = run(&[
+        "ast-merge", "--json",
+        b.to_str().unwrap(), o.to_str().unwrap(), t.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    assert_eq!(v["summary"]["conflicts"], 0);
+    assert_eq!(v["merged"][0]["from"], "ours");
+}
+
+#[test]
+fn theirs_modified_only_takes_theirs() {
+    let b = tmp("tt_base",   "fn f() -> Int { 1 }\n");
+    let o = tmp("tt_ours",   "fn f() -> Int { 1 }\n");
+    let t = tmp("tt_theirs", "fn f() -> Int { 2 }\n");
+    let (code, stdout, _) = run(&[
+        "ast-merge", "--json",
+        b.to_str().unwrap(), o.to_str().unwrap(), t.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    assert_eq!(v["merged"][0]["from"], "theirs");
+}
+
+#[test]
+fn both_made_identical_change_takes_either() {
+    let b = tmp("be_base",   "fn f() -> Int { 1 }\n");
+    let o = tmp("be_ours",   "fn f() -> Int { 2 }\n");
+    let t = tmp("be_theirs", "fn f() -> Int { 2 }\n");
+    let (code, stdout, _) = run(&[
+        "ast-merge", "--json",
+        b.to_str().unwrap(), o.to_str().unwrap(), t.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    assert_eq!(v["summary"]["conflicts"], 0);
+    assert_eq!(v["merged"][0]["from"], "both");
+}
+
+#[test]
+fn modify_modify_conflict_emits_structured_json() {
+    let b = tmp("mm_base",   "fn f() -> Int { 1 }\n");
+    let o = tmp("mm_ours",   "fn f() -> Int { 2 }\n");
+    let t = tmp("mm_theirs", "fn f() -> Int { 3 }\n");
+    let (code, stdout, _) = run(&[
+        "ast-merge", "--json",
+        b.to_str().unwrap(), o.to_str().unwrap(), t.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 2, "expected exit 2 on conflict");
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    assert_eq!(v["summary"]["conflicts"], 1);
+    let c = &v["conflicts"][0];
+    assert_eq!(c["kind"], "modify-modify");
+    assert_eq!(c["name"], "f");
+    assert!(c["base"].as_str().unwrap().contains("1"));
+    assert!(c["ours"].as_str().unwrap().contains("2"));
+    assert!(c["theirs"].as_str().unwrap().contains("3"));
+}
+
+#[test]
+fn modify_delete_conflict_when_ours_modifies_theirs_deletes() {
+    let b = tmp("md_base",   "fn f() -> Int { 1 }\n");
+    let o = tmp("md_ours",   "fn f() -> Int { 2 }\n");
+    let t = tmp("md_theirs", "");  // theirs deleted f
+    let (code, stdout, _) = run(&[
+        "ast-merge", "--json",
+        b.to_str().unwrap(), o.to_str().unwrap(), t.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 2);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    let c = &v["conflicts"][0];
+    assert_eq!(c["kind"], "modify-delete");
+    assert!(c["base"].is_string());
+    assert!(c["ours"].is_string());
+    assert!(c["theirs"].is_null());
+}
+
+#[test]
+fn delete_modify_conflict_when_ours_deletes_theirs_modifies() {
+    let b = tmp("dm_base",   "fn f() -> Int { 1 }\n");
+    let o = tmp("dm_ours",   "");  // ours deleted f
+    let t = tmp("dm_theirs", "fn f() -> Int { 2 }\n");
+    let (code, stdout, _) = run(&[
+        "ast-merge", "--json",
+        b.to_str().unwrap(), o.to_str().unwrap(), t.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 2);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    let c = &v["conflicts"][0];
+    assert_eq!(c["kind"], "delete-modify");
+    assert!(c["ours"].is_null());
+    assert!(c["theirs"].is_string());
+}
+
+#[test]
+fn add_add_conflict_when_both_add_same_name_with_different_bodies() {
+    let b = tmp("aa_base",   "");
+    let o = tmp("aa_ours",   "fn helper() -> Int { 1 }\n");
+    let t = tmp("aa_theirs", "fn helper() -> Int { 2 }\n");
+    let (code, stdout, _) = run(&[
+        "ast-merge", "--json",
+        b.to_str().unwrap(), o.to_str().unwrap(), t.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 2);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    let c = &v["conflicts"][0];
+    assert_eq!(c["kind"], "add-add");
+    assert!(c["base"].is_null());
+    assert!(c["ours"].is_string());
+    assert!(c["theirs"].is_string());
+}
+
+#[test]
+fn add_add_with_identical_bodies_is_clean() {
+    let body = "fn helper() -> Int { 1 }\n";
+    let b = tmp("aa_clean_base", "");
+    let o = tmp("aa_clean_ours", body);
+    let t = tmp("aa_clean_theirs", body);
+    let (code, stdout, _) = run(&[
+        "ast-merge", "--json",
+        b.to_str().unwrap(), o.to_str().unwrap(), t.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    assert_eq!(v["summary"]["conflicts"], 0);
+    assert_eq!(v["merged"][0]["from"], "added-both");
+}
+
+#[test]
+fn output_writes_merged_source_when_clean() {
+    let b = tmp("out_base",   "fn a() -> Int { 1 }\n");
+    let o = tmp("out_ours",   "fn a() -> Int { 2 }\n");
+    let t = tmp("out_theirs", "fn a() -> Int { 1 }\nfn b() -> Int { 99 }\n");
+    let mut out_path = std::env::temp_dir();
+    out_path.push("lex_merge_test_out_merged.lex");
+    let _ = std::fs::remove_file(&out_path);
+
+    let (code, _stdout, stderr) = run(&[
+        "ast-merge", "--output", out_path.to_str().unwrap(),
+        b.to_str().unwrap(), o.to_str().unwrap(), t.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0, "stderr: {stderr}");
+    let merged = std::fs::read_to_string(&out_path).expect("merged file written");
+    // ours' change to a() should be present (took ours).
+    assert!(merged.contains("fn a("), "merged: {merged}");
+    // theirs' added b() should be present.
+    assert!(merged.contains("fn b("), "merged: {merged}");
+}
+
+#[test]
+fn output_refuses_to_write_when_conflicts_present() {
+    let b = tmp("ref_base",   "fn f() -> Int { 1 }\n");
+    let o = tmp("ref_ours",   "fn f() -> Int { 2 }\n");
+    let t = tmp("ref_theirs", "fn f() -> Int { 3 }\n");
+    let mut out_path = std::env::temp_dir();
+    out_path.push("lex_merge_test_should_not_exist.lex");
+    let _ = std::fs::remove_file(&out_path);
+
+    let (code, _stdout, stderr) = run(&[
+        "ast-merge", "--output", out_path.to_str().unwrap(),
+        b.to_str().unwrap(), o.to_str().unwrap(), t.to_str().unwrap(),
+    ]);
+    assert_ne!(code, 0);
+    assert!(stderr.contains("conflict"), "stderr: {stderr}");
+    assert!(!out_path.exists(), "output file should not exist on conflict");
+}
+
+#[test]
+fn text_output_lists_conflict_kinds() {
+    let b = tmp("text_base",   "fn f() -> Int { 1 }\nfn g() -> Int { 1 }\n");
+    let o = tmp("text_ours",   "fn f() -> Int { 2 }\nfn g() -> Int { 2 }\n");
+    let t = tmp("text_theirs", "fn f() -> Int { 3 }\nfn g() -> Int { 1 }\n");
+    let (code, stdout, _) = run(&[
+        "ast-merge",
+        b.to_str().unwrap(), o.to_str().unwrap(), t.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 2);
+    assert!(stdout.contains("modify-modify"), "stdout:\n{stdout}");
+    assert!(stdout.contains("conflict"), "stdout:\n{stdout}");
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -330,6 +330,58 @@ $ lex ast-diff --json before.lex after.lex
 </section>
 
 <section>
+  <h2>Reconciling two agents: <code>lex ast-merge</code></h2>
+  <p class="lede">
+    When two agents change the same file independently, Git serves
+    you broken source with <code>&lt;&lt;&lt;&lt;&lt;&lt;&lt; HEAD</code>
+    markers — text the receiving agent has to re-parse around.
+    <code>lex ast-merge</code> is a three-way structural merge: clean
+    changes land automatically, real conflicts come back as
+    structured JSON the agent can resolve programmatically.
+  </p>
+  <pre><code>$ lex ast-merge base.lex ours.lex theirs.lex
+→ 1 conflict(s), 3 clean merge(s)
+  ✓ base         helper
+  ✓ added-ours   ours_added
+  ✓ added-theirs theirs_added
+  ✗ modify-modify process (both sides modified)
+exit 2
+
+$ lex ast-merge --json base.lex ours.lex theirs.lex
+{
+  "summary": { "total_fns": 4, "clean": 3, "conflicts": 1 },
+  "merged": [
+    { "name": "helper",       "from": "base" },
+    { "name": "ours_added",   "from": "added-ours" },
+    { "name": "theirs_added", "from": "added-theirs" }
+  ],
+  "conflicts": [{
+    "kind":   "modify-modify",
+    "name":   "process",
+    "base":   "fn process(n :: Int) -> Int { n }\n",
+    "ours":   "fn process(n :: Int) -> Int { n + 1 }\n",
+    "theirs": "fn process(n :: Int) -> Int { n + 2 }\n"
+  }]
+}</code></pre>
+  <p>
+    Four conflict kinds are recognized:
+    <code>modify-modify</code>, <code>modify-delete</code>,
+    <code>delete-modify</code>, <code>add-add</code>. Clean cases —
+    *"both sides made the same edit"*, *"only one side touched it"*,
+    *"both added it identically"* — merge automatically with
+    provenance recorded in the <code>from</code> field. With
+    <code>--output PATH</code> the tool writes the merged source for
+    a clean merge and refuses (exit 1) when conflicts remain.
+  </p>
+  <p>
+    Together with <code>lex audit</code> and <code>lex ast-diff</code>,
+    this is the AST-tooling trio: <em>what's in this codebase</em>,
+    <em>what changed</em>, and <em>how do two agents reconcile their
+    changes</em>. Three primitives an agent uses without parsing text.
+  </p>
+</section>
+
+<section>
   <h2>Capability ≠ correctness</h2>
   <p>
     Effect typing answers <em>what your code touches</em>, not


### PR DESCRIPTION
## Summary

Closes the agent-native VC primitive from the user's design doc: when two agents change the same file independently, you get structured JSON conflicts — not corrupted source with `<<<<<<< HEAD` markers. The receiving agent reads the conflict, resolves the logic programmatically, submits the unified AST.

```bash
$ lex ast-merge base.lex ours.lex theirs.lex
→ 1 conflict(s), 3 clean merge(s)
  ✓ base         helper
  ✓ added-ours   ours_added
  ✓ added-theirs theirs_added
  ✗ modify-modify process (both sides modified)
exit 2
```

```json
{
  "summary": { "total_fns": 4, "clean": 3, "conflicts": 1 },
  "merged": [
    { "name": "helper",       "from": "base" },
    { "name": "ours_added",   "from": "added-ours" },
    { "name": "theirs_added", "from": "added-theirs" }
  ],
  "conflicts": [{
    "kind":   "modify-modify",
    "name":   "process",
    "base":   "fn process(n :: Int) -> Int { n }\n",
    "ours":   "fn process(n :: Int) -> Int { n + 1 }\n",
    "theirs": "fn process(n :: Int) -> Int { n + 2 }\n"
  }]
}
```

## Conflict kinds

| Kind | When |
|---|---|
| `modify-modify` | both sides edited the same fn differently |
| `modify-delete` | ours modified, theirs deleted |
| `delete-modify` | ours deleted, theirs modified |
| `add-add` | both added the same name with different bodies |

Clean cases land automatically with `from` provenance: `base`, `both` (same edit), `ours`, `theirs`, `added-ours`, `added-theirs`, `added-both`.

## `--output PATH`

Writes the merged Lex source via the canon-printer when the merge is clean. Refuses (exit 1) on any conflict — output files always represent a fully-resolved tree.

## Pairs with the existing AST tooling

| Question | Tool |
|---|---|
| *"What's in this codebase?"* | `lex audit` |
| *"What did the agent change?"* | `lex ast-diff` |
| *"How do two agents reconcile?"* | `lex ast-merge` |

That's the AST-tooling trio: three primitives an agent uses without parsing text.

## Caveat

Body-level merge (overlapping changes inside one fn) is conservative v1: marked as one `modify-modify` conflict with full bodies returned. Refining into intra-body structural merge is a follow-up — the spec patch ops are the right substrate but introduce depth-by-depth ambiguity v1 avoids.

## Test plan

- [x] 12 integration tests in `crates/lex-cli/tests/ast_merge.rs`:
  - identical inputs / ours-only / theirs-only / both-same-edit
  - all 4 conflict kinds (modify-modify, modify-delete, delete-modify, add-add)
  - add-add with identical bodies = clean
  - `--output` writes on clean / refuses on conflict
  - text output lists conflict kinds
- [x] `cargo test --workspace` green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

## Doc updates

- `docs/index.html` — new section *"Reconciling two agents: `lex ast-merge`"* placed alongside audit + ast-diff
- README toolchain table — one row added

https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh

---
_Generated by [Claude Code](https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh)_