### PR TITLE
VM call-stack depth gate + std.map / std.set (no more stdlib stubs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,14 +405,14 @@ lex/
 | M8 — CLI + agent API server | ✅ |
 | M9 — Core | Phase 1 (shape solver, sized numerics) ✅ ; Phase 2 (mutation analysis, native matmul) ✅ ; Cranelift JIT, source-level `mut`/`for` syntax deferred |
 | M10 — Spec | ✅ randomized + SMT-LIB export ; `--spec` wired into `agent-tool` ; in-process Z3 deferred |
-| Stdlib MVP | ✅ pure builtins + closures + higher-order list ops + `std.flow` orchestration ; `std.math` (linalg + scalar floats) ; `std.tuple` ; **effect polymorphism** on `list.map` / `list.filter` / `list.fold` / `option.map` / `result.map` / `result.and_then` / `result.map_err` ; `flow.parallel` ✅ (sequential v1 — true threading deferred) ; `flow.parallel_record` deferred (needs row polymorphism on records) ; `std.map` / `std.set` deferred (need `Value` variants) |
+| Stdlib MVP | ✅ pure builtins + closures + higher-order list ops + `std.flow` orchestration ; `std.math` (linalg + scalar floats) ; `std.tuple` ; **effect polymorphism** on `list.map` / `list.filter` / `list.fold` / `option.map` / `result.map` / `result.and_then` / `result.map_err` ; `flow.parallel` ✅ (sequential v1 — true threading deferred) ; **`std.map` ✅ ; `std.set` ✅** (persistent collections with `Str`/`Int` keys) ; `flow.parallel_record` deferred (needs row polymorphism on records) |
 | Conformance harness + token budget | ✅ |
 | Agent integration (post-spec) | `lex agent-tool` (sandbox) ✅ ; `lex tool-registry serve` (HTTP registry) ✅ ; correctness ladder: `--examples` ✅ `--spec` ✅ `--diff-body` ✅ ; AST tooling: `lex audit` ✅ `lex ast-diff` (with effect-change highlighting) ✅ `lex ast-merge` ✅ |
 | Agent-native version control | tier-1 ✅ — `lex branch` + `lex store-merge` with `fork_base` snapshots and structured JSON conflicts ; commit history (`lex log`), distributed sync, body-level merge deferred |
 | LLM-agnostic discovery | ✅ — full [ACLI](https://github.com/alpibrusl/acli) compliance: `lex introspect` / `lex skill` / `lex version`, `--output text\|json\|table` on every subcommand, `--dry-run` on state-modifying ones, error envelopes with semantic exit codes |
-| Hardening | [`SECURITY.md`](SECURITY.md) threat model ✅ ; parser-recursion DoS gate (`MAX_DEPTH=96`) ✅ ; libFuzzer CI for parser + type checker ✅ ; VM-level memory / stack bounds and runtime body-merge are open |
+| Hardening | [`SECURITY.md`](SECURITY.md) threat model ✅ ; parser-recursion DoS gate (`MAX_DEPTH=96`) ✅ ; **VM call-stack depth gate (`MAX_CALL_DEPTH=1024`) ✅** ; libFuzzer CI for parser + type checker ✅ ; VM-level memory bounds remain delegated to the host (container memory caps) |
 
-**Workspace test count:** 270 passing, 0 failing. `cargo clippy --workspace --all-targets -- -D warnings` clean. Fuzz CI: 60 s/PR, 5 min nightly across both targets.
+**Workspace test count:** 282 passing, 0 failing. `cargo clippy --workspace --all-targets -- -D warnings` clean. Fuzz CI: 60 s/PR, 5 min nightly across both targets.
 
 ## Building from source
 
@@ -420,7 +420,7 @@ Requires a recent Rust toolchain (any 1.80+ stable should work).
 
 ```bash
 cargo build --release       # full toolchain
-cargo test --workspace      # 270 tests
+cargo test --workspace      # 282 tests
 cargo test --release -p core-compiler -- --ignored   # release-only matmul perf gates
 
 # Optional: run the fuzz suite locally (nightly + cargo-fuzz needed).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,8 +51,14 @@ bound:
   (good for infinite loops); it does **not** cap memory allocations.
   A program declared `pure` can still allocate a list of 10^9 ints
   and OOM the host.
-- **Stack overflow.** Deep recursion eventually overflows. There's
-  no Lex-level recursion-depth limit.
+- **Stack overflow.** The parser caps recursion at `MAX_DEPTH=96`
+  and the VM caps call-frame depth at `MAX_CALL_DEPTH=1024` —
+  both refuse cleanly with structured errors instead of unwinding
+  the host. Tail calls reuse frames, so productive
+  tail-recursive code is unaffected. (Native-stack work the host
+  performs *outside* a VM call — e.g. handling arbitrarily nested
+  JSON in `lex parse` — is not bounded; for adversarial input
+  layer container memory caps.)
 - **CPU time.** `--max-steps` bounds dispatched ops; the per-op
   cost varies. Tight on its own is not a hard wall-clock bound.
 - **Logic bugs that don't cross effect boundaries.** A `[net]`

--- a/crates/conformance/src/runner.rs
+++ b/crates/conformance/src/runner.rs
@@ -220,5 +220,9 @@ fn value_to_json(v: &Value) -> serde_json::Value {
             m.insert("data".into(), J::Array(data.iter().map(|f| J::from(*f)).collect()));
             J::Object(m)
         }
+        Value::Map(m) => J::Array(m.iter().map(|(k, v)| {
+            J::Array(vec![value_to_json(&k.as_value()), value_to_json(v)])
+        }).collect()),
+        Value::Set(s) => J::Array(s.iter().map(|k| value_to_json(&k.as_value())).collect()),
     }
 }

--- a/crates/lex-api/src/handlers.rs
+++ b/crates/lex-api/src/handlers.rs
@@ -405,6 +405,26 @@ fn value_to_json(v: &Value) -> serde_json::Value {
             m.insert("data".into(), J::Array(data.iter().map(|f| J::from(*f)).collect()));
             J::Object(m)
         }
+        Value::Map(m) => {
+            // API output: emit Str-keyed maps as JSON objects (most
+            // ergonomic for HTTP consumers); fall back to a list of
+            // [key, value] pairs when keys are Int.
+            let all_str = m.keys().all(|k| matches!(k, lex_bytecode::MapKey::Str(_)));
+            if all_str {
+                let mut out = serde_json::Map::new();
+                for (k, v) in m {
+                    if let lex_bytecode::MapKey::Str(s) = k {
+                        out.insert(s.clone(), value_to_json(v));
+                    }
+                }
+                J::Object(out)
+            } else {
+                J::Array(m.iter().map(|(k, v)| {
+                    J::Array(vec![value_to_json(&k.as_value()), value_to_json(v)])
+                }).collect())
+            }
+        }
+        Value::Set(s) => J::Array(s.iter().map(|k| value_to_json(&k.as_value())).collect()),
     }
 }
 

--- a/crates/lex-bytecode/src/lib.rs
+++ b/crates/lex-bytecode/src/lib.rs
@@ -9,5 +9,5 @@ pub mod vm;
 pub use compiler::compile_program;
 pub use op::{Const, Op};
 pub use program::{Function, Program};
-pub use value::Value;
-pub use vm::{Vm, VmError};
+pub use value::{MapKey, Value};
+pub use vm::{Vm, VmError, MAX_CALL_DEPTH};

--- a/crates/lex-bytecode/src/value.rs
+++ b/crates/lex-bytecode/src/value.rs
@@ -1,6 +1,7 @@
 //! Runtime values.
 
 use indexmap::IndexMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Value {
@@ -24,6 +25,48 @@ pub enum Value {
     /// matmul perf hits the §13.7 #1 100ms target without paying for
     /// 2M Value boxings at the call boundary.
     F64Array { rows: u32, cols: u32, data: Vec<f64> },
+    /// Persistent map keyed by `MapKey` (`Str` or `Int`). Insertion-
+    /// independent equality (sorted by `BTreeMap`'s `Ord`), so two
+    /// maps built from the same pairs in different orders compare
+    /// equal. Restricting keys to two primitive variants keeps
+    /// `Eq + Hash` requirements off `Value` itself, which has
+    /// closures and floats and can't be hashed soundly.
+    Map(BTreeMap<MapKey, Value>),
+    /// Persistent set with the same key-type discipline as `Map`.
+    Set(BTreeSet<MapKey>),
+}
+
+/// Hashable, ordered key for `Value::Map` / `Value::Set`. v1
+/// supports `Str` and `Int`; extending to other primitives or to
+/// records is forward-compatible since the type is not exposed
+/// to user code beyond the surface API.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum MapKey {
+    Str(String),
+    Int(i64),
+}
+
+impl MapKey {
+    pub fn from_value(v: &Value) -> Result<Self, String> {
+        match v {
+            Value::Str(s) => Ok(MapKey::Str(s.clone())),
+            Value::Int(n) => Ok(MapKey::Int(*n)),
+            other => Err(format!(
+                "map/set key must be Str or Int, got {other:?}")),
+        }
+    }
+    pub fn into_value(self) -> Value {
+        match self {
+            MapKey::Str(s) => Value::Str(s),
+            MapKey::Int(n) => Value::Int(n),
+        }
+    }
+    pub fn as_value(&self) -> Value {
+        match self {
+            MapKey::Str(s) => Value::Str(s.clone()),
+            MapKey::Int(n) => Value::Int(*n),
+        }
+    }
 }
 
 impl Value {

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -17,7 +17,17 @@ pub enum VmError {
     UnknownFunction(u32),
     #[error("effect handler error: {0}")]
     Effect(String),
+    #[error("call stack overflow: recursion depth exceeded ({0})")]
+    CallStackOverflow(u32),
 }
+
+/// Maximum simultaneous call frames. Defends against unbounded
+/// recursion in agent-emitted code: a body that calls itself
+/// without a base case would otherwise blow the host's native
+/// stack and crash the process. Real Lex code rarely exceeds
+/// ~30 frames; 1024 is generous headroom while still well under
+/// the OS stack limit at any per-frame size we use.
+pub const MAX_CALL_DEPTH: u32 = 1024;
 
 /// Host-side effect dispatch. Implementors decide what `kind`/`op` mean
 /// and how arguments map to side effects.
@@ -136,11 +146,23 @@ impl<'a> Vm<'a> {
         }
         let mut locals = vec![Value::Unit; f.locals_count.max(f.arity) as usize];
         for (i, v) in args.into_iter().enumerate() { locals[i] = v; }
-        self.frames.push(Frame {
+        self.push_frame(Frame {
             fn_id, pc: 0, locals, stack_base: self.stack.len(),
             trace_kind: FrameKind::Entry,
-        });
+        })?;
         self.run()
+    }
+
+    /// All call-frame pushes funnel through here so the depth
+    /// check can't be skipped by a missing branch. Returns
+    /// `CallStackOverflow` instead of letting recursion blow the
+    /// host's native stack.
+    fn push_frame(&mut self, frame: Frame) -> Result<(), VmError> {
+        if self.frames.len() as u32 >= MAX_CALL_DEPTH {
+            return Err(VmError::CallStackOverflow(MAX_CALL_DEPTH));
+        }
+        self.frames.push(frame);
+        Ok(())
     }
 
     fn run(&mut self) -> Result<Value, VmError> {
@@ -362,10 +384,10 @@ impl<'a> Vm<'a> {
                     let f = &self.program.functions[fn_id as usize];
                     let mut locals = vec![Value::Unit; f.locals_count.max(f.arity) as usize];
                     for (i, v) in combined.into_iter().enumerate() { locals[i] = v; }
-                    self.frames.push(Frame {
+                    self.push_frame(Frame {
                         fn_id, pc: 0, locals, stack_base: self.stack.len(),
                         trace_kind: FrameKind::Call(node_id),
-                    });
+                    })?;
                 }
                 Op::Call { fn_id, arity, node_id_idx } => {
                     let mut args: Vec<Value> = (0..arity).map(|_| Value::Unit).collect();
@@ -376,10 +398,10 @@ impl<'a> Vm<'a> {
                     let f = &self.program.functions[fn_id as usize];
                     let mut locals = vec![Value::Unit; f.locals_count.max(f.arity) as usize];
                     for (i, v) in args.into_iter().enumerate() { locals[i] = v; }
-                    self.frames.push(Frame {
+                    self.push_frame(Frame {
                         fn_id, pc: 0, locals, stack_base: self.stack.len(),
                         trace_kind: FrameKind::Call(node_id),
-                    });
+                    })?;
                 }
                 Op::TailCall { fn_id, arity, node_id_idx } => {
                     let mut args: Vec<Value> = (0..arity).map(|_| Value::Unit).collect();

--- a/crates/lex-bytecode/tests/run.rs
+++ b/crates/lex-bytecode/tests/run.rs
@@ -2,13 +2,51 @@
 
 use indexmap::IndexMap;
 use lex_ast::canonicalize_program;
-use lex_bytecode::{compile_program, Value, Vm};
+use lex_bytecode::{compile_program, Value, Vm, VmError, MAX_CALL_DEPTH};
 use lex_syntax::parse_source;
 
 fn compile(src: &str) -> lex_bytecode::Program {
     let p = parse_source(src).unwrap();
     let stages = canonicalize_program(&p);
     compile_program(&stages)
+}
+
+#[test]
+fn unbounded_recursion_yields_call_stack_overflow_not_segfault() {
+    // Non-tail recursion (the `+ 1` forces the call to return before
+    // we can use its result), so each call pushes a fresh frame.
+    // Pre-fix the VM would push frames until the host's native stack
+    // exploded; post-fix we get a clean `CallStackOverflow` once we
+    // hit `MAX_CALL_DEPTH`.
+    //
+    // Run on a thread with a small stack so a regression (a recursion
+    // path that bypasses `push_frame`) shows up as a SIGSEGV rather
+    // than passing because the host stack happens to be 8 MiB.
+    let src = "fn deep() -> Int { 1 + deep() }\n";
+    let p = compile(src);
+    let handle = std::thread::Builder::new()
+        .stack_size(512 * 1024)
+        .spawn(move || {
+            let mut vm = Vm::new(&p);
+            vm.call("deep", vec![])
+        })
+        .expect("spawn worker thread");
+    let r = handle.join().expect("worker panicked").expect_err("expected overflow");
+    match r {
+        VmError::CallStackOverflow(n) => assert_eq!(n, MAX_CALL_DEPTH),
+        other => panic!("expected CallStackOverflow, got {other:?}"),
+    }
+}
+
+#[test]
+fn modest_recursion_under_cap_still_runs() {
+    // factorial(20) recurses 20 frames — well under MAX_CALL_DEPTH.
+    // Sanity check that the gate doesn't reject legitimate code.
+    let src = "fn factorial(n :: Int) -> Int { match n { 0 => 1, _ => n * factorial(n - 1) } }\n";
+    let p = compile(src);
+    let mut vm = Vm::new(&p);
+    let r = vm.call("factorial", vec![Value::Int(20)]).unwrap();
+    assert_eq!(r, Value::Int(2_432_902_008_176_640_000));
 }
 
 #[test]

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -482,6 +482,26 @@ fn value_to_json(v: &Value) -> serde_json::Value {
             m.insert("data".into(), J::Array(data.iter().map(|f| J::from(*f)).collect()));
             J::Object(m)
         }
+        Value::Map(m) => {
+            // Render as a JSON object when keys are all strings; as
+            // a list of `[key, value]` pairs otherwise (Int keys
+            // can't be JSON-object keys).
+            let all_str = m.keys().all(|k| matches!(k, lex_bytecode::MapKey::Str(_)));
+            if all_str {
+                let mut out = serde_json::Map::new();
+                for (k, v) in m {
+                    if let lex_bytecode::MapKey::Str(s) = k {
+                        out.insert(s.clone(), value_to_json(v));
+                    }
+                }
+                J::Object(out)
+            } else {
+                J::Array(m.iter().map(|(k, v)| {
+                    J::Array(vec![value_to_json(&k.as_value()), value_to_json(v)])
+                }).collect())
+            }
+        }
+        Value::Set(s) => J::Array(s.iter().map(|k| value_to_json(&k.as_value())).collect()),
     }
 }
 

--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -3,7 +3,8 @@
 //! without policy gates (they have no observable side effects).
 
 use indexmap::IndexMap;
-use lex_bytecode::Value;
+use lex_bytecode::{MapKey, Value};
+use std::collections::{BTreeMap, BTreeSet};
 
 /// Returns Some(...) if `(kind, op)` names a known pure builtin.
 /// `None` means "not handled here; fall through to effect dispatch".
@@ -15,13 +16,9 @@ pub fn try_pure_builtin(kind: &str, op: &str, args: &[Value]) -> Option<Result<V
 /// `kind` is one of the known pure module aliases — used by the policy
 /// walk to skip pure builtins that programs reference via imports.
 pub fn is_pure_module(kind: &str) -> bool {
-    // `map` and `set` are listed in the spec (§11.1) but defer to v1.1
-    // alongside refinement types — they need new `Value` variants for
-    // proper hashing semantics, which is a larger change. Until then,
-    // `import "std.map"` / `"std.set"` resolves to None so users get a
-    // clear "module not found" rather than silently-empty stubs.
     matches!(kind, "str" | "int" | "float" | "bool" | "list"
-        | "option" | "result" | "tuple" | "json" | "bytes" | "flow" | "math")
+        | "option" | "result" | "tuple" | "json" | "bytes" | "flow" | "math"
+        | "map" | "set")
 }
 
 fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
@@ -414,7 +411,122 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             Ok(Value::F64Array { rows: r as u32, cols: c as u32, data })
         }
 
+        // -- map --
+        ("map", "new") => Ok(Value::Map(BTreeMap::new())),
+        ("map", "size") => Ok(Value::Int(expect_map(args.first())?.len() as i64)),
+        ("map", "has") => {
+            let m = expect_map(args.first())?;
+            let k = MapKey::from_value(args.get(1).ok_or("map.has: missing key")?)?;
+            Ok(Value::Bool(m.contains_key(&k)))
+        }
+        ("map", "get") => {
+            let m = expect_map(args.first())?;
+            let k = MapKey::from_value(args.get(1).ok_or("map.get: missing key")?)?;
+            Ok(match m.get(&k) {
+                Some(v) => some(v.clone()),
+                None    => none(),
+            })
+        }
+        ("map", "set") => {
+            let mut m = expect_map(args.first())?.clone();
+            let k = MapKey::from_value(args.get(1).ok_or("map.set: missing key")?)?;
+            let v = args.get(2).ok_or("map.set: missing value")?.clone();
+            m.insert(k, v);
+            Ok(Value::Map(m))
+        }
+        ("map", "delete") => {
+            let mut m = expect_map(args.first())?.clone();
+            let k = MapKey::from_value(args.get(1).ok_or("map.delete: missing key")?)?;
+            m.remove(&k);
+            Ok(Value::Map(m))
+        }
+        ("map", "keys") => {
+            let m = expect_map(args.first())?;
+            Ok(Value::List(m.keys().cloned().map(MapKey::into_value).collect()))
+        }
+        ("map", "values") => {
+            let m = expect_map(args.first())?;
+            Ok(Value::List(m.values().cloned().collect()))
+        }
+        ("map", "entries") => {
+            let m = expect_map(args.first())?;
+            Ok(Value::List(m.iter()
+                .map(|(k, v)| Value::Tuple(vec![k.as_value(), v.clone()]))
+                .collect()))
+        }
+        ("map", "from_list") => {
+            let pairs = expect_list(args.first())?;
+            let mut m = BTreeMap::new();
+            for p in pairs {
+                let items = match p {
+                    Value::Tuple(items) if items.len() == 2 => items,
+                    other => return Err(format!(
+                        "map.from_list element must be a 2-tuple, got {other:?}")),
+                };
+                let k = MapKey::from_value(&items[0])?;
+                m.insert(k, items[1].clone());
+            }
+            Ok(Value::Map(m))
+        }
+
+        // -- set --
+        ("set", "new") => Ok(Value::Set(BTreeSet::new())),
+        ("set", "size") => Ok(Value::Int(expect_set(args.first())?.len() as i64)),
+        ("set", "has") => {
+            let s = expect_set(args.first())?;
+            let k = MapKey::from_value(args.get(1).ok_or("set.has: missing element")?)?;
+            Ok(Value::Bool(s.contains(&k)))
+        }
+        ("set", "add") => {
+            let mut s = expect_set(args.first())?.clone();
+            let k = MapKey::from_value(args.get(1).ok_or("set.add: missing element")?)?;
+            s.insert(k);
+            Ok(Value::Set(s))
+        }
+        ("set", "delete") => {
+            let mut s = expect_set(args.first())?.clone();
+            let k = MapKey::from_value(args.get(1).ok_or("set.delete: missing element")?)?;
+            s.remove(&k);
+            Ok(Value::Set(s))
+        }
+        ("set", "to_list") => {
+            let s = expect_set(args.first())?;
+            Ok(Value::List(s.iter().cloned().map(MapKey::into_value).collect()))
+        }
+        ("set", "from_list") => {
+            let xs = expect_list(args.first())?;
+            let mut s = BTreeSet::new();
+            for x in xs {
+                s.insert(MapKey::from_value(x)?);
+            }
+            Ok(Value::Set(s))
+        }
+        ("set", "union") => {
+            let a = expect_set(args.first())?;
+            let b = expect_set(args.get(1))?;
+            Ok(Value::Set(a.union(b).cloned().collect()))
+        }
+        ("set", "intersect") => {
+            let a = expect_set(args.first())?;
+            let b = expect_set(args.get(1))?;
+            Ok(Value::Set(a.intersection(b).cloned().collect()))
+        }
+
         _ => Err(format!("unknown pure builtin: {kind}.{op}")),
+    }
+}
+
+fn expect_map(v: Option<&Value>) -> Result<&BTreeMap<MapKey, Value>, String> {
+    match v {
+        Some(Value::Map(m)) => Ok(m),
+        other => Err(format!("expected Map, got {other:?}")),
+    }
+}
+
+fn expect_set(v: Option<&Value>) -> Result<&BTreeSet<MapKey>, String> {
+    match v {
+        Some(Value::Set(s)) => Ok(s),
+        other => Err(format!("expected Set, got {other:?}")),
     }
 }
 
@@ -545,6 +657,23 @@ fn value_to_json(v: &Value) -> serde_json::Value {
             m.insert("data".into(), J::Array(data.iter().map(|f| J::from(*f)).collect()));
             J::Object(m)
         }
+        Value::Map(m) => {
+            let all_str = m.keys().all(|k| matches!(k, MapKey::Str(_)));
+            if all_str {
+                let mut out = serde_json::Map::new();
+                for (k, v) in m {
+                    if let MapKey::Str(s) = k {
+                        out.insert(s.clone(), value_to_json(v));
+                    }
+                }
+                J::Object(out)
+            } else {
+                J::Array(m.iter().map(|(k, v)| {
+                    J::Array(vec![value_to_json(&k.as_value()), value_to_json(v)])
+                }).collect())
+            }
+        }
+        Value::Set(s) => J::Array(s.iter().map(|k| value_to_json(&k.as_value())).collect()),
     }
 }
 

--- a/crates/lex-runtime/tests/map_set.rs
+++ b/crates/lex-runtime/tests/map_set.rs
@@ -1,0 +1,181 @@
+//! std.map and std.set — persistent collections with `Str` or `Int`
+//! keys. Tests both that the type signatures unify and that the
+//! runtime returns the right value.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, MapKey, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+
+fn run(src: &str, func: &str, args: Vec<Value>) -> Value {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors: {errs:#?}");
+    }
+    let bc = compile_program(&stages);
+    let handler = DefaultHandler::new(Policy::permissive());
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(func, args).expect("vm")
+}
+
+#[test]
+fn map_set_get_roundtrip() {
+    let src = r#"
+import "std.map" as map
+fn build() -> Map[Str, Int] {
+  let m1 := map.set(map.new(), "a", 1)
+  let m2 := map.set(m1, "b", 2)
+  m2
+}
+fn lookup(m :: Map[Str, Int], k :: Str) -> Int {
+  match map.get(m, k) {
+    Some(n) => n,
+    None    => 0,
+  }
+}
+fn demo() -> Int {
+  let m := build()
+  lookup(m, "a") + lookup(m, "b") + lookup(m, "missing")
+}
+"#;
+    assert_eq!(run(src, "demo", vec![]), Value::Int(3));
+}
+
+#[test]
+fn map_size_grows_with_inserts() {
+    let src = r#"
+import "std.map" as map
+fn count() -> Int {
+  let m := map.set(map.set(map.set(map.new(), "x", 1), "y", 2), "z", 3)
+  map.size(m)
+}
+"#;
+    assert_eq!(run(src, "count", vec![]), Value::Int(3));
+}
+
+#[test]
+fn map_set_overwrites_existing_value() {
+    let src = r#"
+import "std.map" as map
+fn overwrite() -> Int {
+  let m1 := map.set(map.new(), "k", 10)
+  let m2 := map.set(m1, "k", 99)
+  match map.get(m2, "k") {
+    Some(n) => n,
+    None    => -1,
+  }
+}
+"#;
+    assert_eq!(run(src, "overwrite", vec![]), Value::Int(99));
+}
+
+#[test]
+fn map_delete_drops_key() {
+    let src = r#"
+import "std.map" as map
+fn after_delete() -> Bool {
+  let m1 := map.set(map.new(), "k", 1)
+  let m2 := map.delete(m1, "k")
+  map.has(m2, "k")
+}
+"#;
+    assert_eq!(run(src, "after_delete", vec![]), Value::Bool(false));
+}
+
+#[test]
+fn map_int_keys_work() {
+    let src = r#"
+import "std.map" as map
+fn pick(m :: Map[Int, Str], k :: Int) -> Str {
+  match map.get(m, k) {
+    Some(s) => s,
+    None    => "missing",
+  }
+}
+fn build() -> Map[Int, Str] {
+  map.set(map.set(map.new(), 1, "one"), 2, "two")
+}
+fn demo() -> Str { pick(build(), 2) }
+"#;
+    assert_eq!(run(src, "demo", vec![]), Value::Str("two".into()));
+}
+
+#[test]
+fn map_from_list_round_trips_through_entries() {
+    let src = r#"
+import "std.map" as map
+import "std.list" as list
+fn count() -> Int {
+  let m := map.from_list([("a", 1), ("b", 2), ("c", 3)])
+  list.fold(map.values(m), 0, fn (acc :: Int, n :: Int) -> Int { acc + n })
+}
+"#;
+    assert_eq!(run(src, "count", vec![]), Value::Int(6));
+}
+
+#[test]
+fn set_dedupes_a_list() {
+    let src = r#"
+import "std.set" as set
+import "std.list" as list
+fn unique_sum() -> Int {
+  let s := set.from_list([3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5])
+  list.fold(set.to_list(s), 0, fn (acc :: Int, x :: Int) -> Int { acc + x })
+}
+"#;
+    // {1, 2, 3, 4, 5, 6, 9} = 30.
+    assert_eq!(run(src, "unique_sum", vec![]), Value::Int(30));
+}
+
+#[test]
+fn set_union_intersect() {
+    let src = r#"
+import "std.set" as set
+fn check() -> Int {
+  let a := set.from_list([1, 2, 3])
+  let b := set.from_list([2, 3, 4])
+  let u := set.union(a, b)         # {1,2,3,4} -> 4
+  let i := set.intersect(a, b)     # {2,3}     -> 2
+  set.size(u) + set.size(i)
+}
+"#;
+    assert_eq!(run(src, "check", vec![]), Value::Int(6));
+}
+
+#[test]
+fn map_of_non_str_or_int_key_is_runtime_error() {
+    // Keys are typed polymorphically (`Var(0)`) but only `Str` /
+    // `Int` are actually permitted at runtime — anything else
+    // surfaces as `expected Map, got ...` style errors when we
+    // try to convert the key.
+    let src = r#"
+import "std.map" as map
+fn bad() -> Bool { map.has(map.set(map.new(), [1, 2], 1), [3, 4]) }
+"#;
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    // This may or may not type-check (the type variable is opaque
+    // to the runtime); we care that it doesn't reach `Some(true)`.
+    let bc = compile_program(&stages);
+    let handler = DefaultHandler::new(Policy::permissive());
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    let r = vm.call("bad", vec![]);
+    assert!(r.is_err(), "expected runtime error for non-primitive key");
+}
+
+#[test]
+fn map_value_uses_btreemap_directly() {
+    // The Value::Map variant exposes the BTreeMap API so Rust
+    // code (e.g. handlers) can read it without going through
+    // the dispatcher. Sanity check the variant shape.
+    let src = r#"
+import "std.map" as map
+fn build() -> Map[Str, Int] { map.set(map.set(map.new(), "x", 7), "y", 11) }
+"#;
+    let v = run(src, "build", vec![]);
+    let m = match v { Value::Map(m) => m, other => panic!("not a Map: {other:?}") };
+    assert_eq!(m.len(), 2);
+    assert_eq!(m.get(&MapKey::Str("x".into())), Some(&Value::Int(7)));
+    assert_eq!(m.get(&MapKey::Str("y".into())), Some(&Value::Int(11)));
+}

--- a/crates/lex-trace/src/recorder.rs
+++ b/crates/lex-trace/src/recorder.rs
@@ -197,6 +197,21 @@ fn value_to_json(v: &Value) -> serde_json::Value {
             m.insert("data".into(), J::Array(data.iter().map(|f| J::from(*f)).collect()));
             J::Object(m)
         }
+        Value::Map(m) => {
+            let mut o = serde_json::Map::new();
+            o.insert("$map".into(), J::Bool(true));
+            o.insert("entries".into(), J::Array(m.iter().map(|(k, v)| {
+                J::Array(vec![value_to_json(&k.as_value()), value_to_json(v)])
+            }).collect()));
+            J::Object(o)
+        }
+        Value::Set(s) => {
+            let mut o = serde_json::Map::new();
+            o.insert("$set".into(), J::Bool(true));
+            o.insert("items".into(), J::Array(
+                s.iter().map(|k| value_to_json(&k.as_value())).collect()));
+            J::Object(o)
+        }
     }
 }
 

--- a/crates/lex-trace/tests/m7.rs
+++ b/crates/lex-trace/tests/m7.rs
@@ -78,6 +78,11 @@ fn value_to_json(v: &Value) -> serde_json::Value {
             m.insert("data".into(), J::Array(data.iter().map(|f| J::from(*f)).collect()));
             J::Object(m)
         }
+        Value::Map(_) | Value::Set(_) => {
+            // Tests in this file don't exercise Map/Set values; render
+            // as a placeholder so the match is exhaustive.
+            J::String("<map_or_set>".into())
+        }
     }
 }
 

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -422,6 +422,90 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
             ));
             Some(Ty::Record(fields))
         }
+        "map" => {
+            // Persistent map. Keys are `Str` or `Int` only — Lex's
+            // type system tracks them polymorphically as Var(0)
+            // ("K") and lets the runtime check the key shape; both
+            // cases fit into `MapKey`.
+            //
+            // Type variables: 0 = K, 1 = V.
+            let mt   = || Ty::Con("Map".into(), vec![Ty::Var(0), Ty::Var(1)]);
+            let pair = || Ty::Tuple(vec![Ty::Var(0), Ty::Var(1)]);
+            let mut fields = IndexMap::new();
+            // new :: () -> Map[K, V]
+            fields.insert("new".into(), Ty::function(
+                vec![], EffectSet::empty(), mt()));
+            // size :: Map[K, V] -> Int
+            fields.insert("size".into(), Ty::function(
+                vec![mt()], EffectSet::empty(), Ty::int()));
+            // has :: Map[K, V], K -> Bool
+            fields.insert("has".into(), Ty::function(
+                vec![mt(), Ty::Var(0)], EffectSet::empty(), Ty::bool()));
+            // get :: Map[K, V], K -> Option[V]
+            fields.insert("get".into(), Ty::function(
+                vec![mt(), Ty::Var(0)], EffectSet::empty(),
+                Ty::Con("Option".into(), vec![Ty::Var(1)])));
+            // set :: Map[K, V], K, V -> Map[K, V]
+            fields.insert("set".into(), Ty::function(
+                vec![mt(), Ty::Var(0), Ty::Var(1)],
+                EffectSet::empty(), mt()));
+            // delete :: Map[K, V], K -> Map[K, V]
+            fields.insert("delete".into(), Ty::function(
+                vec![mt(), Ty::Var(0)], EffectSet::empty(), mt()));
+            // keys :: Map[K, V] -> List[K]
+            fields.insert("keys".into(), Ty::function(
+                vec![mt()], EffectSet::empty(),
+                Ty::List(Box::new(Ty::Var(0)))));
+            // values :: Map[K, V] -> List[V]
+            fields.insert("values".into(), Ty::function(
+                vec![mt()], EffectSet::empty(),
+                Ty::List(Box::new(Ty::Var(1)))));
+            // entries :: Map[K, V] -> List[(K, V)]
+            fields.insert("entries".into(), Ty::function(
+                vec![mt()], EffectSet::empty(),
+                Ty::List(Box::new(pair()))));
+            // from_list :: List[(K, V)] -> Map[K, V]
+            fields.insert("from_list".into(), Ty::function(
+                vec![Ty::List(Box::new(pair()))],
+                EffectSet::empty(), mt()));
+            Some(Ty::Record(fields))
+        }
+        "set" => {
+            // Persistent set with the same key-type discipline as map.
+            // Type variable: 0 = T (the element type, also the key type).
+            let st   = || Ty::Con("Set".into(), vec![Ty::Var(0)]);
+            let mut fields = IndexMap::new();
+            // new :: () -> Set[T]
+            fields.insert("new".into(), Ty::function(
+                vec![], EffectSet::empty(), st()));
+            // size :: Set[T] -> Int
+            fields.insert("size".into(), Ty::function(
+                vec![st()], EffectSet::empty(), Ty::int()));
+            // has :: Set[T], T -> Bool
+            fields.insert("has".into(), Ty::function(
+                vec![st(), Ty::Var(0)], EffectSet::empty(), Ty::bool()));
+            // add :: Set[T], T -> Set[T]
+            fields.insert("add".into(), Ty::function(
+                vec![st(), Ty::Var(0)], EffectSet::empty(), st()));
+            // delete :: Set[T], T -> Set[T]
+            fields.insert("delete".into(), Ty::function(
+                vec![st(), Ty::Var(0)], EffectSet::empty(), st()));
+            // to_list :: Set[T] -> List[T]
+            fields.insert("to_list".into(), Ty::function(
+                vec![st()], EffectSet::empty(),
+                Ty::List(Box::new(Ty::Var(0)))));
+            // from_list :: List[T] -> Set[T]
+            fields.insert("from_list".into(), Ty::function(
+                vec![Ty::List(Box::new(Ty::Var(0)))],
+                EffectSet::empty(), st()));
+            // union :: Set[T], Set[T] -> Set[T]
+            fields.insert("union".into(), Ty::function(
+                vec![st(), st()], EffectSet::empty(), st()));
+            // intersect :: Set[T], Set[T] -> Set[T]
+            fields.insert("intersect".into(), Ty::function(
+                vec![st(), st()], EffectSet::empty(), st()));
+            Some(Ty::Record(fields))
+        }
         "flow" => {
             // Orchestration primitives (spec §11.2). Each takes one or
             // more closures and returns a closure with a derived shape.
@@ -496,6 +580,8 @@ pub fn module_for_import(reference: &str) -> Option<&'static str> {
         "net" => "net",
         "chat" => "chat",
         "math" => "math",
+        "map" => "map",
+        "set" => "set",
         _ => return None,
     })
 }

--- a/crates/spec-checker/src/checker.rs
+++ b/crates/spec-checker/src/checker.rs
@@ -289,5 +289,9 @@ fn value_to_json(v: &Value) -> serde_json::Value {
             m.insert("data".into(), J::Array(data.iter().map(|f| J::from(*f)).collect()));
             J::Object(m)
         }
+        Value::Map(m) => J::Array(m.iter().map(|(k, v)| {
+            J::Array(vec![value_to_json(&k.as_value()), value_to_json(v)])
+        }).collect()),
+        Value::Set(s) => J::Array(s.iter().map(|k| value_to_json(&k.as_value())).collect()),
     }
 }


### PR DESCRIPTION
## Summary

Closes two of the deferred-stub rows in the Status table:

### VM call-stack depth gate

Closes the SECURITY.md "stack overflow" gap. All `frames.push`
sites now funnel through `push_frame`, which refuses with
`VmError::CallStackOverflow(MAX_CALL_DEPTH)` at 1024 frames.
Tail calls reuse frames so productive tail-recursive code is
unaffected; only true non-tail recursion hits the gate.

Test runs the recursion on a 512 KiB-stack thread so a regression
that bypasses `push_frame` shows as SIGSEGV rather than passing
on the host's 8 MiB default. Companion test confirms `factorial(20)`
still runs (under the cap).

### `std.map` + `std.set` (no more stdlib stubs)

Adds `Value::Map(BTreeMap<MapKey, Value>)` and `Value::Set(BTreeSet<MapKey>)`,
plus a `MapKey { Str, Int }` enum so we get `Eq + Ord` without
polluting `Value` itself (which has closures and floats).

Surface:
- **map**: `new`, `size`, `has`, `get`, `set`, `delete`, `keys`,
  `values`, `entries`, `from_list`
- **set**: `new`, `size`, `has`, `add`, `delete`, `to_list`,
  `from_list`, `union`, `intersect`

Type system uses `Ty::Con("Map", [K, V])` / `Ty::Con("Set", [T])`
parallel to `List` — no parser changes needed.

Fan-out: every `match v` over `Value` across lex-cli, lex-runtime,
lex-trace, lex-api, spec-checker, conformance, the m7 test now
handles `Value::Map` / `Value::Set`. Str-keyed maps render as
JSON objects (most ergonomic); Int-keyed maps and sets render as
arrays.

Demo:

```lex
import "std.map" as map
import "std.list" as list

fn word_counts(words :: List[Str]) -> Map[Str, Int] {
  list.fold(words, map.new(), fn (m, w) -> Map[Str, Int] {
    match map.get(m, w) {
      Some(n) => map.set(m, w, n + 1),
      None    => map.set(m, w, 1),
    }
  })
}
```

```bash
$ lex run demo.lex word_counts '["the","cat","the","mat","cat","the"]'
{"cat":2,"mat":1,"the":3}
```

## Test plan

- [x] 7 new map tests + 3 new set tests in `crates/lex-runtime/tests/map_set.rs`
- [x] 2 new VM tests in `crates/lex-bytecode/tests/run.rs`
- [x] Workspace clippy clean
- [x] Workspace tests: **270 → 282** passing

---
_Generated by [Claude Code](https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh)_