### PR TITLE
Add [proc] effect: subprocess spawn under a binary allow-list

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -78,6 +78,77 @@ bound:
 Treat Lex's effect system as **the innermost ring of defense in
 depth**, not as a complete sandbox.
 
+## The `[proc]` effect: read this before you grant it
+
+`[proc]` (subprocess spawn, `proc.spawn(cmd, args)`) is the
+**escape hatch** in Lex's effect system. A function with `[proc]`
+in its signature can do anything the spawned binary can do —
+which, for a general-purpose tool like `git` or `bash`, is
+*everything*. Once `[proc]` is in scope, the effect system stops
+making strong claims about what the function does.
+
+What `[proc]` **does** still gate:
+
+- **Effect declaration** is mandatory. A function that calls
+  `proc.spawn` without `[proc]` in its signature is rejected at
+  type-check.
+- **Binary basename allow-list** via `--allow-proc=git,gh,cargo`.
+  An empty list means "any binary" (escape hatch — only for
+  trusted code); a non-empty list rejects pre-spawn anything
+  whose basename isn't on the list.
+- **Per-arg length** capped at 64 KiB and **arg-count** capped at
+  1024 — runtime DoS guards.
+- **Type-checked argv shape**: `args :: List[Str]`. No
+  shell-interpolation; the runtime calls `Command::new(cmd).args(args)`
+  which passes argv directly to `execve`, no `/bin/sh -c` in the
+  middle.
+
+What `[proc]` **does not** gate:
+
+- **Argument injection.** A binary that itself accepts an
+  `--exec=...` or `-e ...` flag (think `bash -c`, `git -c
+  alias.x=!sh`, `sed e ...`) can be subverted by attacker-controlled
+  args. The allow-list says "you may run `git`"; it does not say
+  "with these specific subcommands."
+- **Environment variables.** The spawned process inherits the
+  parent's env. A binary that reads `LD_PRELOAD`, `PATH`, or
+  `GIT_*` vars can be redirected by manipulating those.
+- **Working directory.** Inherits the parent's `cwd`. A binary
+  that does `git status` runs against whatever repo your process
+  is in.
+- **Network, filesystem, signals.** Whatever the spawned binary
+  does, the OS does. The Lex effect system doesn't follow
+  execution into the child.
+
+### Best practices when granting `[proc]`
+
+1. **Always pass an explicit `--allow-proc` list.** Empty-list
+   "escape hatch" mode is for one-off scripts you wrote, not for
+   anything that runs LLM-emitted bodies.
+2. **Allow-list narrowly.** `--allow-proc git,gh` is much
+   narrower than `--allow-proc bash`. Avoid shells, interpreters,
+   and any binary with a `--exec`-style flag.
+3. **Validate argv at the Lex layer** before passing it to
+   `proc.spawn`. If an attacker can inject into the args, the
+   binary can do whatever its argv accepts.
+4. **Layer with OS-level isolation.** Run the parent process in
+   a container (`docker run --memory=...`), under gVisor, or
+   with `nsjail` / `bubblewrap`. `[proc]` punches a hole in
+   Lex's effect system; the container is what catches what
+   falls through.
+5. **Audit spawned-binary surfaces.** `lex audit --calls
+   proc.spawn` finds every call site; pair with code review for
+   the args.
+6. **Treat `[proc]` as "I'm writing infrastructure, not running
+   an agent."** Agent-emitted code that needs to call
+   subprocesses should go through a Lex-side adapter that
+   validates the cmd + args, not get `[proc]` directly.
+
+We took the trade because `[proc]` unlocks real workflows
+(orchestrating other CLI agents, running tests, talking to
+`git`) that the existing effect set can't serve. The honesty
+above is the price.
+
 ## Recommended deployment
 
 For untrusted code paths (especially `lex agent-tool` and

--- a/bench/RECORDING.md
+++ b/bench/RECORDING.md
@@ -7,8 +7,10 @@ attempt to escape the declared effect set.
 
 For the **agent-native VC** companion piece (branches, structural
 merge with JSON conflicts, `lex log` + `lex blame`, ACLI discovery)
-see [`RECORDING_VC.md`](RECORDING_VC.md). The two recordings are
-designed to live side-by-side on the landing page.
+see [`RECORDING_VC.md`](RECORDING_VC.md). For the **`[proc]`
+escape-hatch** demo (subprocess dispatch with binary allow-list)
+see [`RECORDING_PROC.md`](RECORDING_PROC.md). The three recordings
+are designed to live side-by-side on the landing page.
 
 ## What you need
 

--- a/bench/RECORDING_PROC.md
+++ b/bench/RECORDING_PROC.md
@@ -1,0 +1,109 @@
+# Recording the `[proc]` agent-dispatcher demo
+
+The third recording, alongside `RECORDING.md` (agent-tool security)
+and `RECORDING_VC.md` (agent-native VC). This one demos the
+**escape-hatch effect**: `[proc]` is the only effect in Lex that
+can spawn arbitrary binaries, and we're explicit about how the
+allow-list contains it.
+
+## What you need
+
+- `asciinema` installed.
+- The release-mode binary (`cargo build --release`).
+- A clean shell.
+
+## Pre-recording setup
+
+```bash
+export PATH="$(pwd)/target/release:$PATH"
+stty cols 100 rows 30
+clear
+```
+
+## Recording flow
+
+```bash
+asciinema rec bench/agent_dispatcher_demo.cast \
+  --idle-time-limit 1.5 \
+  --title "Lex [proc]: agent dispatcher with binary allow-list, type-checked argv"
+```
+
+Inside the session, the **four beats** below. Each is a punchline.
+
+### Beat 1 — The contract
+
+```bash
+# 1. The function declares [proc] in its signature. Read the SECURITY
+#    note in the same file before granting [proc] in production.
+head -30 examples/agent_dispatcher.lex
+```
+
+> **Punchline**: `fn run(cmd, args) -> [proc] Output` says exactly
+> what the function can do. The type checker enforces it.
+
+### Beat 2 — Allowed: spawning `echo`
+
+```bash
+# 2. Grant [proc], allow the `echo` binary, run a benign command.
+lex run --allow-effects proc --allow-proc echo \
+  examples/agent_dispatcher.lex run '"echo"' '["hello","from","agent_dispatcher"]'
+# → {"exit_code":0,"ok":true,"stderr":"","stdout":"hello from agent_dispatcher\n"}
+```
+
+> **Punchline**: clean Output record, exit code 0.
+
+### Beat 3 — Blocked: trying to spawn `rm` with the same policy
+
+```bash
+# 3. Same policy. Ask to spawn `rm` instead — runtime gate blocks it
+#    pre-spawn, no destructive call ever happens.
+lex run --allow-effects proc --allow-proc echo \
+  examples/agent_dispatcher.lex run '"rm"' '["-rf","/tmp/anything"]'
+# → {"exit_code":-1,"ok":false,"stderr":"proc.spawn: `rm` not in --allow-proc [\"echo\"]","stdout":""}
+```
+
+> **Punchline**: `--allow-proc` is the line of defense. Without it
+> on the allow-list, `rm` doesn't run — the runtime returns an Err
+> as a value, not a thrown exception.
+
+### Beat 4 — The honesty: `lex audit` finds every `[proc]` call site
+
+```bash
+# 4. Before you grant [proc] in production, find everywhere it's
+#    used and review the args. lex audit makes this trivial.
+lex audit --effect proc examples/
+# → SUMMARY: ... 1 stages
+#   examples/agent_dispatcher.lex::run
+#     fn run(cmd :: Str, args :: List[Str]) -> [proc] Output
+#   examples/agent_dispatcher.lex::dispatch_all
+#     fn dispatch_all(jobs :: List[Tuple[Str, List[Str]]]) -> [proc] List[Output]
+```
+
+> **Punchline**: `[proc]` is the escape hatch — `lex audit` is how
+> you keep tabs on it. Read SECURITY.md before granting.
+
+### End the session
+
+`Ctrl-D` (or `exit`). Cast file is small.
+
+## Sharing
+
+```bash
+asciinema upload bench/agent_dispatcher_demo.cast
+agg bench/agent_dispatcher_demo.cast bench/agent_dispatcher_demo.gif \
+  --theme monokai --font-size 14 --speed 1.5
+```
+
+## Tips for the take
+
+- Beat 1 is just a `head -30`; pause after it so the viewer reads
+  the signature + the SECURITY note in the file's header.
+- Beat 3 is the money shot — make sure the JSON output is on
+  screen long enough to read.
+- Don't grant `--allow-proc bash` or `--allow-proc sh` in any
+  recording. The point is *narrow* allow-lists.
+
+## Reproducibility
+
+The four commands are idempotent and need no external state. Any
+contributor can re-record by running them.

--- a/crates/conformance/src/runner.rs
+++ b/crates/conformance/src/runner.rs
@@ -152,6 +152,7 @@ fn build_policy(p: &PolicyJson) -> Policy {
         allow_fs_read: p.allow_fs_read.iter().map(PathBuf::from).collect(),
         allow_fs_write: p.allow_fs_write.iter().map(PathBuf::from).collect(),
         allow_net_host: Vec::new(),
+        allow_proc: Vec::new(),
         budget: p.budget,
     }
 }

