### PR TITLE
feat: lex check surfaces required --allow-effects grants (closes #81)

### DIFF
--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -218,8 +218,31 @@ fn cmd_check(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let stages = canonicalize_program(&prog);
     match lex_types::check_program(&stages) {
         Ok(_) => {
-            let data = serde_json::json!({ "ok": true, "stages": stages.len() });
-            acli::emit_or_text("check", data, fmt, || println!("ok"));
+            let summary = effects_summary(&stages);
+            let data = serde_json::json!({
+                "ok": true,
+                "stages": stages.len(),
+                "required_effects": summary.kinds,
+                "required_fs_read": summary.fs_read,
+                "required_fs_write": summary.fs_write,
+                "required_net_host": summary.net_host,
+            });
+            acli::emit_or_text("check", data, fmt, || {
+                println!("ok");
+                if !summary.kinds.is_empty() {
+                    println!("required effects: {}", summary.kinds.join(", "));
+                    if !summary.fs_read.is_empty() {
+                        println!("required fs_read paths: {}", summary.fs_read.join(", "));
+                    }
+                    if !summary.fs_write.is_empty() {
+                        println!("required fs_write paths: {}", summary.fs_write.join(", "));
+                    }
+                    if !summary.net_host.is_empty() {
+                        println!("required net hosts: {}", summary.net_host.join(", "));
+                    }
+                    println!("hint: lex run {} {path} <fn> [args]", suggest_grants(&summary));
+                }
+            });
             Ok(())
         }
         Err(errs) => {
@@ -236,6 +259,66 @@ fn cmd_check(fmt: &OutputFormat, args: &[String]) -> Result<()> {
             std::process::exit(2);
         }
     }
+}
+
+/// Effects required by a program, broken out by kind so the user can
+/// see which `--allow-*` flags they'll need at run time. We aggregate
+/// across every fn declaration in the program: more permissive than
+/// strictly necessary (a single fn might need fewer effects), but
+/// matches the common case of "I just want to run main".
+struct EffectsSummary {
+    kinds: Vec<String>,
+    fs_read: Vec<String>,
+    fs_write: Vec<String>,
+    net_host: Vec<String>,
+}
+
+fn effects_summary(stages: &[lex_ast::Stage]) -> EffectsSummary {
+    use std::collections::BTreeSet;
+    let mut kinds: BTreeSet<String> = BTreeSet::new();
+    let mut fs_read: BTreeSet<String> = BTreeSet::new();
+    let mut fs_write: BTreeSet<String> = BTreeSet::new();
+    let mut net_host: BTreeSet<String> = BTreeSet::new();
+    for s in stages {
+        if let lex_ast::Stage::FnDecl(fd) = s {
+            for e in &fd.effects {
+                kinds.insert(e.name.clone());
+                if let Some(arg) = &e.arg {
+                    let arg_str = match arg {
+                        lex_ast::EffectArg::Str { value } => value.clone(),
+                        lex_ast::EffectArg::Int { value } => value.to_string(),
+                        lex_ast::EffectArg::Ident { value } => value.clone(),
+                    };
+                    match e.name.as_str() {
+                        "fs_read" => { fs_read.insert(arg_str); }
+                        "fs_write" => { fs_write.insert(arg_str); }
+                        "net" => { net_host.insert(arg_str); }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+    EffectsSummary {
+        kinds: kinds.into_iter().collect(),
+        fs_read: fs_read.into_iter().collect(),
+        fs_write: fs_write.into_iter().collect(),
+        net_host: net_host.into_iter().collect(),
+    }
+}
+
+fn suggest_grants(s: &EffectsSummary) -> String {
+    let mut parts = vec![format!("--allow-effects {}", s.kinds.join(","))];
+    for p in &s.fs_read {
+        parts.push(format!("--allow-fs-read {p}"));
+    }
+    for p in &s.fs_write {
+        parts.push(format!("--allow-fs-write {p}"));
+    }
+    for h in &s.net_host {
+        parts.push(format!("--allow-net-host {h}"));
+    }
+    parts.join(" ")
 }
 
 fn cmd_run(fmt: &OutputFormat, args: &[String]) -> Result<()> {

--- a/crates/lex-cli/tests/check_effects.rs
+++ b/crates/lex-cli/tests/check_effects.rs
@@ -1,0 +1,159 @@
+//! `lex check` surfaces the effects a program will need at run time
+//! (closes #81). The pure-program path stays silent so we don't bury
+//! the existing `ok` line in noise.
+
+use std::process::{Command, Stdio};
+
+fn lex_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_lex")
+}
+
+fn run(args: &[&str]) -> (i32, String) {
+    let out = Command::new(lex_bin())
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn lex");
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+    )
+}
+
+fn write_to_tempfile(name: &str, src: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("lex-check-effects-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(name);
+    std::fs::write(&path, src).unwrap();
+    path
+}
+
+#[test]
+fn pure_program_check_is_silent_on_effects() {
+    let path = write_to_tempfile(
+        "pure.lex",
+        "fn add(x :: Int, y :: Int) -> Int { x + y }\n",
+    );
+    let (code, stdout) = run(&["check", path.to_str().unwrap()]);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("ok"), "stdout: {stdout}");
+    assert!(
+        !stdout.contains("required effects"),
+        "pure program shouldn't mention required effects: {stdout}"
+    );
+}
+
+#[test]
+fn io_program_check_surfaces_io() {
+    let path = write_to_tempfile(
+        "echo.lex",
+        r#"import "std.io" as io
+fn echo(s :: Str) -> [io] Nil { io.print(s) }
+"#,
+    );
+    let (code, stdout) = run(&["check", path.to_str().unwrap()]);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("ok"));
+    assert!(
+        stdout.contains("required effects: io"),
+        "expected text hint, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("--allow-effects io"),
+        "expected suggested run command, got: {stdout}"
+    );
+}
+
+#[test]
+fn json_check_includes_required_effects_array() {
+    let path = write_to_tempfile(
+        "echo_json.lex",
+        r#"import "std.io" as io
+fn echo(s :: Str) -> [io] Nil { io.print(s) }
+"#,
+    );
+    let (code, stdout) = run(&["--output", "json", "check", path.to_str().unwrap()]);
+    assert_eq!(code, 0);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("json output");
+    let data = &parsed["data"];
+    assert_eq!(data["ok"], true);
+    let kinds = data["required_effects"].as_array().expect("array");
+    assert!(
+        kinds.iter().any(|v| v == "io"),
+        "expected `io` in required_effects, got: {kinds:?}"
+    );
+}
+
+#[test]
+fn pure_program_in_json_has_empty_effects_array() {
+    let path = write_to_tempfile(
+        "pure_json.lex",
+        "fn add(x :: Int, y :: Int) -> Int { x + y }\n",
+    );
+    let (code, stdout) = run(&["--output", "json", "check", path.to_str().unwrap()]);
+    assert_eq!(code, 0);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("json output");
+    let kinds = parsed["data"]["required_effects"].as_array().expect("array");
+    assert!(kinds.is_empty(), "pure program should report no effects");
+}
+
+#[test]
+fn multiple_effects_in_signature_are_all_surfaced() {
+    let path = write_to_tempfile(
+        "multi.lex",
+        r#"import "std.io" as io
+import "std.net" as net
+fn fetch_and_print(url :: Str) -> [io, net] Result[Nil, Str] {
+  match net.get(url) {
+    Ok(body) => Ok(io.print(body)),
+    Err(e) => Err(e),
+  }
+}
+"#,
+    );
+    let (code, stdout) = run(&["--output", "json", "check", path.to_str().unwrap()]);
+    assert_eq!(code, 0);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("json output");
+    let kinds: Vec<&str> = parsed["data"]["required_effects"]
+        .as_array()
+        .expect("array")
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    // We sort with BTreeSet so the order is alphabetical.
+    assert!(kinds.contains(&"io"), "got {kinds:?}");
+    assert!(kinds.contains(&"net"), "got {kinds:?}");
+}
+
+#[test]
+fn fs_read_path_argument_surfaces_separately() {
+    // The path argument on `fs_read` is a runtime-policy concern (it
+    // gates `--allow-fs-read PATH`); the type system tracks the
+    // declaration but doesn't bind it to a specific stdlib call here,
+    // so a bare declaration with a pure body is the cleanest fixture.
+    let path = write_to_tempfile(
+        "read_data.lex",
+        "fn dummy() -> [fs_read(\"/data\")] Int { 42 }\n",
+    );
+    let (code, stdout) = run(&["--output", "json", "check", path.to_str().unwrap()]);
+    assert_eq!(code, 0);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("json output");
+    let kinds: Vec<&str> = parsed["data"]["required_effects"]
+        .as_array()
+        .expect("array")
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(kinds.contains(&"fs_read"), "got kinds: {kinds:?}");
+    let paths: Vec<&str> = parsed["data"]["required_fs_read"]
+        .as_array()
+        .expect("array")
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(
+        paths.contains(&"/data"),
+        "expected /data in required_fs_read, got: {paths:?}"
+    );
+}


### PR DESCRIPTION
Closes #81.

## Summary

`lex check` now surfaces the effects a program will need at run time, so a fresh user (or an agent driving the CLI) doesn't trip on `effect_not_allowed` the first time they call `lex run`.

```
$ lex check examples/c_echo.lex
ok
required effects: io
hint: lex run --allow-effects io examples/c_echo.lex <fn> [args]
```

JSON mode (`lex --output json check`) adds `required_effects`, `required_fs_read`, `required_fs_write`, and `required_net_host` to the existing payload, so agent-driven flows can synthesize the right `lex run` command without parsing text.

Pure programs stay silent on effects to keep the existing single-line `ok` clean.

## Aggregation

The summary unions effects across every `FnDecl` in the program. That's permissive — a single fn might need fewer effects — but matches the common case of "I just want to run main." Per-fn breakdown is a possible follow-up, not needed for the first-run UX win.

## Test plan

- [x] `crates/lex-cli/tests/check_effects.rs` — 6 cases:
  - pure program → silent on effects (text + JSON empty array)
  - `[io]` program → text hint + JSON `required_effects: ["io"]` + run-command suggestion
  - `[io, net]` program → both surface, alphabetical
  - `[fs_read("/data")]` declaration → path appears under `required_fs_read`
- [x] `cargo test --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s)_