### PR TITLE
comms: add platform-specific launch drafts

### DIFF
--- a/comms/hackernews.md
+++ b/comms/hackernews.md
@@ -6,52 +6,70 @@
 Show HN: Lex – effect types for sandboxing code that LLMs write
 ```
 
-### Alternates, same length budget
+### Alternate
 
-- `Show HN: Lex – a programming language for code no one will read`
 - `Show HN: Lex – type-check rejection of LLM-emitted effects, before any code runs`
 
 ## Body
 
 ```text
-Lex is a small functional language whose bet is that when AI agents
-write more code than humans review, the function signature has to
-become the contract.
+I've been working on Lex, a small functional language. The
+thing I kept wanting when running agent-generated code locally
+was a way to say "this body can touch the network and nothing
+else" and have the type checker actually enforce it, not catch
+it as a runtime exception after something already escaped.
 
-Effects are part of the type. A function annotated
+In Lex, effects are part of the type. A function annotated
 
   fn fetch(url :: Str) -> [net] Result[Str, Str]
 
-cannot reach the filesystem; if the body tries `io.read("/etc/passwd")`,
-the type checker rejects the program before any byte runs. The
-runtime then re-checks the policy at the dispatch site, so a function
-declared `[fs_read("/data")]` granted at startup still has to pass
-the path check at the actual read.
+cannot reach the filesystem; if the body tries
+`io.read("/etc/passwd")`, the program is rejected at type-check
+before it runs. The runtime then re-checks the policy at the
+dispatch site, so a function declared `[fs_read("/data")]` and
+granted at startup still has to pass the path check at the
+actual read.
 
-The motivating workflow is `lex agent-tool`: ask Claude/Codex/etc.
-for a tool body, splice it into a fixed signature, run it under
---allow-effects. Anything outside the declared set is rejected at
-type-check, not caught by a runtime exception. The adversarial bench
-in the repo runs 7 attacks + 2 benign cases through three sandboxes:
-Lex blocks 7/7 and runs 2/2; RestrictedPython blocks 3/7 and runs 2/2;
-naive `exec` blocks 0/7. Reproduce with `cargo test -p lex-cli --test
-agent_sandbox_bench`.
+To check whether the idea held, I wrote `lex agent-tool`: ask
+Claude/Codex/etc. for a tool body, splice it into a fixed
+signature, run it under --allow-effects. Anything outside the
+declared set is rejected at type-check.
+
+The adversarial bench in the repo runs 7 attacks + 2 benign
+cases through three sandboxes — Lex blocks 7/7 and runs 2/2;
+RestrictedPython blocks 3/7 and runs 2/2; naive `exec` blocks
+0/7. The honest read is that the difference isn't cleverer
+rules — it's where the rejection happens. RestrictedPython
+rejects at runtime after starting; Lex rejects at type-check
+before running. I picked the attacks myself, so take the
+numbers with that grain of salt; reproduce with
+`cargo test -p lex-cli --test agent_sandbox_bench`.
 
 Other pieces that fell out of the same design: AST-native diff
-(renames register as renamed, not delete+add), three-way structural
-merge with JSON conflicts instead of <<<<<< markers, a content-
-addressed stage store with `lex blame` for per-function history,
-ACLI-compliant discovery so any LLM agent can drive the CLI without
-a bespoke skill file, and a Spec sibling that emits SMT-LIB 2 for Z3.
+(renames register as renamed, not delete+add), three-way
+structural merge with JSON conflicts instead of <<<<<< markers,
+a content-addressed stage store with `lex blame` for per-
+function history, ACLI-compliant CLI discovery so any LLM
+agent can drive it without a bespoke skill file, and a Spec
+sibling that emits SMT-LIB 2 for Z3.
 
-Implementation: ~14 Rust crates, 285 tests passing, EUPL-1.2.
+Implementation: ~14 Rust crates, 285 tests, EUPL-1.2.
 
-Limitations I'd want feedback on: the effect grammar is intentionally
-small (io, net, fs_read, fs_write, time, rand, proc, budget, chat) and
-adding new ones is a language change, not a library change — is that
-the right call? And the static check can't catch "correct effect,
-wrong intent" (e.g. `[net]` is granted but the body exfiltrates data) —
-Spec proofs cover some of that, but the gap is real.
+Two things I'd genuinely like feedback on:
+
+1. The effect grammar is closed (io, net, fs_read, fs_write,
+   time, rand, proc, budget, chat). Adding one is a language
+   change. I went with closed because the runtime has to know
+   what to enforce — a user-defined effect that the runtime
+   treats as opaque is a silent capability leak. But it pushes
+   "domain effects" (db, email, …) onto host-level policy
+   rather than the type system, which feels like a real cost.
+   Is closed the right call?
+
+2. The static check can't catch "correct effect, wrong intent"
+   — a `[net]`-granted body can still exfiltrate. Spec proofs
+   cover part of that gap. The rest is unclaimed and I don't
+   have a great answer for it yet.
 
 Repo: https://github.com/alpibrusl/lex-lang
 Landing page: https://alpibrusl.github.io/lex-lang/
@@ -77,11 +95,11 @@ Landing page: https://alpibrusl.github.io/lex-lang/
     a clean clone.
   - Test count badge in `README.md` matches reality.
 
-## Likely objections + prepared answers
+## Likely objections + honest answers
 
-| Objection | Short reply |
+| Objection | Reply |
 |---|---|