--- a/crates/lex-api/src/handlers.rs
+++ b/crates/lex-api/src/handlers.rs
@@ -251,6 +251,7 @@ impl PolicyJson {
             allow_fs_read: self.allow_fs_read.into_iter().map(PathBuf::from).collect(),
             allow_fs_write: self.allow_fs_write.into_iter().map(PathBuf::from).collect(),
             allow_net_host: Vec::new(),
+            allow_proc: Vec::new(),
             budget: self.budget,
         }
     }

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -349,6 +349,15 @@ fn parse_run_flags(args: &[String]) -> Result<(Policy, Vec<String>, bool, Option
                 policy.allow_net_host.push(val.clone());
                 i += 2;
             }
+            "--allow-proc" => {
+                // Comma-separated binary basenames the [proc] effect
+                // is allowed to spawn. Read SECURITY.md before granting.
+                let val = args.get(i + 1).ok_or_else(|| anyhow!("--allow-proc needs a value"))?;
+                for name in val.split(',').filter(|s| !s.is_empty()) {
+                    policy.allow_proc.push(name.to_string());
+                }
+                i += 2;
+            }
             "--budget" => {
                 let val = args.get(i + 1).ok_or_else(|| anyhow!("--budget needs a value"))?;
                 policy.budget = Some(val.parse().context("--budget must be an integer")?);

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -257,6 +257,76 @@ impl EffectHandler for DefaultHandler {
                 let body = expect_str(args.get(1))?;
                 Ok(Value::Bool(crate::ws::chat_send(registry, conn_id, body)))
             }
+            ("proc", "spawn") => {
+                // The escape hatch effect. Spawns a child process,
+                // collects its stdout/stderr, returns a structured
+                // record. Allow-list is the binary basename: anything
+                // outside `--allow-proc` is rejected pre-spawn.
+                //
+                // What this does NOT validate (per SECURITY.md):
+                // - per-arg content (a script-like CLI invoked via
+                //   --eval=... can run anything)
+                // - environment variables (inherited from the parent)
+                // - working directory (the parent's)
+                //
+                // For untrusted input, layer with OS-level
+                // sandboxing — gVisor / nsjail / a container.
+                let cmd = expect_str(args.first())?.to_string();
+                let raw_args = match args.get(1) {
+                    Some(Value::List(items)) => items,
+                    Some(other) => return Err(format!(
+                        "proc.spawn: args must be List[Str], got {other:?}")),
+                    None => return Err("proc.spawn: missing args list".into()),
+                };
+                let str_args: Vec<String> = raw_args.iter().map(|v| match v {
+                    Value::Str(s) => Ok(s.clone()),
+                    other => Err(format!("proc.spawn: arg must be Str, got {other:?}")),
+                }).collect::<Result<Vec<_>, _>>()?;
+
+                // Allow-list check: empty list = any binary (escape
+                // hatch); non-empty = basename of cmd must match an
+                // entry exactly.
+                if !self.policy.allow_proc.is_empty() {
+                    let basename = std::path::Path::new(&cmd)
+                        .file_name()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or(&cmd);
+                    if !self.policy.allow_proc.iter().any(|a| a == basename) {
+                        return Ok(err(Value::Str(format!(
+                            "proc.spawn: `{cmd}` not in --allow-proc {:?}",
+                            self.policy.allow_proc
+                        ))));
+                    }
+                }
+
+                // Hard caps: the spec doesn't pin numbers, but
+                // unbounded argv is a DoS vector.
+                if str_args.len() > 1024 {
+                    return Ok(err(Value::Str(
+                        "proc.spawn: arg-count exceeds 1024".into())));
+                }
+                if str_args.iter().any(|a| a.len() > 65_536) {
+                    return Ok(err(Value::Str(
+                        "proc.spawn: per-arg length exceeds 64 KiB".into())));
+                }
+
+                let output = std::process::Command::new(&cmd)
+                    .args(&str_args)
+                    .output();
+                match output {
+                    Ok(o) => {
+                        let mut rec = indexmap::IndexMap::new();
+                        rec.insert("stdout".into(), Value::Str(
+                            String::from_utf8_lossy(&o.stdout).to_string()));
+                        rec.insert("stderr".into(), Value::Str(
+                            String::from_utf8_lossy(&o.stderr).to_string()));
+                        rec.insert("exit_code".into(), Value::Int(
+                            o.status.code().unwrap_or(-1) as i64));
+                        Ok(ok(Value::Record(rec)))
+                    }
+                    Err(e) => Ok(err(Value::Str(format!("spawn `{cmd}`: {e}")))),
+                }
+            }
             other => Err(format!("unsupported effect {}.{}", other.0, other.1)),
         }
     }

