### PR TITLE
Integrate ACLI: lex is now self-describing to any LLM agent

### DIFF
--- a/.cli/README.md
+++ b/.cli/README.md
@@ -1,0 +1,113 @@
+# lex
+
+Version: 0.1.0
+ACLI version: 0.1.0
+
+## Commands
+
+### parse
+
+print canonical AST as JSON
+
+Idempotent: true
+
+### check
+
+type-check; exit 0 or print errors
+
+Idempotent: true
+
+### run
+
+execute fn under capability policy (args parsed as JSON)
+
+Idempotent: false
+
+### hash
+
+print canonical SigId/StageId hashes for each function
+
+Idempotent: true
+
+### publish
+
+publish each stage in a file to the store as Draft
+
+Idempotent: false
+
+### store
+
+browse the content-addressed code store
+
+### trace
+
+print a saved execution trace tree as JSON
+
+Idempotent: true
+
+### replay
+
+re-execute with effect overrides keyed by NodeId
+
+Idempotent: false
+
+### diff
+
+first NodeId where two execution traces diverge
+
+Idempotent: true
+
+### serve
+
+start the agent API HTTP server
+
+Idempotent: false
+
+### conformance
+
+run all JSON test descriptors under a directory
+
+Idempotent: true
+
+### spec
+
+Spec proof checker (randomized + SMT-LIB export)
+
+### agent-tool
+
+have an LLM emit a Lex tool body, run it under declared effects
+
+Idempotent: false
+
+### tool-registry
+
+runtime tool registration over HTTP
+
+### audit
+
+structural code search by effect / call / hostname / AST kind
+
+Idempotent: true
+
+### ast-diff
+
+AST-native diff: added/removed/renamed/modified fns + body patches
+
+Idempotent: true
+
+### ast-merge
+
+three-way structural merge with structured JSON conflicts
+
+Idempotent: false
+
+### branch
+
+snapshot branches in lex-store (tier-1 agent-native VC)
+
+### store-merge
+
+three-way merge between two branches in the store
+
+Idempotent: false
+

--- a/.cli/changelog.md
+++ b/.cli/changelog.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0
+
+- Initial release