-| "Just use Docker / V8 isolates / WASM" | Different layer. Containers gate at the syscall, Lex gates at the signature — the agent has to *declare* what it touches before code runs. Both can stack. (Linked section in `docs/index.html`.) |
-| "Effect typing is just capabilities with extra steps" | Yes — Lex's contribution is that the capability is in the function signature, machine-checked, and surfaced in `lex audit --effect net` for review. |
-| "A new language is a huge ask vs. a Rust crate" | Fair. The pitch isn't "rewrite your stack" — it's "the AI-emitted tool body lives in a 30-line Lex fragment under a known effect set." Rust calls into it via the HTTP API. |
-| "Capability ≠ correctness" | Acknowledged in the post and on the landing page. Spec proofs (`lex spec check`) cover behavioral contracts; the gap between effect-correct and intent-correct is real. |
+| "Just use Docker / V8 isolates / WASM" | Different layer. Containers gate at the syscall, Lex gates at the signature — the agent has to *declare* what it touches before code runs. Both can stack; Lex is meant to ride on top of, not replace, OS-level sandboxing. |
+| "Effect typing is just capabilities with extra steps" | Fair. The contribution Lex is trying to make is keeping the capability in the function signature, machine-checked, and surfaced for review (`lex audit --effect net`). Whether that's worth a new language is a fair question. |
+| "A new language is a huge ask vs. a Rust crate" | Yes. The pitch isn't "rewrite your stack" — it's "the AI-emitted tool body lives in a 30-line Lex fragment under a known effect set." Rust calls into it via the HTTP API. If that framing doesn't help, this probably isn't for you. |
+| "Capability ≠ correctness" | True, and I should say it before someone else does. Spec proofs cover behavioral contracts; the gap between effect-correct and intent-correct is real and unsolved. |

--- a/comms/hackernews.md
+++ b/comms/hackernews.md
@@ -1,0 +1,87 @@
+# Hacker News — Show HN
+
+## Title (≤ 80 chars)
+
+```
+Show HN: Lex – effect types for sandboxing code that LLMs write
+```
+
+### Alternates, same length budget
+
+- `Show HN: Lex – a programming language for code no one will read`
+- `Show HN: Lex – type-check rejection of LLM-emitted effects, before any code runs`
+
+## Body
+
+```text
+Lex is a small functional language whose bet is that when AI agents
+write more code than humans review, the function signature has to
+become the contract.
+
+Effects are part of the type. A function annotated
+
+  fn fetch(url :: Str) -> [net] Result[Str, Str]
+
+cannot reach the filesystem; if the body tries `io.read("/etc/passwd")`,
+the type checker rejects the program before any byte runs. The
+runtime then re-checks the policy at the dispatch site, so a function
+declared `[fs_read("/data")]` granted at startup still has to pass
+the path check at the actual read.
+
+The motivating workflow is `lex agent-tool`: ask Claude/Codex/etc.
+for a tool body, splice it into a fixed signature, run it under
+--allow-effects. Anything outside the declared set is rejected at
+type-check, not caught by a runtime exception. The adversarial bench
+in the repo runs 7 attacks + 2 benign cases through three sandboxes:
+Lex blocks 7/7 and runs 2/2; RestrictedPython blocks 3/7 and runs 2/2;
+naive `exec` blocks 0/7. Reproduce with `cargo test -p lex-cli --test
+agent_sandbox_bench`.
+
+Other pieces that fell out of the same design: AST-native diff
+(renames register as renamed, not delete+add), three-way structural
+merge with JSON conflicts instead of <<<<<< markers, a content-
+addressed stage store with `lex blame` for per-function history,
+ACLI-compliant discovery so any LLM agent can drive the CLI without
+a bespoke skill file, and a Spec sibling that emits SMT-LIB 2 for Z3.
+
+Implementation: ~14 Rust crates, 285 tests passing, EUPL-1.2.
+
+Limitations I'd want feedback on: the effect grammar is intentionally
+small (io, net, fs_read, fs_write, time, rand, proc, budget, chat) and
+adding new ones is a language change, not a library change — is that
+the right call? And the static check can't catch "correct effect,
+wrong intent" (e.g. `[net]` is granted but the body exfiltrates data) —
+Spec proofs cover some of that, but the gap is real.
+
+Repo: https://github.com/alpibrusl/lex-lang
+Landing page: https://alpibrusl.github.io/lex-lang/
+```
+
+## Posting notes
+
+- **Window:** Tue–Thu, 8–10am Pacific is the strongest slot for
+  technical Show HNs. Avoid Fridays and holidays.
+- **First comment from you (the author):** post one immediately
+  with the asciinema cast (or GIF) from `bench/RECORDING.md`. HN
+  rewards a 60-second demo.
+- **Engage replies fast.** First-hour engagement drives ranking.
+  Have the repo + landing page open and reply to objections with
+  links to specific files / tests, not marketing copy.
+- **Don't edit the title after posting.** HN resets the rank when
+  you do.
+- **Don't link to Twitter / paywalled press.** Direct repo +
+  landing page only.
+- **Verify before posting:**
+  - GitHub Pages URL resolves (`alpibrusl.github.io/lex-lang/`).
+  - `cargo test -p lex-cli --test agent_sandbox_bench` passes on
+    a clean clone.
+  - Test count badge in `README.md` matches reality.
+
+## Likely objections + prepared answers
+
+| Objection | Short reply |
+|---|---|
+| "Just use Docker / V8 isolates / WASM" | Different layer. Containers gate at the syscall, Lex gates at the signature — the agent has to *declare* what it touches before code runs. Both can stack. (Linked section in `docs/index.html`.) |
+| "Effect typing is just capabilities with extra steps" | Yes — Lex's contribution is that the capability is in the function signature, machine-checked, and surfaced in `lex audit --effect net` for review. |
+| "A new language is a huge ask vs. a Rust crate" | Fair. The pitch isn't "rewrite your stack" — it's "the AI-emitted tool body lives in a 30-line Lex fragment under a known effect set." Rust calls into it via the HTTP API. |
+| "Capability ≠ correctness" | Acknowledged in the post and on the landing page. Spec proofs (`lex spec check`) cover behavioral contracts; the gap between effect-correct and intent-correct is real. |