--- a/crates/lex-runtime/src/policy.rs
+++ b/crates/lex-runtime/src/policy.rs
@@ -26,6 +26,14 @@ pub struct Policy {
     /// scoped to e.g. `api.openai.com` only — without this, [net]
     /// is a blank check to exfiltrate anywhere.
     pub allow_net_host: Vec<String>,
+    /// Per-binary scope on the [proc] effect. Empty = ANY binary
+    /// allowed once [proc] is granted (treat as a global escape
+    /// hatch; only acceptable for trusted code). Non-empty =
+    /// `proc.spawn(cmd, args)` must match `cmd` against the
+    /// basename portion of one of these entries. Per-arg validation
+    /// is the *caller's* responsibility — see SECURITY.md's
+    /// "argument injection" note.
+    pub allow_proc: Vec<String>,
     pub budget: Option<u64>,
 }
 
@@ -42,6 +50,7 @@ impl Policy {
             allow_fs_read: Vec::new(),
             allow_fs_write: Vec::new(),
             allow_net_host: Vec::new(),
+            allow_proc: Vec::new(),
             budget: None,
         }
     }

--- a/crates/lex-runtime/tests/proc_effect.rs
+++ b/crates/lex-runtime/tests/proc_effect.rs
@@ -1,0 +1,124 @@
+//! Integration tests for the `[proc]` effect.
+//!
+//! Spawns small, ubiquitous binaries (`echo`, `true`, `false`) so
+//! the tests don't require a special environment. Skipped on
+//! platforms where these aren't on `PATH` — checked with `which`.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::collections::BTreeSet;
+
+fn policy_with(effects: &[&str], procs: &[&str]) -> Policy {
+    let mut p = Policy::pure();
+    p.allow_effects = effects.iter().map(|s| s.to_string()).collect::<BTreeSet<_>>();
+    p.allow_proc = procs.iter().map(|s| s.to_string()).collect();
+    p
+}
+
+fn run(src: &str, func: &str, args: Vec<Value>, policy: Policy) -> Result<Value, String> {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors: {errs:#?}");
+    }
+    let bc = compile_program(&stages);
+    let handler = DefaultHandler::new(policy);
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(func, args).map_err(|e| format!("{e}"))
+}
+
+fn unwrap_record(v: &Value) -> &indexmap::IndexMap<String, Value> {
+    match v {
+        Value::Record(r) => r,
+        other => panic!("expected Record, got {other:?}"),
+    }
+}
+
+fn variant_args(v: &Value, expected_name: &str) -> Vec<Value> {
+    match v {
+        Value::Variant { name, args } if name == expected_name => args.clone(),
+        other => panic!("expected Variant(`{expected_name}`), got {other:?}"),
+    }
+}
+
+const SRC: &str = r#"
+import "std.proc" as proc
+fn echo(args :: List[Str]) -> [proc] Result[{ stdout :: Str, stderr :: Str, exit_code :: Int }, Str] {
+  proc.spawn("echo", args)
+}
+fn forbidden() -> [proc] Result[{ stdout :: Str, stderr :: Str, exit_code :: Int }, Str] {
+  proc.spawn("/usr/bin/whoami", [])
+}
+fn falsy() -> [proc] Result[{ stdout :: Str, stderr :: Str, exit_code :: Int }, Str] {
+  proc.spawn("false", [])
+}
+"#;
+
+#[test]
+fn proc_spawn_runs_echo_and_returns_stdout() {
+    let r = run(SRC, "echo",
+        vec![Value::List(vec![
+            Value::Str("hello".into()),
+            Value::Str("world".into()),
+        ])],
+        policy_with(&["proc"], &["echo"])).expect("run");
+    let inner = variant_args(&r, "Ok");
+    let rec = unwrap_record(&inner[0]);
+    assert_eq!(rec.get("stdout"), Some(&Value::Str("hello world\n".into())));
+    assert_eq!(rec.get("exit_code"), Some(&Value::Int(0)));
+}
+
+#[test]
+fn proc_spawn_blocks_binary_outside_allow_proc() {
+    // `whoami` not in --allow-proc; surface as Err(..) Result.
+    let r = run(SRC, "forbidden",
+        vec![],
+        policy_with(&["proc"], &["echo"])).expect("run");
+    let inner = variant_args(&r, "Err");
+    let msg = match &inner[0] {
+        Value::Str(s) => s.clone(),
+        other => panic!("expected Str err, got {other:?}"),
+    };
+    assert!(msg.contains("not in --allow-proc"), "msg: {msg}");
+    assert!(msg.contains("whoami"), "msg: {msg}");
+}
+
+#[test]
+fn proc_spawn_with_empty_allow_proc_is_escape_hatch() {
+    // Empty allow_proc list = any binary permitted (escape hatch).
+    // Documented in SECURITY.md and in the policy field doc-comment.
+    let r = run(SRC, "echo",
+        vec![Value::List(vec![Value::Str("x".into())])],
+        policy_with(&["proc"], &[])).expect("run");
+    let inner = variant_args(&r, "Ok");
+    let rec = unwrap_record(&inner[0]);
+    assert_eq!(rec.get("stdout"), Some(&Value::Str("x\n".into())));
+}
+
+#[test]
+fn proc_spawn_propagates_non_zero_exit() {
+    let r = run(SRC, "falsy",
+        vec![],
+        policy_with(&["proc"], &["false"])).expect("run");
+    let inner = variant_args(&r, "Ok");
+    let rec = unwrap_record(&inner[0]);
+    let exit = match rec.get("exit_code") {
+        Some(Value::Int(n)) => *n,
+        other => panic!("exit_code: {other:?}"),
+    };
+    assert_ne!(exit, 0, "false should exit non-zero");
+}
+
+#[test]
+fn proc_spawn_without_proc_in_allow_effects_is_runtime_rejected() {
+    // The static check would reject this at type-check time; here we
+    // bypass by not granting the effect kind. The handler errors
+    // before running.
+    let r = run(SRC, "echo",
+        vec![Value::List(vec![Value::Str("x".into())])],
+        policy_with(&[], &[]));  // proc not granted
+    let err = r.expect_err("proc.spawn without --allow-effects proc must error");
+    assert!(err.contains("proc"), "err: {err}");
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -326,6 +326,31 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
             ));
             Some(Ty::Record(fields))
         }
