### PR TITLE
feat: local file imports between .lex modules (closes #78)

### DIFF
--- a/crates/lex-api/src/handlers.rs
+++ b/crates/lex-api/src/handlers.rs
@@ -10,7 +10,7 @@ use lex_ast::canonicalize_program;
 use lex_bytecode::{compile_program, vm::Vm, Value};
 use lex_runtime::{check_program as check_policy, DefaultHandler, Policy};
 use lex_store::Store;
-use lex_syntax::parse_source;
+use lex_syntax::load_program_from_str;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::path::PathBuf;
@@ -103,7 +103,7 @@ fn parse_handler(body: &str) -> Response<std::io::Cursor<Vec<u8>>> {
     let req: ParseReq = match serde_json::from_str(body) {
         Ok(r) => r, Err(e) => return error_response(400, format!("bad request: {e}")),
     };
-    match parse_source(&req.source) {
+    match load_program_from_str(&req.source) {
         Ok(prog) => {
             let stages = canonicalize_program(&prog);
             json_response(200, &serde_json::to_value(&stages).unwrap())
@@ -116,7 +116,7 @@ fn check_handler(body: &str) -> Response<std::io::Cursor<Vec<u8>>> {
     let req: ParseReq = match serde_json::from_str(body) {
         Ok(r) => r, Err(e) => return error_response(400, format!("bad request: {e}")),
     };
-    let prog = match parse_source(&req.source) {
+    let prog = match load_program_from_str(&req.source) {
         Ok(p) => p, Err(e) => return error_response(400, format!("syntax error: {e}")),
     };
     let stages = canonicalize_program(&prog);
@@ -133,7 +133,7 @@ fn publish_handler(state: &State, body: &str) -> Response<std::io::Cursor<Vec<u8
     let req: PublishReq = match serde_json::from_str(body) {
         Ok(r) => r, Err(e) => return error_response(400, format!("bad request: {e}")),
     };
-    let prog = match parse_source(&req.source) {
+    let prog = match load_program_from_str(&req.source) {
         Ok(p) => p, Err(e) => return error_response(400, format!("syntax error: {e}")),
     };
     let stages = canonicalize_program(&prog);
@@ -270,7 +270,7 @@ fn run_handler(state: &State, body: &str, with_overrides: bool) -> Response<std:
     let req: RunReq = match serde_json::from_str(body) {
         Ok(r) => r, Err(e) => return error_response(400, format!("bad request: {e}")),
     };
-    let prog = match parse_source(&req.source) {
+    let prog = match load_program_from_str(&req.source) {
         Ok(p) => p, Err(e) => return error_response(400, format!("syntax error: {e}")),
     };
     let stages = canonicalize_program(&prog);

--- a/crates/lex-cli/src/ast_merge.rs
+++ b/crates/lex-cli/src/ast_merge.rs
@@ -20,7 +20,7 @@ use lex_ast::{
     canon_print::print_stages, canonicalize_program, FnDecl, Stage,
     stage_canonical_hash_hex,
 };
-use lex_syntax::parse_source;
+use lex_syntax::load_program;
 use serde::Serialize;
 use std::collections::BTreeMap;
 use std::fs;
@@ -181,10 +181,8 @@ fn parse_args(args: &[String]) -> Result<MergeOpts> {
 }
 
 fn load_fns(path: &std::path::Path) -> Result<BTreeMap<String, FnDecl>> {
-    let src = fs::read_to_string(path)
-        .with_context(|| format!("read {}", path.display()))?;
-    let prog = parse_source(&src)
-        .map_err(|e| anyhow!("parse {}: {e}", path.display()))?;
+    let prog = load_program(path)
+        .map_err(|e| anyhow!("load {}: {e}", path.display()))?;
     let stages = canonicalize_program(&prog);
     let mut out = BTreeMap::new();
     for stage in stages {

--- a/crates/lex-cli/src/audit.rs
+++ b/crates/lex-cli/src/audit.rs
@@ -17,7 +17,7 @@ use crate::acli as acli_mod;
 use ::acli::OutputFormat;
 use anyhow::{anyhow, Context, Result};
 use lex_ast::{canonicalize_program, CExpr, CLit, Effect, FnDecl, Stage, TypeExpr};
-use lex_syntax::parse_source;
+use lex_syntax::load_program;
 use serde::Serialize;
 use std::collections::BTreeMap;
 use std::fs;
@@ -68,17 +68,13 @@ pub fn cmd_audit(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let mut report = AuditReport { summary: BTreeMap::new(), hits: Vec::new() };
 
     for path in &files {
-        let src = match fs::read_to_string(path) {
-            Ok(s) => s,
-            Err(_) => continue,
-        };
         // Parse + canonicalize. Errors are printed once, then we keep
         // going — partial audits over a half-broken codebase are
         // strictly more useful than refusing to run.
-        let prog = match parse_source(&src) {
+        let prog = match load_program(path) {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("warning: parse error in {}: {e}", path.display());
+                eprintln!("warning: load error in {}: {e}", path.display());
                 continue;
             }
         };

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -25,7 +25,8 @@ use lex_ast::{canonicalize_program, sig_id, stage_canonical_hash_hex, stage_id, 
 use lex_bytecode::{compile_program, vm::Vm, Value};
 use lex_runtime::{check_program as check_policy, DefaultHandler, Policy};
 use lex_store::Store;
-use lex_syntax::parse_source;
+use lex_syntax::syntax::Program as SynProgram;
+use lex_syntax::{load_program, load_program_from_str};
 use std::collections::BTreeSet;
 use std::fs;
 use std::io::Read;
@@ -187,10 +188,22 @@ fn read_source(path: &str) -> Result<String> {
     }
 }
 
+/// Read a Lex program from a file path or `-` (stdin), expanding local
+/// imports relative to the file's directory. For stdin, local imports
+/// are rejected (no base path to resolve from).
+fn read_program(path: &str) -> Result<SynProgram> {
+    if path == "-" {
+        let mut s = String::new();
+        std::io::stdin().read_to_string(&mut s).context("reading stdin")?;
+        load_program_from_str(&s).map_err(Into::into)
+    } else {
+        load_program(std::path::Path::new(path)).map_err(Into::into)
+    }
+}
+
 fn cmd_parse(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let path = args.first().ok_or_else(|| anyhow!("usage: lex parse <file>"))?;
-    let src = read_source(path)?;
-    let prog = parse_source(&src)?;
+    let prog = read_program(path)?;
     let stages = canonicalize_program(&prog);
     let data = serde_json::to_value(&stages)?;
     acli::emit_or_text("parse", data.clone(), fmt, || {
@@ -201,8 +214,7 @@ fn cmd_parse(fmt: &OutputFormat, args: &[String]) -> Result<()> {
 
 fn cmd_check(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let path = args.first().ok_or_else(|| anyhow!("usage: lex check <file>"))?;
-    let src = read_source(path)?;
-    let prog = parse_source(&src)?;
+    let prog = read_program(path)?;
     let stages = canonicalize_program(&prog);
     match lex_types::check_program(&stages) {
         Ok(_) => {
@@ -249,8 +261,7 @@ fn cmd_run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         acli::emit_dry_run("run", fmt,
             &format!("would call `{func}` in {path}"), actions);
     }
-    let src = read_source(path)?;
-    let prog = parse_source(&src)?;
+    let prog = read_program(path)?;
     let stages = canonicalize_program(&prog);
     if let Err(errs) = lex_types::check_program(&stages) {
         let arr: Vec<serde_json::Value> = errs.iter()
@@ -409,8 +420,7 @@ fn cmd_diff(fmt: &OutputFormat, args: &[String]) -> Result<()> {
 
 fn cmd_hash(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let path = args.first().ok_or_else(|| anyhow!("usage: lex hash <file>"))?;
-    let src = read_source(path)?;
-    let prog = parse_source(&src)?;
+    let prog = read_program(path)?;
     let stages = canonicalize_program(&prog);
     let entries: Vec<serde_json::Value> = stages.iter().map(|s| {
         let name = stage_name(s);
@@ -438,8 +448,7 @@ fn cmd_blame(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     // usage: lex blame [--store DIR] <file>
     let (root, rest, _, _) = parse_store_flag(args);
     let path = rest.first().ok_or_else(|| anyhow!("usage: lex blame [--store DIR] <file>"))?;
-    let src = read_source(path)?;
-    let prog = parse_source(&src)?;
+    let prog = read_program(path)?;
     let stages = canonicalize_program(&prog);
     let store = Store::open(&root).with_context(|| format!("opening store at {}", root.display()))?;
 
@@ -601,8 +610,7 @@ fn parse_store_flag(args: &[String]) -> (PathBuf, Vec<String>, bool, bool) {
 fn cmd_publish(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let (root, rest, activate, dry_run) = parse_store_flag(args);
     let path = rest.first().ok_or_else(|| anyhow!("usage: lex publish [--store DIR] [--activate] <file>"))?;
-    let src = read_source(path)?;
-    let prog = parse_source(&src)?;
+    let prog = read_program(path)?;
     let stages = canonicalize_program(&prog);
     if let Err(errs) = lex_types::check_program(&stages) {
         let arr: Vec<serde_json::Value> = errs.iter()
@@ -728,8 +736,7 @@ fn cmd_replay(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let path = positional.get(1).ok_or_else(|| anyhow!("missing <file>"))?;
     let func = positional.get(2).ok_or_else(|| anyhow!("missing <fn>"))?;
 
-    let src = read_source(path)?;
-    let prog = parse_source(&src)?;
+    let prog = read_program(path)?;
     let stages = canonicalize_program(&prog);
     if let Err(errs) = lex_types::check_program(&stages) {
         let arr: Vec<serde_json::Value> = errs.iter()
@@ -987,7 +994,7 @@ fn cmd_agent_tool(args: &[String]) -> Result<()> {
     // 3) Parse + type-check. This is where a malicious body gets caught:
     // any effect not in `[allowed_effects]` shows up as an undeclared
     // effect on `fn tool` and the checker rejects it.
-    let prog = parse_source(&src).context("parse agent-generated source")?;
+    let prog = load_program_from_str(&src).context("parse agent-generated source")?;
     let stages = canonicalize_program(&prog);
     if let Err(errs) = lex_types::check_program(&stages) {
         eprintln!("→ TYPE-CHECK REJECTED — tool not run.");
@@ -1082,7 +1089,7 @@ fn cmd_agent_tool(args: &[String]) -> Result<()> {
         };
         let diff_body_text = strip_code_fences(&diff_body_text);
         let diff_src = build_tool_program(&diff_body_text, &opts.allowed_effects);
-        let prog_b = parse_source(&diff_src).context("parse diff body")?;
+        let prog_b = load_program_from_str(&diff_src).context("parse diff body")?;
         let stages_b = canonicalize_program(&prog_b);
         if let Err(errs) = lex_types::check_program(&stages_b) {
             eprintln!("→ DIFF BODY type-check rejected.");

--- a/crates/lex-cli/src/tool_registry.rs
+++ b/crates/lex-cli/src/tool_registry.rs
@@ -33,7 +33,7 @@ use anyhow::{anyhow, Result};
 use lex_ast::canonicalize_program;
 use lex_bytecode::{compile_program, vm::Vm, Program, Value};
 use lex_runtime::{check_program as check_policy, DefaultHandler, Policy};
-use lex_syntax::parse_source;
+use lex_syntax::load_program_from_str;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::collections::BTreeSet;
@@ -189,7 +189,7 @@ fn post_tools(body_str: &str, registry: &Registry) -> Response<std::io::Cursor<V
     let src = build_tool_program(&parsed.body, &parsed.allowed_effects);
 
     // 2) Parse + type-check.
-    let prog = match parse_source(&src) {
+    let prog = match load_program_from_str(&src) {
         Ok(p) => p,
         Err(e) => return json_response(400, json!({
             "error_kind": "parse", "detail": e.to_string(),

--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -18,3 +18,4 @@ lex-bytecode = { path = "../lex-bytecode" }
 lex-syntax = { path = "../lex-syntax" }
 lex-ast = { path = "../lex-ast" }
 lex-types = { path = "../lex-types" }
+tempfile = "3"

--- a/crates/lex-runtime/tests/local_imports_e2e.rs
+++ b/crates/lex-runtime/tests/local_imports_e2e.rs
@@ -1,0 +1,128 @@
+//! End-to-end: load a multi-file project, type-check, compile, run a
+//! function. Exercises the loader + canonicalize + check + bytecode +
+//! VM pipeline against the issue #78 use case.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::load_program;
+
+fn write(dir: &std::path::Path, name: &str, src: &str) {
+    std::fs::write(dir.join(name), src).unwrap();
+}
+
+fn run(entry: &std::path::Path, fn_name: &str, args: Vec<Value>) -> Value {
+    let prog = load_program(entry).expect("load");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors:\n{errs:#?}");
+    }
+    let bc = std::sync::Arc::new(compile_program(&stages));
+    let handler = DefaultHandler::new(Policy::pure()).with_program(std::sync::Arc::clone(&bc));
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(fn_name, args).expect("run")
+}
+
+#[test]
+fn two_file_project_runs() {
+    let dir = tempfile::tempdir().unwrap();
+    write(
+        dir.path(),
+        "helpers.lex",
+        r#"fn double(x :: Int) -> Int { x + x }
+"#,
+    );
+    write(
+        dir.path(),
+        "main.lex",
+        r#"import "./helpers" as h
+fn main(x :: Int) -> Int { h.double(x) + 1 }
+"#,
+    );
+
+    let v = run(&dir.path().join("main.lex"), "main", vec![Value::Int(20)]);
+    assert_eq!(v, Value::Int(41));
+}
+
+#[test]
+fn imported_type_used_in_signature_runs() {
+    let dir = tempfile::tempdir().unwrap();
+    write(
+        dir.path(),
+        "models.lex",
+        r#"type Status = Healthy | Sick
+fn label(s :: Status) -> Str {
+  match s {
+    Healthy => "ok",
+    Sick    => "nope",
+  }
+}
+"#,
+    );
+    write(
+        dir.path(),
+        "main.lex",
+        r#"import "./models" as m
+fn describe(s :: m.Status) -> Str { m.label(s) }
+"#,
+    );
+
+    let v = run(
+        &dir.path().join("main.lex"),
+        "describe",
+        vec![Value::Variant {
+            name: "Healthy".into(),
+            args: vec![],
+        }],
+    );
+    assert_eq!(v, Value::Str("ok".into()));
+}
+
+#[test]
+fn transitive_imports_run() {
+    let dir = tempfile::tempdir().unwrap();
+    write(dir.path(), "c.lex", "fn z(x :: Int) -> Int { x * 2 }\n");
+    write(
+        dir.path(),
+        "b.lex",
+        r#"import "./c" as c
+fn y(x :: Int) -> Int { c.z(x) + 1 }
+"#,
+    );
+    write(
+        dir.path(),
+        "a.lex",
+        r#"import "./b" as b
+fn run(x :: Int) -> Int { b.y(x) }
+"#,
+    );
+
+    let v = run(&dir.path().join("a.lex"), "run", vec![Value::Int(5)]);
+    assert_eq!(v, Value::Int(11));
+}
+
+#[test]
+fn shadowed_let_binding_works_at_runtime() {
+    // Regression for the mangler's shadow-tracking.
+    let dir = tempfile::tempdir().unwrap();
+    write(
+        dir.path(),
+        "h.lex",
+        r#"fn inner(x :: Int) -> Int { x + 1000 }
+fn caller(x :: Int) -> Int {
+  let inner := x + 7
+  inner
+}
+"#,
+    );
+    write(
+        dir.path(),
+        "main.lex",
+        r#"import "./h" as h
+fn run(x :: Int) -> Int { h.caller(x) }
+"#,
+    );
+
+    let v = run(&dir.path().join("main.lex"), "run", vec![Value::Int(3)]);
+    assert_eq!(v, Value::Int(10), "let-bound `inner` should win over top-level `inner`");
+}

--- a/crates/lex-syntax/Cargo.toml
+++ b/crates/lex-syntax/Cargo.toml
@@ -10,3 +10,6 @@ serde_json.workspace = true
 thiserror.workspace = true
 logos.workspace = true
 indexmap.workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/lex-syntax/src/lib.rs
+++ b/crates/lex-syntax/src/lib.rs
@@ -6,7 +6,9 @@ pub mod token;
 pub mod syntax;
 pub mod parser;
 pub mod printer;
+pub mod loader;
 
+pub use loader::{load_program, load_program_from_str, LoadError};
 pub use parser::{parse, ParseError};
 pub use printer::print_program;
 pub use syntax::*;

--- a/crates/lex-syntax/src/loader.rs
+++ b/crates/lex-syntax/src/loader.rs
@@ -1,0 +1,518 @@
+//! Multi-file loader: resolves `import "./..."`, `import "../..."`, and
+//! `import "/abs/..."` statements relative to the importer, recursively
+//! parses, and produces a single [`Program`] with all stages merged.
+//!
+//! Names that are local to an imported file are mangled with the alias
+//! path so they don't collide with the importer's names. Stdlib imports
+//! (`import "std.foo" as bar`) pass through unchanged.
+//!
+//! ## Mangling
+//!
+//! Each loaded file has an "alias path" — empty for the root file, `f`
+//! for `import "./X" as f` from the root, `f.g` for `import "./Y" as g`
+//! inside X, etc. Within a file at alias path `P`:
+//!
+//! - `fn foo` declared in this file becomes `<P>.foo` (just `foo` at root).
+//! - `type T` declared in this file becomes `<P>.T`.
+//! - References to a locally-declared name get mangled, **unless** the
+//!   name is shadowed by a binder (let, fn param, lambda param, or
+//!   pattern binder) in scope.
+//! - `m.foo` where `m` is a path-import alias is rewritten to the
+//!   imported file's alias-path-qualified name.
+//! - `m.foo` where `m` is a stdlib alias is unchanged.
+//!
+//! Variant constructors are **not** mangled — they live in a global
+//! namespace, and a collision between two imported types' constructors
+//! surfaces later as a type-check error. Same for record field names.
+//!
+//! ## Limitations (tracked separately)
+//!
+//! Mangling means the SigId / StageId of an imported function depends
+//! on the alias chain the importer chose. `lex blame` across imports
+//! is not stable yet — see the future-work tracker for store-native
+//! imports (`import "stage:..."`).
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+use crate::syntax::*;
+use crate::{parse_source, SyntaxError};
+
+#[derive(Debug, Error)]
+pub enum LoadError {
+    #[error("read {path}: {source}")]
+    Io {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("parse {path}: {source}")]
+    Syntax {
+        path: String,
+        #[source]
+        source: SyntaxError,
+    },
+    #[error("import cycle: {chain}")]
+    Cycle { chain: String },
+    #[error("import \"{reference}\" from {importer}: file not found")]
+    NotFound { importer: String, reference: String },
+    #[error("local imports (`./`, `../`, `/`) require a base path; cannot resolve from a string source")]
+    LocalImportInStringSource,
+}
+
+/// Load a multi-file Lex program, expanding local imports relative to
+/// the entry path. Stdlib imports (`std.*`) pass through unchanged.
+pub fn load_program(entry: &Path) -> Result<Program, LoadError> {
+    let mut state = LoaderState {
+        in_progress: Vec::new(),
+    };
+    state.load(entry, "")
+}
+
+/// Load a Lex program from a string source. Local-path imports are
+/// rejected up-front since there's no base path to resolve from.
+pub fn load_program_from_str(src: &str) -> Result<Program, LoadError> {
+    let prog = parse_source(src).map_err(|source| LoadError::Syntax {
+        path: "<input>".into(),
+        source,
+    })?;
+    for item in &prog.items {
+        if let Item::Import(imp) = item {
+            if is_path_import(&imp.reference) {
+                return Err(LoadError::LocalImportInStringSource);
+            }
+        }
+    }
+    Ok(prog)
+}
+
+struct LoaderState {
+    in_progress: Vec<PathBuf>,
+}
+
+impl LoaderState {
+    fn load(&mut self, path: &Path, alias_path: &str) -> Result<Program, LoadError> {
+        let canonical = path.canonicalize().map_err(|source| LoadError::Io {
+            path: path.display().to_string(),
+            source,
+        })?;
+        if self.in_progress.contains(&canonical) {
+            let mut chain: Vec<String> = self
+                .in_progress
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect();
+            chain.push(canonical.display().to_string());
+            return Err(LoadError::Cycle {
+                chain: chain.join(" -> "),
+            });
+        }
+        self.in_progress.push(canonical.clone());
+
+        let src = std::fs::read_to_string(&canonical).map_err(|source| LoadError::Io {
+            path: canonical.display().to_string(),
+            source,
+        })?;
+        let prog = parse_source(&src).map_err(|source| LoadError::Syntax {
+            path: canonical.display().to_string(),
+            source,
+        })?;
+
+        let local_names: HashSet<String> = prog
+            .items
+            .iter()
+            .filter_map(|item| match item {
+                Item::FnDecl(fd) => Some(fd.name.clone()),
+                Item::TypeDecl(td) => Some(td.name.clone()),
+                _ => None,
+            })
+            .collect();
+
+        let mut path_imports: HashMap<String, String> = HashMap::new();
+        let mut merged_children: Vec<Item> = Vec::new();
+        let mut std_imports: Vec<Item> = Vec::new();
+        let mut my_items: Vec<Item> = Vec::new();
+
+        for item in prog.items {
+            match item {
+                Item::Import(ref imp) if is_path_import(&imp.reference) => {
+                    let resolved = resolve_import(&canonical, &imp.reference)?;
+                    let child_alias_path = if alias_path.is_empty() {
+                        imp.alias.clone()
+                    } else {
+                        format!("{alias_path}.{}", imp.alias)
+                    };
+                    path_imports.insert(imp.alias.clone(), child_alias_path.clone());
+                    let child_prog = self.load(&resolved, &child_alias_path)?;
+                    merged_children.extend(child_prog.items);
+                }
+                Item::Import(_) => std_imports.push(item),
+                _ => my_items.push(item),
+            }
+        }
+
+        let mangler = Mangler {
+            alias_path: alias_path.to_string(),
+            local_names: &local_names,
+            path_imports: &path_imports,
+        };
+        let mangled: Vec<Item> = my_items
+            .into_iter()
+            .map(|i| mangler.mangle_item(i))
+            .collect();
+
+        self.in_progress.pop();
+
+        // Output order: std imports first (deduped against children's),
+        // then merged children's items, then this file's items.
+        let mut out: Vec<Item> = Vec::new();
+        for s in std_imports {
+            if !merged_children.iter().any(|m| m == &s) {
+                out.push(s);
+            }
+        }
+        out.extend(merged_children);
+        out.extend(mangled);
+        Ok(Program { items: out })
+    }
+}
+
+fn is_path_import(reference: &str) -> bool {
+    reference.starts_with("./") || reference.starts_with("../") || reference.starts_with('/')
+}
+
+fn resolve_import(importer: &Path, reference: &str) -> Result<PathBuf, LoadError> {
+    let importer_dir = importer.parent().unwrap_or_else(|| Path::new("."));
+    let mut resolved: PathBuf = if reference.starts_with('/') {
+        PathBuf::from(reference)
+    } else {
+        importer_dir.join(reference)
+    };
+    if resolved.extension().is_none() {
+        resolved.set_extension("lex");
+    }
+    if !resolved.exists() {
+        return Err(LoadError::NotFound {
+            importer: importer.display().to_string(),
+            reference: reference.to_string(),
+        });
+    }
+    Ok(resolved)
+}
+
+struct Mangler<'a> {
+    alias_path: String,
+    local_names: &'a HashSet<String>,
+    /// Map from local alias to the imported file's alias path.
+    path_imports: &'a HashMap<String, String>,
+}
+
+impl<'a> Mangler<'a> {
+    fn qualify(&self, name: &str) -> String {
+        if self.alias_path.is_empty() {
+            name.to_string()
+        } else {
+            format!("{}.{}", self.alias_path, name)
+        }
+    }
+
+    fn mangle_item(&self, item: Item) -> Item {
+        match item {
+            Item::Import(imp) => Item::Import(imp),
+            Item::TypeDecl(td) => Item::TypeDecl(self.mangle_type_decl(td)),
+            Item::FnDecl(fd) => Item::FnDecl(self.mangle_fn_decl(fd)),
+        }
+    }
+
+    fn mangle_type_decl(&self, td: TypeDecl) -> TypeDecl {
+        TypeDecl {
+            name: self.qualify(&td.name),
+            params: td.params,
+            definition: self.mangle_type_expr(td.definition),
+        }
+    }
+
+    fn mangle_fn_decl(&self, fd: FnDecl) -> FnDecl {
+        let mut shadow = HashSet::new();
+        for p in &fd.params {
+            shadow.insert(p.name.clone());
+        }
+        FnDecl {
+            name: self.qualify(&fd.name),
+            type_params: fd.type_params,
+            params: fd
+                .params
+                .into_iter()
+                .map(|p| Param {
+                    name: p.name,
+                    ty: self.mangle_type_expr(p.ty),
+                })
+                .collect(),
+            effects: fd.effects,
+            return_type: self.mangle_type_expr(fd.return_type),
+            body: self.mangle_block(fd.body, &shadow),
+        }
+    }
+
+    fn mangle_type_expr(&self, te: TypeExpr) -> TypeExpr {
+        match te {
+            TypeExpr::Named { name, args } => TypeExpr::Named {
+                name: self.rewrite_type_name(&name),
+                args: args.into_iter().map(|a| self.mangle_type_expr(a)).collect(),
+            },
+            TypeExpr::Record(fields) => TypeExpr::Record(
+                fields
+                    .into_iter()
+                    .map(|f| TypeField {
+                        name: f.name,
+                        ty: self.mangle_type_expr(f.ty),
+                    })
+                    .collect(),
+            ),
+            TypeExpr::Tuple(items) => {
+                TypeExpr::Tuple(items.into_iter().map(|t| self.mangle_type_expr(t)).collect())
+            }
+            TypeExpr::Function {
+                params,
+                effects,
+                ret,
+            } => TypeExpr::Function {
+                params: params
+                    .into_iter()
+                    .map(|t| self.mangle_type_expr(t))
+                    .collect(),
+                effects,
+                ret: Box::new(self.mangle_type_expr(*ret)),
+            },
+            TypeExpr::Union(variants) => TypeExpr::Union(
+                variants
+                    .into_iter()
+                    .map(|v| UnionVariant {
+                        name: v.name,
+                        payload: v.payload.map(|t| self.mangle_type_expr(t)),
+                    })
+                    .collect(),
+            ),
+        }
+    }
+
+    /// Rewrite a possibly-qualified type name to its mangled form.
+    fn rewrite_type_name(&self, name: &str) -> String {
+        if let Some((alias, rest)) = name.split_once('.') {
+            if let Some(child) = self.path_imports.get(alias) {
+                return format!("{child}.{rest}");
+            }
+            return name.to_string();
+        }
+        if self.local_names.contains(name) {
+            return self.qualify(name);
+        }
+        name.to_string()
+    }
+
+    fn mangle_block(&self, b: Block, shadow: &HashSet<String>) -> Block {
+        let mut shadow = shadow.clone();
+        let statements = b
+            .statements
+            .into_iter()
+            .map(|s| match s {
+                Statement::Let { name, ty, value } => {
+                    let value = self.mangle_expr(value, &shadow);
+                    let ty = ty.map(|t| self.mangle_type_expr(t));
+                    shadow.insert(name.clone());
+                    Statement::Let { name, ty, value }
+                }
+                Statement::Expr(e) => Statement::Expr(self.mangle_expr(e, &shadow)),
+            })
+            .collect();
+        let result = Box::new(self.mangle_expr(*b.result, &shadow));
+        Block { statements, result }
+    }
+
+    fn mangle_expr(&self, e: Expr, shadow: &HashSet<String>) -> Expr {
+        match e {
+            Expr::Lit(_) => e,
+            Expr::Var(name) => {
+                if !shadow.contains(&name) && self.local_names.contains(&name) {
+                    Expr::Var(self.qualify(&name))
+                } else {
+                    Expr::Var(name)
+                }
+            }
+            Expr::Block(b) => Expr::Block(self.mangle_block(b, shadow)),
+            Expr::Call { callee, args } => {
+                let mangled_args: Vec<Expr> = args
+                    .into_iter()
+                    .map(|a| self.mangle_expr(a, shadow))
+                    .collect();
+                if let Expr::Field { value, field } = (*callee).clone() {
+                    if let Expr::Var(alias) = *value {
+                        if !shadow.contains(&alias) {
+                            if let Some(child) = self.path_imports.get(&alias) {
+                                return Expr::Call {
+                                    callee: Box::new(Expr::Var(format!("{child}.{field}"))),
+                                    args: mangled_args,
+                                };
+                            }
+                        }
+                    }
+                }
+                Expr::Call {
+                    callee: Box::new(self.mangle_expr(*callee, shadow)),
+                    args: mangled_args,
+                }
+            }
+            Expr::Pipe { left, right } => Expr::Pipe {
+                left: Box::new(self.mangle_expr(*left, shadow)),
+                right: Box::new(self.mangle_expr(*right, shadow)),
+            },
+            Expr::Try(inner) => Expr::Try(Box::new(self.mangle_expr(*inner, shadow))),
+            Expr::Field { value, field } => {
+                if let Expr::Var(alias) = (*value).clone() {
+                    if !shadow.contains(&alias) {
+                        if let Some(child) = self.path_imports.get(&alias) {
+                            return Expr::Var(format!("{child}.{field}"));
+                        }
+                    }
+                }
+                Expr::Field {
+                    value: Box::new(self.mangle_expr(*value, shadow)),
+                    field,
+                }
+            }
+            Expr::BinOp { op, lhs, rhs } => Expr::BinOp {
+                op,
+                lhs: Box::new(self.mangle_expr(*lhs, shadow)),
+                rhs: Box::new(self.mangle_expr(*rhs, shadow)),
+            },
+            Expr::UnaryOp { op, expr } => Expr::UnaryOp {
+                op,
+                expr: Box::new(self.mangle_expr(*expr, shadow)),
+            },
+            Expr::If {
+                cond,
+                then_block,
+                else_block,
+            } => Expr::If {
+                cond: Box::new(self.mangle_expr(*cond, shadow)),
+                then_block: self.mangle_block(then_block, shadow),
+                else_block: self.mangle_block(else_block, shadow),
+            },
+            Expr::Match { scrutinee, arms } => Expr::Match {
+                scrutinee: Box::new(self.mangle_expr(*scrutinee, shadow)),
+                arms: arms
+                    .into_iter()
+                    .map(|a| {
+                        let mut arm_shadow = shadow.clone();
+                        collect_pattern_binders(&a.pattern, &mut arm_shadow);
+                        Arm {
+                            pattern: self.mangle_pattern(a.pattern),
+                            body: self.mangle_expr(a.body, &arm_shadow),
+                        }
+                    })
+                    .collect(),
+            },
+            Expr::RecordLit(fields) => Expr::RecordLit(
+                fields
+                    .into_iter()
+                    .map(|f| RecordLitField {
+                        name: f.name,
+                        value: self.mangle_expr(f.value, shadow),
+                    })
+                    .collect(),
+            ),
+            Expr::TupleLit(items) => Expr::TupleLit(
+                items
+                    .into_iter()
+                    .map(|i| self.mangle_expr(i, shadow))
+                    .collect(),
+            ),
+            Expr::ListLit(items) => Expr::ListLit(
+                items
+                    .into_iter()
+                    .map(|i| self.mangle_expr(i, shadow))
+                    .collect(),
+            ),
+            Expr::Constructor { name, args } => Expr::Constructor {
+                name,
+                args: args
+                    .into_iter()
+                    .map(|a| self.mangle_expr(a, shadow))
+                    .collect(),
+            },
+            Expr::Lambda(lambda) => {
+                let mut lam_shadow = shadow.clone();
+                for p in &lambda.params {
+                    lam_shadow.insert(p.name.clone());
+                }
+                Expr::Lambda(Box::new(Lambda {
+                    params: lambda
+                        .params
+                        .into_iter()
+                        .map(|p| Param {
+                            name: p.name,
+                            ty: self.mangle_type_expr(p.ty),
+                        })
+                        .collect(),
+                    return_type: self.mangle_type_expr(lambda.return_type),
+                    effects: lambda.effects,
+                    body: self.mangle_block(lambda.body, &lam_shadow),
+                }))
+            }
+        }
+    }
+
+    fn mangle_pattern(&self, p: Pattern) -> Pattern {
+        match p {
+            Pattern::Constructor { name, args } => Pattern::Constructor {
+                name,
+                args: args.into_iter().map(|a| self.mangle_pattern(a)).collect(),
+            },
+            Pattern::Record { fields, rest } => Pattern::Record {
+                fields: fields
+                    .into_iter()
+                    .map(|f| RecordPatField {
+                        name: f.name,
+                        pattern: f.pattern.map(|p| self.mangle_pattern(p)),
+                    })
+                    .collect(),
+                rest,
+            },
+            Pattern::Tuple(items) => {
+                Pattern::Tuple(items.into_iter().map(|p| self.mangle_pattern(p)).collect())
+            }
+            Pattern::Lit(_) | Pattern::Var(_) | Pattern::Wild => p,
+        }
+    }
+}
+
+fn collect_pattern_binders(p: &Pattern, out: &mut HashSet<String>) {
+    match p {
+        Pattern::Var(name) => {
+            out.insert(name.clone());
+        }
+        Pattern::Constructor { args, .. } => {
+            for a in args {
+                collect_pattern_binders(a, out);
+            }
+        }
+        Pattern::Record { fields, .. } => {
+            for f in fields {
+                match &f.pattern {
+                    Some(p) => collect_pattern_binders(p, out),
+                    // `{ name }` shorthand binds `name`.
+                    None => {
+                        out.insert(f.name.clone());
+                    }
+                }
+            }
+        }
+        Pattern::Tuple(items) => {
+            for p in items {
+                collect_pattern_binders(p, out);
+            }
+        }
+        Pattern::Lit(_) | Pattern::Wild => {}
+    }
+}

--- a/crates/lex-syntax/src/parser.rs
+++ b/crates/lex-syntax/src/parser.rs
@@ -205,7 +205,17 @@ impl Parser {
             Some(TokenKind::LBrace) => self.parse_record_type(),
             Some(TokenKind::LParen) => self.parse_paren_type_or_function(),
             Some(TokenKind::Ident(_)) => {
-                let name = self.expect_ident("in type expr")?;
+                let mut name = self.expect_ident("in type expr")?;
+                // Module-qualified type: `m.Type` or `m.n.Type`. We accept
+                // dotted names here and let the loader rewrite them to the
+                // file-local mangled form. After the loader pass, all type
+                // names referenced by the type checker are single segments.
+                while matches!(self.peek(), Some(TokenKind::Dot)) {
+                    self.bump();
+                    let next = self.expect_ident("after `.` in qualified type")?;
+                    name.push('.');
+                    name.push_str(&next);
+                }
                 let args = if matches!(self.peek(), Some(TokenKind::LBracket)) {
                     self.bump();
                     let mut args = Vec::new();

--- a/crates/lex-syntax/tests/loader_smoke.rs
+++ b/crates/lex-syntax/tests/loader_smoke.rs
@@ -1,0 +1,352 @@
+//! Multi-file loader smoke tests: two-file project, transitive imports,
+//! diamond, cycle detection, missing file, m.Type qualified types,
+//! shadowing.
+
+use lex_syntax::syntax::*;
+use lex_syntax::{load_program, load_program_from_str, LoadError};
+use std::fs;
+
+fn write(dir: &std::path::Path, name: &str, src: &str) {
+    fs::write(dir.join(name), src).unwrap();
+}
+
+fn fn_names(prog: &Program) -> Vec<String> {
+    prog.items
+        .iter()
+        .filter_map(|i| match i {
+            Item::FnDecl(fd) => Some(fd.name.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn type_names(prog: &Program) -> Vec<String> {
+    prog.items
+        .iter()
+        .filter_map(|i| match i {
+            Item::TypeDecl(td) => Some(td.name.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+#[test]
+fn two_file_project_mangles_imported_names() {
+    let dir = tempfile::tempdir().unwrap();
+    write(
+        dir.path(),
+        "models.lex",
+        r#"type Status = Healthy | Sick
+fn label(s :: Status) -> Str {
+  match s {
+    Healthy => "ok",
+    Sick    => "nope",
+  }
+}
+"#,
+    );
+    write(
+        dir.path(),
+        "main.lex",
+        r#"import "./models" as m
+
+fn main(s :: m.Status) -> Str { m.label(s) }
+"#,
+    );
+
+    let prog = load_program(&dir.path().join("main.lex")).expect("load");
+    let fns = fn_names(&prog);
+    let types = type_names(&prog);
+
+    // Imported fn is mangled with the alias.
+    assert!(fns.contains(&"m.label".to_string()), "got fns: {fns:?}");
+    // Imported type is mangled.
+    assert!(types.contains(&"m.Status".to_string()), "got types: {types:?}");
+    // Root fn is unmangled.
+    assert!(fns.contains(&"main".to_string()), "got fns: {fns:?}");
+}
+
+#[test]
+fn root_calls_imported_function_via_alias() {
+    let dir = tempfile::tempdir().unwrap();
+    write(
+        dir.path(),
+        "helpers.lex",
+        r#"fn double(x :: Int) -> Int { x + x }
+"#,
+    );
+    write(
+        dir.path(),
+        "main.lex",
+        r#"import "./helpers" as h
+fn main(x :: Int) -> Int { h.double(x) }
+"#,
+    );
+
+    let prog = load_program(&dir.path().join("main.lex")).expect("load");
+    // The call site `h.double(x)` should have been rewritten to `Var("h.double")`.
+    let main_fn = prog
+        .items
+        .iter()
+        .find_map(|i| match i {
+            Item::FnDecl(fd) if fd.name == "main" => Some(fd),
+            _ => None,
+        })
+        .expect("main fn present");
+
+    if let Expr::Call { callee, .. } = &*main_fn.body.result {
+        if let Expr::Var(name) = &**callee {
+            assert_eq!(name, "h.double");
+            return;
+        }
+    }
+    panic!("main body not rewritten as expected: {:?}", main_fn.body.result);
+}
+
+#[test]
+fn unqualified_local_call_inside_imported_file_is_mangled() {
+    let dir = tempfile::tempdir().unwrap();
+    // helpers.lex defines `inner` and calls it from `outer`. After the
+    // loader pass, both should live under the `h` alias path.
+    write(
+        dir.path(),
+        "helpers.lex",
+        r#"fn inner(x :: Int) -> Int { x + 1 }
+fn outer(x :: Int) -> Int { inner(x) }
+"#,
+    );
+    write(
+        dir.path(),
+        "main.lex",
+        r#"import "./helpers" as h
+fn main(x :: Int) -> Int { h.outer(x) }
+"#,
+    );
+
+    let prog = load_program(&dir.path().join("main.lex")).expect("load");
+    let outer = prog
+        .items
+        .iter()
+        .find_map(|i| match i {
+            Item::FnDecl(fd) if fd.name == "h.outer" => Some(fd),
+            _ => None,
+        })
+        .expect("h.outer present");
+    // Inside h.outer, the call to `inner(x)` should now be `h.inner(x)`.
+    if let Expr::Call { callee, .. } = &*outer.body.result {
+        if let Expr::Var(name) = &**callee {
+            assert_eq!(name, "h.inner");
+            return;
+        }
+    }
+    panic!("h.outer body not rewritten: {:?}", outer.body.result);
+}
+
+#[test]
+fn shadowed_let_binding_is_not_mangled() {
+    let dir = tempfile::tempdir().unwrap();
+    // `inner` is a top-level fn AND a let binding inside `caller`.
+    // The let binding should win inside the body — no mangling.
+    write(
+        dir.path(),
+        "helpers.lex",
+        r#"fn inner(x :: Int) -> Int { x }
+fn caller(x :: Int) -> Int {
+  let inner := x + 100
+  inner
+}
+"#,
+    );
+    write(
+        dir.path(),
+        "main.lex",
+        r#"import "./helpers" as h
+fn main(x :: Int) -> Int { h.caller(x) }
+"#,
+    );
+
+    let prog = load_program(&dir.path().join("main.lex")).expect("load");
+    let caller = prog
+        .items
+        .iter()
+        .find_map(|i| match i {
+            Item::FnDecl(fd) if fd.name == "h.caller" => Some(fd),
+            _ => None,
+        })
+        .expect("h.caller present");
+    if let Expr::Var(name) = &*caller.body.result {
+        // The let-bound `inner` shadows the top-level `h.inner`,
+        // so the result expression should reference the unmangled
+        // local binder.
+        assert_eq!(name, "inner", "let-bound var should not be mangled");
+        return;
+    }
+    panic!("h.caller result not a Var: {:?}", caller.body.result);
+}
+
+#[test]
+fn transitive_imports_chain() {
+    let dir = tempfile::tempdir().unwrap();
+    write(dir.path(), "c.lex", "fn z(x :: Int) -> Int { x }\n");
+    write(
+        dir.path(),
+        "b.lex",
+        r#"import "./c" as c
+fn y(x :: Int) -> Int { c.z(x) }
+"#,
+    );
+    write(
+        dir.path(),
+        "a.lex",
+        r#"import "./b" as b
+fn main(x :: Int) -> Int { b.y(x) }
+"#,
+    );
+
+    let prog = load_program(&dir.path().join("a.lex")).expect("load");
+    let fns = fn_names(&prog);
+    assert!(fns.contains(&"main".to_string()));
+    assert!(fns.contains(&"b.y".to_string()));
+    assert!(fns.contains(&"b.c.z".to_string()), "got: {fns:?}");
+}
+
+#[test]
+fn cycle_detection_errors_with_chain() {
+    let dir = tempfile::tempdir().unwrap();
+    write(dir.path(), "a.lex", "import \"./b\" as b\nfn fa() -> Int { 1 }\n");
+    write(dir.path(), "b.lex", "import \"./a\" as a\nfn fb() -> Int { 2 }\n");
+
+    let err = load_program(&dir.path().join("a.lex")).expect_err("expected cycle error");
+    let msg = format!("{err}");
+    match err {
+        LoadError::Cycle { .. } => {
+            assert!(msg.contains("a.lex"), "msg: {msg}");
+            assert!(msg.contains("b.lex"), "msg: {msg}");
+        }
+        other => panic!("expected Cycle, got: {other:?}"),
+    }
+}
+
+#[test]
+fn missing_file_errors_clearly() {
+    let dir = tempfile::tempdir().unwrap();
+    write(
+        dir.path(),
+        "main.lex",
+        "import \"./nonexistent\" as x\nfn main() -> Int { 0 }\n",
+    );
+
+    let err = load_program(&dir.path().join("main.lex")).expect_err("expected missing-file error");
+    match err {
+        LoadError::NotFound { reference, .. } => assert_eq!(reference, "./nonexistent"),
+        other => panic!("expected NotFound, got: {other:?}"),
+    }
+}
+
+#[test]
+fn string_source_rejects_local_imports() {
+    let err = load_program_from_str("import \"./foo\" as f\nfn main() -> Int { 0 }\n")
+        .expect_err("expected rejection");
+    matches!(err, LoadError::LocalImportInStringSource);
+}
+
+#[test]
+fn string_source_accepts_std_imports() {
+    let prog = load_program_from_str("import \"std.io\" as io\nfn main() -> Int { 0 }\n")
+        .expect("std import in string source");
+    assert!(prog
+        .items
+        .iter()
+        .any(|i| matches!(i, Item::Import(imp) if imp.reference == "std.io")));
+}
+
+#[test]
+fn diamond_keeps_shared_module_once() {
+    let dir = tempfile::tempdir().unwrap();
+    write(
+        dir.path(),
+        "shared.lex",
+        "fn util(x :: Int) -> Int { x + 1 }\n",
+    );
+    write(
+        dir.path(),
+        "left.lex",
+        "import \"./shared\" as s\nfn lhs(x :: Int) -> Int { s.util(x) }\n",
+    );
+    write(
+        dir.path(),
+        "right.lex",
+        "import \"./shared\" as s\nfn rhs(x :: Int) -> Int { s.util(x) }\n",
+    );
+    write(
+        dir.path(),
+        "main.lex",
+        r#"import "./left" as l
+import "./right" as r
+fn main(x :: Int) -> Int { l.lhs(x) + r.rhs(x) }
+"#,
+    );
+
+    let prog = load_program(&dir.path().join("main.lex")).expect("load");
+    let fns = fn_names(&prog);
+    // We accept duplication of `shared.util` under each parent's path
+    // for the MVP. The test documents current behavior:
+    // - `l.s.util` and `r.s.util` both appear.
+    // (See follow-up tracker for store-native imports / SigId stability.)
+    let l_util = fns.iter().filter(|n| n == &"l.s.util").count();
+    let r_util = fns.iter().filter(|n| n == &"r.s.util").count();
+    assert_eq!(l_util, 1, "got fns: {fns:?}");
+    assert_eq!(r_util, 1, "got fns: {fns:?}");
+}
+
+#[test]
+fn std_import_in_imported_file_is_preserved() {
+    let dir = tempfile::tempdir().unwrap();
+    write(
+        dir.path(),
+        "io_helper.lex",
+        r#"import "std.io" as io
+fn say(s :: Str) -> [io] Nil { io.print(s) }
+"#,
+    );
+    write(
+        dir.path(),
+        "main.lex",
+        r#"import "./io_helper" as h
+fn main(s :: Str) -> [io] Nil { h.say(s) }
+"#,
+    );
+
+    let prog = load_program(&dir.path().join("main.lex")).expect("load");
+    let std_imports: Vec<&Import> = prog
+        .items
+        .iter()
+        .filter_map(|i| match i {
+            Item::Import(imp) => Some(imp),
+            _ => None,
+        })
+        .collect();
+    // The std.io import should appear exactly once, even though both
+    // files would have included it.
+    assert_eq!(std_imports.len(), 1, "got: {std_imports:?}");
+    assert_eq!(std_imports[0].reference, "std.io");
+    // io.print inside h.say should NOT have been rewritten.
+    let say = prog
+        .items
+        .iter()
+        .find_map(|i| match i {
+            Item::FnDecl(fd) if fd.name == "h.say" => Some(fd),
+            _ => None,
+        })
+        .expect("h.say present");
+    if let Expr::Call { callee, .. } = &*say.body.result {
+        if let Expr::Field { value, field } = &**callee {
+            if let Expr::Var(alias) = &**value {
+                assert_eq!(alias, "io");
+                assert_eq!(field, "print");
+                return;
+            }
+        }
+    }
+    panic!("h.say body not preserving io.print: {:?}", say.body.result);
+}


### PR DESCRIPTION
Closes #78.

## Summary

Adds support for `import "./relative.lex" as m` and friends alongside the existing `import "std.*"` builtins. Path imports are resolved at the syntax → AST step by a new loader in `lex-syntax/src/loader.rs`. Imported files' top-level fn and type names get prefixed with the alias path (`m.label`, `m.Status`, `b.c.z`); references to those names — including `m.foo(...)` call sites and `m.Type` annotations — get rewritten in place. Variant constructors and record field names are deliberately not mangled.

## What works

- `import "./X" as a`, `import "../X" as a`, `import "/abs/X.lex" as a`
- Auto-appends `.lex` if the path has no extension
- Transitive imports (a imports b imports c)
- `m.Type` in type expressions (parser change at `crates/lex-syntax/src/parser.rs:202-237`)
- `m.foo(...)` call sites in expressions
- Cycle detection with the full path chain in the error message
- Missing files surface a clear error pointing at the importer
- `lex serve` HTTP API and agent-tool string sources reject local imports up-front (no base path to resolve from)
- Shadowing: let-bindings, fn params, lambda params, and pattern binders correctly hide top-level names; the mangler doesn't rewrite shadowed references
- Std imports inside imported files are preserved and de-duplicated across the merged stage list

## How

- `crates/lex-syntax/src/loader.rs` (new, ~400 LOC) — recursive file loader + name mangler with scope-aware shadow tracking. Returns a single flat `Program` ready for canonicalize.
- `crates/lex-syntax/src/parser.rs` — `parse_type_expr` accepts dotted names like `m.Type`; the loader rewrites them to the mangled form.
- CLI commands that take a file path (`check`, `run`, `parse`, `publish`, `hash`, `audit`, `ast-merge`, …) go through a new `read_program` helper that calls `load_program(path)`.
- String-source contexts (`lex serve` HTTP, agent-tool, tool-registry, diff-body) call `load_program_from_str`, which rejects local imports with a clear error.

## Limitations (deliberate, tracked)

The same imported function imported under different aliases gets a different mangled name, so its SigId / StageId differs. `lex blame` across imports is not stable. The proper fix is store-native imports — tracked in #82 — where the unit of identity is the StageId itself.

## Test plan

- [x] `crates/lex-syntax/tests/loader_smoke.rs` — 11 unit tests covering two-file mangling, qualified-call rewriting, transitive, diamond, cycle, missing file, std-import preservation + dedupe, shadowing, string-source rejection.
- [x] `crates/lex-runtime/tests/local_imports_e2e.rs` — 4 end-to-end tests through loader → canonicalize → check → bytecode → VM (two-file, imported nominal type in signature, transitive, shadowing).
- [x] `cargo test --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `lex check` / `lex run` smoke tested on a real two-file project from the release binary

https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s)_