--- a/comms/linkedin.md
+++ b/comms/linkedin.md
@@ -1,0 +1,84 @@
+# LinkedIn
+
+LinkedIn rewards story + numbers, punishes hacker-skepticism.
+Different audience: founders, engineering managers, security
+leadership, and the long tail of dev-tool buyers. Use it when
+you want reach beyond the HN/Lobsters circle, not when you
+want a technical critique.
+
+## Length guidance
+
+- 1300-char limit on the "see more" fold; everything past is hidden
+  by default. Put the hook + headline number above the fold.
+- Around 1500–2500 chars total for the post body works well.
+- Native carousels and embedded video out-perform external links;
+  consider uploading the asciinema GIF directly rather than just
+  linking.
+
+## Post
+
+```text
+Most security tooling assumes humans review the code that runs.
+
+Agents are about to break that assumption — and once they do,
+the function signature has to become the contract.
+
+I've been building Lex, a small functional language whose type
+system encodes effects in the signature itself:
+
+   fn fetch(url) -> [net] Result[Str, Str]
+
+If the body tries to touch the filesystem, the program is
+rejected at type-check, before any byte runs.
+
+To test the idea, I ran 7 adversarial attacks + 2 benign cases
+through three sandboxes:
+
+  • Naive Python exec:        0 / 7 attacks blocked
+  • RestrictedPython:         3 / 7 attacks blocked
+  • Lex:                      7 / 7 attacks blocked
+
+The difference isn't cleverer rules. It's where the rejection
+happens:
+
+  • RestrictedPython rejects at runtime — a NameError after the
+    AST has been rewritten and execution has started.
+  • Lex rejects at type-check — pre-execution. The body never
+    runs.
+
+The motivating workflow is `lex agent-tool`: ask Claude or
+Codex for a tool body, splice it into a fixed signature, and
+run it under a declared effect set. Anything outside the set
+fails to compile.
+
+I'd love feedback from anyone running LLM-generated code in
+production — what's your current sandboxing layer, and where
+does it leak?
+
+Repo (open source, EUPL-1.2):
+https://github.com/alpibrusl/lex-lang
+
+Bench methodology + per-case breakdown:
+https://github.com/alpibrusl/lex-lang/blob/main/bench/REPORT.md
+```
+
+## Posting notes
+
+- **Time:** Tuesday or Wednesday, 8–10am in your audience's
+  timezone. LinkedIn engagement decays fast outside business
+  hours.
+- **No hashtags in the body.** Add 3–5 at the bottom if you
+  want discovery: #softwareengineering #typesafety
+  #aisecurity #programminglanguages #rust
+- **Drop the GIF inline.** Either the asciinema cast (LinkedIn
+  supports MP4 upload) or a static screenshot of the type-
+  check rejection. Inline media beats external links.
+- **Reply to every comment** in the first 4 hours. LinkedIn's
+  feed algorithm rewards thread depth.
+- **Tag people sparingly.** One or two collaborators or
+  reviewers who'd genuinely want to see this. Mass-tagging
+  gets the post throttled.
+- **Don't repost the HN copy verbatim.** Different audience,
+  different register. The HN draft asks "is the closed effect
+  grammar the right call" — that question won't resonate
+  here. Save it for HN.

