### PR TITLE
Tier S onramp trio: lex repl, lex watch, pre-built binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,123 @@
+name: release
+
+# Triggers on `v*` tags. Build cross-platform binaries, attach
+# them to a GitHub Release. Manual `workflow_dispatch` lets us
+# rehearse without tagging.
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (e.g. v0.1.0). Required for manual runs."
+        required: true
+
+jobs:
+  build:
+    name: build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive: tar.gz
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive: tar.gz
+            cross: true
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            archive: zip
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Install cross (linux aarch64 only)
+        if: matrix.cross
+        run: cargo install cross --locked
+
+      - name: Build (cargo)
+        if: ${{ !matrix.cross }}
+        run: cargo build --release --target ${{ matrix.target }} --bin lex
+
+      - name: Build (cross)
+        if: matrix.cross
+        run: cross build --release --target ${{ matrix.target }} --bin lex
+
+      - name: Stage artifact
+        shell: bash
+        run: |
+          set -e
+          TAG="${GITHUB_REF_NAME:-${{ github.event.inputs.tag }}}"
+          NAME="lex-${TAG}-${{ matrix.target }}"
+          mkdir -p "dist/${NAME}"
+          cp README.md LICENSE CHANGELOG.md "dist/${NAME}/" 2>/dev/null || true
+          if [ "${{ matrix.archive }}" = "zip" ]; then
+            cp "target/${{ matrix.target }}/release/lex.exe" "dist/${NAME}/"
+            (cd dist && 7z a "${NAME}.zip" "${NAME}")
+          else
+            cp "target/${{ matrix.target }}/release/lex" "dist/${NAME}/"
+            tar -C dist -czf "dist/${NAME}.tar.gz" "${NAME}"
+          fi
+          ls -la dist/
+
+      - name: Compute sha256
+        shell: bash
+        run: |
+          cd dist
+          for f in *.tar.gz *.zip; do
+            [ -f "$f" ] || continue
+            shasum -a 256 "$f" > "${f}.sha256" 2>/dev/null || sha256sum "$f" > "${f}.sha256"
+          done
+          ls -la
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: lex-${{ matrix.target }}
+          path: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/*.sha256
+          if-no-files-found: error
+
+  publish:
+    name: publish to GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: List downloaded
+        run: ls -la dist/
+
+      - name: Create / update Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name || github.event.inputs.tag }}
+          generate_release_notes: true
+          files: |
+            dist/*.tar.gz
+            dist/*.zip
+            dist/*.sha256

--- a/README.md
+++ b/README.md
@@ -327,6 +327,8 @@ them to GIFs for README / Twitter / LinkedIn.
 |---|---|
 | `lex parse <file>` | Print the canonical AST as JSON |
 | `lex check <file>` | Type-check; exit 0 or print structured errors |
+| `lex repl` | Interactive evaluator. `fn`/`type`/`import` extend the session; expressions are evaluated under a permissive policy. `.help`, `.list`, `.reset`, `.quit` |
+| `lex watch <file> [check\|run] [args...]` | Re-run on every save. Default action is `check`; `run` re-executes. Forwarded args (`--allow-effects ...`) pass through to the underlying subcommand |
 | `lex hash <file>` | Print SigId / StageId per stage |
 | `lex blame [--store DIR] <file>` | Per-fn stage history from the store: which StageId is currently in source, which is Active, predecessors with statuses + timestamps |
 | `lex run [policy] <file> <fn> [args]` | Execute a function (args are JSON) |
@@ -428,6 +430,23 @@ lex/
 | Hardening | [`SECURITY.md`](SECURITY.md) threat model ✅ ; parser-recursion DoS gate (`MAX_DEPTH=96`) ✅ ; **VM call-stack depth gate (`MAX_CALL_DEPTH=1024`) ✅** ; libFuzzer CI for parser + type checker ✅ ; VM-level memory bounds remain delegated to the host (container memory caps) |
 
 **Workspace test count:** 285 passing, 0 failing, 3 ignored (WS chat example, flaky on CI runners — pass locally with `--ignored`). `cargo clippy --workspace --all-targets -- -D warnings` clean. Fuzz CI: 60 s/PR, 5 min nightly across both targets.
+
+## Install
+
+**Pre-built binaries** (no Rust toolchain needed) are attached to
+[GitHub Releases](https://github.com/alpibrusl/lex-lang/releases)
+for Linux (x86_64 / aarch64), macOS (x86_64 / aarch64), and
+Windows (x86_64). Each archive contains the `lex` binary plus
+README / LICENSE / CHANGELOG. SHA-256 sums are uploaded alongside
+each tarball.
+
+```bash
+# Pick the right archive for your platform from the Releases page,
+# then:
+tar -xzf lex-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz
+mv lex-vX.Y.Z-x86_64-unknown-linux-gnu/lex /usr/local/bin/
+lex version
+```
 
 ## Building from source
 

--- a/crates/lex-cli/Cargo.toml
+++ b/crates/lex-cli/Cargo.toml
@@ -26,3 +26,4 @@ lex-api = { path = "../lex-api" }
 conformance = { path = "../conformance" }
 spec-checker = { path = "../spec-checker" }
 acli = "0.5"
+notify = { version = "6", default-features = false, features = ["macos_kqueue"] }

--- a/crates/lex-cli/src/acli.rs
+++ b/crates/lex-cli/src/acli.rs
@@ -129,7 +129,32 @@ fn commands() -> Vec<CommandInfo> {
         cmd_branch(),
         cmd_store_merge(),
         cmd_log(),
+        cmd_repl(),
+        cmd_watch(),
     ]
+}
+
+fn cmd_repl() -> CommandInfo {
+    CommandInfo::new("repl", "interactive evaluator (Lex source line-by-line)")
+        .idempotent(false)
+        .with_examples(vec![
+            ("Start a session", "lex repl"),
+            ("Evaluate at the prompt", "lex> 1 + 2 * 3"),
+        ])
+        .with_see_also(vec!["check", "run"])
+}
+
+fn cmd_watch() -> CommandInfo {
+    CommandInfo::new("watch", "re-run check or run on file save (agent inner loop)")
+        .idempotent(false)
+        .add_argument("file", "string", "file or directory to watch", true)
+        .add_argument("action", "enum[check|run]", "what to re-run on change (default: check)", false)
+        .add_argument("forwarded", "string[]", "forwarded to the underlying subcommand", false)
+        .with_examples(vec![
+            ("Watch + check", "lex watch app.lex"),
+            ("Watch + run", "lex watch app.lex run main"),
+        ])
+        .with_see_also(vec!["check", "run"])
 }
 
 // ---- per-command metadata -----------------------------------------

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -16,6 +16,8 @@ mod diff;
 mod ast_merge;
 mod branch;
 mod acli;
+mod repl;
+mod watch;
 
 use ::acli::OutputFormat;
 use anyhow::{anyhow, bail, Context, Result};
@@ -94,6 +96,8 @@ fn run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         "branch" => branch::cmd_branch(fmt, &args[1..]),
         "store-merge" => branch::cmd_store_merge(fmt, &args[1..]),
         "log" => branch::cmd_log(fmt, &args[1..]),
+        "repl" => repl::cmd_repl(&args[1..]),
+        "watch" => watch::cmd_watch(&args[1..]),
         "help" | "--help" | "-h" => { print_usage(); Ok(()) }
         other => bail!("unknown command `{other}`. try `lex help`"),
     }

--- a/crates/lex-cli/src/repl.rs
+++ b/crates/lex-cli/src/repl.rs
@@ -1,0 +1,207 @@
+//! `lex repl` — interactive evaluator.
+//!
+//! v1 design: REPL state is the *Lex source* of all stages defined
+//! since startup, kept in a `String`. On every input, we splice the
+//! input into the program (either as a new top-level stage or as an
+//! expression wrapped in `fn __repl_eval() -> _ { … }`) and re-parse
+//! / re-type-check / re-compile from scratch. The VM is recreated
+//! each turn.
+//!
+//! That's slow per character but correct under every Lex invariant —
+//! incremental compilation in the VM is its own project. For human
+//! REPL pace (1 input / second) it's invisible.
+//!
+//! Multi-line input: lines accumulate until brace-depth returns to
+//! 0 (and the line isn't blank). A blank line cancels the
+//! current input. `.help`, `.quit`, `.reset`, `.list` are meta
+//! commands.
+
+use anyhow::{anyhow, Result};
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm};
+use lex_runtime::{check_program as check_policy, DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::io::{BufRead, Write};
+
+const BANNER: &str = "lex repl — type .help for commands, .quit to exit";
+
+pub fn cmd_repl(_args: &[String]) -> Result<()> {
+    println!("{BANNER}");
+    let mut session = Session::new();
+    let stdin = std::io::stdin();
+    let mut stdin = stdin.lock();
+    let mut buf = String::new();
+
+    loop {
+        // Multi-line read: keep pulling lines until brace-balanced.
+        buf.clear();
+        let mut depth: i64 = 0;
+        let mut first = true;
+        loop {
+            print!("{}", if first { "lex> " } else { ".... " });
+            std::io::stdout().flush().ok();
+            let mut line = String::new();
+            let n = stdin.read_line(&mut line).map_err(|e| anyhow!("stdin: {e}"))?;
+            if n == 0 {
+                println!();
+                return Ok(());
+            }
+            // Blank line on the first prompt = noop; on continuation lines = abort.
+            if line.trim().is_empty() {
+                if first { continue; } else { buf.clear(); break; }
+            }
+            first = false;
+            depth += brace_balance(&line);
+            buf.push_str(&line);
+            if depth <= 0 { break; }
+        }
+        let input = buf.trim();
+        if input.is_empty() { continue; }
+
+        // Meta commands.
+        if let Some(rest) = input.strip_prefix('.') {
+            match rest.trim() {
+                "help" => print_help(),
+                "quit" | "exit" => return Ok(()),
+                "reset" => { session = Session::new(); println!("(session cleared)"); }
+                "list" => println!("{}", session.stages),
+                other => println!("unknown meta command `.{other}` (try .help)"),
+            }
+            continue;
+        }
+
+        // Try as a stage first (fn/type/import); fall back to expression.
+        if looks_like_stage(input) {
+            session.add_stage(input);
+            match session.check() {
+                Ok(_) => println!("(ok)"),
+                Err(e) => {
+                    println!("error: {e}");
+                    session.rollback();
+                }
+            }
+        } else {
+            match session.eval_expr(input) {
+                Ok(s) => println!("=> {s}"),
+                Err(e) => println!("error: {e}"),
+            }
+        }
+    }
+}
+
+fn print_help() {
+    println!("Commands:");
+    println!("  .help       this message");
+    println!("  .quit       exit the REPL");
+    println!("  .reset      drop all defined stages, start over");
+    println!("  .list       print the current accumulated source");
+    println!();
+    println!("Top-level inputs (`fn …`, `type …`, `import …`) are added");
+    println!("to the session. Anything else is evaluated as an expression");
+    println!("under a permissive policy (all effects allowed); use the");
+    println!("CLI's `lex run` for policy-gated execution.");
+}
+
+/// Heuristic: `fn`, `type`, `import` lead a stage. Everything else
+/// is an expression.
+fn looks_like_stage(s: &str) -> bool {
+    let head = s.split_whitespace().next().unwrap_or("");
+    matches!(head, "fn" | "type" | "import")
+}
+
+/// Net `{`s minus `}`s on a line. Lets the prompt continue into a
+/// multi-line definition.
+fn brace_balance(line: &str) -> i64 {
+    let mut d: i64 = 0;
+    for ch in line.chars() {
+        match ch {
+            '{' => d += 1,
+            '}' => d -= 1,
+            _ => {}
+        }
+    }
+    d
+}
+
+struct Session {
+    /// Accumulated Lex source. New stages append; rollback truncates.
+    stages: String,
+    /// Snapshots so we can roll back failed adds.
+    history: Vec<usize>,
+    /// Counter for unique `replEval<n>` names.
+    eval_count: u32,
+}
+
+impl Session {
+    fn new() -> Self { Self { stages: String::new(), history: Vec::new(), eval_count: 0 } }
+
+    fn add_stage(&mut self, src: &str) {
+        self.history.push(self.stages.len());
+        self.stages.push_str(src);
+        self.stages.push('\n');
+    }
+
+    fn rollback(&mut self) {
+        if let Some(len) = self.history.pop() {
+            self.stages.truncate(len);
+        }
+    }
+
+    fn check(&self) -> Result<()> {
+        let prog = parse_source(&self.stages).map_err(|e| anyhow!("parse: {e}"))?;
+        let stages = canonicalize_program(&prog);
+        if let Err(errs) = lex_types::check_program(&stages) {
+            let lines: Vec<String> = errs.iter()
+                .map(|e| serde_json::to_string(e).unwrap_or_else(|_| format!("{e:?}")))
+                .collect();
+            return Err(anyhow!(lines.join("\n")));
+        }
+        Ok(())
+    }
+
+    fn eval_expr(&mut self, expr: &str) -> Result<String> {
+        // Wrap the expression in a fresh fn that returns Str via
+        // `json.stringify(<expr>)`. `json.stringify` is polymorphic
+        // (`T -> Str`), so the wrapper accepts any expression type
+        // and we get a printable result back. The wrapper is
+        // ephemeral — each eval gets a fresh name, so `.list` shows
+        // only stages the user added explicitly.
+        //
+        // We auto-inject `import "std.json" as json` at the top of
+        // the program if the user hasn't already, so REPL eval works
+        // before any explicit imports.
+        self.eval_count += 1;
+        let name = format!("replEval{}", self.eval_count);
+        let needs_json_import = !self.stages.contains("std.json");
+        let preamble = if needs_json_import {
+            "import \"std.json\" as json\n".to_string()
+        } else {
+            String::new()
+        };
+        let wrapped = format!("\nfn {name}() -> Str {{ json.stringify({expr}) }}\n");
+        let combined = format!("{preamble}{}{wrapped}", self.stages);
+        let prog = parse_source(&combined).map_err(|e| anyhow!("parse: {e}"))?;
+        let stages = canonicalize_program(&prog);
+        if let Err(errs) = lex_types::check_program(&stages) {
+            let lines: Vec<String> = errs.iter()
+                .map(|e| serde_json::to_string(e).unwrap_or_else(|_| format!("{e:?}")))
+                .collect();
+            return Err(anyhow!(lines.join("\n")));
+        }
+        let bc = compile_program(&stages);
+        let policy = Policy::permissive();
+        check_policy(&bc, &policy).map_err(|v| anyhow!(format!("{v:?}")))?;
+        let bc = std::sync::Arc::new(bc);
+        let handler = DefaultHandler::new(policy).with_program(std::sync::Arc::clone(&bc));
+        let mut vm = Vm::with_handler(&bc, Box::new(handler));
+        let v = vm.call(&name, vec![]).map_err(|e| anyhow!("runtime: {e}"))?;
+        // The wrapper returns a Str (the JSON encoding of the
+        // original value). Unwrap one layer so the user sees the
+        // JSON directly, not a quoted string.
+        match v {
+            lex_bytecode::Value::Str(s) => Ok(s),
+            other => Ok(serde_json::to_string(&other.to_json())
+                .unwrap_or_else(|_| format!("{other:?}"))),
+        }
+    }
+}

--- a/crates/lex-cli/src/watch.rs
+++ b/crates/lex-cli/src/watch.rs
@@ -1,0 +1,95 @@
+//! `lex watch <file> [check|run] [args...]` — re-run a command on
+//! every save of `<file>`. The agent inner loop: edit → save →
+//! see results in <100ms, no terminal switching.
+//!
+//! Default action is `check`. `lex watch app.lex run main` re-runs
+//! the program on save. Forwarded args (`--allow-effects ...`)
+//! pass through to the underlying subcommand.
+//!
+//! v1 watches a single file; multi-file projects can pass the
+//! directory and we'll re-run on any `.lex` save under it.
+
+use anyhow::{anyhow, Context, Result};
+use notify::{event::EventKind, RecursiveMode, Watcher};
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::channel;
+use std::time::{Duration, Instant};
+
+pub fn cmd_watch(args: &[String]) -> Result<()> {
+    let path = args.first()
+        .ok_or_else(|| anyhow!("usage: lex watch <file> [check|run] [forwarded args...]"))?;
+    let action = args.get(1).cloned().unwrap_or_else(|| "check".into());
+    let forwarded: Vec<String> = if args.len() > 2 { args[2..].to_vec() } else { Vec::new() };
+
+    if !matches!(action.as_str(), "check" | "run") {
+        return Err(anyhow!(
+            "watch action must be `check` or `run`, got `{action}`. \
+             usage: lex watch <file> [check|run] [args...]"));
+    }
+
+    let watch_path = PathBuf::from(path);
+    if !watch_path.exists() {
+        return Err(anyhow!("watch target does not exist: {path}"));
+    }
+
+    eprintln!("→ watching {} (action: {action})", watch_path.display());
+
+    let (tx, rx) = channel();
+    let mut watcher = notify::recommended_watcher(move |res| {
+        let _ = tx.send(res);
+    }).context("create file watcher")?;
+    let mode = if watch_path.is_dir() { RecursiveMode::Recursive } else { RecursiveMode::NonRecursive };
+    watcher.watch(&watch_path, mode).context("start watching")?;
+
+    // Run once on startup so the user sees baseline output.
+    run_once(&action, path, &forwarded);
+
+    let mut last_run = Instant::now();
+    let debounce = Duration::from_millis(150);
+
+    for event in rx {
+        let event = match event {
+            Ok(e) => e, Err(e) => { eprintln!("watch: {e}"); continue; }
+        };
+        // Filter: only react to writes (saves), creates, renames.
+        // Many editors do atomic-rename-on-save, so all three matter.
+        let actionable = matches!(event.kind,
+            EventKind::Modify(_) | EventKind::Create(_) | EventKind::Remove(_));
+        if !actionable { continue; }
+        // Only react to .lex files when watching a directory.
+        if mode == RecursiveMode::Recursive
+            && !event.paths.iter().any(|p| is_lex_file(p))
+        { continue; }
+        // Debounce: editors often emit multiple events per save.
+        if last_run.elapsed() < debounce { continue; }
+        last_run = Instant::now();
+
+        run_once(&action, path, &forwarded);
+    }
+    Ok(())
+}
+
+fn run_once(action: &str, path: &str, forwarded: &[String]) {
+    println!("\n────────────────────────────────────────────────────────");
+    println!("⟲ {action} {path}{}",
+        if forwarded.is_empty() { String::new() } else { format!(" {}", forwarded.join(" ")) });
+    println!("────────────────────────────────────────────────────────");
+    let started = Instant::now();
+    let exe = std::env::current_exe()
+        .unwrap_or_else(|_| PathBuf::from("lex"));
+    let mut cmd = std::process::Command::new(&exe);
+    cmd.arg(action).arg(path);
+    for a in forwarded { cmd.arg(a); }
+    let status = match cmd.status() {
+        Ok(s) => s,
+        Err(e) => { eprintln!("watch: spawn `{}`: {e}", exe.display()); return; }
+    };
+    let elapsed = started.elapsed();
+    let code = status.code().unwrap_or(-1);
+    let icon = if status.success() { "✓" } else { "✗" };
+    println!("{icon} exit {code}  ({:.0}ms)", elapsed.as_secs_f64() * 1000.0);
+}
+
+fn is_lex_file(p: &Path) -> bool {
+    p.extension().and_then(|e| e.to_str()) == Some("lex")
+}

--- a/crates/lex-cli/tests/repl.rs
+++ b/crates/lex-cli/tests/repl.rs
@@ -1,0 +1,63 @@
+//! Black-box tests for `lex repl`. Drive the binary with stdin
+//! input, assert on stdout. Each block of input ends with `.quit`.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn lex_bin() -> &'static str { env!("CARGO_BIN_EXE_lex") }
+
+fn run_repl(input: &str) -> String {
+    let mut child = Command::new(lex_bin())
+        .arg("repl")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn lex repl");
+    child.stdin.as_mut().unwrap().write_all(input.as_bytes()).unwrap();
+    let out = child.wait_with_output().expect("wait");
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+#[test]
+fn repl_evaluates_arithmetic() {
+    let out = run_repl("1 + 2 * 3\n.quit\n");
+    assert!(out.contains("=> 7"), "stdout: {out}");
+}
+
+#[test]
+fn repl_returns_string_literal_unquoted_via_json_wrapper() {
+    let out = run_repl("\"hello, world\"\n.quit\n");
+    // json.stringify wraps Str in quotes; the REPL strips the outer
+    // Str layer and prints the JSON, so the user sees the quotes.
+    assert!(out.contains("\"hello, world\""), "stdout: {out}");
+}
+
+#[test]
+fn repl_evaluates_list_expression() {
+    let out = run_repl("[1, 2, 3]\n.quit\n");
+    assert!(out.contains("[1,2,3]"), "stdout: {out}");
+}
+
+#[test]
+fn repl_keeps_definitions_across_inputs() {
+    let out = run_repl("fn double(x :: Int) -> Int { x * 2 }\ndouble(21)\n.quit\n");
+    assert!(out.contains("=> 42"), "stdout: {out}");
+}
+
+#[test]
+fn repl_reports_type_errors_inline() {
+    let out = run_repl("\"a\" + 1\n.quit\n");
+    assert!(out.contains("error:"), "stdout: {out}");
+}
+
+#[test]
+fn repl_reset_clears_session() {
+    let out = run_repl(
+        "fn keep(n :: Int) -> Int { n + 1 }\n\
+         .reset\n\
+         keep(0)\n\
+         .quit\n");
+    assert!(out.contains("(session cleared)"), "stdout: {out}");
+    assert!(out.contains("error:"), "stdout: {out}");
+}


### PR DESCRIPTION
## Summary

Three onramp features that close the "feels unfinished" / "30-min
install" friction every new language hits on launch day. After
this PR, an HN visitor can:

1. Download a binary in 30 seconds (no Rust toolchain).
2. Try `1 + 2` interactively without writing a file (`lex repl`).
3. Edit a `.lex` file and see results inline as they save (`lex watch`).

### `lex repl`

```
$ lex repl
lex repl — type .help for commands, .quit to exit
lex> 1 + 2 * 3
=> 7
lex> "hello, world"
=> "hello, world"
lex> fn double(x :: Int) -> Int { x * 2 }
(ok)
lex> double(21)
=> 42
lex> .quit
```

`fn` / `type` / `import` extend the session source; expressions
get wrapped in `fn replEvalN() -> Str { json.stringify(<expr>) }`
so any value type prints. Meta commands: `.help`, `.list`,
`.reset`, `.quit`. Multi-line input continues until brace-balanced.

### `lex watch <file> [check|run] [args...]`

```
$ lex watch app.lex run main --allow-effects io
→ watching app.lex (action: run)
────────────────────────────────────────────────────────
⟲ run app.lex --allow-effects io
────────────────────────────────────────────────────────
hello, lex
✓ exit 0  (12ms)

# … you save the file …
────────────────────────────────────────────────────────
⟲ run app.lex --allow-effects io
────────────────────────────────────────────────────────
hello, lex (now louder)
✓ exit 0  (10ms)
```

Default action is `check`; `run` re-executes. 150ms debounce
(editors emit multiple events per save), prints elapsed time per
run, forwards trailing args. Watching a directory only reacts to
`.lex` files.

### Pre-built binaries

`.github/workflows/release.yml` runs on `v*` tag push:

- **linux x86_64 / aarch64** (aarch64 via `cross`)
- **macOS x86_64 / aarch64**
- **windows x86_64**

Each archive bundles the binary + README + LICENSE + CHANGELOG;
sha256 sums uploaded alongside. README gains an "Install" section
above "Building from source" pointing at the Releases page.

## Test plan

- [x] 6 new black-box REPL tests (arithmetic, strings, lists,
      cross-input definitions, type errors surface inline, `.reset`
      clears state)
- [x] End-to-end smoke for `lex watch`: ok-on-save then break-on-save,
      both surface with the right exit code
- [x] Workspace clippy clean
- [x] Workspace tests: **285 → 291** passing
- [x] Release workflow lints (it can be exercised manually via
      `workflow_dispatch` before any real tag, then via tag push)

## Notes

- `lex repl` deliberately runs under a permissive policy. For
  gated execution use `lex run`.
- New crate dep: `notify = "6"` (default-features off) for the
  watcher.

---
_Generated by [Claude Code](https://claude.ai/code/session_012wioWFtKD7oS3HtAFbVJZh)_