--- a/.cli/commands.json
+++ b/.cli/commands.json
@@ -1,0 +1,930 @@
+{
+  "name": "lex",
+  "version": "0.1.0",
+  "acli_version": "0.1.0",
+  "commands": [
+    {
+      "name": "parse",
+      "description": "print canonical AST as JSON",
+      "arguments": [
+        {
+          "name": "file",
+          "type": "string",
+          "description": "path to a .lex file (or `-` for stdin)",
+          "required": true
+        }
+      ],
+      "options": [],
+      "subcommands": [],
+      "idempotent": true,
+      "examples": [
+        {
+          "description": "Parse a file",
+          "invocation": "lex parse hello.lex"
+        },
+        {
+          "description": "Parse stdin",
+          "invocation": "cat hello.lex | lex parse -"
+        }
+      ],
+      "see_also": [
+        "check",
+        "hash"
+      ]
+    },
+    {
+      "name": "check",
+      "description": "type-check; exit 0 or print errors",
+      "arguments": [
+        {
+          "name": "file",
+          "type": "string",
+          "description": "path to a .lex file",
+          "required": true
+        }
+      ],
+      "options": [],
+      "subcommands": [],
+      "idempotent": true,
+      "examples": [
+        {
+          "description": "Type-check a file",
+          "invocation": "lex check hello.lex"
+        },
+        {
+          "description": "Check before running",
+          "invocation": "lex check app.lex && lex run app.lex main"
+        }
+      ],
+      "see_also": [
+        "parse",
+        "run"
+      ]
+    },
+    {
+      "name": "run",
+      "description": "execute fn under capability policy (args parsed as JSON)",
+      "arguments": [
+        {
+          "name": "file",
+          "type": "string",
+          "description": "path to a .lex file",
+          "required": true
+        },
+        {
+          "name": "fn",
+          "type": "string",
+          "description": "function name to invoke",
+          "required": true
+        },
+        {
+          "name": "args",
+          "type": "string[]",
+          "description": "JSON-encoded positional args",
+          "required": false
+        }
+      ],
+      "options": [
+        {
+          "name": "--allow-effects",
+          "type": "string",
+          "description": "comma-separated effect kinds to permit"
+        },
+        {
+          "name": "--allow-fs-read",
+          "type": "string",
+          "description": "filesystem path tree readable by fs_read"
+        },
+        {
+          "name": "--allow-fs-write",
+          "type": "string",
+          "description": "filesystem path tree writable by fs_write"
+        },
+        {
+          "name": "--allow-net-host",
+          "type": "string",
+          "description": "permit net effects to this host"
+        },
+        {
+          "name": "--budget",
+          "type": "int",
+          "description": "cap aggregate declared budget"
+        },
+        {
+          "name": "--max-steps",
+          "type": "int",
+          "description": "cap VM opcode dispatches (DoS guard)"
+        }
+      ],
+      "subcommands": [],
+      "idempotent": false,
+      "examples": [
+        {
+          "description": "Run main()",
+          "invocation": "lex run app.lex main"
+        },
+        {
+          "description": "Run with fs read scope",
+          "invocation": "lex run --allow-fs-read /tmp app.lex load \"/tmp/x.json\""
+        }
+      ],
+      "see_also": [
+        "check",
+        "replay",
+        "trace"
+      ]
+    },
+    {
+      "name": "hash",
+      "description": "print canonical SigId/StageId hashes for each function",
+      "arguments": [
+        {
+          "name": "file",
+          "type": "string",
+          "description": "path to a .lex file",
+          "required": true
+        }
+      ],
+      "options": [],
+      "subcommands": [],
+      "idempotent": true,
+      "examples": [
+        {
+          "description": "Hash a file",
+          "invocation": "lex hash app.lex"
+        },
+        {
+          "description": "Diff hashes across versions",
+          "invocation": "diff <(lex hash a.lex) <(lex hash b.lex)"
+        }
+      ],
+      "see_also": [
+        "publish",
+        "ast-diff"
+      ]
+    },
+    {
+      "name": "publish",
+      "description": "publish each stage in a file to the store as Draft",
+      "arguments": [
+        {
+          "name": "file",
+          "type": "string",
+          "description": "path to a .lex file",
+          "required": true
+        }
+      ],
+      "options": [
+        {
+          "name": "--store",
+          "type": "string",
+          "description": "store root directory (default: ~/.lex/store)"
+        },
+        {
+          "name": "--activate",
+          "type": "bool",
+          "description": "transition published stages to Active"
+        }
+      ],
+      "subcommands": [],
+      "idempotent": false,
+      "examples": [
+        {
+          "description": "Publish drafts",
+          "invocation": "lex publish app.lex"
+        },
+        {
+          "description": "Publish + activate",
+          "invocation": "lex publish --activate app.lex"
+        }
+      ],
+      "see_also": [
+        "store",
+        "branch"
+      ]
+    },
+    {
+      "name": "store",
+      "description": "browse the content-addressed code store",
+      "arguments": [],
+      "options": [],
+      "subcommands": [
+        {
+          "name": "list",
+          "description": "list SigIds in the store",
+          "arguments": [],
+          "options": [
+            {
+              "name": "--store",
+              "type": "string",
+              "description": "store root directory"
+            }
+          ],
+          "subcommands": [],
+          "idempotent": true
+        },
+        {
+          "name": "get",
+          "description": "print metadata + canonical AST for a StageId",
+          "arguments": [
+            {
+              "name": "stage",
+              "type": "string",
+              "description": "StageId hex",
+              "required": true
+            }
+          ],
+          "options": [
+            {
+              "name": "--store",
+              "type": "string",
+              "description": "store root directory"
+            }
+          ],
+          "subcommands": [],
+          "idempotent": true
+        }
+      ],
+      "examples": [
+        {
+          "description": "List sigs",
+          "invocation": "lex store list"
+        },
+        {
+          "description": "Get a stage",
+          "invocation": "lex store get abc123..."
+        }
+      ],
+      "see_also": [
+        "publish",
+        "branch",
+        "store-merge"
+      ]
+    },
+    {
+      "name": "trace",
+      "description": "print a saved execution trace tree as JSON",
+      "arguments": [
+        {
+          "name": "run_id",
+          "type": "string",
+          "description": "run identifier",
+          "required": true
+        }
+      ],
+      "options": [],
+      "subcommands": [],
+      "idempotent": true,
+      "examples": [
+        {
+          "description": "Inspect a trace",
+          "invocation": "lex trace 2024-01-15-abc"
+        }
+      ],
+      "see_also": [
+        "replay",
+        "diff"
+      ]
+    },
+    {
+      "name": "replay",
+      "description": "re-execute with effect overrides keyed by NodeId",
+      "arguments": [
+        {
+          "name": "run_id",
+          "type": "string",
+          "description": "run identifier",
+          "required": true
+        },
+        {
+          "name": "file",
+          "type": "string",
+          "description": "source file",
+          "required": true
+        },
+        {
+          "name": "fn",
+          "type": "string",
+          "description": "function name",
+          "required": true
+        },
+        {
+          "name": "args",
+          "type": "string[]",
+          "description": "JSON-encoded positional args",
+          "required": false
+        }
+      ],
+      "options": [
+        {
+          "name": "--override",
+          "type": "string",
+          "description": "NODE=JSON override (repeatable)"
+        }
+      ],
+      "subcommands": [],
+      "idempotent": false,
+      "examples": [
+        {
+          "description": "Replay verbatim",
+          "invocation": "lex replay 2024-01-15-abc app.lex main"
+        },
+        {
+          "description": "Replay with override",
+          "invocation": "lex replay 2024-01-15-abc app.lex main --override 7=42"
+        }
+      ],
+      "see_also": [
+        "run",
+        "trace",
+        "diff"
+      ]
+    },
+    {
+      "name": "diff",
+      "description": "first NodeId where two execution traces diverge",
+      "arguments": [
+        {
+          "name": "run_a",
+          "type": "string",
+          "description": "first run id",
+          "required": true
+        },
+        {
+          "name": "run_b",
+          "type": "string",
+          "description": "second run id",
+          "required": true
+        }
+      ],
+      "options": [],
+      "subcommands": [],
+      "idempotent": true,
+      "examples": [
+        {
+          "description": "Compare two runs",
+          "invocation": "lex diff run-1 run-2"
+        }
+      ],
+      "see_also": [
+        "replay",
+        "trace",
+        "ast-diff"
+      ]
+    },
+    {
+      "name": "serve",
+      "description": "start the agent API HTTP server",
+      "arguments": [],
+      "options": [
+        {
+          "name": "--port",
+          "type": "int",
+          "description": "TCP port (default: 7000)"
+        },
+        {
+          "name": "--store",
+          "type": "string",
+          "description": "store root directory"
+        }
+      ],
+      "subcommands": [],
+      "idempotent": false,
+      "examples": [
+        {
+          "description": "Start with defaults",
+          "invocation": "lex serve"
+        },
+        {
+          "description": "Pin port + store",
+          "invocation": "lex serve --port 8080 --store /var/lex"
+        }
+      ],
+      "see_also": [
+        "tool-registry"
+      ]
+    },
+    {
+      "name": "conformance",
+      "description": "run all JSON test descriptors under a directory",
+      "arguments": [
+        {
+          "name": "dir",
+          "type": "string",
+          "description": "directory of conformance descriptors",
+          "required": true
+        }
+      ],
+      "options": [],
+      "subcommands": [],
+      "idempotent": true,
+      "examples": [
+        {
+          "description": "Run shipped suite",
+          "invocation": "lex conformance crates/conformance/tests/data"
+        }
+      ],
+      "see_also": [
+        "check",
+        "spec"
+      ]
+    },
+    {
+      "name": "spec",
+      "description": "Spec proof checker (randomized + SMT-LIB export)",
+      "arguments": [],
+      "options": [],
+      "subcommands": [
+        {
+          "name": "check",
+          "description": "check a Spec against a Lex source",
+          "arguments": [
+            {
+              "name": "spec",
+              "type": "string",
+              "description": "spec file",
+              "required": true
+            }
+          ],
+          "options": [
+            {
+              "name": "--source",
+              "type": "string",
+              "description": "source file to verify against"
+            }
+          ],
+          "subcommands": [],
+          "idempotent": true
+        },
+        {
+          "name": "smt",
+          "description": "emit SMT-LIB for external Z3",
+          "arguments": [
+            {
+              "name": "spec",
+              "type": "string",
+              "description": "spec file",
+              "required": true
+            }
+          ],
+          "options": [],
+          "subcommands": [],
+          "idempotent": true
+        }
+      ],
+      "examples": [
+        {
+          "description": "Check a spec",
+          "invocation": "lex spec check sort.spec --source sort.lex"
+        },
+        {
+          "description": "Export SMT-LIB",
+          "invocation": "lex spec smt sort.spec"
+        }
+      ],
+      "see_also": [
+        "check",
+        "conformance"
+      ]
+    },
+    {
+      "name": "agent-tool",
+      "description": "have an LLM emit a Lex tool body, run it under declared effects",
+      "arguments": [],
+      "options": [
+        {
+          "name": "--allow-effects",
+          "type": "string",
+          "description": "permitted effect kinds"
+        },
+        {
+          "name": "--request",
+          "type": "string",
+          "description": "natural-language request"
+        },
+        {
+          "name": "--body",
+          "type": "string",
+          "description": "inline tool body"
+        },
+        {
+          "name": "--body-file",
+          "type": "string",
+          "description": "tool body in a file"
+        },
+        {
+          "name": "--spec",
+          "type": "string",
+          "description": "spec file for behavioral verification"
+        },
+        {
+          "name": "--examples",
+          "type": "string",
+          "description": "JSON examples for behavioral checking"
+        },
+        {
+          "name": "--diff-body",
+          "type": "string",
+          "description": "differential evaluation: alternate body"
+        },
+        {
+          "name": "--diff-body-file",
+          "type": "string",
+          "description": "differential evaluation: alternate body file"
+        },
+        {
+          "name": "--json",
+          "type": "bool",
+          "description": "machine-readable output"
+        }
+      ],
+      "subcommands": [],
+      "idempotent": false,
+      "examples": [
+        {
+          "description": "Run with allow-list",
+          "invocation": "lex agent-tool --allow-effects fs_read --request \"sum lines of /tmp/log\""
+        },
+        {
+          "description": "Verify against spec",
+          "invocation": "lex agent-tool --spec sort.spec --body-file body.lex --json"
+        }
+      ],
+      "see_also": [
+        "check",
+        "spec",
+        "run"
+      ]
+    },
+    {
+      "name": "tool-registry",
+      "description": "runtime tool registration over HTTP",
+      "arguments": [],
+      "options": [],
+      "subcommands": [
+        {
+          "name": "serve",
+          "description": "HTTP service to register Lex tools and invoke them",
+          "arguments": [],
+          "options": [
+            {
+              "name": "--port",
+              "type": "int",
+              "description": "TCP port"
+            }
+          ],
+          "subcommands": [],
+          "idempotent": false
+        }
+      ],
+      "examples": [
+        {
+          "description": "Run on default port",
+          "invocation": "lex tool-registry serve"
+        }
+      ],
+      "see_also": [
+        "serve",
+        "agent-tool"
+      ]
+    },
+    {
+      "name": "audit",
+      "description": "structural code search by effect / call / hostname / AST kind",
+      "arguments": [
+        {
+          "name": "paths",
+          "type": "string[]",
+          "description": "files / directories to scan",
+          "required": false
+        }
+      ],
+      "options": [
+        {
+          "name": "--effect",
+          "type": "string",
+          "description": "effect kind filter"
+        },
+        {
+          "name": "--call",
+          "type": "string",
+          "description": "called-function filter"
+        },
+        {
+          "name": "--host",
+          "type": "string",
+          "description": "hostname filter (literal)"
+        },
+        {
+          "name": "--kind",
+          "type": "string",
+          "description": "AST node kind filter"
+        },
+        {
+          "name": "--json",
+          "type": "bool",
+          "description": "machine-readable output"
+        }
+      ],
+      "subcommands": [],
+      "idempotent": true,
+      "examples": [
+        {
+          "description": "Find network calls",
+          "invocation": "lex audit --effect net examples"
+        },
+        {
+          "description": "Find a host as JSON",
+          "invocation": "lex audit --host api.example.com --json src"
+        }
+      ],
+      "see_also": [
+        "ast-diff",
+        "ast-merge"
+      ]
+    },
+    {
+      "name": "ast-diff",
+      "description": "AST-native diff: added/removed/renamed/modified fns + body patches",
+      "arguments": [
+        {
+          "name": "file_a",
+          "type": "string",
+          "description": "left source file",
+          "required": true
+        },
+        {
+          "name": "file_b",
+          "type": "string",
+          "description": "right source file",
+          "required": true
+        }
+      ],
+      "options": [
+        {
+          "name": "--json",
+          "type": "bool",
+          "description": "structured JSON output"
+        }
+      ],
+      "subcommands": [],
+      "idempotent": true,
+      "examples": [
+        {
+          "description": "Compare two versions",
+          "invocation": "lex ast-diff a.lex b.lex"
+        },
+        {
+          "description": "Machine-readable",
+          "invocation": "lex ast-diff --json a.lex b.lex"
+        }
+      ],
+      "see_also": [
+        "audit",
+        "ast-merge"
+      ]
+    },
+    {
+      "name": "ast-merge",
+      "description": "three-way structural merge with structured JSON conflicts",
+      "arguments": [
+        {
+          "name": "base",
+          "type": "string",
+          "description": "common ancestor source",
+          "required": true
+        },
+        {
+          "name": "ours",
+          "type": "string",
+          "description": "our side",
+          "required": true
+        },
+        {
+          "name": "theirs",
+          "type": "string",
+          "description": "their side",
+          "required": true
+        }
+      ],
+      "options": [
+        {
+          "name": "--output",
+          "type": "string",
+          "description": "write merged source to a file"
+        },
+        {
+          "name": "--json",
+          "type": "bool",
+          "description": "emit conflicts as JSON"
+        }
+      ],
+      "subcommands": [],
+      "idempotent": false,
+      "examples": [
+        {
+          "description": "Merge three versions",
+          "invocation": "lex ast-merge base.lex ours.lex theirs.lex"
+        },
+        {
+          "description": "Materialize merge",
+          "invocation": "lex ast-merge base.lex ours.lex theirs.lex --output merged.lex"
+        }
+      ],
+      "see_also": [
+        "ast-diff",
+        "store-merge"
+      ]
+    },
+    {
+      "name": "branch",
+      "description": "snapshot branches in lex-store (tier-1 agent-native VC)",
+      "arguments": [],
+      "options": [],
+      "subcommands": [
+        {
+          "name": "list",
+          "description": "list branches in the store",
+          "arguments": [],
+          "options": [
+            {
+              "name": "--store",
+              "type": "string",
+              "description": "store root"
+            }
+          ],
+          "subcommands": [],
+          "idempotent": true
+        },
+        {
+          "name": "show",
+          "description": "show a branch's head map",
+          "arguments": [
+            {
+              "name": "name",
+              "type": "string",
+              "description": "branch name",
+              "required": true
+            }
+          ],
+          "options": [
+            {
+              "name": "--store",
+              "type": "string",
+              "description": "store root"
+            }
+          ],
+          "subcommands": [],
+          "idempotent": true
+        },
+        {
+          "name": "create",
+          "description": "create a branch",
+          "arguments": [
+            {
+              "name": "name",
+              "type": "string",
+              "description": "branch name",
+              "required": true
+            }
+          ],
+          "options": [
+            {
+              "name": "--from",
+              "type": "string",
+              "description": "parent branch (default: main)"
+            },
+            {
+              "name": "--store",
+              "type": "string",
+              "description": "store root"
+            }
+          ],
+          "subcommands": [],
+          "idempotent": false
+        },
+        {
+          "name": "delete",
+          "description": "delete a non-current, non-default branch",
+          "arguments": [
+            {
+              "name": "name",
+              "type": "string",
+              "description": "branch name",
+              "required": true
+            }
+          ],
+          "options": [
+            {
+              "name": "--store",
+              "type": "string",
+              "description": "store root"
+            }
+          ],
+          "subcommands": [],
+          "idempotent": false
+        },
+        {
+          "name": "use",
+          "description": "set the current branch",
+          "arguments": [
+            {
+              "name": "name",
+              "type": "string",
+              "description": "branch name",
+              "required": true
+            }
+          ],
+          "options": [
+            {
+              "name": "--store",
+              "type": "string",
+              "description": "store root"
+            }
+          ],
+          "subcommands": [],
+          "idempotent": false
+        },
+        {
+          "name": "current",
+          "description": "print the current branch",
+          "arguments": [],
+          "options": [
+            {
+              "name": "--store",
+              "type": "string",
+              "description": "store root"
+            }
+          ],
+          "subcommands": [],
+          "idempotent": true
+        }
+      ],
+      "examples": [
+        {
+          "description": "List branches",
+          "invocation": "lex branch list"
+        },
+        {
+          "description": "Create a feature",
+          "invocation": "lex branch create feature --from main"
+        }
+      ],
+      "see_also": [
+        "store-merge",
+        "store"
+      ]
+    },
+    {
+      "name": "store-merge",
+      "description": "three-way merge between two branches in the store",
+      "arguments": [
+        {
+          "name": "src",
+          "type": "string",
+          "description": "source branch",
+          "required": true
+        },
+        {
+          "name": "dst",
+          "type": "string",
+          "description": "destination branch",
+          "required": true
+        }
+      ],
+      "options": [
+        {
+          "name": "--commit",
+          "type": "bool",
+          "description": "apply a clean merge to dst (refused if conflicts)"
+        },
+        {
+          "name": "--json",
+          "type": "bool",
+          "description": "emit the merge report as JSON"
+        },
+        {
+          "name": "--store",
+          "type": "string",
+          "description": "store root directory"
+        }
+      ],
+      "subcommands": [],
+      "idempotent": false,
+      "examples": [
+        {
+          "description": "Preview a merge",
+          "invocation": "lex store-merge feature main"
+        },
+        {
+          "description": "Commit a clean merge",
+          "invocation": "lex store-merge feature main --commit"
+        }
+      ],
+      "see_also": [
+        "branch",
+        "ast-merge"
+      ]
+    }
+  ]
+}

--- a/.cli/examples/agent-tool.sh
+++ b/.cli/examples/agent-tool.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Examples for: agent-tool
+
+# Run with allow-list
+lex agent-tool --allow-effects fs_read --request "sum lines of /tmp/log"
+
+# Verify against spec
+lex agent-tool --spec sort.spec --body-file body.lex --json

--- a/.cli/examples/ast-diff.sh
+++ b/.cli/examples/ast-diff.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Examples for: ast-diff
+
+# Compare two versions
+lex ast-diff a.lex b.lex
+
+# Machine-readable
+lex ast-diff --json a.lex b.lex

--- a/.cli/examples/ast-merge.sh
+++ b/.cli/examples/ast-merge.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Examples for: ast-merge
+
+# Merge three versions
+lex ast-merge base.lex ours.lex theirs.lex
+
+# Materialize merge
+lex ast-merge base.lex ours.lex theirs.lex --output merged.lex

--- a/.cli/examples/audit.sh
+++ b/.cli/examples/audit.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Examples for: audit
+
+# Find network calls
+lex audit --effect net examples
+
+# Find a host as JSON
+lex audit --host api.example.com --json src

--- a/.cli/examples/branch.sh
+++ b/.cli/examples/branch.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Examples for: branch
+
+# List branches
+lex branch list
+
+# Create a feature
+lex branch create feature --from main

