### PR TITLE
Open-source housekeeping: badges, server example, CONTRIBUTING + CoC + templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Something is doing the wrong thing
+labels: bug
+---
+
+**What did you expect?**
+
+A clear, one-sentence description of the expected behavior.
+
+**What happened instead?**
+
+What actually happened. Paste the verbatim error if there is one.
+
+**Reproducer**
+
+The smallest `.lex` source / shell command that triggers the bug.
+
+```lex
+fn example() -> Int { 1 }
+```
+
+```bash
+$ lex check example.lex
+```
+
+**Environment**
+
+- `lex --version` output:
+- OS / arch:
+- Rust toolchain (`rustc --version`):
+
+**Additional context**
+
+Anything else that helps — recent changes, suspected component
+(parser, type checker, runtime, store, CLI), etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/alpibrusl/lex-lang/security/advisories/new
+    about: Don't open a public issue for security bugs. Use a Security Advisory.
+  - name: Question / discussion
+    url: https://github.com/alpibrusl/lex-lang/discussions
+    about: For open-ended questions about Lex's design or roadmap.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,38 @@
+---
+name: Feature request
+about: Propose an addition or change
+labels: enhancement
+---
+
+**The problem**
+
+What can't you do today? One paragraph.
+
+**Proposed solution**
+
+Concrete API, CLI flag, syntax, or design sketch. The more specific,
+the easier to discuss.
+
+**Alternatives considered**
+
+What else have you tried or thought about? Why is this proposal
+better than the alternatives?
+
+**Affected components**
+
+Which crates / commands does this touch?
+- [ ] `lex-syntax` (parser)
+- [ ] `lex-ast` (canonical AST)
+- [ ] `lex-types` (type / effect system)
+- [ ] `lex-bytecode` (compiler / VM)
+- [ ] `lex-runtime` (effects, stdlib)
+- [ ] `lex-store` (content-addressed store, branches)
+- [ ] `lex-cli` (CLI surface)
+- [ ] `lex-api` (HTTP server)
+- [ ] Spec / docs only
+
+**Backwards-compatibility impact**
+
+Does this change `SigId` / `StageId` hashes, the JSON wire format,
+the canonical AST, or any documented CLI flag? Pre-1.0 we'll ship
+breaking changes when justified, but we want to know up front.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!--
+Thanks for contributing! See CONTRIBUTING.md for the conventions
+this project follows. CI runs `cargo build`, `cargo test`, and
+`cargo clippy --workspace --all-targets -- -D warnings`; please
+make sure all three are green locally before pushing.
+-->
+
+## Summary
+
+What does this PR change? One paragraph.
+
+## Why
+
+What's the user-facing problem this solves, or the gap this
+closes? If it's tied to a tracked issue, link it (`closes #N`).
+
+## Test plan
+
+- [ ] `cargo test --workspace` passes locally
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
+- [ ] New behavior has a regression test
+- [ ] If this changes a public CLI flag or JSON shape, README /
+      Toolchain reference / langspec is updated
+
+## Risk / scope
+
+- Touches: `<crate-list-or-CLI-or-docs>`
+- Breaking change to wire format / SigId / StageId / canonical AST? **yes / no**
+- Adds a new effect kind or runtime variant? **yes / no**

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  - package-ecosystem: "cargo"
+    directory: "/fuzz"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+    labels:
+      - "dependencies"
+      - "fuzz"
+    commit-message:
+      prefix: "fuzz/deps"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,86 @@
+# Changelog
+
+All notable changes to lex-lang. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
+versioning follows [SemVer](https://semver.org/) (pre-1.0; minor
+bumps may carry breaking changes when justified).
+
+## [Unreleased]
+
+### Added
+
+- `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, GitHub issue / PR
+  templates, Dependabot config — open-source housekeeping.
+
+### Documentation
+
+- Badges row at the top of the README (CI, fuzz, tests, license,
+  Rust MSRV).
+- Worked `lex serve` example with `curl /v1/check` and `/v1/run`
+  in the Quickstart.
+
+## [0.1.0] — 2026-05
+
+The pre-launch baseline. Everything below is what shipped before
+the changelog itself was started; entries are coarse-grained.
+
+### Added
+
+- **Agent-native VC, tier 1.** `lex branch` (`list` / `show` /
+  `create` / `delete` / `use` / `current`), `lex store-merge`
+  with three-way structural merge over branch heads using
+  `fork_base` snapshots, `lex log` per-branch merge journal,
+  `lex blame` per-fn stage history.
+- **LLM-agnostic discovery.** Full [ACLI](https://github.com/alpibrusl/acli)
+  compliance: `lex introspect` / `lex skill` / `lex version`,
+  `--output text|json|table` on every subcommand, `--dry-run` on
+  state-modifying ones, ACLI error envelopes with semantic exit
+  codes. Auto-generated `.cli/` folder is committed.
+- **AST tooling.** `lex audit` (structural search by effect / call
+  / hostname / AST kind), `lex ast-diff` (with effect-change
+  highlighting), `lex ast-merge` (three-way structural merge with
+  JSON conflicts).
+- **Persistent collections.** `std.map` and `std.set` with `Str`
+  or `Int` keys (via `MapKey` so `Value` itself stays free of
+  `Eq + Hash` constraints).
+- **Effect polymorphism** on stdlib HOFs (`list.map`, `list.filter`,
+  `list.fold`, `option.map`, `result.map`, `result.and_then`,
+  `result.map_err`).
+- **`lex agent-tool`.** Sandboxed runner for LLM-emitted tool
+  bodies with effect declaration. Correctness ladder: `--examples`,
+  `--spec`, `--diff-body`. Adversarial benchmark vs Python sandboxes.
+- **`lex tool-registry serve`.** HTTP service to register Lex tools
+  at runtime + invoke via `/tools/{id}/invoke`.
+- **`lex spec`.** Randomized property checking + SMT-LIB export
+  for external Z3.
+- **Trace tree + replay + diff** (`lex run --trace`, `lex trace`,
+  `lex replay`, `lex diff`).
+- **Content-addressed store** (`lex publish`, `lex store list/get`)
+  with stage lifecycle (Draft / Active / Deprecated / Tombstone).
+- **Capability runtime + effect system** (`--allow-effects`,
+  `--allow-fs-read PATH`, `--allow-fs-write PATH`,
+  `--allow-net-host HOST`, `--budget`, `--max-steps`).
+- **Type system**: HM inference, sized numerics, tensor shape
+  solver, mutation analysis (Core), native matmul.
+- **Stdlib MVP**: `std.str`, `std.int`, `std.float`, `std.bool`,
+  `std.list`, `std.option`, `std.result`, `std.tuple`, `std.json`,
+  `std.bytes`, `std.flow`, `std.math`, `std.io`, `std.net`,
+  `std.chat`, `std.time`, `std.rand`.
+- **Example apps**: weather REST API, multi-user WebSocket chat,
+  CSV analytics, ML (linreg + logistic), webhook router, gateway
+  service.
+- **Conformance harness** with property tests.
+- **Agent API server** (`lex serve` / `/v1/{parse,check,run,
+  publish,patch,trace,replay,diff,stage}`).
+
+### Hardening
+
+- Parser recursion-depth gate (`MAX_DEPTH = 96`); closes a
+  stack-overflow DoS the libFuzzer parser target found.
+- VM call-stack depth gate (`MAX_CALL_DEPTH = 1024`); refuses with
+  `VmError::CallStackOverflow` instead of unwinding the host.
+- `SECURITY.md` threat model with deployment recommendations.
+- `cargo fuzz` CI for parser + type checker (60 s/PR, 5 min nightly).
+
+[Unreleased]: https://github.com/alpibrusl/lex-lang/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/alpibrusl/lex-lang/releases/tag/v0.1.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,38 @@
+# Code of Conduct
+
+We follow the spirit of the [Contributor Covenant
+2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/);
+read the canonical text there. The short version:
+
+## Expectations
+
+- Be respectful. Assume good faith. Disagree about technical choices
+  in public; disagree about people in private, if at all.
+- Welcome new contributors. The first PR is the hardest one to write.
+- Keep discussions on-topic and grounded in code, examples, and the
+  spec.
+- Report unacceptable behavior to the maintainers (see
+  [`Cargo.toml`](Cargo.toml) `authors` for emails, or open a
+  [Security Advisory](https://github.com/alpibrusl/lex-lang/security/advisories/new)
+  if you'd rather it stay private).
+
+## Unacceptable behavior
+
+Personal attacks, sustained disruption of discussions, publishing
+others' private information without consent, or any conduct a
+reasonable maintainer would consider inappropriate in a professional
+setting.
+
+## Enforcement
+
+Maintainers will warn, then remove participation rights, then ban as
+appropriate. We don't run a formal review board — single-maintainer
+project, single-maintainer judgement. The Contributor Covenant FAQ
+explains the principles we lean on.
+
+## Scope
+
+This applies to project spaces (this repo, issues, PRs, the
+`docs/index.html` landing page comments if any) and to project-related
+public communication elsewhere when a contributor is representing the
+project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,92 @@
+# Contributing to lex-lang
+
+Thanks for considering a contribution. Lex is pre-1.0 — the
+roadmap is opinionated and the test bar is high, but we welcome
+small fixes, fresh examples, and well-scoped features.
+
+## Quick start
+
+```bash
+git clone https://github.com/alpibrusl/lex-lang
+cd lex-lang
+cargo build --release
+cargo test --workspace
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+CI on every PR runs the same three steps. Anything that doesn't pass
+locally won't pass in CI; please don't push known-red branches.
+
+## Branch naming
+
+Branches that touch shipped code use the `claude/<short-slug>` prefix
+(legacy naming from when most contributions came through agents). New
+human contributions can use `<github-handle>/<short-slug>`. PRs on
+either pattern are accepted.
+
+## What changes are easy to land
+
+- **Bug fixes** with a regression test that fails before the fix and
+  passes after. The smaller the diff, the faster the review.
+- **New stdlib operations** in pure modules (`std.str` / `std.list` /
+  `std.option` / etc.) — see `crates/lex-runtime/src/builtins.rs`.
+  Add the type signature in `crates/lex-types/src/builtins.rs` and a
+  test in `crates/lex-runtime/tests/`.
+- **Example apps** under `examples/` that exercise a real workflow.
+  Pair with an integration test in `crates/lex-runtime/tests/`.
+- **Doc updates**, especially the README's status table and the
+  langspec when behavior changes.
+
+## What needs design discussion first
+
+Open an issue (with the `discussion` label) before writing code if
+your change:
+
+- Adds a new effect kind (`io` / `net` / etc.) — touches the policy
+  gate and the agent contract.
+- Changes the canonical AST or hashing — `SigId` / `StageId`
+  identity is a wire format.
+- Changes the runtime `Value` enum — every `match v` site has to
+  grow a new arm.
+- Touches the spec checker's proof obligations.
+
+## Style + invariants
+
+- **No new `unwrap`/`expect`** in production paths. Tests and
+  hand-rolled internals can use them when failure means a programmer
+  bug, not user input. Errors at boundaries flow through `Result`.
+- **Tests live alongside the crate they exercise** —
+  `crates/<crate>/tests/<name>.rs`. End-to-end CLI tests live in
+  `crates/lex-cli/tests/`.
+- **Comments explain WHY, not WHAT.** A line that's surprising,
+  load-bearing, or contradicts the surrounding pattern earns a
+  comment; a line that does what it says doesn't.
+- **No backwards-compatibility shims** for unused features.
+- **No throwaway feature flags** for one-off rollouts.
+
+## Submitting a pull request
+
+1. Make a branch (see naming above).
+2. Push commits — small, atomic, with `<area>: <imperative summary>`
+   first lines (e.g. `parser: cap recursion depth at 96`).
+3. Open the PR. Use the template in `.github/PULL_REQUEST_TEMPLATE.md`.
+4. CI runs build + test + clippy + fuzz on parser/AST/type-checker
+   touches. All must be green.
+5. Review happens on the PR. Push fixes as new commits — squash
+   happens at merge time.
+
+## Security issues
+
+**Don't open a public issue.** See [`SECURITY.md`](SECURITY.md) for
+the disclosure path.
+
+## Licensing
+
+Lex is [EUPL-1.2](LICENSE). Contributions are under the same license.
+By submitting a PR you agree to license your changes under EUPL-1.2.
+
+## Code of conduct
+
+We follow the [Contributor Covenant 2.1](CODE_OF_CONDUCT.md). Disrespect
+toward other contributors gets you uninvited, regardless of the merit
+of your code.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # lex-lang
 