+        "proc" => {
+            // Subprocess dispatch. Effect: [proc]. Returns a Result
+            // with a record on success carrying stdout / stderr /
+            // exit_code. The runtime allow-lists which binary
+            // basenames are spawnable — `cmd` is the program to
+            // run, `args` is the literal argv (no shell parsing).
+            //
+            // Read SECURITY.md before adding [proc] to a policy:
+            // it weakens the "we know what this fn does" claim.
+            let mut fields = IndexMap::new();
+            let mut result_rec = IndexMap::new();
+            result_rec.insert("stdout".into(), Ty::str());
+            result_rec.insert("stderr".into(), Ty::str());
+            result_rec.insert("exit_code".into(), Ty::int());
+            // spawn :: Str, List[Str] -> [proc] Result[{stdout, stderr, exit_code}, Str]
+            fields.insert("spawn".into(), Ty::function(
+                vec![Ty::str(), Ty::List(Box::new(Ty::str()))],
+                EffectSet::singleton("proc"),
+                Ty::Con("Result".into(), vec![
+                    Ty::Record(result_rec),
+                    Ty::str(),
+                ]),
+            ));
+            Some(Ty::Record(fields))
+        }
         "json" => {
             let mut fields = IndexMap::new();
             // stringify :: T -> Str  (polymorphic on input)
@@ -582,6 +607,7 @@ pub fn module_for_import(reference: &str) -> Option<&'static str> {
         "math" => "math",
         "map" => "map",
         "set" => "set",
+        "proc" => "proc",
         _ => return None,
     })
 }

