### PR TITLE
deps: update sha2 requirement from 0.10 to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ license = "EUPL-1.2"
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sha2 = "0.10"
+sha2 = "0.11"
 thiserror = "2"
 anyhow = "1"
 logos = "0.16"


### PR DESCRIPTION
Direct port of #68 (which conflicted after the thiserror/logos bumps landed). No source changes — `Sha256::new()` + `Digest` trait usage compiles and tests pass on 0.11.

## Test plan
- [x] `cargo check --workspace --all-targets`
- [x] `cargo test --workspace`

Closes #68.

https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s)_