+[![CI](https://github.com/alpibrusl/lex-lang/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/alpibrusl/lex-lang/actions/workflows/ci.yml)
+[![fuzz](https://github.com/alpibrusl/lex-lang/actions/workflows/fuzz.yml/badge.svg?branch=main)](https://github.com/alpibrusl/lex-lang/actions/workflows/fuzz.yml)
+[![tests](https://img.shields.io/badge/tests-285_passing-success.svg)](#building-from-source)
+[![License: EUPL-1.2](https://img.shields.io/badge/license-EUPL--1.2-blue.svg)](LICENSE)
+[![Rust 1.80+](https://img.shields.io/badge/rust-1.80%2B-orange.svg)](#building-from-source)
+
 A language family designed for code no one will read. AI agents write more than humans review; Lex's bet is that when nobody reads bodies, the function signature has to be the contract. Effects are part of the type; the type checker, runtime policy gate, and Spec proofs verify the body honors it — without anyone reading the body.
 
 **Lex** is the general-purpose surface; **Core** covers performance-critical work (sized numerics, tensor shapes); **Spec** carries proof annotations. Implementation of `langspecs.md`; this README focuses on what currently runs.
@@ -53,7 +59,20 @@ lex store get <stage_id>
 lex conformance conformance/
 
 # Start the agent API server (HTTP/JSON, port 4040 by default).
-lex serve
+lex serve &
+
+# In another shell — type-check a snippet over HTTP:
+curl -sX POST http://localhost:4040/v1/check \
+  -H 'content-type: application/json' \
+  -d '{"source":"fn add(x :: Int, y :: Int) -> Int { x + y }"}'
+# → {"ok": true}
+
+# Run a function over HTTP with policy:
+curl -sX POST http://localhost:4040/v1/run \
+  -H 'content-type: application/json' \
+  -d '{"source":"fn add(x :: Int, y :: Int) -> Int { x + y }",
+       "fn":"add", "args":[2,3], "policy":{"allow_effects":[]}}'
+# → {"run_id":"...","output":5}
 ```
 
 ### Quickstart: agent-native tooling


### PR DESCRIPTION
## Summary

Pre-launch open-source housekeeping. First-time visitors expect
certain signals at the top of the README and certain files at the
repo root; this PR adds them.

### README
- **Badges row**: CI, fuzz, tests-passing, EUPL-1.2 license, Rust 1.80+ MSRV
- **Worked `lex serve` example** in the Quickstart (with `curl /v1/check`
  and `/v1/run` showing the JSON envelopes)

### New files
- `CONTRIBUTING.md` — branch naming, build/test/clippy expectations,
  what-to-discuss-first list, style invariants, PR submission flow
- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1 summary, points at
  the canonical text
- `.github/ISSUE_TEMPLATE/{bug_report,feature_request,config}.{md,yml}`
  — bug + feature templates, plus a config that routes security
  reports to GitHub Security Advisories
- `.github/PULL_REQUEST_TEMPLATE.md` — summary / why / test plan /
  risk checklist
- `.github/dependabot.yml` — weekly Cargo + GitHub Actions updates
  (separate workspace tracking for `/fuzz`)
- `CHANGELOG.md` — Keep-a-Changelog format; baseline v0.1.0 entry
  covers everything that landed before the changelog itself started

## Test plan

- [x] No code changes
- [x] All Markdown renders cleanly (verified the badges resolve with
      shields.io / GitHub workflow URLs)

---
_Generated by [Claude Code](https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh)_