--- a/comms/linkedin.md
+++ b/comms/linkedin.md
@@ -18,42 +18,55 @@ want a technical critique.
 ## Post
 
 ```text
-Most security tooling assumes humans review the code that runs.
+Sharing something I've been working on for a while.
 
-Agents are about to break that assumption — and once they do,
-the function signature has to become the contract.
+I run agent-generated code locally as part of my workflow,
+and I kept wanting a sandbox where the host could say "this
+body can touch the network and nothing else" and have a type
+checker enforce it — not catch it as a runtime exception
+after something already escaped.
 
-I've been building Lex, a small functional language whose type
-system encodes effects in the signature itself:
+Lex is the small language that fell out of that. A function
+annotated
 
    fn fetch(url) -> [net] Result[Str, Str]
 
-If the body tries to touch the filesystem, the program is
-rejected at type-check, before any byte runs.
+cannot reach the filesystem. If the body tries to read a
+file, the program is rejected at type-check, before it runs.
 
-To test the idea, I ran 7 adversarial attacks + 2 benign cases
-through three sandboxes:
+To check whether the idea actually held, I ran a small
+adversarial bench: 7 attacks + 2 benign cases through three
+sandboxes. Numbers below — methodology and per-case detail
+in the repo's bench/REPORT.md:
 
-  • Naive Python exec:        0 / 7 attacks blocked
-  • RestrictedPython:         3 / 7 attacks blocked
-  • Lex:                      7 / 7 attacks blocked
+  • Naive Python exec:    0 / 7 attacks blocked
+  • RestrictedPython:     3 / 7 attacks blocked
+  • Lex:                  7 / 7 attacks blocked
 
-The difference isn't cleverer rules. It's where the rejection
-happens:
+The honest read is that most of the gap isn't cleverer rules.
+It's where the rejection happens: RestrictedPython rejects at
+runtime after the body has started; Lex rejects at type-check
+before it runs. Different layer, not necessarily a better
+idea — and I picked the attacks myself, so the numbers come
+with that grain of salt.
 
-  • RestrictedPython rejects at runtime — a NameError after the
-    AST has been rewritten and execution has started.
-  • Lex rejects at type-check — pre-execution. The body never
-    runs.
+Two things I want to be upfront about:
 
-The motivating workflow is `lex agent-tool`: ask Claude or
-Codex for a tool body, splice it into a fixed signature, and
-run it under a declared effect set. Anything outside the set
-fails to compile.
+Capability ≠ correctness. A function granted [net] can still
+exfiltrate data; the type system answers what your code
+touches, not whether the touch is wise. Spec proofs cover
+some of that gap. The rest is unclaimed.
 
-I'd love feedback from anyone running LLM-generated code in
-production — what's your current sandboxing layer, and where
-does it leak?
+A new language is a real ask. The pitch isn't "rewrite your
+stack" — it's "the AI-emitted tool body lives in a 30-line
+Lex fragment under a known effect set, and the rest of your
+code keeps doing what it's doing." If that framing doesn't
+help, this probably isn't for you.
+
+If you run LLM-generated code in production, I'd genuinely
+like to hear what your current sandboxing layer is and
+where it leaks. Trying to learn what the gap actually looks
+like in practice, not just in benchmarks.
 
 Repo (open source, EUPL-1.2):
 https://github.com/alpibrusl/lex-lang

--- a/comms/lobsters.md
+++ b/comms/lobsters.md
@@ -1,0 +1,84 @@
+# Lobsters
+
+Lobsters is technical, skeptical, and dislikes anything that smells
+like a press release. Lead with code, not motivation. Tags help —
+pick narrowly.
+
+## Tags
+
+`programming`, `rust`, `plt`, `ai`
+
+(Drop `ai` if Lobsters' anti-AI mood is hot that week; the language
+stands on PLT + sandboxing without it.)
+
+## Title
+
+```
+Lex: effect types in the function signature, checked before the body runs
+```
+
+## URL
+
+Submit the repo, not the landing page:
+`https://github.com/alpibrusl/lex-lang`
+
+## Author comment (post immediately)
+
+```text
+I built Lex because I kept watching agents emit tool bodies and
+wanted the host to be able to say "this can touch the network and
+nothing else" in a way the type checker enforced. Effects are part
+of the type:
+
+    fn fetch(url :: Str) -> [net] Result[Str, Str]
+
+A body that calls io.read in there is rejected at type-check —
+no runtime NameError, no exec-time exception. The runtime then
+re-checks the policy at the dispatch site (per-path / per-host),
+so static + dynamic both fire.
+
+The hairier design questions, since this is Lobsters:
+
+1. Effects are a closed grammar (io, net, fs_read, fs_write, time,
+   rand, proc, budget, chat). Adding one is a language change. I
+   went with closed because every host has to learn what to enforce;
+   a user-defined effect that the runtime doesn't know about is a
+   silent capability leak. Open to being wrong about this.
+
+2. Effect typing is row-based with subtyping; if `f` declares
+   `[net]` and `g` declares `[net, io]`, you can pass `f` where
+   `g` is expected but not vice-versa. There's no effect
+   polymorphism (no row variables in user code). That keeps the
+   error messages legible at the cost of some `flow.sequential`
+   verbosity.
+
+3. The bench at `bench/REPORT.md` compares Lex against naive
+   exec and RestrictedPython on 7 attacks + 2 benign cases. Lex
+   is 7/7 + 2/2 because the rejection happens at type-check;
+   RestrictedPython is 3/7 + 2/2 because its blocks are runtime
+   NameErrors after AST rewrite. The methodological caveat is
+   that I picked the attacks — happy to take suggestions for
+   ones that should embarrass Lex.
+
+Capability ≠ correctness. A `[net]`-granted body can still
+exfiltrate. Spec proofs (`lex spec check`, SMT-LIB 2 export to
+Z3) cover the gap partially.
+
+Repo includes a sandboxed `lex agent-tool` binary that wires
+this to Anthropic's API, a content-addressed stage store with
+`lex blame` for per-function history, and AST-native diff/
+three-way merge as fallout from "the AST is the interface."
+
+285 tests, EUPL-1.2, ~14 Rust crates.
+```
+
+## Posting notes
+
+- Lobsters is invite-only — use the account that's actually
+  active. Don't burn an invite to seed-post.
+- Don't cross-post to HN within 48h. Lobsters notices.
+- If the post lands flat, **don't bump it**. Move on.
+- Expect at least one comment about "why not Koka / Eff /
+  algebraic effects" — link to `docs/index.html`'s "Why this
+  differs" section if it covers the angle, otherwise reply
+  honestly that Lex is a deliberately small subset.

--- a/comms/lobsters.md
+++ b/comms/lobsters.md
@@ -14,7 +14,7 @@ stands on PLT + sandboxing without it.)
 ## Title
 
 ```
-Lex: effect types in the function signature, checked before the body runs
+Lex: a small functional language with effects in the function signature
 ```
 
 ## URL