--- a/examples/agent_dispatcher.lex
+++ b/examples/agent_dispatcher.lex
@@ -1,0 +1,69 @@
+# An "agent dispatcher" that calls another CLI agent (claude-code,
+# cursor-cli, gemini-cli, ...) over stdout. The signature declares
+# `[proc]`, so the type checker rejects any body that tries to do
+# anything but `proc.spawn`. The runtime gates on which binary
+# basenames are spawnable via `--allow-proc`.
+#
+# This is the use case agents-orchestrating-agents need: a Lex
+# program that dispatches to subprocess CLIs while keeping the
+# attack surface visible at the type level.
+#
+# Run:
+#   lex run --allow-effects proc --allow-proc echo \
+#     examples/agent_dispatcher.lex run "echo" "hello world"
+#
+# Adversarial scenario:
+#   The runtime *will* refuse to spawn a binary not in --allow-proc,
+#   even when [proc] itself is granted. Try:
+#     lex run --allow-effects proc --allow-proc echo \
+#       examples/agent_dispatcher.lex run "rm" "-rf" "/"
+#   → "proc.spawn: `rm` not in --allow-proc [\"echo\"]"
+#
+#   Exit codes:
+#     0  — sub-binary returned 0 (success)
+#     non-zero (returned in `exit_code`) — sub-binary failed
+#     A `proc.spawn` not-allowed surfaces as Err(...), which we
+#     return as the JSON output of `run`.
+
+import "std.proc" as proc
+import "std.list" as list
+import "std.str" as str
+import "std.int" as int
+
+type Output = {
+  ok :: Bool,
+  exit_code :: Int,
+  stdout :: Str,
+  stderr :: Str,
+}
+
+# Dispatch to a sub-binary with a list of args; flatten the
+# Result into a uniform Output record so a parent agent doesn't
+# have to pattern-match on Result + Record.
+fn run(cmd :: Str, args :: List[Str]) -> [proc] Output {
+  match proc.spawn(cmd, args) {
+    Ok(r) => {
+      ok: r.exit_code == 0,
+      exit_code: r.exit_code,
+      stdout: r.stdout,
+      stderr: r.stderr,
+    },
+    Err(e) => {
+      ok: false,
+      exit_code: -1,
+      stdout: "",
+      stderr: e,
+    },
+  }
+}
+
+# A higher-level pattern: dispatch a *list* of commands and collect
+# the outputs. Useful for "fan out a sprint to N agents and gather
+# their summaries". Each entry is `(cmd, args)`.
+fn dispatch_all(jobs :: List[Tuple[Str, List[Str]]]) -> [proc] List[Output] {
+  list.map(jobs, fn (j :: Tuple[Str, List[Str]]) -> [proc] Output {
+    run(tuple.fst(j), tuple.snd(j))
+  })
+}
+
+import "std.tuple" as tuple


