### PR TITLE
Refresh README + landing page: catch up to the trailing PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,29 @@ lex conformance conformance/
 lex serve
 ```
 
+### Quickstart: agent-native tooling
+
+```bash
+# Sandbox an LLM-emitted tool body. Effects outside --allow-effects are
+# rejected at type-check, before any code runs.
+lex agent-tool --allow-effects net --input "x" \
+  --body 'match io.read("/etc/passwd") { Ok(s) => s, Err(e) => e }'
+# → TYPE-CHECK REJECTED — tool not run.   exit 2
+
+# Audit a codebase by structure: every fn that touches the network.
+lex audit --effect net examples/
+
+# AST-native diff. Renames register as "renamed", not "delete + add".
+lex ast-diff before.lex after.lex
+
+# Three-way structural merge. Conflicts are JSON, not <<<<<< HEAD markers.
+lex ast-merge base.lex ours.lex theirs.lex
+
+# Runtime tool registry: register Lex tools over HTTP, get back a stable
+# /tools/{id}/invoke endpoint with the effect manifest at /tools/{id}.
+lex tool-registry serve --port 8390
+```
+
 ## Examples
 
 ### 1. Factorial — recursion + pattern match
@@ -192,7 +215,24 @@ lex spec smt clamp.spec
 # (SMT-LIB 2 script for `z3 -smt2 -`)
 ```
 
-### 8. Core — tensor shape solver
+### 8. Real-world examples
+
+Eight runnable example apps live in `examples/`:
+
+| File | Shape |
+|---|---|
+| `weather_app.lex` | Single-handler REST API with [net]-only effects |
+| `chat_app.lex` | Multi-user WebSocket chat with [chat] effect + room registry |
+| `analytics_app.lex` | CSV → group-by → JSON over HTTP, with `--allow-fs-read` scope |
+| `ml_app.lex` | Linear + logistic regression trained on a 25-row CSV; `/predict_*` endpoints |
+| `inbox_app.lex` | Webhook-driven typed-handler router (4 handlers, 4 effect signatures) |
+| `gateway_app.lex` | Multi-route service; each route has its own narrow effect set |
+| `agent_tool` (binary) | LLM-emitted tool sandbox — see `Sandboxing agent-generated code` below |
+| `tool-registry` (binary) | HTTP service for runtime tool registration with effect manifests |
+
+Each example header contains an *Adversarial scenario* spelling out what the runtime gates would reject and the verbatim error string.
+
+### 9. Core — tensor shape solver
 
 The Core sibling adds sized numerics (`U8`–`U64`, `I8`–`I64`, `F32`/`F64`) and tensors with type-level shape arithmetic. Shape mismatches are caught at compile time:
 
@@ -282,6 +322,7 @@ A long-running HTTP/JSON server that exposes the same operations as the CLI. The
 | `POST /v1/parse` | `{source}` → CanonicalAst \| 4xx |
 | `POST /v1/check` | `{source}` → `{ok}` \| 422 with structured TypeError list |
 | `POST /v1/publish` | `{source, activate?}` → `[{name, sig_id, stage_id, status}, ...]` |
+| `POST /v1/patch` | `{stage_id, patch}` → `{new_stage_id}` \| 422 with structured TypeError list if the patched AST doesn't type-check |
 | `GET  /v1/stage/<id>` | `{metadata, ast, status}` |
 | `POST /v1/run` | `{source, fn, args, policy}` → `{run_id, output \| error}`; 403 with structured policy violation if disallowed |
 | `GET  /v1/trace/<run_id>` | TraceTree |
@@ -299,11 +340,13 @@ lex/
 │   ├── lex-ast/        # M2: canonical AST, NodeIds, canonical-JSON, SigId/StageId
 │   ├── lex-types/      # M3: HM type checker + effect system
 │   ├── lex-bytecode/   # M4: bytecode definition, compiler, stack VM
-│   ├── lex-runtime/    # M5: capability policy, effect handlers, pure stdlib builtins
+│   ├── lex-runtime/    # M5: capability policy, effect handlers, all stdlib builtins live here
 │   ├── lex-store/      # M6: content-addressed store (filesystem)
 │   ├── lex-trace/      # M7: trace tree + replay + diff
-│   ├── lex-stdlib/     # M11: stdlib stages (in progress; many ops live in lex-runtime)
-│   ├── lex-cli/        # M8/M12: command-line tool
+│   ├── lex-stdlib/     # M11: reserved for stdlib stages-as-store-entries (currently a stub;
+│   │                   #      pure stdlib lives in lex-runtime/builtins.rs)
+│   ├── lex-cli/        # M8/M12: command-line tool (also hosts agent-tool, tool-registry,
+│   │                   #         audit, ast-diff, ast-merge subcommands)
 │   ├── lex-api/        # M8/M12: agent HTTP/JSON server
 │   ├── core-syntax/    # M13: Core lexer/parser (stub; reuses lex-syntax)
 │   ├── core-compiler/  # M9:  Core type system (shape solver, sized numerics, mut analysis, native matmul)