@@ -25,49 +25,55 @@ Submit the repo, not the landing page:
 ## Author comment (post immediately)
 
 ```text
-I built Lex because I kept watching agents emit tool bodies and
-wanted the host to be able to say "this can touch the network and
-nothing else" in a way the type checker enforced. Effects are part
-of the type:
+I built Lex because I kept running agent-emitted tool bodies
+locally and wanted the host to be able to say "this can touch
+the network and nothing else" in a way the type checker
+enforced. Effects are part of the type:
 
     fn fetch(url :: Str) -> [net] Result[Str, Str]
 
 A body that calls io.read in there is rejected at type-check —
-no runtime NameError, no exec-time exception. The runtime then
+no runtime NameError, no exec-time exception. The runtime
 re-checks the policy at the dispatch site (per-path / per-host),
 so static + dynamic both fire.
 
-The hairier design questions, since this is Lobsters:
+Three design choices I'd actually like to argue about, since
+this is Lobsters:
 
-1. Effects are a closed grammar (io, net, fs_read, fs_write, time,
-   rand, proc, budget, chat). Adding one is a language change. I
-   went with closed because every host has to learn what to enforce;
-   a user-defined effect that the runtime doesn't know about is a
-   silent capability leak. Open to being wrong about this.
+1. Effects are a closed grammar (io, net, fs_read, fs_write,
+   time, rand, proc, budget, chat). Adding one is a language
+   change. I went with closed because the runtime has to know
+   what to enforce — a user-defined effect the runtime treats
+   as opaque is a silent capability leak. The cost is real
+   though: domain effects (db, email, …) ride on top of these
+   plus host-level policy rather than living in the type
+   system. Genuinely open to being wrong about this.
 
-2. Effect typing is row-based with subtyping; if `f` declares
-   `[net]` and `g` declares `[net, io]`, you can pass `f` where
-   `g` is expected but not vice-versa. There's no effect
-   polymorphism (no row variables in user code). That keeps the
-   error messages legible at the cost of some `flow.sequential`
-   verbosity.
+2. Effect typing is row-based with subtyping. `f : [net]` is
+   passable where `g : [net, io]` is expected, not vice-versa.
+   No effect polymorphism in user syntax (the internal
+   representation has row variables; the surface doesn't).
+   That keeps the error messages legible at the cost of some
+   `flow.sequential` verbosity. Right tradeoff?
 
 3. The bench at `bench/REPORT.md` compares Lex against naive
-   exec and RestrictedPython on 7 attacks + 2 benign cases. Lex
-   is 7/7 + 2/2 because the rejection happens at type-check;
-   RestrictedPython is 3/7 + 2/2 because its blocks are runtime
-   NameErrors after AST rewrite. The methodological caveat is
-   that I picked the attacks — happy to take suggestions for
-   ones that should embarrass Lex.
+   exec and RestrictedPython on 7 attacks + 2 benign cases:
+   7/7 vs 3/7 vs 0/7 blocked. Most of that gap is *where*
+   the rejection happens, not how clever the rules are. I
+   picked the attacks myself, so the numbers come with that
+   grain of salt — happy to take suggestions for cases that
+   should embarrass Lex.
 
-Capability ≠ correctness. A `[net]`-granted body can still
-exfiltrate. Spec proofs (`lex spec check`, SMT-LIB 2 export to
-Z3) cover the gap partially.
+Capability ≠ correctness, and I want to be upfront. A
+`[net]`-granted body can still exfiltrate. Spec proofs
+(`lex spec check`, SMT-LIB 2 export to Z3) cover that gap
+partially; the rest I don't have a great answer for.
 
-Repo includes a sandboxed `lex agent-tool` binary that wires
-this to Anthropic's API, a content-addressed stage store with
-`lex blame` for per-function history, and AST-native diff/
-three-way merge as fallout from "the AST is the interface."
+Repo includes a sandboxed `lex agent-tool` binary wiring
+this to Anthropic's API, a content-addressed stage store
+with `lex blame` for per-function history, and AST-native
+diff / three-way merge as fallout from "the AST is the
+interface."
 
 285 tests, EUPL-1.2, ~14 Rust crates.
 ```