### PR DESCRIPTION
## Summary

Adds the `[proc]` effect: subprocess spawn under a binary
allow-list. Closes the largest gap blocking real
agent-orchestration workflows — driving `git`, dispatching to
other CLI agents, running tests — that the existing effect set
couldn't serve.

### Surface

```lex
import "std.proc" as proc

fn run(cmd :: Str, args :: List[Str]) -> [proc] Result[
  { stdout :: Str, stderr :: Str, exit_code :: Int },
  Str
] {
  proc.spawn(cmd, args)
}
```

```bash
$ lex run --allow-effects proc --allow-proc echo \
    examples/agent_dispatcher.lex run '"echo"' '["hello"]'
{"exit_code":0,"ok":true,"stderr":"","stdout":"hello\n"}

$ lex run --allow-effects proc --allow-proc echo \
    examples/agent_dispatcher.lex run '"rm"' '["-rf","/tmp/x"]'
{"exit_code":-1,"ok":false,"stderr":"proc.spawn: `rm` not in --allow-proc [\"echo\"]","stdout":""}
```

### Constraints

- **Mandatory effect declaration** (caught at type-check)
- **Binary basename allow-list** (`--allow-proc git,gh,cargo`)
  — empty list = "any binary" (escape hatch for trusted code)
- **No shell interpolation** — argv passes directly to `execve`
- **DoS caps**: 1024 args max, 64 KiB per arg

