### PR TITLE
Add lex log: per-branch merge journal

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,11 +408,11 @@ lex/
 | Stdlib MVP | ✅ pure builtins + closures + higher-order list ops + `std.flow` orchestration ; `std.math` (linalg + scalar floats) ; `std.tuple` ; **effect polymorphism** on `list.map` / `list.filter` / `list.fold` / `option.map` / `result.map` / `result.and_then` / `result.map_err` ; `flow.parallel` ✅ (sequential v1 — true threading deferred) ; **`std.map` ✅ ; `std.set` ✅** (persistent collections with `Str`/`Int` keys) ; `flow.parallel_record` deferred (needs row polymorphism on records) |
 | Conformance harness + token budget | ✅ |
 | Agent integration (post-spec) | `lex agent-tool` (sandbox) ✅ ; `lex tool-registry serve` (HTTP registry) ✅ ; correctness ladder: `--examples` ✅ `--spec` ✅ `--diff-body` ✅ ; AST tooling: `lex audit` ✅ `lex ast-diff` (with effect-change highlighting) ✅ `lex ast-merge` ✅ |
-| Agent-native version control | tier-1 ✅ — `lex branch` + `lex store-merge` with `fork_base` snapshots and structured JSON conflicts ; commit history (`lex log`), distributed sync, body-level merge deferred |
+| Agent-native version control | tier-1 ✅ — `lex branch` + `lex store-merge` with `fork_base` snapshots and structured JSON conflicts ; **`lex log` ✅** (per-branch merge journal) ; distributed sync + body-level merge deferred |
 | LLM-agnostic discovery | ✅ — full [ACLI](https://github.com/alpibrusl/acli) compliance: `lex introspect` / `lex skill` / `lex version`, `--output text\|json\|table` on every subcommand, `--dry-run` on state-modifying ones, error envelopes with semantic exit codes |
 | Hardening | [`SECURITY.md`](SECURITY.md) threat model ✅ ; parser-recursion DoS gate (`MAX_DEPTH=96`) ✅ ; **VM call-stack depth gate (`MAX_CALL_DEPTH=1024`) ✅** ; libFuzzer CI for parser + type checker ✅ ; VM-level memory bounds remain delegated to the host (container memory caps) |
 
-**Workspace test count:** 282 passing, 0 failing. `cargo clippy --workspace --all-targets -- -D warnings` clean. Fuzz CI: 60 s/PR, 5 min nightly across both targets.
+**Workspace test count:** 286 passing, 0 failing. `cargo clippy --workspace --all-targets -- -D warnings` clean. Fuzz CI: 60 s/PR, 5 min nightly across both targets.
 
 ## Building from source
 
@@ -420,7 +420,7 @@ Requires a recent Rust toolchain (any 1.80+ stable should work).
 
 ```bash
 cargo build --release       # full toolchain
-cargo test --workspace      # 282 tests
+cargo test --workspace      # 286 tests
 cargo test --release -p core-compiler -- --ignored   # release-only matmul perf gates
 
 # Optional: run the fuzz suite locally (nightly + cargo-fuzz needed).

--- a/crates/lex-cli/src/acli.rs
+++ b/crates/lex-cli/src/acli.rs
@@ -127,6 +127,7 @@ fn commands() -> Vec<CommandInfo> {
         cmd_ast_merge(),
         cmd_branch(),
         cmd_store_merge(),
+        cmd_log(),
     ]
 }
 
@@ -386,14 +387,29 @@ fn cmd_branch() -> CommandInfo {
         .add_option("--store", "string", "store root", None);
     let current = CommandInfo::new("current", "print the current branch").idempotent(true)
         .add_option("--store", "string", "store root", None);
+    let log = CommandInfo::new("log", "print the merge journal of a branch").idempotent(true)
+        .add_argument("name", "string", "branch name (default: current)", false)
+        .add_option("--store", "string", "store root", None);
     let mut info = CommandInfo::new("branch", "snapshot branches in lex-store (tier-1 agent-native VC)")
         .with_examples(vec![
             ("List branches", "lex branch list"),
             ("Create a feature", "lex branch create feature --from main"),
         ])
-        .with_see_also(vec!["store-merge", "store"]);
-    info.subcommands = vec![list, show, create, delete, use_b, current];
+        .with_see_also(vec!["store-merge", "store", "log"]);
+    info.subcommands = vec![list, show, create, delete, use_b, current, log];
     info
+}
+
+fn cmd_log() -> CommandInfo {
+    CommandInfo::new("log", "show the merge journal of a branch (top-level alias for `lex branch log`)")
+        .idempotent(true)
+        .add_argument("name", "string", "branch name (default: current)", false)
+        .add_option("--store", "string", "store root", None)
+        .with_examples(vec![
+            ("Log of the current branch", "lex log"),
+            ("Log of a named branch as JSON", "lex --output json log feature"),
+        ])
+        .with_see_also(vec!["branch", "store-merge"])
 }
 
 fn cmd_store_merge() -> CommandInfo {

--- a/crates/lex-cli/src/branch.rs
+++ b/crates/lex-cli/src/branch.rs
@@ -9,7 +9,7 @@
 use crate::acli as acli_mod;
 use ::acli::OutputFormat;
 use anyhow::{anyhow, bail, Result};
-use lex_store::{MergeReport, Store};
+use lex_store::{MergeReport, Store, DEFAULT_BRANCH};
 use std::path::PathBuf;
 
 fn open_store(args_iter: &mut dyn Iterator<Item = String>) -> Result<(Store, Vec<String>)> {
@@ -51,8 +51,19 @@ pub fn cmd_branch(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         "delete"  => delete(fmt, &store, &rest, dry_run),
         "use"     => use_branch(fmt, &store, &rest, dry_run),
         "current" => current(fmt, &store),
+        "log"     => log(fmt, &store, &rest),
         other     => bail!("unknown `lex branch` subcommand `{other}`"),
     }
+}
+
+/// Top-level `lex log [branch]` shortcut. Defaults to the current
+/// branch when no name is given. Equivalent to `lex branch log [name]`.
+pub fn cmd_log(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    let mut iter = args.iter().cloned();
+    let raw: Vec<String> = iter.by_ref().collect();
+    let mut filtered: std::vec::IntoIter<String> = raw.into_iter().collect::<Vec<_>>().into_iter();
+    let (store, rest) = open_store(&mut filtered)?;
+    log(fmt, &store, &rest)
 }
 
 pub fn cmd_store_merge(fmt: &OutputFormat, args: &[String]) -> Result<()> {
@@ -138,6 +149,68 @@ fn current(fmt: &OutputFormat, store: &Store) -> Result<()> {
     let data = serde_json::json!({ "current": &cur });
     acli_mod::emit_or_text("branch", data, fmt, || println!("{cur}"));
     Ok(())
+}
+
+fn log(fmt: &OutputFormat, store: &Store, args: &[String]) -> Result<()> {
+    // Default to the current branch when no name is given. `lex log`
+    // alone is then "show me the merge history of where I am".
+    let name = args.first().cloned()
+        .unwrap_or_else(|| store.current_branch());
+    let entries = store.branch_log(&name)
+        .map_err(|e| anyhow!("log {name}: {e}"))?;
+    let data = serde_json::json!({
+        "branch": &name,
+        "merges": entries.iter().map(|m| serde_json::json!({
+            "src": m.src,
+            "at": m.at,
+            "merged": m.merged,
+            "conflicts": m.conflicts,
+        })).collect::<Vec<_>>(),
+    });
+    let entries_for_text = entries.clone();
+    acli_mod::emit_or_text("branch", data, fmt, move || {
+        if entries_for_text.is_empty() {
+            // Render "no merges yet" instead of an empty list so a
+            // human running by hand gets a useful signal. main with
+            // no explicit merges is the common case.
+            let suffix = if name == DEFAULT_BRANCH { " (no merges yet)" } else { "" };
+            println!("{name}: no merge history{suffix}");
+            return;
+        }
+        println!("{name}: {} merge(s)", entries_for_text.len());
+        for m in &entries_for_text {
+            println!("  • {} → {name}    {} fns @ {}",
+                m.src, m.merged, format_ts(m.at));
+        }
+    });
+    Ok(())
+}
+
+/// Render a Unix timestamp as a compact ISO-8601-ish string in UTC.
+/// Avoids pulling chrono into the workspace; we only need
+/// minute-resolution output for log display.
+fn format_ts(secs: u64) -> String {
+    // Compute Y/M/D/h/m from the Unix epoch directly.
+    let mut s = secs as i64;
+    let mut days = s.div_euclid(86_400);
+    s = s.rem_euclid(86_400);
+    let h = s / 3600; s %= 3600;
+    let m = s / 60;
+    let mut y: i64 = 1970;
+    loop {
+        let yd = if is_leap(y) { 366 } else { 365 };
+        if days < yd { break; }
+        days -= yd;
+        y += 1;
+    }
+    let mdays = [31, if is_leap(y) { 29 } else { 28 }, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    let mut mo = 0usize;
+    while mo < 12 && days >= mdays[mo] { days -= mdays[mo]; mo += 1; }
+    format!("{y:04}-{:02}-{:02}T{:02}:{:02}Z", mo + 1, days + 1, h, m)
+}
+
+fn is_leap(y: i64) -> bool {
+    (y % 4 == 0 && y % 100 != 0) || y % 400 == 0
 }
 
 fn show(fmt: &OutputFormat, store: &Store, args: &[String]) -> Result<()> {

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -92,6 +92,7 @@ fn run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         "ast-merge" => ast_merge::cmd_ast_merge(fmt, &args[1..]),
         "branch" => branch::cmd_branch(fmt, &args[1..]),
         "store-merge" => branch::cmd_store_merge(fmt, &args[1..]),
+        "log" => branch::cmd_log(fmt, &args[1..]),
         "help" | "--help" | "-h" => { print_usage(); Ok(()) }
         other => bail!("unknown command `{other}`. try `lex help`"),
     }

--- a/crates/lex-store/src/branches.rs
+++ b/crates/lex-store/src/branches.rs
@@ -66,7 +66,26 @@ pub struct Branch {
     /// have this populated.
     #[serde(default)]
     pub fork_base: Option<BTreeMap<String, String>>,
+    /// Append-only journal of merges committed *into* this branch.
+    /// Read by `Store::branch_log` / `lex log`. `#[serde(default)]`
+    /// for back-compat with branch files written before this field.
+    #[serde(default)]
+    pub merges: Vec<MergeRecord>,
     pub created_at: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MergeRecord {
+    /// The branch the merge pulled *from*.
+    pub src: String,
+    /// Wall-clock seconds since the Unix epoch.
+    pub at: u64,
+    /// Number of (SigId, StageId) entries the merge resolved cleanly.
+    pub merged: usize,
+    /// Number of conflicts at merge-record time. Always 0 for a
+    /// committed merge (commit_merge refuses with conflicts), but
+    /// preserved here for symmetry and future "uncommitted" entries.
+    pub conflicts: usize,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -82,6 +101,14 @@ pub struct MergeSummary {
     pub clean: usize,
     pub conflicts: usize,
     pub base: Option<String>,
+    /// The branch the merge was sourced from. Empty by default
+    /// (back-compat); populated by `Store::merge`. Used by
+    /// `commit_merge` to journal a `MergeRecord` on `dst`.
+    #[serde(default)]
+    pub src: String,
+    /// The destination branch.
+    #[serde(default)]
+    pub dst: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -173,6 +200,19 @@ impl Store {
         Err(StoreError::UnknownBranch(name.into()))
     }
 
+    /// Read the journal of merges committed *into* `name`. Returns
+    /// the records in insertion order (oldest first). For `main`
+    /// without an explicit branch file, returns an empty Vec —
+    /// merges into main only get journaled once main has been
+    /// materialized via `set_branch_head_entry` or `commit_merge`.
+    pub fn branch_log(&self, name: &str) -> Result<Vec<MergeRecord>, StoreError> {
+        match self.get_branch(name)? {
+            Some(b) => Ok(b.merges),
+            None if name == DEFAULT_BRANCH => Ok(Vec::new()),
+            None => Err(StoreError::UnknownBranch(name.into())),
+        }
+    }
+
     /// Snapshot the source branch's head into a new named branch.
     /// Errors if the branch already exists. Sets `parent` to `from`.
     pub fn create_branch(&self, name: &str, from: &str) -> Result<(), StoreError> {
@@ -191,6 +231,7 @@ impl Store {
             parent: Some(from.into()),
             fork_base: Some(head.clone()),
             head,
+            merges: Vec::new(),
             created_at: now(),
         };
         fs::write(self.branch_path(name), serde_json::to_string_pretty(&b)?)?;
@@ -231,6 +272,7 @@ impl Store {
                 parent: None,
                 head: self.branch_head(DEFAULT_BRANCH)?,
                 fork_base: None,
+                merges: Vec::new(),
                 created_at: now(),
             },
             None => return Err(StoreError::UnknownBranch(name.into())),
@@ -255,6 +297,8 @@ impl Store {
         let mut report = MergeReport {
             summary: MergeSummary {
                 base: base_name.clone(),
+                src: src.into(),
+                dst: dst.into(),
                 ..Default::default()
             },
             merged: Vec::new(),
@@ -356,6 +400,7 @@ impl Store {
                 parent: None,
                 head: self.branch_head(DEFAULT_BRANCH)?,
                 fork_base: None,
+                merges: Vec::new(),
                 created_at: now(),
             },
             None => return Err(StoreError::UnknownBranch(dst.into())),
@@ -366,6 +411,17 @@ impl Store {
             head.insert(m.sig_id.clone(), m.stage_id.clone());
         }
         b.head = head;
+        // Journal the merge so `lex log` can show it. `summary.src`
+        // is empty for the legacy `Store::merge` callers (pre-this
+        // field); skip the record in that case to avoid noise.
+        if !report.summary.src.is_empty() {
+            b.merges.push(MergeRecord {
+                src: report.summary.src.clone(),
+                at: now(),
+                merged: report.merged.len(),
+                conflicts: 0,
+            });
+        }
         fs::create_dir_all(self.branches_dir())?;
         fs::write(self.branch_path(dst), serde_json::to_string_pretty(&b)?)?;
         Ok(())

--- a/crates/lex-store/src/lib.rs
+++ b/crates/lex-store/src/lib.rs
@@ -32,5 +32,6 @@ mod branches;
 pub use model::{Lifecycle, Metadata, Spec, StageStatus, Test, Transition};
 pub use store::{Store, StoreError};
 pub use branches::{
-    Branch, MergeConflict, MergeEntry, MergeReport, MergeSummary, DEFAULT_BRANCH,
+    Branch, MergeConflict, MergeEntry, MergeRecord, MergeReport, MergeSummary,
+    DEFAULT_BRANCH,
 };

--- a/crates/lex-store/tests/branches.rs
+++ b/crates/lex-store/tests/branches.rs
@@ -184,3 +184,60 @@ fn commit_merge_refuses_when_conflicts_remain() {
     let report = s.merge("feature", DEFAULT_BRANCH).unwrap();
     assert!(s.commit_merge(DEFAULT_BRANCH, &report).is_err());
 }
+
+#[test]
+fn branch_log_records_committed_merges() {
+    let (s, _tmp) = fresh_store("log-records");
+    put_head(&s, DEFAULT_BRANCH, "sig1", "stageA");
+    s.create_branch("feature", DEFAULT_BRANCH).expect("create");
+    put_head(&s, "feature", "sig1", "stageB");
+
+    // Pre-merge: log on main is empty (no commits yet).
+    assert!(s.branch_log(DEFAULT_BRANCH).expect("log").is_empty());
+
+    let report = s.merge("feature", DEFAULT_BRANCH).expect("merge");
+    s.commit_merge(DEFAULT_BRANCH, &report).expect("commit");
+
+    let entries = s.branch_log(DEFAULT_BRANCH).expect("log after commit");
+    assert_eq!(entries.len(), 1, "one merge committed → one record");
+    assert_eq!(entries[0].src, "feature");
+    assert_eq!(entries[0].merged, 1, "sig1 was merged");
+    assert_eq!(entries[0].conflicts, 0);
+    assert!(entries[0].at > 0, "timestamp populated");
+}
+
+#[test]
+fn branch_log_grows_across_multiple_merges() {
+    let (s, _tmp) = fresh_store("log-multi");
+    s.create_branch("a", DEFAULT_BRANCH).unwrap();
+    s.create_branch("b", DEFAULT_BRANCH).unwrap();
+    put_head(&s, "a", "sigA", "stage1");
+    put_head(&s, "b", "sigB", "stage2");
+
+    let r1 = s.merge("a", DEFAULT_BRANCH).unwrap();
+    s.commit_merge(DEFAULT_BRANCH, &r1).unwrap();
+    let r2 = s.merge("b", DEFAULT_BRANCH).unwrap();
+    s.commit_merge(DEFAULT_BRANCH, &r2).unwrap();
+
+    let entries = s.branch_log(DEFAULT_BRANCH).unwrap();
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].src, "a");
+    assert_eq!(entries[1].src, "b");
+    assert!(entries[0].at <= entries[1].at, "entries in chronological order");
+}
+
+#[test]
+fn branch_log_for_unknown_branch_errors() {
+    let (s, _tmp) = fresh_store("log-unknown");
+    assert!(s.branch_log("does-not-exist").is_err());
+}
+
+#[test]
+fn branch_log_for_main_without_branch_file_returns_empty() {
+    // Fresh store: main has no explicit branch file. `branch_log`
+    // returns an empty vec rather than erroring, since main is a
+    // valid branch reference even without an explicit file.
+    let (s, _tmp) = fresh_store("log-main-empty");
+    let entries = s.branch_log(DEFAULT_BRANCH).expect("log main");
+    assert!(entries.is_empty());
+}


### PR DESCRIPTION
## Summary

Closes the visible gap in agent-native VC: a `lex` branch was a
snapshot without history. After this PR, `lex log [branch]` shows
the journal of merges committed into it.

```
$ lex log main
main: 2 merge(s)
  • feature → main    3 fns @ 2026-05-01T19:19Z
  • hotfix  → main    1 fns @ 2026-05-01T20:34Z

$ lex --output json log main
{
  "ok": true,
  "command": "branch",
  "data": {
    "branch": "main",
    "merges": [
      {"src": "feature", "at": 1777663191, "merged": 3, "conflicts": 0},
      {"src": "hotfix",  "at": 1777667659, "merged": 1, "conflicts": 0}
    ]
  },
  ...
}
```

### Mechanism

- `MergeRecord { src, at, merged, conflicts }` (new) appended to
  `Branch.merges` (new, `#[serde(default)]` for back-compat) by
  `commit_merge`.
- `MergeReport.summary` carries `src` / `dst` so the journal entry
  has the right source name without changing the `commit_merge`
  signature.
- `Store::branch_log(name)` reads the journal; returns empty for
  `main` when there's no explicit branch file (rather than erroring),
  since `main` is always a valid branch reference.
- CLI: top-level `lex log [branch]` plus the symmetric
  `lex branch log [branch]`; both default to the current branch.
- Registered with ACLI so `lex introspect` lists it.

ISO-8601-ish timestamps are rendered locally without pulling
`chrono` into the workspace — log display only needs minute
resolution.

## Test plan

- [x] 4 new integration tests in `crates/lex-store/tests/branches.rs`:
      record-on-commit, multi-merge ordering, unknown-branch error,
      and the empty-main no-file case
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Workspace tests: **282 → 286** passing
- [x] End-to-end smoke test: `lex log main` after `lex store-merge feature main --commit`

---
_Generated by [Claude Code](https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh)_