### PR TITLE
ast-diff: surface effect changes as a dedicated field

### DIFF
--- a/crates/lex-cli/src/diff.rs
+++ b/crates/lex-cli/src/diff.rs
@@ -21,12 +21,24 @@
 //!       "signature_before": "...",
 //!       "signature_after":  "...",
 //!       "signature_changed": true|false,
+//!       "effect_changes": {
+//!         "before":  ["..."],
+//!         "after":   ["..."],
+//!         "added":   ["..."],
+//!         "removed": ["..."]
+//!       },
 //!       "body_patches": [{"op": "Replace", "node_path": "...",
 //!                         "from_kind": "...", "to_kind": "..."}]
 //!     }
 //!   ]
 //! }
 //! ```
+//!
+//! Effect changes are surfaced as a dedicated field — separate from
+//! `signature_changed` — because for security review they're the
+//! single most important kind of change. A reviewer (human or agent)
+//! scanning a diff for "did this fn newly gain `[net]`?" should not
+//! have to re-parse the rendered signature string.
 
 use anyhow::{anyhow, Context, Result};
 use lex_ast::{
@@ -67,7 +79,21 @@ struct Modified {
     signature_before: String,
     signature_after: String,
     signature_changed: bool,
+    effect_changes: EffectChanges,
     body_patches: Vec<BodyPatch>,
+}
+
+/// Effect-set delta for a modified fn. Empty `added`/`removed`
+/// means effect-equivalent (the body or non-effect parts of the
+/// signature changed). Renderings include the effect arg, so e.g.
+/// `fs_read("/tmp")` vs. `fs_read("/etc")` show up as one removed
+/// + one added.
+#[derive(Serialize, Default)]
+struct EffectChanges {
+    before:  Vec<String>,
+    after:   Vec<String>,
+    added:   Vec<String>,
+    removed: Vec<String>,
 }
 
 #[derive(Serialize, Clone)]
@@ -121,6 +147,14 @@ pub fn cmd_diff(args: &[String]) -> Result<()> {
             m.signature_after.clone()
         };
         println!("~ modified {sig}");
+        if !m.effect_changes.added.is_empty() {
+            println!("             ⚠ effects gained: [{}]",
+                m.effect_changes.added.join(", "));
+        }
+        if !m.effect_changes.removed.is_empty() {
+            println!("             ✓ effects dropped: [{}]",
+                m.effect_changes.removed.join(", "));
+        }
         for p in &m.body_patches {
             if p.from_kind == p.to_kind {
                 println!("             @ {}: {} edited", p.node_path, p.from_kind);
@@ -234,11 +268,13 @@ fn compute_diff(
             patches
         } else { Vec::new() };
 
+        let effect_changes = effect_diff(&fa.effects, &fb.effects);
         report.modified.push(Modified {
             name: (*n).clone(),
             signature_before: sig_a.clone(),
             signature_after: sig_b.clone(),
             signature_changed: sig_a != sig_b,
+            effect_changes,
             body_patches,
         });
     }
@@ -404,11 +440,41 @@ fn render_signature(fd: &FnDecl) -> String {
     let params: Vec<String> = fd.params.iter()
         .map(|p| format!("{} :: {}", p.name, render_type(&p.ty))).collect();
     let eff = if fd.effects.is_empty() { String::new() } else {
-        let names: Vec<&str> = fd.effects.iter().map(|e: &Effect| e.name.as_str()).collect();
-        format!("[{}] ", names.join(", "))
+        let labels: Vec<String> = fd.effects.iter().map(effect_label).collect();
+        format!("[{}] ", labels.join(", "))
     };
     format!("fn {}({}) -> {}{}", fd.name, params.join(", "),
         eff, render_type(&fd.return_type))
+}
+
+/// Render an effect with its arg if present: `fs_read("/tmp")`,
+/// `net("api.example.com")`, or just `io`. Used by both signature
+/// rendering and effect-diff so the same string identifies the
+/// same effect in either context.
+fn effect_label(e: &Effect) -> String {
+    use lex_ast::EffectArg;
+    match &e.arg {
+        Some(EffectArg::Str { value })   => format!("{}({:?})", e.name, value),
+        Some(EffectArg::Int { value })   => format!("{}({})",   e.name, value),
+        Some(EffectArg::Ident { value }) => format!("{}({})",   e.name, value),
+        None => e.name.clone(),
+    }
+}
+
+/// Set-style diff over two effect lists. Order-insensitive within
+/// the lists; ordering of the output is sorted-by-label so the
+/// JSON is stable.
+fn effect_diff(a: &[Effect], b: &[Effect]) -> EffectChanges {
+    let labels_a: BTreeSet<String> = a.iter().map(effect_label).collect();
+    let labels_b: BTreeSet<String> = b.iter().map(effect_label).collect();
+    let added:   Vec<String> = labels_b.difference(&labels_a).cloned().collect();
+    let removed: Vec<String> = labels_a.difference(&labels_b).cloned().collect();
+    EffectChanges {
+        before:  labels_a.into_iter().collect(),
+        after:   labels_b.into_iter().collect(),
+        added,
+        removed,
+    }
 }
 
 fn render_type(t: &TypeExpr) -> String {

--- a/crates/lex-cli/tests/ast_diff.rs
+++ b/crates/lex-cli/tests/ast_diff.rs
@@ -178,6 +178,111 @@ fn no_body_flag_skips_body_patches() {
 }
 
 #[test]
+fn effect_changes_surface_added_and_removed() {
+    // before: pure `safe`, [net] `risky`.
+    // after:  [io] `safe`,  [net, fs_read] `risky`.
+    // Expected: safe gains [io]; risky gains [fs_read].
+    let a = tmp("a_eff",
+        "fn safe(x :: Int) -> Int { x }\n\
+         fn risky() -> [net] Int { 0 }\n");
+    let b = tmp("b_eff",
+        "fn safe(x :: Int) -> [io] Int { x }\n\
+         fn risky() -> [net, fs_read] Int { 0 }\n");
+    let (code, stdout, _) = run(&[
+        "ast-diff", "--json", a.to_str().unwrap(), b.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    let modified = v["modified"].as_array().expect("modified array");
+    assert_eq!(modified.len(), 2);
+
+    let by_name: std::collections::BTreeMap<&str, &serde_json::Value> =
+        modified.iter()
+            .map(|m| (m["name"].as_str().unwrap(), m))
+            .collect();
+
+    let safe = by_name["safe"];
+    let added: Vec<&str> = safe["effect_changes"]["added"].as_array().unwrap()
+        .iter().map(|x| x.as_str().unwrap()).collect();
+    assert_eq!(added, vec!["io"]);
+    assert!(safe["effect_changes"]["removed"].as_array().unwrap().is_empty());
+
+    let risky = by_name["risky"];
+    let added: Vec<&str> = risky["effect_changes"]["added"].as_array().unwrap()
+        .iter().map(|x| x.as_str().unwrap()).collect();
+    assert_eq!(added, vec!["fs_read"]);
+}
+
+#[test]
+fn effect_dropped_shows_in_removed() {
+    // [io, net] → [net]: io is dropped.
+    let a = tmp("a_drop", "fn f() -> [io, net] Int { 0 }\n");
+    let b = tmp("b_drop", "fn f() -> [net] Int { 0 }\n");
+    let (code, stdout, _) = run(&[
+        "ast-diff", "--json", a.to_str().unwrap(), b.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    let m = &v["modified"][0];
+    let removed: Vec<&str> = m["effect_changes"]["removed"].as_array().unwrap()
+        .iter().map(|x| x.as_str().unwrap()).collect();
+    assert_eq!(removed, vec!["io"]);
+    assert!(m["effect_changes"]["added"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn effect_arg_change_surfaces_as_paired_add_remove() {
+    // fs_read("/tmp") → fs_read("/etc"): semantically distinct
+    // scopes; show as one removed + one added so reviewers see the
+    // path change explicitly.
+    let a = tmp("a_arg",
+        "fn f(p :: Str) -> [fs_read(\"/tmp\")] Str { p }\n");
+    let b = tmp("b_arg",
+        "fn f(p :: Str) -> [fs_read(\"/etc\")] Str { p }\n");
+    let (code, stdout, _) = run(&[
+        "ast-diff", "--json", a.to_str().unwrap(), b.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    let m = &v["modified"][0];
+    let added: Vec<&str> = m["effect_changes"]["added"].as_array().unwrap()
+        .iter().map(|x| x.as_str().unwrap()).collect();
+    let removed: Vec<&str> = m["effect_changes"]["removed"].as_array().unwrap()
+        .iter().map(|x| x.as_str().unwrap()).collect();
+    assert_eq!(added.len(), 1);
+    assert_eq!(removed.len(), 1);
+    assert!(added[0].contains("/etc"), "added: {added:?}");
+    assert!(removed[0].contains("/tmp"), "removed: {removed:?}");
+}
+
+#[test]
+fn effects_unchanged_yields_empty_added_removed() {
+    // Only the body changed; effects are identical.
+    let a = tmp("a_body_only", "fn f() -> [io] Int { 1 }\n");
+    let b = tmp("b_body_only", "fn f() -> [io] Int { 2 }\n");
+    let (code, stdout, _) = run(&[
+        "ast-diff", "--json", a.to_str().unwrap(), b.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    let m = &v["modified"][0];
+    assert!(m["effect_changes"]["added"].as_array().unwrap().is_empty());
+    assert!(m["effect_changes"]["removed"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn text_mode_flags_effect_gain() {
+    let a = tmp("a_text_eff", "fn f() -> Int { 1 }\n");
+    let b = tmp("b_text_eff", "fn f() -> [io] Int { 1 }\n");
+    let (code, stdout, _) = run(&[
+        "ast-diff", a.to_str().unwrap(), b.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("effects gained"), "stdout: {stdout}");
+    assert!(stdout.contains("io"), "stdout: {stdout}");
+}
+
+#[test]
 fn parse_errors_surface_clearly() {
     let a = tmp("a_bad", "fn ok() -> Int { 1 }\n");
     let b = tmp("b_bad", "fn broken( - this is not valid lex\n");


### PR DESCRIPTION
## Summary

Adds an `effect_changes` field to `lex ast-diff` modified entries
so reviewers can spot effect deltas without re-parsing rendered
signatures. Surfaced both in JSON and as warning lines in text mode:

```
~ modified fn fetcher(url :: Str) -> [net] Str
             → fn fetcher(url :: Str) -> [net, fs_read] Str
             ⚠ effects gained: [fs_read]
```

```json
"effect_changes": {
  "before":  ["net"],
  "after":   ["fs_read", "net"],
  "added":   ["fs_read"],
  "removed": []
}
```

Effects are rendered with args, so `fs_read("/tmp")` vs
`fs_read("/etc")` shows up as a paired add+remove — these are
semantically distinct scopes for `--allow-fs-read`.

Why a dedicated field: `signature_changed` conflates parameter
types, return types, and effects. For security review, effects
are the security-critical axis and deserve isolation.

This is the only one of the audit's "high-priority" items that's
both real and small. Implements audit Issue #9.

## Test plan

- [x] 5 new integration tests in `crates/lex-cli/tests/ast_diff.rs`:
      added effects, removed effects, arg-change, no-op, text-mode
- [x] All 15 ast_diff tests pass
- [x] Workspace clippy clean
- [x] Workspace tests pass (the flaky `net_serve_tls` test is
      pre-existing and unrelated)

---
_Generated by [Claude Code](https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh)_