@@ -328,11 +371,12 @@ lex/
 | M7 — Trace tree + replay + diff | ✅ |
 | M8 — CLI + agent API server | ✅ |
 | M9 — Core | Phase 1 (shape solver, sized numerics) ✅ ; Phase 2 (mutation analysis, native matmul) ✅ ; Cranelift JIT, source-level `mut`/`for` syntax deferred |
-| M10 — Spec | ✅ randomized + SMT-LIB export ; in-process Z3 deferred |
-| M11 — Stdlib MVP | ✅ pure builtins + closures + higher-order list ops + `std.flow` orchestration ; `flow.parallel`/`parallel_record` deferred |
+| M10 — Spec | ✅ randomized + SMT-LIB export ; `--spec` wired into `agent-tool` ; in-process Z3 deferred |
+| M11 — Stdlib MVP | ✅ pure builtins + closures + higher-order list ops + `std.flow` orchestration ; `std.math` (linalg + scalar floats) ; `std.tuple` ; **effect polymorphism** on `list.map` / `list.filter` / `list.fold` / `option.map` / `result.map` / `result.and_then` / `result.map_err` ; `flow.parallel` ✅ (sequential v1 — true threading deferred) ; `flow.parallel_record` deferred (needs row polymorphism on records) ; `std.map` / `std.set` deferred (need `Value` variants) |
 | M16 — Conformance harness + token budget | ✅ |
+| Agent integration (post-spec) | `lex agent-tool` (sandbox) ✅ ; `lex tool-registry serve` (HTTP registry) ✅ ; correctness ladder: `--examples` ✅ `--spec` ✅ `--diff-body` ✅ ; AST tooling: `lex audit` ✅ `lex ast-diff` ✅ `lex ast-merge` ✅ |
 
-**Workspace test count:** 125 passing, 0 failing. `cargo clippy --workspace --all-targets -- -D warnings` clean.
+**Workspace test count:** 251 passing, 0 failing. `cargo clippy --workspace --all-targets -- -D warnings` clean.
 
 ## Building from source
 
@@ -340,7 +384,7 @@ Requires a recent Rust toolchain (any 1.80+ stable should work).
 
 ```bash
 cargo build --release       # full toolchain
-cargo test --workspace      # 125 tests
+cargo test --workspace      # 251 tests
 cargo test --release -p core-compiler -- --ignored   # release-only matmul perf gates
 ```
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -391,19 +391,18 @@ $ lex ast-merge --json base.lex ours.lex theirs.lex
     one rung of the ladder. There are higher rungs:
   </p>
   <ul class="tight">