--- a/.cli/examples/check.sh
+++ b/.cli/examples/check.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Examples for: check
+
+# Type-check a file
+lex check hello.lex
+
+# Check before running
+lex check app.lex && lex run app.lex main

--- a/.cli/examples/conformance.sh
+++ b/.cli/examples/conformance.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Examples for: conformance
+
+# Run shipped suite
+lex conformance crates/conformance/tests/data

--- a/.cli/examples/diff.sh
+++ b/.cli/examples/diff.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Examples for: diff
+
+# Compare two runs
+lex diff run-1 run-2

--- a/.cli/examples/hash.sh
+++ b/.cli/examples/hash.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Examples for: hash
+
+# Hash a file
+lex hash app.lex
+
+# Diff hashes across versions
+diff <(lex hash a.lex) <(lex hash b.lex)

--- a/.cli/examples/parse.sh
+++ b/.cli/examples/parse.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Examples for: parse
+
+# Parse a file
+lex parse hello.lex
+
+# Parse stdin
+cat hello.lex | lex parse -

--- a/.cli/examples/publish.sh
+++ b/.cli/examples/publish.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Examples for: publish
+
+# Publish drafts
+lex publish app.lex
+
+# Publish + activate
+lex publish --activate app.lex

--- a/.cli/examples/replay.sh
+++ b/.cli/examples/replay.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Examples for: replay
+
+# Replay verbatim
+lex replay 2024-01-15-abc app.lex main
+
+# Replay with override
+lex replay 2024-01-15-abc app.lex main --override 7=42

--- a/.cli/examples/run.sh
+++ b/.cli/examples/run.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Examples for: run
+
+# Run main()
+lex run app.lex main
+
+# Run with fs read scope
+lex run --allow-fs-read /tmp app.lex load "/tmp/x.json"

--- a/.cli/examples/serve.sh
+++ b/.cli/examples/serve.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Examples for: serve
+
+# Start with defaults
+lex serve
+
+# Pin port + store
+lex serve --port 8080 --store /var/lex

--- a/.cli/examples/spec.sh
+++ b/.cli/examples/spec.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Examples for: spec
+
+# Check a spec
+lex spec check sort.spec --source sort.lex
+
+# Export SMT-LIB
+lex spec smt sort.spec

--- a/.cli/examples/store-merge.sh
+++ b/.cli/examples/store-merge.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Examples for: store-merge
+
+# Preview a merge
+lex store-merge feature main
+
+# Commit a clean merge
+lex store-merge feature main --commit

--- a/.cli/examples/store.sh
+++ b/.cli/examples/store.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Examples for: store
+
+# List sigs
+lex store list
+
+# Get a stage
+lex store get abc123...

--- a/.cli/examples/tool-registry.sh
+++ b/.cli/examples/tool-registry.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Examples for: tool-registry
+
+# Run on default port
+lex tool-registry serve

--- a/.cli/examples/trace.sh
+++ b/.cli/examples/trace.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Examples for: trace
+
+# Inspect a trace
+lex trace 2024-01-15-abc

--- a/crates/lex-cli/Cargo.toml
+++ b/crates/lex-cli/Cargo.toml
@@ -25,3 +25,4 @@ lex-trace = { path = "../lex-trace" }
 lex-api = { path = "../lex-api" }
 conformance = { path = "../conformance" }
 spec-checker = { path = "../spec-checker" }
+acli = "0.5"

--- a/crates/lex-cli/src/acli.rs
+++ b/crates/lex-cli/src/acli.rs
@@ -1,0 +1,340 @@
+//! ACLI integration — register every `lex` subcommand with the
+//! [acli](https://github.com/alpibrusl/acli) Rust SDK so the binary
+//! is self-describing to any LLM agent (Claude, Codex, Gemini,
+//! Qwen, ...) via a single spec instead of one bespoke skill per
+//! agent platform.
+//!
+//! What ships:
+//!
+//! - `lex introspect [--output text|json]` — full command tree as
+//!   JSON per ACLI §1.2; agents read this once and learn the surface.
+//! - `lex skill [--output text|json]` — markdown + YAML frontmatter
+//!   per agentskills.io; suitable for `cp <(lex skill) SKILL.md`.
+//! - `lex version [--output text|json]` — name + version + acli
+//!   spec version.
+//!
+//! `--output` is also accepted as a top-level flag *before* the
+//! subcommand name (`lex --output json introspect`); it's consumed
+//! by `parse_output_format` in `main.rs` and passed through here.
+//!
+//! Implementation note: we register `CommandInfo` *manually* — the
+//! `acli` crate's `acli_args!` / `register::<C>()` path assumes
+//! commands are clap-derived structs, which `lex` is not. The
+//! manual builder gives us the same JSON envelope output without
+//! migrating ~1000 lines of hand-rolled arg parsing.
+
+use acli::introspect::CommandInfo;
+use acli::AcliApp;
+
+pub fn build_app() -> AcliApp {
+    let mut app = AcliApp::new("lex", env!("CARGO_PKG_VERSION"));
+    for cmd in commands() {
+        app.register_command(cmd);
+    }
+    app
+}
+
+fn commands() -> Vec<CommandInfo> {
+    vec![
+        cmd_parse(),
+        cmd_check(),
+        cmd_run(),
+        cmd_hash(),
+        cmd_publish(),
+        cmd_store(),
+        cmd_trace(),
+        cmd_replay(),
+        cmd_diff(),
+        cmd_serve(),
+        cmd_conformance(),
+        cmd_spec(),
+        cmd_agent_tool(),
+        cmd_tool_registry(),
+        cmd_audit(),
+        cmd_ast_diff(),
+        cmd_ast_merge(),
+        cmd_branch(),
+        cmd_store_merge(),
+    ]
+}
+
+// ---- per-command metadata -----------------------------------------
+
+fn cmd_parse() -> CommandInfo {
+    CommandInfo::new("parse", "print canonical AST as JSON")
+        .idempotent(true)
+        .add_argument("file", "string", "path to a .lex file (or `-` for stdin)", true)
+        .with_examples(vec![
+            ("Parse a file", "lex parse hello.lex"),
+            ("Parse stdin", "cat hello.lex | lex parse -"),
+        ])
+        .with_see_also(vec!["check", "hash"])
+}
+
+fn cmd_check() -> CommandInfo {
+    CommandInfo::new("check", "type-check; exit 0 or print errors")
+        .idempotent(true)
+        .add_argument("file", "string", "path to a .lex file", true)
+        .with_examples(vec![
+            ("Type-check a file", "lex check hello.lex"),
+            ("Check before running", "lex check app.lex && lex run app.lex main"),
+        ])
+        .with_see_also(vec!["parse", "run"])
+}
+
+fn cmd_run() -> CommandInfo {
+    CommandInfo::new("run", "execute fn under capability policy (args parsed as JSON)")
+        .idempotent(false)
+        .add_argument("file", "string", "path to a .lex file", true)
+        .add_argument("fn", "string", "function name to invoke", true)
+        .add_argument("args", "string[]", "JSON-encoded positional args", false)
+        .add_option("--allow-effects", "string", "comma-separated effect kinds to permit", None)
+        .add_option("--allow-fs-read", "string", "filesystem path tree readable by fs_read", None)
+        .add_option("--allow-fs-write", "string", "filesystem path tree writable by fs_write", None)
+        .add_option("--allow-net-host", "string", "permit net effects to this host", None)
+        .add_option("--budget", "int", "cap aggregate declared budget", None)
+        .add_option("--max-steps", "int", "cap VM opcode dispatches (DoS guard)", None)
+        .with_examples(vec![
+            ("Run main()", "lex run app.lex main"),
+            ("Run with fs read scope", "lex run --allow-fs-read /tmp app.lex load \"/tmp/x.json\""),
+        ])
+        .with_see_also(vec!["check", "replay", "trace"])
+}
+
+fn cmd_hash() -> CommandInfo {
+    CommandInfo::new("hash", "print canonical SigId/StageId hashes for each function")
+        .idempotent(true)
+        .add_argument("file", "string", "path to a .lex file", true)
+        .with_examples(vec![
+            ("Hash a file", "lex hash app.lex"),
+            ("Diff hashes across versions", "diff <(lex hash a.lex) <(lex hash b.lex)"),
+        ])
+        .with_see_also(vec!["publish", "ast-diff"])
+}
+
+fn cmd_publish() -> CommandInfo {
+    CommandInfo::new("publish", "publish each stage in a file to the store as Draft")
+        .idempotent(false)
+        .add_argument("file", "string", "path to a .lex file", true)
+        .add_option("--store", "string", "store root directory (default: ~/.lex/store)", None)
+        .add_option("--activate", "bool", "transition published stages to Active", None)
+        .with_examples(vec![
+            ("Publish drafts", "lex publish app.lex"),
+            ("Publish + activate", "lex publish --activate app.lex"),
+        ])
+        .with_see_also(vec!["store", "branch"])
+}
+
+fn cmd_store() -> CommandInfo {
+    let list = CommandInfo::new("list", "list SigIds in the store")
+        .idempotent(true)
+        .add_option("--store", "string", "store root directory", None);
+    let get = CommandInfo::new("get", "print metadata + canonical AST for a StageId")
+        .idempotent(true)
+        .add_argument("stage", "string", "StageId hex", true)
+        .add_option("--store", "string", "store root directory", None);
+    let mut info = CommandInfo::new("store", "browse the content-addressed code store")
+        .with_examples(vec![
+            ("List sigs", "lex store list"),
+            ("Get a stage", "lex store get abc123..."),
+        ])
+        .with_see_also(vec!["publish", "branch", "store-merge"]);
+    info.subcommands = vec![list, get];
+    info
+}
+
+fn cmd_trace() -> CommandInfo {
+    CommandInfo::new("trace", "print a saved execution trace tree as JSON")
+        .idempotent(true)
+        .add_argument("run_id", "string", "run identifier", true)
+        .with_examples(vec![
+            ("Inspect a trace", "lex trace 2024-01-15-abc"),
+        ])
+        .with_see_also(vec!["replay", "diff"])
+}
+
+fn cmd_replay() -> CommandInfo {
+    CommandInfo::new("replay", "re-execute with effect overrides keyed by NodeId")
+        .idempotent(false)
+        .add_argument("run_id", "string", "run identifier", true)
+        .add_argument("file", "string", "source file", true)
+        .add_argument("fn", "string", "function name", true)
+        .add_argument("args", "string[]", "JSON-encoded positional args", false)
+        .add_option("--override", "string", "NODE=JSON override (repeatable)", None)
+        .with_examples(vec![
+            ("Replay verbatim", "lex replay 2024-01-15-abc app.lex main"),
+            ("Replay with override", "lex replay 2024-01-15-abc app.lex main --override 7=42"),
+        ])
+        .with_see_also(vec!["run", "trace", "diff"])
+}
+
+fn cmd_diff() -> CommandInfo {
+    CommandInfo::new("diff", "first NodeId where two execution traces diverge")
+        .idempotent(true)
+        .add_argument("run_a", "string", "first run id", true)
+        .add_argument("run_b", "string", "second run id", true)
+        .with_examples(vec![
+            ("Compare two runs", "lex diff run-1 run-2"),
+        ])
+        .with_see_also(vec!["replay", "trace", "ast-diff"])
+}
+
+fn cmd_serve() -> CommandInfo {
+    CommandInfo::new("serve", "start the agent API HTTP server")
+        .idempotent(false)
+        .add_option("--port", "int", "TCP port (default: 7000)", None)
+        .add_option("--store", "string", "store root directory", None)
+        .with_examples(vec![
+            ("Start with defaults", "lex serve"),
+            ("Pin port + store", "lex serve --port 8080 --store /var/lex"),
+        ])
+        .with_see_also(vec!["tool-registry"])
+}
+
+fn cmd_conformance() -> CommandInfo {
+    CommandInfo::new("conformance", "run all JSON test descriptors under a directory")
+        .idempotent(true)
+        .add_argument("dir", "string", "directory of conformance descriptors", true)
+        .with_examples(vec![
+            ("Run shipped suite", "lex conformance crates/conformance/tests/data"),
+        ])
+        .with_see_also(vec!["check", "spec"])
+}
+
+fn cmd_spec() -> CommandInfo {
+    let check = CommandInfo::new("check", "check a Spec against a Lex source")
+        .idempotent(true)
+        .add_argument("spec", "string", "spec file", true)
+        .add_option("--source", "string", "source file to verify against", None);
+    let smt = CommandInfo::new("smt", "emit SMT-LIB for external Z3")
+        .idempotent(true)
+        .add_argument("spec", "string", "spec file", true);
+    let mut info = CommandInfo::new("spec", "Spec proof checker (randomized + SMT-LIB export)")
+        .with_examples(vec![
+            ("Check a spec", "lex spec check sort.spec --source sort.lex"),
+            ("Export SMT-LIB", "lex spec smt sort.spec"),
+        ])
+        .with_see_also(vec!["check", "conformance"]);
+    info.subcommands = vec![check, smt];
+    info
+}
+
+fn cmd_agent_tool() -> CommandInfo {
+    CommandInfo::new("agent-tool", "have an LLM emit a Lex tool body, run it under declared effects")
+        .idempotent(false)
+        .add_option("--allow-effects", "string", "permitted effect kinds", None)
+        .add_option("--request", "string", "natural-language request", None)
+        .add_option("--body", "string", "inline tool body", None)
+        .add_option("--body-file", "string", "tool body in a file", None)
+        .add_option("--spec", "string", "spec file for behavioral verification", None)
+        .add_option("--examples", "string", "JSON examples for behavioral checking", None)
+        .add_option("--diff-body", "string", "differential evaluation: alternate body", None)
+        .add_option("--diff-body-file", "string", "differential evaluation: alternate body file", None)
+        .add_option("--json", "bool", "machine-readable output", None)
+        .with_examples(vec![
+            ("Run with allow-list", "lex agent-tool --allow-effects fs_read --request \"sum lines of /tmp/log\""),
+            ("Verify against spec", "lex agent-tool --spec sort.spec --body-file body.lex --json"),
+        ])
+        .with_see_also(vec!["check", "spec", "run"])
+}
+
+fn cmd_tool_registry() -> CommandInfo {
+    let serve = CommandInfo::new("serve", "HTTP service to register Lex tools and invoke them")
+        .idempotent(false)
+        .add_option("--port", "int", "TCP port", None);
+    let mut info = CommandInfo::new("tool-registry", "runtime tool registration over HTTP")
+        .with_examples(vec![
+            ("Run on default port", "lex tool-registry serve"),
+        ])
+        .with_see_also(vec!["serve", "agent-tool"]);
+    info.subcommands = vec![serve];
+    info
+}
+
+fn cmd_audit() -> CommandInfo {
+    CommandInfo::new("audit", "structural code search by effect / call / hostname / AST kind")
+        .idempotent(true)
+        .add_argument("paths", "string[]", "files / directories to scan", false)
+        .add_option("--effect", "string", "effect kind filter", None)
+        .add_option("--call", "string", "called-function filter", None)
+        .add_option("--host", "string", "hostname filter (literal)", None)
+        .add_option("--kind", "string", "AST node kind filter", None)
+        .add_option("--json", "bool", "machine-readable output", None)
+        .with_examples(vec![
+            ("Find network calls", "lex audit --effect net examples"),
+            ("Find a host as JSON", "lex audit --host api.example.com --json src"),
+        ])
+        .with_see_also(vec!["ast-diff", "ast-merge"])
+}
+
+fn cmd_ast_diff() -> CommandInfo {
+    CommandInfo::new("ast-diff", "AST-native diff: added/removed/renamed/modified fns + body patches")
+        .idempotent(true)
+        .add_argument("file_a", "string", "left source file", true)
+        .add_argument("file_b", "string", "right source file", true)
+        .add_option("--json", "bool", "structured JSON output", None)
+        .with_examples(vec![
+            ("Compare two versions", "lex ast-diff a.lex b.lex"),
+            ("Machine-readable", "lex ast-diff --json a.lex b.lex"),
+        ])
+        .with_see_also(vec!["audit", "ast-merge"])
+}
+
+fn cmd_ast_merge() -> CommandInfo {
+    CommandInfo::new("ast-merge", "three-way structural merge with structured JSON conflicts")
+        .idempotent(false)
+        .add_argument("base", "string", "common ancestor source", true)
+        .add_argument("ours", "string", "our side", true)
+        .add_argument("theirs", "string", "their side", true)
+        .add_option("--output", "string", "write merged source to a file", None)
+        .add_option("--json", "bool", "emit conflicts as JSON", None)
+        .with_examples(vec![
+            ("Merge three versions", "lex ast-merge base.lex ours.lex theirs.lex"),
+            ("Materialize merge", "lex ast-merge base.lex ours.lex theirs.lex --output merged.lex"),
+        ])
+        .with_see_also(vec!["ast-diff", "store-merge"])
+}
+
+fn cmd_branch() -> CommandInfo {
+    let list = CommandInfo::new("list", "list branches in the store").idempotent(true)
+        .add_option("--store", "string", "store root", None);
+    let show = CommandInfo::new("show", "show a branch's head map").idempotent(true)
+        .add_argument("name", "string", "branch name", true)
+        .add_option("--store", "string", "store root", None);
+    let create = CommandInfo::new("create", "create a branch").idempotent(false)
+        .add_argument("name", "string", "branch name", true)
+        .add_option("--from", "string", "parent branch (default: main)", None)
+        .add_option("--store", "string", "store root", None);
+    let delete = CommandInfo::new("delete", "delete a non-current, non-default branch")
+        .idempotent(false)
+        .add_argument("name", "string", "branch name", true)
+        .add_option("--store", "string", "store root", None);
+    let use_b = CommandInfo::new("use", "set the current branch").idempotent(false)
+        .add_argument("name", "string", "branch name", true)
+        .add_option("--store", "string", "store root", None);
+    let current = CommandInfo::new("current", "print the current branch").idempotent(true)
+        .add_option("--store", "string", "store root", None);
+    let mut info = CommandInfo::new("branch", "snapshot branches in lex-store (tier-1 agent-native VC)")
+        .with_examples(vec![
+            ("List branches", "lex branch list"),
+            ("Create a feature", "lex branch create feature --from main"),
+        ])
+        .with_see_also(vec!["store-merge", "store"]);
+    info.subcommands = vec![list, show, create, delete, use_b, current];
+    info
+}
+
+fn cmd_store_merge() -> CommandInfo {
+    CommandInfo::new("store-merge", "three-way merge between two branches in the store")
+        .idempotent(false)
+        .add_argument("src", "string", "source branch", true)
+        .add_argument("dst", "string", "destination branch", true)
+        .add_option("--commit", "bool", "apply a clean merge to dst (refused if conflicts)", None)
+        .add_option("--json", "bool", "emit the merge report as JSON", None)
+        .add_option("--store", "string", "store root directory", None)
+        .with_examples(vec![
+            ("Preview a merge", "lex store-merge feature main"),
+            ("Commit a clean merge", "lex store-merge feature main --commit"),
+        ])
+        .with_see_also(vec!["branch", "ast-merge"])
+}