--- a/comms/reddit.md
+++ b/comms/reddit.md
@@ -1,0 +1,218 @@
+# Reddit
+
+Reddit fragments by sub. Pick one or two — don't blast all four
+the same day, the mod queues notice cross-posts and people downvote
+them.
+
+## /r/rust
+
+Audience: Rust developers. Lead with the implementation, not the
+language pitch.
+
+### Title
+
+```
+Lex: a small functional language in ~14 Rust crates with effect-typed sandboxing for LLM-emitted tool bodies
+```
+
+### Body
+
+```text
+Hi r/rust — sharing a project I've been building.
+
+Lex is a functional language whose type system encodes effects in
+function signatures (`fn f(...) -> [net] Result[Str, Str]`). The
+implementation is a Rust workspace: lex-syntax (logos lexer + a
+hand-written parser), lex-ast (canonical AST + structural diff/
+merge), lex-types (the effect-aware type checker), lex-bytecode
+(stack-based VM), lex-runtime (effect handlers — gated tiny_http
+server, ureq client, tungstenite WS), lex-store (content-
+addressed sig/stage store), lex-cli (the `lex` binary), plus a
+Core sibling for sized numerics + tensor shape arithmetic.
+
+A few Rust-flavored things that turned out useful:
+
+- **logos for the lexer.** ~70 tokens, derives the DFA. The
+  performance is good enough that the parser is the bottleneck,
+  not the lexer.
+- **rustls + platform-verifier via ureq 3.x** for the HTTP
+  client. Native cert store, no native-tls dependency.
+- **tungstenite 0.29 for the WS chat builtin.** Per-connection
+  worker thread + mpsc::channel for outbound; the room registry
+  is `Arc<Mutex<IndexMap<...>>>`. Lex code stays pure; the
+  shared state lives in the host runtime.
+- **The whole CLI is ACLI-spec compliant** (`lex --output json
+  introspect`), so any LLM agent can drive it without a bespoke
+  skill file. The `.cli/commands.json` is generated and committed
+  for agents browsing the repo.
+
+The bit I'm proudest of and would love feedback on: the
+effect-checker's error messages thread the path of effect
+inheritance through `flow.sequential` / `flow.branch` so that
+when a higher-order combinator's body has an unexpected effect,
+the error points to the inner lambda, not the combinator call
+site. It's not novel research — just a lot of careful spans —
+but the output is legible.
+
+285 tests, EUPL-1.2, MSRV 1.80.
+
+Repo: https://github.com/alpibrusl/lex-lang
+```
+
+### Notes
+
+- Don't crosspost to /r/programming the same day.
+- /r/rust mods sometimes redirect language-pitch posts to a
+  weekly thread. If that happens, repost in the thread and
+  link there from your other launches.
+
+---
+
+## /r/ProgrammingLanguages
+
+Audience: PL nerds. Lead with design choices and tradeoffs.
+
+### Title
+
+```
+Lex: row-based effects in a small functional language designed for LLM-emitted code
+```
+
+### Body
+
+```text
+I've been building a small functional language with effects in
+the function signature — not algebraic effects (no handlers in
+user code), just a closed row of capability tags that propagate
+through application and pattern-match.
+
+    fn fetch(url :: Str) -> [net] Result[Str, Str]
+    fn echo(line :: Str) -> [io] Nil
+
+Type rule: a function declared `[E]` can only call functions
+whose effect set is a subset of `E ∪ {pure}`. Subtyping is
+row-based with subset; no row variables in user syntax (the
+internal representation has them, the surface doesn't).
+
+Three design choices I'd genuinely like to argue about:
+
+1. **Closed effect grammar.** io, net, fs_read, fs_write, time,
+   rand, proc, budget, chat. Adding one is a language change.
+   I picked closed because the runtime has to know what to
+   enforce; user-defined effects that the runtime treats as
+   opaque are silent capability leaks. The cost is that
+   "domain effect" use cases (e.g. `[db]`, `[email]`) have to
+   ride on top of one of the existing tags + a host-level
+   policy.
+
+2. **No effect polymorphism in user syntax.** Functions can be
+   parameterized over types but not effect rows. This makes the
+   error messages much better but means combinators like
+   `flow.sequential` are monomorphized per effect set in the
+   stdlib. Fair tradeoff?
+
+3. **Effects as part of the canonical AST hash.** Two functions
+   with the same body but different effect annotations get
+   different StageIds in the content-addressed store. This is
+   the basis for `lex blame` — per-fn lifecycle history that
+   tracks effect changes as separate stages.
+
+The motivating workflow is sandboxing LLM-emitted tool bodies:
+the host declares `--allow-effects net` and any body that
+reaches outside is rejected at type-check, before execution.
+Adversarial bench (7 attacks + 2 benign) at bench/REPORT.md
+compares against RestrictedPython.
+
+Spec sibling adds randomized property checking + SMT-LIB 2
+export to Z3 for behavioral contracts (capability ≠ correctness).
+
+Repo: https://github.com/alpibrusl/lex-lang
+```
+
+### Notes
+
+- /r/ProgrammingLanguages reads carefully and asks substantive
+  questions. Budget at least a couple hours after posting.
+- Be ready to reply about Koka / Eff / Frank / OCaml 5 effect
+  handlers. The honest answer is "Lex is a deliberately
+  smaller subset."
+
+---
+
+## /r/programming
+
+Audience: broad. Lead with the practical problem.
+
+### Title
+
+```
+A programming language designed for code no one will read
+```
+
+### Body
+
+```text
+Watching agents emit tool bodies, I kept wanting a way for the
+host to say "this code can touch the network and nothing else"
+that the type checker would actually enforce. Lex is what fell
+out of that.
+
+Effects are part of the type:
+
+    fn fetch(url :: Str) -> [net] Result[Str, Str]
+
+If the body of fetch tries to read a file, the type checker
+rejects the whole program before any byte runs. The runtime
+also re-checks the policy at the dispatch site, so a function
+declared with `[fs_read("/data")]` and granted at startup still
+has to pass the path check at the actual read.
+
+I ran an adversarial bench: 7 attacks + 2 benign cases against
+naive Python exec, RestrictedPython, and Lex. Lex blocks 7/7
+and runs 2/2 (rejection happens at type-check). RestrictedPython
+blocks 3/7 and runs 2/2 (its rejections are runtime NameErrors).
+Naive exec blocks 0/7. Reproduce: cargo test -p lex-cli --test
+agent_sandbox_bench.
+
+A few other things that fell out of "the AST is the interface":
+AST-native diff (renames register as renamed, not delete+add),
+three-way structural merge with JSON conflicts instead of
+<<<<<< markers, content-addressed stage store with `lex blame`.
+
+Repo: https://github.com/alpibrusl/lex-lang
+Landing page: https://alpibrusl.github.io/lex-lang/
+
+Honest weak spot: capability ≠ correctness. A `[net]`-granted
+body can still exfiltrate. Spec proofs (Z3 export) cover the
+gap partially. Curious how others have thought about this.
+```
+
+### Notes
+
+- /r/programming gets a lot of low-effort posts. Title should
+  do work — "designed for code no one will read" is a hook,
+  but you need substance in the first two paragraphs to
+  survive the cynicism.
+- Expect "this is just capabilities with extra steps" comments.
+  Reply factually, not defensively.
+
+---
+
+## /r/MachineLearning (only if angle holds)
+
+This sub trends toward research/experimental ML. Lex is not an
+ML project; only post here if framed specifically around the
+agent-tool sandbox use case, and expect it to land flat unless
+you have measurable LLM safety numbers.
+
+### Title (only post with substance)
+
+```
+[P] Sandboxing LLM-emitted tool code with type-system-enforced effects: 7/7 vs 3/7 RestrictedPython
+```
+
+### Notes
+
+Don't post here unless you have a concrete LLM-safety-research
+framing and are ready to defend the bench against "but adversarial
+ML benchmarks are worth nothing." If unsure, skip.