-    <li><strong>Spec proofs (§14 of <code>langspecs.md</code>).</strong> Attach a behavioral contract — <code>forall x :: Int, lo, hi where lo &lt;= hi: clamp(x, lo, hi) &gt;= lo and ... &lt;= hi</code> — and the checker discharges it via Z3 (or property-tests when SMT can't decide). Verdict travels with the stage in the store, so downstream agents can require <em>spec-proven</em> dependencies, not just well-typed ones.</li>
     <li><strong>Examples-driven verification.</strong> Pass <code>--examples FILE</code>; the host hands the agent a small set of <code>{input → expected}</code> pairs and Lex runs the emitted body against each before trusting it for live traffic. Any mismatch exits 5 with a per-case diff. Catches <em>wrong-but-consistent</em> behavior (the wrong-site scrape) at minimal cost; doesn't need SMT.</li>
-    <li><strong>Spec proofs.</strong> Pass <code>--spec FILE</code>; the host attaches a behavioral contract — <code>forall x :: Int where x &gt;= 0: tool(x) == expected(x)</code> — and the spec checker discharges it via Z3 (or a randomized fallback). Counterexamples abort with exit 5; inconclusive proofs abort with 6 unless <code>--spec-allow-inconclusive</code> is set. Strongest available pre-execution check on behavior.</li>
+    <li><strong>Spec proofs.</strong> Pass <code>--spec FILE</code>; attach a behavioral contract — <code>forall x :: Int, lo, hi where lo &lt;= hi: clamp(x, lo, hi) &gt;= lo and ... &lt;= hi</code> — and the spec checker discharges it via Z3 (or a randomized fallback when SMT can't decide). Counterexamples abort with exit 5; inconclusive proofs abort with 6 unless <code>--spec-allow-inconclusive</code> is set. Strongest available pre-execution check on behavior.</li>
+    <li><strong>Differential evaluation.</strong> Pass <code>--diff-body 'src'</code> (or <code>--diff-body-file</code>); both bodies run on each input and any output divergence aborts with exit 7. Cheap regression detection across model upgrades — no oracle needed.</li>
     <li><strong>Capability scoping.</strong> <code>--allow-net-host github.com</code> means the wrong-site scraping case can't even <em>reach</em> attacker.com — the blast radius of a behavioral bug is bounded.</li>
-    <li><strong>Differential evaluation.</strong> Pass <code>--diff-body 'src'</code> (or <code>--diff-body-file</code>); both bodies run on each input (single <code>--input</code> or every entry from <code>--examples</code>); any output divergence aborts with exit 7. Cheap regression detection across model upgrades — no oracle needed.</li>
   </ul>
   <p>
-    All four rungs ship today: effects, capability scoping,
-    examples-driven verification, Spec proofs, and differential
-    evaluation. The point isn't that capability typing solves
-    correctness — it doesn't — it's that the contract lives in the
-    language, free of inference cost, and each higher rung composes
-    on top of the previous one.
+    All four rungs ship today, on top of the effect-typing base:
+    examples-driven verification, Spec proofs, differential evaluation,
+    and capability scoping. The point isn't that capability typing
+    solves correctness — it doesn't — it's that the contract lives
+    in the language, free of inference cost, and each higher rung
+    composes on top of the previous one.
   </p>
 </section>
 
@@ -418,7 +417,16 @@ lex agent-tool --allow-effects net --input x \
   --body 'match io.read("/etc/passwd") { Ok(s) =&gt; s, Err(e) =&gt; e }'
 # → TYPE-CHECK REJECTED — tool not run.
 
-# Run the live demo (needs ANTHROPIC_API_KEY):
+# AST tooling — review/diff/merge what an agent wrote, no text parsing:
+lex audit --effect net examples/                  # find all [net] fns
+lex ast-diff before.lex after.lex                 # structural diff
+lex ast-merge base.lex ours.lex theirs.lex        # 3-way merge → JSON conflicts
+
+# Runtime tool registry — register tools over HTTP, get a stable URL +
+# public effect manifest at /tools/{id}:
+lex tool-registry serve --port 8390
+
+# Run the live agent demo (needs ANTHROPIC_API_KEY):
 export ANTHROPIC_API_KEY=sk-ant-...
 lex agent-tool --allow-effects net \
   --request 'fetch https://api.github.com/zen and return its first line'</code></pre>
@@ -426,15 +434,18 @@ lex agent-tool --allow-effects net \
     Source is at <a href="https://github.com/alpibrusl/lex-lang">github.com/alpibrusl/lex-lang</a>.
     The <a href="https://github.com/alpibrusl/lex-lang/blob/main/README.md">README</a> covers
     the full toolchain (parse, check, run, hash, publish, trace, replay,
-    serve, conformance, spec).
+    serve, conformance, spec, agent-tool, tool-registry, audit, ast-diff, ast-merge).
   </p>
 </section>
 
 <footer>
   <div class="wrap">
     Lex is implemented in Rust under <a href="https://github.com/alpibrusl/lex-lang/blob/main/LICENSE">EUPL-1.2</a>.
-    Status: experimental. Agent integration ships in <code>lex agent-tool</code>; full spec lives in
-    <code>langspecs.md</code>.
+    Status: experimental. Agent integration ships across
+    <code>lex agent-tool</code>, <code>lex tool-registry</code>,
+    <code>lex audit</code>, <code>lex ast-diff</code>, and
+    <code>lex ast-merge</code>. Full spec lives in <code>langspecs.md</code>.
+    251 workspace tests passing as of this writing.
   </div>
 </footer>
 


### PR DESCRIPTION
## Summary

A doc pass to make sure the public pages reflect what actually shipped this session. No code changes.

## README

- **Test count** `125 → 251` in two places (Status + Building from source)
- **M11 Stdlib status row** corrected: `flow.parallel` shipped (sequential v1, threading deferred); `flow.parallel_record` alone deferred; new entries for `std.math`, `std.tuple`, **effect polymorphism** on stdlib HOFs; `std.map` / `std.set` noted as deferred (need `Value` variants)
- **New status row "Agent integration (post-spec)"** enumerating `agent-tool`, `tool-registry`, the verification ladder rungs (`--examples` / `--spec` / `--diff-body`), and the AST-tooling trio. Previously these landed without a status-table mention.
- **New §8 "Real-world examples"** table pointing at the eight runnable apps; Core renumbered to §9
- **New "Quickstart: agent-native tooling"** subsection — readers find the four agent-native commands without scrolling to the toolchain table
- **Repo layout** — `lex-stdlib` clarified as a stub (active stdlib lives in `lex-runtime/builtins.rs`); `lex-cli` annotated with the subcommands it hosts
- **Agent API table** — `/v1/patch` was missing despite being live in `lex-api`; added

## docs/index.html

- **"Capability ≠ correctness"** section had Spec proofs listed twice (abstract idea + `--spec` flag) and the summary said *"all four rungs"* while listing five items. Merged the two Spec entries; corrected the count
- **"Try it"** section showcases the AST tooling alongside `agent-tool`. Previously only `agent-tool` was demoed in the install block
- **Footer** enumerates all five agent-native commands plus the test count
- **Toolchain reference list** at the bottom of "Try it" gets the full set: parse, check, run, hash, publish, trace, replay, serve, conformance, spec, agent-tool, tool-registry, audit, ast-diff, ast-merge

## Test plan

- [x] `cargo test --workspace` — 251 passing
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] All `examples/*.lex` paths referenced in the README still exist
- [x] All API endpoints listed in the README's table are wired in `lex-api`

https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh

---
_Generated by [Claude Code](https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh)_