--- a/crates/lex-cli/src/acli.rs
+++ b/crates/lex-cli/src/acli.rs
@@ -24,14 +24,86 @@
 //! migrating ~1000 lines of hand-rolled arg parsing.
 
 use acli::introspect::CommandInfo;
+use acli::output::{emit, error_envelope, success_envelope, OutputFormat};
 use acli::AcliApp;
+use serde_json::Value;
+
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn build_app() -> AcliApp {
-    let mut app = AcliApp::new("lex", env!("CARGO_PKG_VERSION"));
+    let mut app = AcliApp::new("lex", VERSION);
     for cmd in commands() {
         app.register_command(cmd);
     }
     app
+}
+
+/// Emit a successful JSON envelope when the format is JSON; otherwise
+/// run the supplied text printer. Centralizes the
+/// "if json then envelope, else text" branch each subcommand needs.
+pub fn emit_or_text<F: FnOnce()>(cmd: &str, data: Value, fmt: &OutputFormat, text: F) {
+    match fmt {
+        OutputFormat::Json => {
+            let env = success_envelope(cmd, data, VERSION, None, None);
+            emit(&env, fmt);
+        }
+        OutputFormat::Text | OutputFormat::Table => text(),
+    }
+}
+
+/// Emit a "dry run" envelope (exit code 9 per ACLI spec §3) for
+/// state-modifying commands invoked with `--dry-run`. In text mode
+/// we render the planned actions as a bullet list so a human
+/// running by hand still sees what would happen.
+pub fn emit_dry_run(
+    cmd: &str,
+    fmt: &OutputFormat,
+    summary: &str,
+    actions: Vec<Value>,
+) {
+    match fmt {
+        OutputFormat::Json => {
+            // Build the envelope manually — the SDK's success_envelope
+            // doesn't accept a `dry_run` flag; we serialize directly.
+            let env = serde_json::json!({
+                "ok": true,
+                "command": cmd,
+                "dry_run": true,
+                "planned_actions": actions,
+                "data": null,
+                "meta": { "duration_ms": 0, "version": VERSION },
+            });
+            println!("{}", serde_json::to_string_pretty(&env).unwrap());
+        }
+        OutputFormat::Text | OutputFormat::Table => {
+            eprintln!("dry-run: {summary}");
+            for a in &actions {
+                eprintln!("  • {}", a);
+            }
+        }
+    }
+    std::process::exit(9);
+}
+
+/// Emit an error envelope for the top-level error path.
+/// Maps anyhow's display string into ACLI's error structure;
+/// the exit code is the caller's responsibility.
+pub fn emit_error(cmd: &str, msg: &str, fmt: &OutputFormat, code: acli::ExitCode) {
+    if matches!(fmt, OutputFormat::Json) {
+        let env = error_envelope(
+            cmd,
+            code,
+            msg,
+            None,
+            None,
+            None,
+            VERSION,
+            None,
+        );
+        emit(&env, fmt);
+    } else {
+        eprintln!("error: {msg}");
+    }
 }
 
 fn commands() -> Vec<CommandInfo> {

--- a/crates/lex-cli/src/ast_merge.rs
+++ b/crates/lex-cli/src/ast_merge.rs
@@ -13,6 +13,8 @@
 //! and both bodies are returned in the JSON. Refining body-level
 //! patches into structural-merge is a follow-up.
 
+use crate::acli as acli_mod;
+use ::acli::OutputFormat;
 use anyhow::{anyhow, Context, Result};
 use lex_ast::{
     canon_print::print_stages, canonicalize_program, FnDecl, Stage,
@@ -28,7 +30,12 @@ use std::path::PathBuf;
 struct MergeOpts {
     files: Vec<PathBuf>, // [base, ours, theirs]
     json: bool,
+    /// Where to write the merged source. Renamed from `--output` to
+    /// `--write` to avoid colliding with ACLI's `--output FORMAT`.
+    /// Old `--output PATH` still accepted for backwards compat as
+    /// long as PATH isn't a known format keyword (text/json/table).
     output: Option<PathBuf>,
+    dry_run: bool,
 }
 
 #[derive(Serialize)]
@@ -70,39 +77,56 @@ struct MergeSummary {
     conflicts: usize,
 }
 
-pub fn cmd_ast_merge(args: &[String]) -> Result<()> {
+pub fn cmd_ast_merge(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let opts = parse_args(args)?;
     if opts.files.len() != 3 {
         return Err(anyhow!(
             "usage: lex ast-merge <base.lex> <ours.lex> <theirs.lex> \
-             [--json] [--output PATH]"));
+             [--json] [--write PATH] [--dry-run]"));
     }
     let base   = load_fns(&opts.files[0])?;
     let ours   = load_fns(&opts.files[1])?;
     let theirs = load_fns(&opts.files[2])?;
     let report = compute_merge(&base, &ours, &theirs);
+    let json = opts.json || matches!(fmt, OutputFormat::Json);
+
+    if opts.dry_run {
+        let action = serde_json::json!({
+            "action": "merge",
+            "base": opts.files[0].display().to_string(),
+            "ours": opts.files[1].display().to_string(),
+            "theirs": opts.files[2].display().to_string(),
+            "would_write": opts.output.as_ref().map(|p| p.display().to_string()),
+            "merged": report.merged.len(),
+            "conflicts": report.conflicts.len(),
+        });
+        acli_mod::emit_dry_run("ast-merge", fmt, "would compute three-way merge",
+            vec![action]);
+    }
 
     if let Some(out) = &opts.output {
         if !report.conflicts.is_empty() {
             return Err(anyhow!(
                 "{} conflicts; refusing to write merged source. \
-                 Re-run without --output to see structured JSON.",
+                 Re-run without --write to see structured JSON.",
                 report.conflicts.len()));
         }
-        // Re-emit the merged set as Lex source via the canon printer.
         let stages: Vec<Stage> = report.merged.iter()
             .map(|m| pick_fn(&m.name, &base, &ours, &theirs, m.from))
             .map(Stage::FnDecl)
             .collect();
         let src = print_stages(&stages);
         fs::write(out, src).with_context(|| format!("write {}", out.display()))?;
-        if !opts.json {
+        if !json {
             eprintln!("→ wrote merged source to {} ({} fns)",
                 out.display(), report.merged.len());
         }
     }
 
-    if opts.json {
+    if matches!(fmt, OutputFormat::Json) {
+        let data = serde_json::to_value(&report)?;
+        acli_mod::emit_or_text("ast-merge", data, fmt, || {});
+    } else if opts.json {
         println!("{}", serde_json::to_string_pretty(&report)?);
     } else {
         if report.conflicts.is_empty() {
@@ -119,8 +143,6 @@ pub fn cmd_ast_merge(args: &[String]) -> Result<()> {
                 short_kind_message(c.kind));
         }
     }
-    // Exit 2 on conflicts regardless of output format — lets agent
-    // loops branch on the exit code without re-parsing the report.
     if !report.conflicts.is_empty() {
         std::process::exit(2);
     }
@@ -132,9 +154,23 @@ fn parse_args(args: &[String]) -> Result<MergeOpts> {
     let mut i = 0;
     while i < args.len() {
         match args[i].as_str() {
-            "--json"   => { o.json = true; i += 1; }
+            "--json"    => { o.json = true; i += 1; }
+            "--dry-run" => { o.dry_run = true; i += 1; }
+            "--write" => {
+                let v = args.get(i + 1).ok_or_else(|| anyhow!("--write needs a path"))?;
+                o.output = Some(PathBuf::from(v));
+                i += 2;
+            }
             "--output" => {
+                // Back-compat: accept `--output PATH` as long as PATH
+                // isn't an ACLI format keyword (which would have been
+                // consumed at the dispatcher level).
                 let v = args.get(i + 1).ok_or_else(|| anyhow!("--output needs a path"))?;
+                if matches!(v.as_str(), "text" | "json" | "table") {
+                    return Err(anyhow!(
+                        "`--output {v}` is the ACLI format flag — put it before the subcommand: \
+                         `lex --output {v} ast-merge ...`. Use `--write PATH` for the merged source path."));
+                }
                 o.output = Some(PathBuf::from(v));
                 i += 2;
             }

--- a/crates/lex-cli/src/audit.rs
+++ b/crates/lex-cli/src/audit.rs
@@ -13,6 +13,8 @@
 //! defaults are tuned for piping into another agent's eval loop:
 //! one fn per line, fully-qualified.
 
+use crate::acli as acli_mod;
+use ::acli::OutputFormat;
 use anyhow::{anyhow, Context, Result};
 use lex_ast::{canonicalize_program, CExpr, CLit, Effect, FnDecl, Stage, TypeExpr};
 use lex_syntax::parse_source;
@@ -56,8 +58,9 @@ struct AuditReport {
     hits: Vec<FnHit>,
 }
 
-pub fn cmd_audit(args: &[String]) -> Result<()> {
-    let opts = parse_audit_args(args)?;
+pub fn cmd_audit(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    let mut opts = parse_audit_args(args)?;
+    if matches!(fmt, OutputFormat::Json) { opts.json = true; }
     if opts.paths.is_empty() {
         return Err(anyhow!("usage: lex audit [paths...] [--effect KIND] [--calls FN] [--uses-host HOST] [--kind NODE] [--json]"));
     }
@@ -104,7 +107,14 @@ pub fn cmd_audit(args: &[String]) -> Result<()> {
         }
     }
 
+    if matches!(fmt, OutputFormat::Json) {
+        // Top-level `--output json` → ACLI envelope.
+        let data = serde_json::to_value(&report)?;
+        acli_mod::emit_or_text("audit", data, fmt, || {});
+        return Ok(());
+    }
     if opts.json {
+        // Legacy `--json` (without `--output json`): raw report.
         println!("{}", serde_json::to_string_pretty(&report)?);
         return Ok(());
     }

--- a/crates/lex-cli/src/branch.rs
+++ b/crates/lex-cli/src/branch.rs
@@ -6,6 +6,8 @@
 //! existing content-addressed substrate. See `lex-store/src/branches.rs`
 //! for the data model + deferred items list.
 
+use crate::acli as acli_mod;
+use ::acli::OutputFormat;
 use anyhow::{anyhow, bail, Result};
 use lex_store::{MergeReport, Store};
 use std::path::PathBuf;
@@ -32,37 +34,45 @@ fn open_store(args_iter: &mut dyn Iterator<Item = String>) -> Result<(Store, Vec
     Ok((store, rest))
 }
 
-pub fn cmd_branch(args: &[String]) -> Result<()> {
+pub fn cmd_branch(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let mut iter = args.iter().cloned();
     let sub = iter.next().ok_or_else(|| anyhow!(
         "usage: lex branch <list|show|create|delete|use|current> [--store DIR] ..."))?;
-    let (store, rest) = open_store(&mut iter)?;
+    // Detect a trailing --dry-run shared by state-modifying subcommands.
+    let raw: Vec<String> = iter.collect();
+    let dry_run = raw.iter().any(|a| a == "--dry-run");
+    let mut filtered: std::vec::IntoIter<String> = raw.into_iter()
+        .filter(|a| a != "--dry-run").collect::<Vec<_>>().into_iter();
+    let (store, rest) = open_store(&mut filtered)?;
     match sub.as_str() {
-        "list"    => list(&store),
-        "show"    => show(&store, &rest),
-        "create"  => create(&store, &rest),
-        "delete"  => delete(&store, &rest),
-        "use"     => use_branch(&store, &rest),
-        "current" => current(&store),
+        "list"    => list(fmt, &store),
+        "show"    => show(fmt, &store, &rest),
+        "create"  => create(fmt, &store, &rest, dry_run),
+        "delete"  => delete(fmt, &store, &rest, dry_run),
+        "use"     => use_branch(fmt, &store, &rest, dry_run),
+        "current" => current(fmt, &store),
         other     => bail!("unknown `lex branch` subcommand `{other}`"),
     }
 }
 
-pub fn cmd_store_merge(args: &[String]) -> Result<()> {
+pub fn cmd_store_merge(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let mut commit = false;
-    let mut json = false;
+    // `--json` is the legacy flag; `--output json` from the parent
+    // dispatcher is the spec-compliant equivalent — honor either.
+    let mut json = matches!(fmt, OutputFormat::Json);
+    let mut dry_run = false;
     let mut positional: Vec<String> = Vec::new();
     for a in args.iter().cloned() {
         match a.as_str() {
-            "--commit" => commit = true,
-            "--json"   => json = true,
-            _          => positional.push(a),
+            "--commit"  => commit = true,
+            "--json"    => json = true,
+            "--dry-run" => dry_run = true,
+            _           => positional.push(a),
         }
     }
     if positional.len() < 2 {
         bail!("usage: lex store-merge <src> <dst> [--commit] [--json] [--store DIR]");
     }
-    // Allow `--store` to appear anywhere; re-parse over what we kept.
     let mut iter2 = positional.into_iter();
     let (store, rest) = open_store(&mut iter2)?;
     if rest.len() != 2 {
@@ -73,6 +83,18 @@ pub fn cmd_store_merge(args: &[String]) -> Result<()> {
 
     let report = store.merge(src, dst)
         .map_err(|e| anyhow!("merge {src} into {dst}: {e}"))?;
+
+    if dry_run && commit {
+        let action = serde_json::json!({
+            "action": "commit-merge",
+            "src": src,
+            "dst": dst,
+            "merged": report.merged.len(),
+            "conflicts": report.conflicts.len(),
+        });
+        acli_mod::emit_dry_run("store-merge", fmt,
+            &format!("would commit merge of `{src}` into `{dst}`"), vec![action]);
+    }
 
     if json {
         println!("{}", serde_json::to_string_pretty(&report)?);
@@ -95,37 +117,52 @@ pub fn cmd_store_merge(args: &[String]) -> Result<()> {
 
 // ---- branch subcommands -------------------------------------------
 
-fn list(store: &Store) -> Result<()> {
+fn list(fmt: &OutputFormat, store: &Store) -> Result<()> {
     let branches = store.list_branches().map_err(|e| anyhow!("list: {e}"))?;
     let cur = store.current_branch();
-    for name in branches {
-        let marker = if name == cur { "*" } else { " " };
-        println!("{marker} {name}");
-    }
+    let entries: Vec<serde_json::Value> = branches.iter()
+        .map(|n| serde_json::json!({ "name": n, "current": *n == cur }))
+        .collect();
+    let data = serde_json::json!({ "branches": entries, "current": cur });
+    acli_mod::emit_or_text("branch", data, fmt, || {
+        for name in &branches {
+            let marker = if *name == cur { "*" } else { " " };
+            println!("{marker} {name}");
+        }
+    });
     Ok(())
 }
 
-fn current(store: &Store) -> Result<()> {
-    println!("{}", store.current_branch());
+fn current(fmt: &OutputFormat, store: &Store) -> Result<()> {
+    let cur = store.current_branch();
+    let data = serde_json::json!({ "current": &cur });
+    acli_mod::emit_or_text("branch", data, fmt, || println!("{cur}"));
     Ok(())
 }
 
-fn show(store: &Store, args: &[String]) -> Result<()> {
+fn show(fmt: &OutputFormat, store: &Store, args: &[String]) -> Result<()> {
     let name = args.first().ok_or_else(|| anyhow!("usage: lex branch show <name>"))?;
     let head = store.branch_head(name)
         .map_err(|e| anyhow!("head {name}: {e}"))?;
-    if head.is_empty() {
-        println!("{name}: (no stages)");
-        return Ok(());
-    }
-    println!("{name}: {} stage(s)", head.len());
-    for (sig, stage) in &head {
-        println!("  {sig:.16}…  →  {stage:.16}…");
-    }
+    let data = serde_json::json!({
+        "name": name,
+        "stage_count": head.len(),
+        "head": serde_json::to_value(&head)?,
+    });
+    acli_mod::emit_or_text("branch", data, fmt, || {
+        if head.is_empty() {
+            println!("{name}: (no stages)");
+        } else {
+            println!("{name}: {} stage(s)", head.len());
+            for (sig, stage) in &head {
+                println!("  {sig:.16}…  →  {stage:.16}…");
+            }
+        }
+    });
     Ok(())
 }
 
-fn create(store: &Store, args: &[String]) -> Result<()> {
+fn create(fmt: &OutputFormat, store: &Store, args: &[String], dry_run: bool) -> Result<()> {
     let mut name: Option<String> = None;
     let mut from = lex_store::DEFAULT_BRANCH.to_string();
     let mut i = 0;
@@ -140,25 +177,49 @@ fn create(store: &Store, args: &[String]) -> Result<()> {
         }
     }
     let name = name.ok_or_else(|| anyhow!("usage: lex branch create <name> [--from BRANCH]"))?;
+    if dry_run {
+        let action = serde_json::json!({ "action": "create-branch", "name": name, "from": from });
+        acli_mod::emit_dry_run("branch", fmt,
+            &format!("would create `{name}` from `{from}`"), vec![action]);
+    }
     store.create_branch(&name, &from)
         .map_err(|e| anyhow!("create {name} (from {from}): {e}"))?;
-    println!("→ created branch `{name}` from `{from}`");
+    let data = serde_json::json!({ "created": &name, "from": &from });
+    acli_mod::emit_or_text("branch", data, fmt, || {
+        println!("→ created branch `{name}` from `{from}`");
+    });
     Ok(())
 }
 
-fn delete(store: &Store, args: &[String]) -> Result<()> {
+fn delete(fmt: &OutputFormat, store: &Store, args: &[String], dry_run: bool) -> Result<()> {
     let name = args.first().ok_or_else(|| anyhow!("usage: lex branch delete <name>"))?;
+    if dry_run {
+        let action = serde_json::json!({ "action": "delete-branch", "name": name });
+        acli_mod::emit_dry_run("branch", fmt,
+            &format!("would delete `{name}`"), vec![action]);
+    }
     store.delete_branch(name)
         .map_err(|e| anyhow!("delete {name}: {e}"))?;
-    println!("→ deleted branch `{name}`");
+    let data = serde_json::json!({ "deleted": name });
+    acli_mod::emit_or_text("branch", data, fmt, || {
+        println!("→ deleted branch `{name}`");
+    });
     Ok(())
 }
 
-fn use_branch(store: &Store, args: &[String]) -> Result<()> {
+fn use_branch(fmt: &OutputFormat, store: &Store, args: &[String], dry_run: bool) -> Result<()> {
     let name = args.first().ok_or_else(|| anyhow!("usage: lex branch use <name>"))?;
+    if dry_run {
+        let action = serde_json::json!({ "action": "use-branch", "name": name });
+        acli_mod::emit_dry_run("branch", fmt,
+            &format!("would switch to `{name}`"), vec![action]);
+    }
     store.set_current_branch(name)
         .map_err(|e| anyhow!("use {name}: {e}"))?;
-    println!("→ on `{name}`");
+    let data = serde_json::json!({ "current": name });
+    acli_mod::emit_or_text("branch", data, fmt, || {
+        println!("→ on `{name}`");
+    });
     Ok(())
 }
 

--- a/crates/lex-cli/src/diff.rs
+++ b/crates/lex-cli/src/diff.rs
@@ -28,6 +28,8 @@
 //! }
 //! ```
 
+use crate::acli as acli_mod;
+use ::acli::OutputFormat;
 use anyhow::{anyhow, Context, Result};
 use lex_ast::{
     canonicalize_program, CExpr, Effect, FnDecl, Stage, TypeExpr,
@@ -86,7 +88,7 @@ struct DiffReport {
     modified: Vec<Modified>,
 }
 
-pub fn cmd_diff(args: &[String]) -> Result<()> {
+pub fn cmd_diff(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let opts = parse_diff_args(args)?;
     if opts.files.len() != 2 {
         return Err(anyhow!("usage: lex diff <file_a> <file_b> [--json] [--no-body]"));
@@ -95,6 +97,11 @@ pub fn cmd_diff(args: &[String]) -> Result<()> {
     let b = load_fns(&opts.files[1])?;
     let report = compute_diff(&a, &b, opts.body_patches);
 
+    if matches!(fmt, OutputFormat::Json) {
+        let data = serde_json::to_value(&report)?;
+        acli_mod::emit_or_text("ast-diff", data, fmt, || {});
+        return Ok(());
+    }
     if opts.json {
         println!("{}", serde_json::to_string_pretty(&report)?);
         return Ok(());

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -15,7 +15,9 @@ mod audit;
 mod diff;
 mod ast_merge;
 mod branch;
+mod acli;
 
+use ::acli::OutputFormat;
 use anyhow::{anyhow, bail, Context, Result};
 use lex_ast::{canonicalize_program, sig_id, stage_canonical_hash_hex, stage_id, Stage};
 use lex_bytecode::{compile_program, vm::Vm, Value};
@@ -36,8 +38,25 @@ fn main() {
 }
 
 fn run(args: &[String]) -> Result<()> {
+    // Pull off ACLI's top-level `--output text|json|table` flag (it
+    // also appears on individual built-ins below). The output format
+    // is consumed only by the introspect/skill/version handlers in
+    // tier-1; subcommand-level structured output remains a follow-up.
+    let (output, args) = parse_output_format(args)?;
+
     let cmd = args.first().ok_or_else(|| anyhow!("usage: lex <command> ..."))?;
     match cmd.as_str() {
+        // ACLI built-ins — emit JSON envelopes via the SDK.
+        "introspect" => { acli::build_app().handle_introspect(&output); Ok(()) }
+        "skill" => {
+            let out_path = args.get(1).map(|s| s.as_str());
+            acli::build_app().handle_skill(out_path, &output);
+            Ok(())
+        }
+        "version" | "--version" | "-V" => {
+            acli::build_app().handle_version(&output);
+            Ok(())
+        }
         "parse" => cmd_parse(&args[1..]),
         "check" => cmd_check(&args[1..]),
         "run" => cmd_run(&args[1..]),
@@ -60,6 +79,34 @@ fn run(args: &[String]) -> Result<()> {
         "help" | "--help" | "-h" => { print_usage(); Ok(()) }
         other => bail!("unknown command `{other}`. try `lex help`"),
     }
+}
+
+/// Strip a leading `--output FORMAT` (or `--output=FORMAT`) from
+/// `args`. Accepts `text` / `json` / `table`. Defaults to text.
+/// We only scan up to the first non-`--output` token so we don't
+/// swallow per-subcommand `--output` flags (e.g. `lex ast-merge
+/// --output merged.lex`, which is a path, not a format).
+fn parse_output_format(args: &[String]) -> Result<(OutputFormat, Vec<String>)> {
+    use std::str::FromStr;
+    let mut out: Vec<String> = Vec::with_capacity(args.len());
+    let mut format = OutputFormat::Text;
+    let mut i = 0;
+    while i < args.len() {
+        let a = &args[i];
+        if a == "--output" && i + 1 < args.len() {
+            format = OutputFormat::from_str(&args[i + 1]).map_err(|e| anyhow!(e))?;
+            i += 2;
+        } else if let Some(v) = a.strip_prefix("--output=") {
+            format = OutputFormat::from_str(v).map_err(|e| anyhow!(e))?;
+            i += 1;
+        } else {
+            // Stop scanning at first positional / unrelated flag — the
+            // remaining `--output` (if any) belongs to a subcommand.
+            out.extend_from_slice(&args[i..]);
+            break;
+        }
+    }
+    Ok((format, out))
 }
 
 fn print_usage() {

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -31,51 +31,67 @@ use std::path::PathBuf;
 
 fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
-    if let Err(e) = run(&args) {
-        eprintln!("error: {e:#}");
+    // Pre-parse `--output` so we can route errors through ACLI's
+    // error envelope when the agent asked for JSON. Errors here
+    // (e.g. invalid format) fall back to text reporting since we
+    // haven't yet committed to a format.
+    let (fmt, rest_after_format) = match parse_output_format(&args) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("error: {e:#}");
+            std::process::exit(2);
+        }
+    };
+    let cmd_for_err = rest_after_format.first().cloned()
+        .unwrap_or_else(|| "lex".into());
+    if let Err(e) = run(&fmt, &rest_after_format) {
+        acli::emit_error(&cmd_for_err, &format!("{e:#}"), &fmt,
+            ::acli::ExitCode::GeneralError);
         std::process::exit(1);
     }
 }
 
-fn run(args: &[String]) -> Result<()> {
-    // Pull off ACLI's top-level `--output text|json|table` flag (it
-    // also appears on individual built-ins below). The output format
-    // is consumed only by the introspect/skill/version handlers in
-    // tier-1; subcommand-level structured output remains a follow-up.
-    let (output, args) = parse_output_format(args)?;
-
+fn run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let cmd = args.first().ok_or_else(|| anyhow!("usage: lex <command> ..."))?;
     match cmd.as_str() {
         // ACLI built-ins — emit JSON envelopes via the SDK.
-        "introspect" => { acli::build_app().handle_introspect(&output); Ok(()) }
+        "introspect" => { acli::build_app().handle_introspect(fmt); Ok(()) }
         "skill" => {
             let out_path = args.get(1).map(|s| s.as_str());
-            acli::build_app().handle_skill(out_path, &output);
+            acli::build_app().handle_skill(out_path, fmt);
             Ok(())
         }
         "version" | "--version" | "-V" => {
-            acli::build_app().handle_version(&output);
+            acli::build_app().handle_version(fmt);
             Ok(())
         }
-        "parse" => cmd_parse(&args[1..]),
-        "check" => cmd_check(&args[1..]),
-        "run" => cmd_run(&args[1..]),
-        "hash" => cmd_hash(&args[1..]),
-        "publish" => cmd_publish(&args[1..]),
-        "store" => cmd_store(&args[1..]),
-        "trace" => cmd_trace(&args[1..]),
-        "replay" => cmd_replay(&args[1..]),
-        "diff" => cmd_diff(&args[1..]),
+        "parse" => cmd_parse(fmt, &args[1..]),
+        "check" => cmd_check(fmt, &args[1..]),
+        "run" => cmd_run(fmt, &args[1..]),
+        "hash" => cmd_hash(fmt, &args[1..]),
+        "publish" => cmd_publish(fmt, &args[1..]),
+        "store" => cmd_store(fmt, &args[1..]),
+        "trace" => cmd_trace(fmt, &args[1..]),
+        "replay" => cmd_replay(fmt, &args[1..]),
+        "diff" => cmd_diff(fmt, &args[1..]),
         "serve" => cmd_serve(&args[1..]),
-        "conformance" => cmd_conformance(&args[1..]),
-        "spec" => cmd_spec(&args[1..]),
-        "agent-tool" => cmd_agent_tool(&args[1..]),
+        "conformance" => cmd_conformance(fmt, &args[1..]),
+        "spec" => cmd_spec(fmt, &args[1..]),
+        "agent-tool" => {
+            // agent-tool has its own `--json`; propagate `--output json`
+            // into it without breaking the legacy flag.
+            let mut a: Vec<String> = args[1..].to_vec();
+            if matches!(fmt, OutputFormat::Json) && !a.iter().any(|s| s == "--json") {
+                a.push("--json".into());
+            }
+            cmd_agent_tool(&a)
+        }
         "tool-registry" => tool_registry::cmd_tool_registry(&args[1..]),
-        "audit" => audit::cmd_audit(&args[1..]),
-        "ast-diff" => diff::cmd_diff(&args[1..]),
-        "ast-merge" => ast_merge::cmd_ast_merge(&args[1..]),
-        "branch" => branch::cmd_branch(&args[1..]),
-        "store-merge" => branch::cmd_store_merge(&args[1..]),
+        "audit" => audit::cmd_audit(fmt, &args[1..]),
+        "ast-diff" => diff::cmd_diff(fmt, &args[1..]),
+        "ast-merge" => ast_merge::cmd_ast_merge(fmt, &args[1..]),
+        "branch" => branch::cmd_branch(fmt, &args[1..]),
+        "store-merge" => branch::cmd_store_merge(fmt, &args[1..]),
         "help" | "--help" | "-h" => { print_usage(); Ok(()) }
         other => bail!("unknown command `{other}`. try `lex help`"),
     }
@@ -165,57 +181,93 @@ fn read_source(path: &str) -> Result<String> {
     }
 }
 
-fn cmd_parse(args: &[String]) -> Result<()> {
+fn cmd_parse(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let path = args.first().ok_or_else(|| anyhow!("usage: lex parse <file>"))?;
     let src = read_source(path)?;
     let prog = parse_source(&src)?;
     let stages = canonicalize_program(&prog);
-    let json = serde_json::to_string_pretty(&stages)?;
-    println!("{json}");
+    let data = serde_json::to_value(&stages)?;
+    acli::emit_or_text("parse", data.clone(), fmt, || {
+        println!("{}", serde_json::to_string_pretty(&data).unwrap());
+    });
     Ok(())
 }
 
-fn cmd_check(args: &[String]) -> Result<()> {
+fn cmd_check(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let path = args.first().ok_or_else(|| anyhow!("usage: lex check <file>"))?;
     let src = read_source(path)?;
     let prog = parse_source(&src)?;
     let stages = canonicalize_program(&prog);
     match lex_types::check_program(&stages) {
         Ok(_) => {
-            println!("ok");
+            let data = serde_json::json!({ "ok": true, "stages": stages.len() });
+            acli::emit_or_text("check", data, fmt, || println!("ok"));
             Ok(())
         }
         Err(errs) => {
-            for e in &errs {
-                let json = serde_json::to_string(e)?;
-                println!("{json}");
-            }
+            let arr: Vec<serde_json::Value> = errs.iter()
+                .map(|e| serde_json::to_value(e).unwrap()).collect();
+            let data = serde_json::json!({ "ok": false, "errors": arr });
+            acli::emit_or_text("check", data, fmt, || {
+                for e in &errs {
+                    if let Ok(j) = serde_json::to_string(e) {
+                        println!("{j}");
+                    }
+                }
+            });
             std::process::exit(2);
         }
     }
 }
 
-fn cmd_run(args: &[String]) -> Result<()> {
-    let (policy, positional, trace, max_steps) = parse_run_flags(args)?;
+fn cmd_run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    let (policy, positional, trace, max_steps, dry_run) = parse_run_flags(args)?;
     let path = positional.first().ok_or_else(|| anyhow!("usage: lex run [policy] <file> <fn> [args]"))?;
     let func = positional.get(1).ok_or_else(|| anyhow!("missing function name"))?;
+    if dry_run {
+        let actions = vec![serde_json::json!({
+            "action": "execute",
+            "file": path,
+            "function": func,
+            "args": &positional[2..],
+            "policy": {
+                "allow_effects": policy.allow_effects.iter().collect::<Vec<_>>(),
+                "allow_fs_read": policy.allow_fs_read.iter().map(|p| p.display().to_string()).collect::<Vec<_>>(),
+                "allow_fs_write": policy.allow_fs_write.iter().map(|p| p.display().to_string()).collect::<Vec<_>>(),
+                "allow_net_host": &policy.allow_net_host,
+                "budget": policy.budget,
+            },
+            "trace": trace,
+            "max_steps": max_steps,
+        })];
+        acli::emit_dry_run("run", fmt,
+            &format!("would call `{func}` in {path}"), actions);
+    }
     let src = read_source(path)?;
     let prog = parse_source(&src)?;
     let stages = canonicalize_program(&prog);
     if let Err(errs) = lex_types::check_program(&stages) {
-        for e in &errs {
-            let json = serde_json::to_string(e)?;
-            eprintln!("{json}");
-        }
+        let arr: Vec<serde_json::Value> = errs.iter()
+            .map(|e| serde_json::to_value(e).unwrap()).collect();
+        let data = serde_json::json!({ "phase": "type-check", "errors": arr });
+        acli::emit_or_text("run", data, fmt, || {
+            for e in &errs {
+                if let Ok(j) = serde_json::to_string(e) { eprintln!("{j}"); }
+            }
+        });
         std::process::exit(2);
     }
     let bc = compile_program(&stages);
 
     if let Err(violations) = check_policy(&bc, &policy) {
-        for v in &violations {
-            let json = serde_json::to_string(v)?;
-            eprintln!("{json}");
-        }
+        let arr: Vec<serde_json::Value> = violations.iter()
+            .map(|v| serde_json::to_value(v).unwrap()).collect();
+        let data = serde_json::json!({ "phase": "policy", "violations": arr });
+        acli::emit_or_text("run", data, fmt, || {
+            for v in &violations {
+                if let Ok(j) = serde_json::to_string(v) { eprintln!("{j}"); }
+            }
+        });
         std::process::exit(3);
     }
 
@@ -240,6 +292,7 @@ fn cmd_run(args: &[String]) -> Result<()> {
     let result = vm.call(func, vargs);
     let ended = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
+    let mut trace_id: Option<String> = None;
     if trace {
         let store = lex_store::Store::open(default_store_root())?;
         let (root_out, root_err) = match &result {
@@ -249,18 +302,26 @@ fn cmd_run(args: &[String]) -> Result<()> {
         let tree = trace_handle.finalize(func.clone(), serde_json::Value::Null,
             root_out, root_err, started, ended);
         let id = store.save_trace(&tree)?;
-        eprintln!("trace saved: {id}");
+        trace_id = Some(id.clone());
+        if !matches!(fmt, OutputFormat::Json) { eprintln!("trace saved: {id}"); }
     }
     let r = result.map_err(|e| anyhow!("runtime: {e}"))?;
-    println!("{}", value_to_json_string(&r));
+    let result_json = value_to_json(&r);
+    let data = match &trace_id {
+        Some(id) => serde_json::json!({ "result": result_json, "trace_id": id }),
+        None => serde_json::json!({ "result": result_json }),
+    };
+    acli::emit_or_text("run", data, fmt, || println!("{}", value_to_json_string(&r)));
     Ok(())
 }
 
-fn parse_run_flags(args: &[String]) -> Result<(Policy, Vec<String>, bool, Option<u64>)> {
+#[allow(clippy::type_complexity)]
+fn parse_run_flags(args: &[String]) -> Result<(Policy, Vec<String>, bool, Option<u64>, bool)> {
     let mut policy = Policy::pure();
     let mut positional = Vec::new();
     let mut trace = false;
     let mut max_steps: Option<u64> = None;
+    let mut dry_run = false;
     let mut i = 0;
     while i < args.len() {
         let a = &args[i];
@@ -297,46 +358,64 @@ fn parse_run_flags(args: &[String]) -> Result<(Policy, Vec<String>, bool, Option
                 i += 2;
             }
             "--trace" => { trace = true; i += 1; }
+            "--dry-run" => { dry_run = true; i += 1; }
             _ => { positional.push(a.clone()); i += 1; }
         }
     }
-    Ok((policy, positional, trace, max_steps))
+    Ok((policy, positional, trace, max_steps, dry_run))
 }
 
-fn cmd_trace(args: &[String]) -> Result<()> {
+fn cmd_trace(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let id = args.first().ok_or_else(|| anyhow!("usage: lex trace <run_id>"))?;
     let store = lex_store::Store::open(default_store_root())?;
     let tree = store.load_trace(id)?;
-    println!("{}", serde_json::to_string_pretty(&tree)?);
+    let data = serde_json::to_value(&tree)?;
+    acli::emit_or_text("trace", data.clone(), fmt, || {
+        println!("{}", serde_json::to_string_pretty(&data).unwrap());
+    });
     Ok(())
 }
 
-fn cmd_diff(args: &[String]) -> Result<()> {
+fn cmd_diff(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let a = args.first().ok_or_else(|| anyhow!("usage: lex diff <run_a> <run_b>"))?;
     let b = args.get(1).ok_or_else(|| anyhow!("missing second run id"))?;
     let store = lex_store::Store::open(default_store_root())?;
     let ta = store.load_trace(a)?;
     let tb = store.load_trace(b)?;
-    match lex_trace::diff_runs(&ta, &tb) {
-        Some(d) => {
-            println!("{}", serde_json::to_string_pretty(&d)?);
-            Ok(())
-        }
-        None => { println!("{{\"divergence\":null}}"); Ok(()) }
-    }
+    let data = match lex_trace::diff_runs(&ta, &tb) {
+        Some(d) => serde_json::to_value(&d)?,
+        None => serde_json::json!({ "divergence": null }),
+    };
+    acli::emit_or_text("diff", data.clone(), fmt, || {
+        println!("{}", serde_json::to_string_pretty(&data).unwrap());
+    });
+    Ok(())
 }
 
-fn cmd_hash(args: &[String]) -> Result<()> {
+fn cmd_hash(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let path = args.first().ok_or_else(|| anyhow!("usage: lex hash <file>"))?;
     let src = read_source(path)?;
     let prog = parse_source(&src)?;
     let stages = canonicalize_program(&prog);
-    for s in &stages {
+    let entries: Vec<serde_json::Value> = stages.iter().map(|s| {
         let name = stage_name(s);
         let h = stage_canonical_hash_hex(s);
         let sid = stage_id(s).unwrap_or_else(|| "-".into());
-        println!("{name}\tcanonical_ast={h}\tstage_id={sid}");
-    }
+        serde_json::json!({
+            "name": name,
+            "canonical_ast": h,
+            "stage_id": sid,
+        })
+    }).collect();
+    let data = serde_json::json!({ "stages": entries });
+    acli::emit_or_text("hash", data, fmt, || {
+        for s in &stages {
+            let name = stage_name(s);
+            let h = stage_canonical_hash_hex(s);
+            let sid = stage_id(s).unwrap_or_else(|| "-".into());
+            println!("{name}\tcanonical_ast={h}\tstage_id={sid}");
+        }
+    });
     Ok(())
 }
 
@@ -416,10 +495,11 @@ fn default_store_root() -> PathBuf {
     PathBuf::from(".lex-store")
 }
 
-fn parse_store_flag(args: &[String]) -> (PathBuf, Vec<String>, bool) {
-    // Returns (store_root, remaining_args, activate).
+fn parse_store_flag(args: &[String]) -> (PathBuf, Vec<String>, bool, bool) {
+    // Returns (store_root, remaining_args, activate, dry_run).
     let mut root = default_store_root();
     let mut activate = false;
+    let mut dry_run = false;
     let mut rest = Vec::new();
     let mut i = 0;
     while i < args.len() {
@@ -428,23 +508,46 @@ fn parse_store_flag(args: &[String]) -> (PathBuf, Vec<String>, bool) {
                 if let Some(v) = args.get(i + 1) { root = PathBuf::from(v); i += 2; } else { i += 1; }
             }
             "--activate" => { activate = true; i += 1; }
+            "--dry-run" => { dry_run = true; i += 1; }
             _ => { rest.push(args[i].clone()); i += 1; }
         }
     }
-    (root, rest, activate)
+    (root, rest, activate, dry_run)
 }
 
-fn cmd_publish(args: &[String]) -> Result<()> {
-    let (root, rest, activate) = parse_store_flag(args);
+fn cmd_publish(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    let (root, rest, activate, dry_run) = parse_store_flag(args);
     let path = rest.first().ok_or_else(|| anyhow!("usage: lex publish [--store DIR] [--activate] <file>"))?;
     let src = read_source(path)?;
     let prog = parse_source(&src)?;
     let stages = canonicalize_program(&prog);
     if let Err(errs) = lex_types::check_program(&stages) {
-        for e in &errs {
-            eprintln!("{}", serde_json::to_string(e)?);
-        }
+        let arr: Vec<serde_json::Value> = errs.iter()
+            .map(|e| serde_json::to_value(e).unwrap()).collect();
+        let data = serde_json::json!({ "phase": "type-check", "errors": arr });
+        acli::emit_or_text("publish", data, fmt, || {
+            for e in &errs {
+                if let Ok(j) = serde_json::to_string(e) { eprintln!("{j}"); }
+            }
+        });
         std::process::exit(2);
+    }
+    if dry_run {
+        let actions: Vec<serde_json::Value> = stages.iter()
+            .filter(|s| !matches!(s, Stage::Import(_)))
+            .map(|s| {
+                let name = match s { Stage::FnDecl(fd) => &fd.name, Stage::TypeDecl(td) => &td.name, _ => "?" };
+                serde_json::json!({
+                    "action": "publish",
+                    "name": name,
+                    "sig_id": sig_id(s).unwrap_or_else(|| "-".into()),
+                    "store": root.display().to_string(),
+                    "activate": activate,
+                })
+            }).collect();
+        acli::emit_dry_run("publish", fmt,
+            &format!("would publish {} stage(s) to {}", actions.len(), root.display()),
+            actions);
     }
     let store = Store::open(&root).with_context(|| format!("opening store at {}", root.display()))?;
     let mut out = Vec::new();
@@ -465,26 +568,36 @@ fn cmd_publish(args: &[String]) -> Result<()> {
         });
         out.push(entry);
     }
-    println!("{}", serde_json::to_string_pretty(&out)?);
+    let data = serde_json::json!({ "published": out });
+    acli::emit_or_text("publish", data, fmt, || {
+        println!("{}", serde_json::to_string_pretty(&out).unwrap());
+    });
     Ok(())
 }
 
-fn cmd_store(args: &[String]) -> Result<()> {
+fn cmd_store(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let sub = args.first().ok_or_else(|| anyhow!("usage: lex store {{list|get}} ..."))?;
     let rest = &args[1..];
     match sub.as_str() {
         "list" => {
-            let (root, _rest, _) = parse_store_flag(rest);
+            let (root, _rest, _, _) = parse_store_flag(rest);
             let store = Store::open(&root).with_context(|| format!("opening store at {}", root.display()))?;
             let sigs = store.list_sigs()?;
-            for s in sigs {
-                let active = store.resolve_sig(&s)?.unwrap_or_default();
-                println!("{s}\tactive={active}");
-            }
+            let entries: Vec<serde_json::Value> = sigs.iter().map(|s| {
+                let active = store.resolve_sig(s).ok().flatten().unwrap_or_default();
+                serde_json::json!({ "sig_id": s, "active_stage_id": active })
+            }).collect();
+            let data = serde_json::json!({ "sigs": entries });
+            acli::emit_or_text("store", data, fmt, || {
+                for s in &sigs {
+                    let active = store.resolve_sig(s).ok().flatten().unwrap_or_default();
+                    println!("{s}\tactive={active}");
+                }
+            });
             Ok(())
         }
         "get" => {
-            let (root, rest, _) = parse_store_flag(rest);
+            let (root, rest, _, _) = parse_store_flag(rest);
             let store = Store::open(&root).with_context(|| format!("opening store at {}", root.display()))?;
             let id = rest.first().ok_or_else(|| anyhow!("usage: lex store get <stage_id>"))?;
             let meta = store.get_metadata(id)?;
@@ -494,19 +607,17 @@ fn cmd_store(args: &[String]) -> Result<()> {
                 "status": format!("{:?}", store.get_status(id)?).to_lowercase(),
                 "ast": serde_json::to_value(&ast)?,
             });
-            println!("{}", serde_json::to_string_pretty(&v)?);
+            acli::emit_or_text("store", v.clone(), fmt, || {
+                println!("{}", serde_json::to_string_pretty(&v).unwrap());
+            });
             Ok(())
         }
         other => bail!("unknown `lex store` subcommand: {other}"),
     }
 }
 
-fn cmd_replay(args: &[String]) -> Result<()> {
+fn cmd_replay(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     // usage: lex replay <run_id> <file> <fn> [args] [--override NODE=JSON]
-    // Re-runs the function with overrides keyed by NodeId. Saves a fresh
-    // trace and prints its run_id. The original run_id is referenced for
-    // the user's bookkeeping; we don't currently load it (the function is
-    // re-executed from source).
     let mut overrides: indexmap::IndexMap<String, serde_json::Value> = indexmap::IndexMap::new();
     let mut policy = Policy::pure();
     let mut positional: Vec<String> = Vec::new();
@@ -538,12 +649,26 @@ fn cmd_replay(args: &[String]) -> Result<()> {
     let prog = parse_source(&src)?;
     let stages = canonicalize_program(&prog);
     if let Err(errs) = lex_types::check_program(&stages) {
-        for e in &errs { eprintln!("{}", serde_json::to_string(e)?); }
+        let arr: Vec<serde_json::Value> = errs.iter()
+            .map(|e| serde_json::to_value(e).unwrap()).collect();
+        let data = serde_json::json!({ "phase": "type-check", "errors": arr });
+        acli::emit_or_text("replay", data, fmt, || {
+            for e in &errs {
+                if let Ok(j) = serde_json::to_string(e) { eprintln!("{j}"); }
+            }
+        });
         std::process::exit(2);
     }
     let bc = compile_program(&stages);
     if let Err(violations) = check_policy(&bc, &policy) {
-        for v in &violations { eprintln!("{}", serde_json::to_string(v)?); }
+        let arr: Vec<serde_json::Value> = violations.iter()
+            .map(|v| serde_json::to_value(v).unwrap()).collect();
+        let data = serde_json::json!({ "phase": "policy", "violations": arr });
+        acli::emit_or_text("replay", data, fmt, || {
+            for v in &violations {
+                if let Ok(j) = serde_json::to_string(v) { eprintln!("{j}"); }
+            }
+        });
         std::process::exit(3);
     }
 
@@ -571,9 +696,13 @@ fn cmd_replay(args: &[String]) -> Result<()> {
     };
     let tree = handle.finalize(func.clone(), serde_json::Value::Null, root_out, root_err, started, ended);
     let new_run_id = store.save_trace(&tree)?;
-    eprintln!("trace saved: {new_run_id}");
+    if !matches!(fmt, OutputFormat::Json) { eprintln!("trace saved: {new_run_id}"); }
     let r = result.map_err(|e| anyhow!("runtime: {e}"))?;
-    println!("{}", value_to_json_string(&r));
+    let data = serde_json::json!({
+        "result": value_to_json(&r),
+        "trace_id": new_run_id,
+    });
+    acli::emit_or_text("replay", data, fmt, || println!("{}", value_to_json_string(&r)));
     Ok(())
 }
 
@@ -601,17 +730,30 @@ fn cmd_serve(args: &[String]) -> Result<()> {
     lex_api::serve(port, store_root)
 }
 
-fn cmd_conformance(args: &[String]) -> Result<()> {
+fn cmd_conformance(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let dir = args.first().ok_or_else(|| anyhow!("usage: lex conformance <dir>"))?;
     let report = conformance::run_directory(dir).context("reading conformance directory")?;
-    for name in &report.passed { println!("PASS  {name}"); }
-    for (name, why) in &report.failed { println!("FAIL  {name}: {why}"); }
-    println!();
-    println!("{}/{} passed", report.passed.len(), report.total());
+    let total = report.total();
+    let passed_n = report.passed.len();
+    let failed: Vec<serde_json::Value> = report.failed.iter()
+        .map(|(n, w)| serde_json::json!({ "name": n, "reason": w })).collect();
+    let data = serde_json::json!({
+        "passed": &report.passed,
+        "failed": failed,
+        "total": total,
+        "passed_count": passed_n,
+        "ok": report.ok(),
+    });
+    acli::emit_or_text("conformance", data, fmt, || {
+        for name in &report.passed { println!("PASS  {name}"); }
+        for (name, why) in &report.failed { println!("FAIL  {name}: {why}"); }
+        println!();
+        println!("{}/{} passed", passed_n, total);
+    });
     if report.ok() { Ok(()) } else { std::process::exit(4); }
 }
 
-fn cmd_spec(args: &[String]) -> Result<()> {
+fn cmd_spec(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let sub = args.first().ok_or_else(|| anyhow!("usage: lex spec {{check|smt}} ..."))?;
     let rest = &args[1..];
     match sub.as_str() {
@@ -639,7 +781,10 @@ fn cmd_spec(args: &[String]) -> Result<()> {
             let spec = spec_checker::parse_spec(&spec_src)
                 .map_err(|e| anyhow!("spec parse: {e}"))?;
             let r = spec_checker::check_spec(&spec, &lex_src, trials);
-            println!("{}", serde_json::to_string_pretty(&r)?);
+            let data = serde_json::to_value(&r)?;
+            acli::emit_or_text("spec", data.clone(), fmt, || {
+                println!("{}", serde_json::to_string_pretty(&data).unwrap());
+            });
             // Exit code: 0 proved, 5 counterexample, 6 inconclusive.
             match r.status {
                 spec_checker::ProofStatus::Proved => Ok(()),
@@ -652,7 +797,9 @@ fn cmd_spec(args: &[String]) -> Result<()> {
             let spec_src = read_source(path)?;
             let spec = spec_checker::parse_spec(&spec_src)
                 .map_err(|e| anyhow!("spec parse: {e}"))?;
-            print!("{}", spec_checker::to_smtlib(&spec));
+            let smt = spec_checker::to_smtlib(&spec);
+            let data = serde_json::json!({ "smt_lib": &smt });
+            acli::emit_or_text("spec", data, fmt, || print!("{smt}"));
             Ok(())
         }
         other => bail!("unknown `lex spec` subcommand: {other}"),


### PR DESCRIPTION
## Summary

Full [ACLI](https://github.com/alpibrusl/acli) compliance. `lex` is
now self-describing to any LLM agent — Claude Code, Codex, Gemini,
Qwen, Mistral — via a single spec. No more bespoke skill files per
agent platform.

**Stacked on `claude/lex-store-branches`** (PR #50). Land that one first.

### Discovery layer

- `lex introspect [--output text|json|table]` — full command tree
  per ACLI spec §1.2: name, description, arguments, options,
  subcommands, idempotency, examples, see_also for every command.
- `lex skill` — agentskills.io-compliant markdown + YAML frontmatter,
  drop-in for `~/.claude/skills/`, `~/.codex/skills/`, etc.
- `lex version` — tool + ACLI spec version, JSON-enveloped under
  `--output json`.

### Execution layer

- `--output text|json|table` is honored by every user-facing
  subcommand. JSON mode wraps each command's primary output in
  `success_envelope`; errors emit `error_envelope` from main().
- `--dry-run` lands on every state-modifying command:
  `lex run`, `lex publish`, `lex branch create|delete|use`,
  `lex store-merge --commit`, `lex ast-merge`. Returns
  `planned_actions[]`, exits 9.
- Legacy `--json` flags on audit / ast-diff / ast-merge /
  store-merge / agent-tool also honor `--output json`; the raw
  JSON is rewrapped in an envelope when the parent format is JSON.
- `lex ast-merge`'s `--output PATH` is renamed to `--write PATH`
  to free up `--output` as the ACLI format flag. Old usage still
  works unless PATH collides with a format keyword.

### Why manual `CommandInfo` registration

`lex` keeps its hand-rolled arg parsing — the ACLI Rust SDK's
`acli_args!` / `register::<C>()` path assumes clap-derived structs.
The SDK's `register_command(CommandInfo)` accepts manual
registration, so we get spec compliance without migrating ~1000
lines to clap.

### Repo-level discoverability

The auto-generated `.cli/` folder is committed so agents browsing
the repo on GitHub can read `commands.json` without running the
binary. Includes one example shell script per subcommand.

## Test plan

- [x] All three modes verified: `lex --output {text,json,table} introspect`
- [x] Error envelopes verified: invalid file → JSON error envelope
      with `code`, `message`, `meta`
- [x] Dry-run envelopes verified: `lex --output json run --dry-run`,
      `lex --output json branch create feature --dry-run`
- [x] Workspace tests pass
- [x] Clippy clean
- [x] Smoke-tested every subcommand under both text and JSON output

---
_Generated by [Claude Code](https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh)_