### Honesty

`[proc]` is the **escape hatch**. Once granted, the effect system
stops making strong claims about what the function does. New
SECURITY.md section spells out:
- What `[proc]` does NOT gate (argument injection, env vars, cwd,
  what the spawned binary itself does)
- Six best-practice rules for granting it (narrow allow-lists,
  validate argv, layer with OS-level isolation, audit call sites,
  treat as infrastructure rather than agent-runtime)

### Files

- `crates/lex-runtime/src/{policy,handler}.rs` — `allow_proc`
  field + `("proc", "spawn")` dispatch
- `crates/lex-types/src/builtins.rs` — `std.proc` module + import
  alias
- `crates/lex-cli/src/main.rs` — `--allow-proc` flag
- `crates/lex-runtime/tests/proc_effect.rs` — 5 new tests
- `examples/agent_dispatcher.lex` — the use case as a real example
- `bench/RECORDING_PROC.md` — asciinema script alongside the
  existing security + VC recordings
- `SECURITY.md` — dedicated `[proc]` section
- Misc Policy initializer updates (conformance, lex-api)

## Test plan

- [x] 5 new integration tests (allowed binary, blocked binary,
      empty-allow-list escape hatch, non-zero exit propagation,
      effect-not-granted rejection)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Workspace tests: **285 → 290** passing
- [x] End-to-end smoke: `lex run --allow-proc=echo …` allows; same
      policy rejecting `rm` returns Err as a value

---
_Generated by [Claude Code](https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh)_