--- a/comms/reddit.md
+++ b/comms/reddit.md
@@ -12,47 +12,48 @@ language pitch.
 ### Title
 
 ```
-Lex: a small functional language in ~14 Rust crates with effect-typed sandboxing for LLM-emitted tool bodies
+Lex: a small functional language in Rust with effect-typed sandboxing for LLM-emitted tool bodies
 ```
 
 ### Body
 
 ```text
-Hi r/rust — sharing a project I've been building.
+Hi r/rust — sharing a project I've been working on for a while.
 
-Lex is a functional language whose type system encodes effects in
-function signatures (`fn f(...) -> [net] Result[Str, Str]`). The
-implementation is a Rust workspace: lex-syntax (logos lexer + a
-hand-written parser), lex-ast (canonical AST + structural diff/
-merge), lex-types (the effect-aware type checker), lex-bytecode
-(stack-based VM), lex-runtime (effect handlers — gated tiny_http
-server, ureq client, tungstenite WS), lex-store (content-
-addressed sig/stage store), lex-cli (the `lex` binary), plus a
-Core sibling for sized numerics + tensor shape arithmetic.
+Lex is a functional language whose type system encodes effects
+in function signatures (`fn f(...) -> [net] Result[Str, Str]`).
+The implementation is a Rust workspace: lex-syntax (logos lexer
++ a hand-written parser), lex-ast (canonical AST + structural
+diff/merge), lex-types (the effect-aware type checker),
+lex-bytecode (stack-based VM), lex-runtime (effect handlers —
+gated tiny_http server, ureq client, tungstenite WS),
+lex-store (content-addressed sig/stage store), lex-cli (the
+`lex` binary), plus a Core sibling for sized numerics + tensor
+shape arithmetic.
 
-A few Rust-flavored things that turned out useful:
+A few Rust-flavored choices that turned out useful, since this
+is r/rust:
 
 - **logos for the lexer.** ~70 tokens, derives the DFA. The
-  performance is good enough that the parser is the bottleneck,
-  not the lexer.
+  parser ends up the bottleneck, not the lexer.
 - **rustls + platform-verifier via ureq 3.x** for the HTTP
   client. Native cert store, no native-tls dependency.
 - **tungstenite 0.29 for the WS chat builtin.** Per-connection
   worker thread + mpsc::channel for outbound; the room registry
-  is `Arc<Mutex<IndexMap<...>>>`. Lex code stays pure; the
-  shared state lives in the host runtime.
-- **The whole CLI is ACLI-spec compliant** (`lex --output json
-  introspect`), so any LLM agent can drive it without a bespoke
-  skill file. The `.cli/commands.json` is generated and committed
-  for agents browsing the repo.
+  is `Arc<Mutex<IndexMap<...>>>`. Lex code stays pure, so the
+  shared state lives in the host runtime, not the language.
+- **ACLI-compliant CLI** (`lex --output json introspect`), so
+  any LLM agent can drive it without a bespoke skill file. The
+  `.cli/commands.json` is generated and committed so agents
+  browsing the repo can read it without running the binary.
 
-The bit I'm proudest of and would love feedback on: the
-effect-checker's error messages thread the path of effect
-inheritance through `flow.sequential` / `flow.branch` so that
-when a higher-order combinator's body has an unexpected effect,
-the error points to the inner lambda, not the combinator call
-site. It's not novel research — just a lot of careful spans —
-but the output is legible.
+The part I'd most like feedback on: the effect-checker threads
+the path of effect inheritance through `flow.sequential` /
+`flow.branch` so that when a higher-order combinator's body
+has an unexpected effect, the error points to the inner lambda,
+not the combinator call site. Not novel — just a lot of careful
+span bookkeeping — but the output is legible and I'd like to
+hear if there's a cleaner way.
 
 285 tests, EUPL-1.2, MSRV 1.80.
 
@@ -75,16 +76,16 @@ Audience: PL nerds. Lead with design choices and tradeoffs.
 ### Title
 
 ```
-Lex: row-based effects in a small functional language designed for LLM-emitted code
+Lex: row-based effects in a small functional language for sandboxing LLM-emitted code
 ```
 
 ### Body
 
 ```text
-I've been building a small functional language with effects in
-the function signature — not algebraic effects (no handlers in
-user code), just a closed row of capability tags that propagate
-through application and pattern-match.
+I've been working on a small functional language with effects
+in the function signature — not algebraic effects (no handlers
+in user code), just a closed row of capability tags that
+propagate through application and pattern-match.
 
     fn fetch(url :: Str) -> [net] Result[Str, Str]
     fn echo(line :: Str) -> [io] Nil
@@ -100,31 +101,35 @@ Three design choices I'd genuinely like to argue about:
    rand, proc, budget, chat. Adding one is a language change.
    I picked closed because the runtime has to know what to
    enforce; user-defined effects that the runtime treats as
-   opaque are silent capability leaks. The cost is that
-   "domain effect" use cases (e.g. `[db]`, `[email]`) have to
-   ride on top of one of the existing tags + a host-level
-   policy.
+   opaque are silent capability leaks. The cost is real:
+   domain effects (db, email, …) have to ride on top of these
+   plus host-level policy. Wrong call?
 
-2. **No effect polymorphism in user syntax.** Functions can be
-   parameterized over types but not effect rows. This makes the
-   error messages much better but means combinators like
-   `flow.sequential` are monomorphized per effect set in the
-   stdlib. Fair tradeoff?
+2. **No effect polymorphism in user syntax.** Functions are
+   parameterized over types but not effect rows. The error
+   messages are much better, but combinators like
+   `flow.sequential` end up monomorphized per effect set in
+   the stdlib. Fair tradeoff or papering over a missing
+   feature?
 
 3. **Effects as part of the canonical AST hash.** Two functions
    with the same body but different effect annotations get
    different StageIds in the content-addressed store. This is
    the basis for `lex blame` — per-fn lifecycle history that
-   tracks effect changes as separate stages.
+   treats an effect change as a new stage, not an edit. I'm
+   less sure about this one than the other two.
 
 The motivating workflow is sandboxing LLM-emitted tool bodies:
 the host declares `--allow-effects net` and any body that
 reaches outside is rejected at type-check, before execution.
 Adversarial bench (7 attacks + 2 benign) at bench/REPORT.md
-compares against RestrictedPython.
+compares against RestrictedPython; the gap is mostly *when*
+the rejection happens, not cleverness.
 
 Spec sibling adds randomized property checking + SMT-LIB 2
-export to Z3 for behavioral contracts (capability ≠ correctness).
+export to Z3 for behavioral contracts. Capability ≠ correctness;
+the type system answers "what does this code touch", not
+"is the touch wise."
 
 Repo: https://github.com/alpibrusl/lex-lang
 ```
@@ -146,15 +151,17 @@ Audience: broad. Lead with the practical problem.
 ### Title
 
 ```
-A programming language designed for code no one will read
+A small language for sandboxing the code AI agents write
 ```
 
 ### Body
 
 ```text
-Watching agents emit tool bodies, I kept wanting a way for the
-host to say "this code can touch the network and nothing else"
-that the type checker would actually enforce. Lex is what fell
+I run agent-generated code locally as part of my workflow,
+and I kept wanting a sandbox where the host could say "this
+body can touch the network and nothing else" and have the
+type checker actually enforce it — not catch it as a runtime
+exception after something already escaped. Lex is what fell
 out of that.
 
 Effects are part of the type:
@@ -164,27 +171,33 @@ Effects are part of the type:
 If the body of fetch tries to read a file, the type checker
 rejects the whole program before any byte runs. The runtime
 also re-checks the policy at the dispatch site, so a function
-declared with `[fs_read("/data")]` and granted at startup still
-has to pass the path check at the actual read.
+declared with `[fs_read("/data")]` and granted at startup
+still has to pass the path check at the actual read.
 
-I ran an adversarial bench: 7 attacks + 2 benign cases against
-naive Python exec, RestrictedPython, and Lex. Lex blocks 7/7
-and runs 2/2 (rejection happens at type-check). RestrictedPython
-blocks 3/7 and runs 2/2 (its rejections are runtime NameErrors).
-Naive exec blocks 0/7. Reproduce: cargo test -p lex-cli --test
-agent_sandbox_bench.
+To check whether the idea held, I ran an adversarial bench:
+7 attacks + 2 benign cases against naive Python exec,
+RestrictedPython, and Lex. Lex blocks 7/7 and runs 2/2;
+RestrictedPython blocks 3/7 and runs 2/2; naive exec blocks
+0/7. The honest read is that most of the gap is *where* the
+rejection happens, not how clever the rules are: Lex rejects
+at type-check, RestrictedPython at runtime. I picked the
+attacks myself, so take the numbers with that grain of salt.
+Reproduce: `cargo test -p lex-cli --test agent_sandbox_bench`.
 
-A few other things that fell out of "the AST is the interface":
-AST-native diff (renames register as renamed, not delete+add),
-three-way structural merge with JSON conflicts instead of
-<<<<<< markers, content-addressed stage store with `lex blame`.
+A few other things that fell out of "the AST is the
+interface": AST-native diff (renames register as renamed,
+not delete+add), three-way structural merge with JSON
+conflicts instead of <<<<<< markers, content-addressed
+stage store with `lex blame`.
+
+Honest weak spot: capability ≠ correctness. A `[net]`-granted
+body can still exfiltrate; effect typing answers what the
+code touches, not whether the touch is wise. Spec proofs
+(Z3 export) cover that gap partially. Curious how others
+have thought about it.
 
 Repo: https://github.com/alpibrusl/lex-lang
 Landing page: https://alpibrusl.github.io/lex-lang/
-
-Honest weak spot: capability ≠ correctness. A `[net]`-granted
-body can still exfiltrate. Spec proofs (Z3 export) cover the
-gap partially. Curious how others have thought about this.
 ```
 
 ### Notes


### PR DESCRIPTION
## Summary

Adds a `comms/` folder for platform-specific launch drafts, mirroring how `bench/RECORDING.md` and `bench/RECORDING_VC.md` already host the asciinema scripts.

- `comms/hackernews.md` — Show HN draft, alternate title, posting window, pre-post checklist, and an honest-answers map for likely objections
- `comms/lobsters.md` — same idea retuned for the skeptical / PLT crowd; leads with the closed-effect-grammar tradeoff
- `comms/reddit.md` — separate drafts for r/rust (implementation angle), r/ProgrammingLanguages (PL design tradeoffs), r/programming (broad framing); a small note on r/MachineLearning saying skip unless there's measurable LLM-safety substance
- `comms/linkedin.md` — story + numbers framing for a non-hacker audience, with the format guidance (1300-char fold, GIF inline, hashtag etiquette)

Twitter, Mastodon, and Bluesky deliberately omitted.

## Tone

Voice across drafts is humble, honest, professional — first-person, leads with a problem I ran into rather than a thesis statement, names weak spots (capability ≠ correctness, I picked the attacks myself, a new language is a real ask) instead of burying them. No predictive or grand framings.

## Test plan

- [ ] Read each draft as if you were the audience for that platform; flag anything that still reads as overselling
- [ ] Confirm the GitHub Pages URL (`alpibrusl.github.io/lex-lang/`) is live before posting any of these
- [ ] Confirm the test count badge in `README.md` (`285 passing`) matches reality at post time
- [ ] Run `cargo test -p lex-cli --test agent_sandbox_bench` on a clean clone to verify the bench numbers are still 7 / 3 / 0

https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s)_