### PR TITLE
fix: record literals coerce to nominal record types at every position (closes #79)

### DIFF
--- a/crates/lex-types/src/checker.rs
+++ b/crates/lex-types/src/checker.rs
@@ -169,6 +169,57 @@ impl Checker {
         ty
     }
 
+    /// Unify two types, asymmetrically coercing an anonymous record
+    /// against a nominal record alias at any level of nesting. So a
+    /// `{ x: 1, y: 2 }` literal can be passed to a fn taking
+    /// `Inner = { x :: Int, y :: Int }`, even when the literal is the
+    /// inner field of an outer record literal.
+    ///
+    /// We deliberately keep nominal-vs-nominal mismatches strict: two
+    /// distinct `Ty::Con` names won't unify just because their record
+    /// shapes match. The coercion fires only when one side is a bare
+    /// `Ty::Record` and the other is a `Ty::Con` whose alias is a
+    /// record.
+    fn unify_with_record_coercion(&mut self, a: &Ty, b: &Ty) -> Result<(), UnifyError> {
+        let a = self.u.resolve(a);
+        let b = self.u.resolve(b);
+        self.unify_coerce_inner(a, b)
+    }
+
+    fn unify_coerce_inner(&mut self, a: Ty, b: Ty) -> Result<(), UnifyError> {
+        // Asymmetric Record↔Con(record-alias) coercion at this level.
+        let (a, b) = match (&a, &b) {
+            (Ty::Record(_), Ty::Con(_, _)) => (a, self.unfold_record_alias(b.clone())),
+            (Ty::Con(_, _), Ty::Record(_)) => (self.unfold_record_alias(a.clone()), b),
+            _ => (a, b),
+        };
+
+        match (&a, &b) {
+            (Ty::Record(fa), Ty::Record(fb)) => {
+                if fa.len() != fb.len() {
+                    return Err(UnifyError::Mismatch { a: a.clone(), b: b.clone() });
+                }
+                for (k, va) in fa.clone() {
+                    match fb.get(&k) {
+                        Some(vb) => self.unify_coerce_inner(va, vb.clone())?,
+                        None => return Err(UnifyError::Mismatch { a: a.clone(), b: b.clone() }),
+                    }
+                }
+                Ok(())
+            }
+            (Ty::List(ta), Ty::List(tb)) => {
+                self.unify_coerce_inner((**ta).clone(), (**tb).clone())
+            }
+            (Ty::Tuple(xs), Ty::Tuple(ys)) if xs.len() == ys.len() => {
+                for (x, y) in xs.clone().into_iter().zip(ys.clone()) {
+                    self.unify_coerce_inner(x, y)?;
+                }
+                Ok(())
+            }
+            _ => self.u.unify(&a, &b),
+        }
+    }
+
     fn check_fn(&mut self, fd: &a::FnDecl) -> Result<Scheme, Vec<TypeError>> {
         // Instantiate fn's signature with fresh vars for its type params.
         let scheme = function_scheme(fd);
@@ -186,19 +237,13 @@ impl Checker {
         let body_ty = self.check_expr(&fd.body, "n_0", &mut locals, &mut inferred_effects)
             .map_err(|e| vec![e])?;
 
-        // Unfold record-aliased return types so users can declare
-        //   `type Response = { ... }`
-        // and return a record literal directly. If the body itself
-        // produces an aliased Con (e.g. a value of type `Matrix`
-        // returned to a `-> Matrix` signature), the two sides should
-        // match nominally — try the un-unfolded pair first, fall
-        // back to unfolded.
-        if self.u.unify(&body_ty, &ret_ty).is_err() {
-            let ret_ty_unfolded = self.unfold_record_alias(ret_ty.clone());
-            let body_ty_unfolded = self.unfold_record_alias(self.u.resolve(&body_ty));
-            if let Err(e) = self.u.unify(&body_ty_unfolded, &ret_ty_unfolded) {
-                return Err(vec![mismatch_err("n_0", e, &self.u, vec![format!("in function `{}`", fd.name)])]);
-            }
+        // The body may produce an anonymous record literal where the
+        // signature expects a nominal record alias (and vice-versa,
+        // and at any nested level). `unify_with_record_coercion`
+        // handles that asymmetry while keeping nominal-vs-nominal
+        // mismatches strict.
+        if let Err(e) = self.unify_with_record_coercion(&body_ty, &ret_ty) {
+            return Err(vec![mismatch_err("n_0", e, &self.u, vec![format!("in function `{}`", fd.name)])]);
         }
 
         if !inferred_effects.is_subset(&declared_effects) {
@@ -240,7 +285,7 @@ impl Checker {
                 let v_ty = self.check_expr(value, node_id, locals, effs)?;
                 if let Some(declared) = ty {
                     let d = ty_from_canon(declared, &[]);
-                    if let Err(err) = self.u.unify(&v_ty, &d) {
+                    if let Err(err) = self.unify_with_record_coercion(&v_ty, &d) {
                         return Err(mismatch_err(node_id, err, &self.u, vec![format!("in let `{}`", name)]));
                     }
                 }
@@ -264,7 +309,7 @@ impl Checker {
                     let mut arm_locals = locals.clone();
                     self.bind_pattern(&arm.pattern, &scrut_ty, &mut arm_locals, node_id)?;
                     let arm_ty = self.check_expr(&arm.body, node_id, &mut arm_locals, effs)?;
-                    if let Err(err) = self.u.unify(&arm_ty, &result_ty) {
+                    if let Err(err) = self.unify_with_record_coercion(&arm_ty, &result_ty) {
                         return Err(mismatch_err(node_id, err, &self.u, vec!["in match arm".into()]));
                     }
                 }
@@ -298,7 +343,7 @@ impl Checker {
                 let elem = self.u.fresh();
                 for it in items {
                     let t = self.check_expr(it, node_id, locals, effs)?;
-                    if let Err(err) = self.u.unify(&t, &elem) {
+                    if let Err(err) = self.unify_with_record_coercion(&t, &elem) {
                         return Err(mismatch_err(node_id, err, &self.u, vec!["in list literal".into()]));
                     }
                 }
@@ -350,7 +395,7 @@ impl Checker {
                 }
                 let mut inner_effs = EffectSet::empty();
                 let body_ty = self.check_expr(body, node_id, &mut inner_locals, &mut inner_effs)?;
-                if let Err(err) = self.u.unify(&body_ty, &ret_ty) {
+                if let Err(err) = self.unify_with_record_coercion(&body_ty, &ret_ty) {
                     return Err(mismatch_err(node_id, err, &self.u, vec!["in lambda body".into()]));
                 }
                 if !inner_effs.is_subset(&declared) {
@@ -483,7 +528,7 @@ impl Checker {
                 }
                 for (i, (a, p)) in args.iter().zip(params.iter()).enumerate() {
                     let at = self.check_expr(a, node_id, locals, effs)?;
-                    if let Err(err) = self.u.unify(&at, p) {
+                    if let Err(err) = self.unify_with_record_coercion(&at, p) {
                         return Err(mismatch_err(node_id, err, &self.u, vec![format!("argument {} of call", i + 1)]));
                     }
                 }
@@ -562,12 +607,12 @@ impl Checker {
                 }
                 if args.len() == 1 {
                     let at = self.check_expr(&args[0], node_id, locals, effs)?;
-                    self.u.unify(&at, &inst_payload).map_err(|e| mismatch_err(node_id, e, &self.u, vec![format!("constructor `{}`", name)]))?;
+                    self.unify_with_record_coercion(&at, &inst_payload).map_err(|e| mismatch_err(node_id, e, &self.u, vec![format!("constructor `{}`", name)]))?;
                 } else {
                     if let Ty::Tuple(items) = inst_payload {
                         for (i, (a, t)) in args.iter().zip(items.iter()).enumerate() {
                             let at = self.check_expr(a, node_id, locals, effs)?;
-                            self.u.unify(&at, t).map_err(|e| mismatch_err(node_id, e, &self.u, vec![format!("constructor `{}` arg {}", name, i + 1)]))?;
+                            self.unify_with_record_coercion(&at, t).map_err(|e| mismatch_err(node_id, e, &self.u, vec![format!("constructor `{}` arg {}", name, i + 1)]))?;
                         }
                     }
                 }
@@ -594,7 +639,7 @@ impl Checker {
             }
             a::Pattern::PLiteral { value } => {
                 let lt = lit_type(value);
-                self.u.unify(&lt, ty).map_err(|e| mismatch_err(node_id, e, &self.u, vec!["in pattern".into()]))?;
+                self.unify_with_record_coercion(&lt, ty).map_err(|e| mismatch_err(node_id, e, &self.u, vec!["in pattern".into()]))?;
                 Ok(())
             }
             a::Pattern::PConstructor { name, args } => {
@@ -612,7 +657,7 @@ impl Checker {
                     con_args.push(fresh);
                 }
                 let con_ty = Ty::Con(owning.clone(), con_args);
-                self.u.unify(&con_ty, ty).map_err(|e| mismatch_err(node_id, e, &self.u, vec![format!("constructor pattern `{}`", name)]))?;
+                self.unify_with_record_coercion(&con_ty, ty).map_err(|e| mismatch_err(node_id, e, &self.u, vec![format!("constructor pattern `{}`", name)]))?;
                 let payload = match &def.kind {
                     TypeDefKind::Union(v) => v.get(name).cloned().flatten(),
                     _ => None,
@@ -664,7 +709,7 @@ impl Checker {
                     Ty::Var(_) => {
                         let fresh: Vec<Ty> = items.iter().map(|_| self.u.fresh()).collect();
                         let tup_ty = Ty::Tuple(fresh.clone());
-                        self.u.unify(&tup_ty, ty).map_err(|e| mismatch_err(node_id, e, &self.u, vec!["in tuple pattern".into()]))?;
+                        self.unify_with_record_coercion(&tup_ty, ty).map_err(|e| mismatch_err(node_id, e, &self.u, vec!["in tuple pattern".into()]))?;
                         fresh
                     }
                     other => return Err(TypeError::TypeMismatch {

--- a/crates/lex-types/tests/record_coercion.rs
+++ b/crates/lex-types/tests/record_coercion.rs
@@ -1,0 +1,146 @@
+//! Anonymous record literals coerce to nominal record aliases at any
+//! position, not only function returns (closes #79). Two distinct
+//! nominal types with the same shape stay nominally distinct.
+
+use lex_ast::canonicalize_program;
+use lex_syntax::parse_source;
+
+fn check(src: &str) -> Result<(), Vec<lex_types::TypeError>> {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    lex_types::check_program(&stages).map(|_| ())
+}
+
+#[test]
+fn record_literal_coerces_at_function_argument_position() {
+    let src = r#"
+type Community = { data_status :: Str, score :: Float }
+
+fn show(c :: Community) -> Str { c.data_status }
+
+fn main() -> Str {
+  show({ data_status: "ok", score: 0.9 })
+}
+"#;
+    check(src).expect("should accept");
+}
+
+#[test]
+fn record_literal_coerces_as_nested_field_of_outer_record() {
+    let src = r#"
+type Inner = { x :: Int, y :: Int }
+type Outer = { inner :: Inner, label :: Str }
+
+fn build() -> Outer {
+  { inner: { x: 1, y: 2 }, label: "hi" }
+}
+"#;
+    check(src).expect("should accept");
+}
+
+#[test]
+fn record_literal_coerces_at_function_return() {
+    // The pre-existing return-position case still works after the
+    // refactor.
+    let src = r#"
+type Pair = { fst :: Int, snd :: Int }
+
+fn make() -> Pair { { fst: 1, snd: 2 } }
+"#;
+    check(src).expect("should accept");
+}
+
+#[test]
+fn record_literal_coerces_in_let_binding_with_type_annotation() {
+    let src = r#"
+type Pt = { x :: Int, y :: Int }
+
+fn main() -> Int {
+  let p :: Pt := { x: 1, y: 2 }
+  p.x
+}
+"#;
+    check(src).expect("should accept");
+}
+
+#[test]
+fn record_literal_coerces_as_list_element() {
+    let src = r#"
+type Pt = { x :: Int, y :: Int }
+
+fn pts() -> List[Pt] {
+  [{ x: 1, y: 2 }, { x: 3, y: 4 }]
+}
+"#;
+    check(src).expect("should accept");
+}
+
+#[test]
+fn declared_field_order_is_irrelevant() {
+    // `type Community` declares fields in {score, data_status}; the
+    // literal lists them in {data_status, score}. They unify because
+    // record unification is key-based, not positional.
+    let src = r#"
+type Community = { score :: Float, data_status :: Str }
+
+fn show() -> Community { { data_status: "ok", score: 0.9 } }
+"#;
+    check(src).expect("should accept regardless of declared field order");
+}
+
+#[test]
+fn nominal_vs_nominal_still_rejects() {
+    // Two type aliases with identical record shapes are still
+    // nominally distinct; the coercion only fires when one side is
+    // a bare record literal.
+    let src = r#"
+type Apple = { weight :: Int }
+type Box = { weight :: Int }
+
+fn ship(b :: Box) -> Int { b.weight }
+fn make_apple() -> Apple { { weight: 5 } }
+
+fn main() -> Int { ship(make_apple()) }
+"#;
+    let errs = check(src).expect_err("should reject Apple where Box expected");
+    let msg = format!("{errs:?}");
+    assert!(msg.contains("Apple") || msg.contains("Box"), "msg: {msg}");
+}
+
+#[test]
+fn missing_field_still_rejects() {
+    let src = r#"
+type Community = { data_status :: Str, score :: Float }
+
+fn show(c :: Community) -> Str { c.data_status }
+
+fn main() -> Str {
+  show({ data_status: "ok" })
+}
+"#;
+    check(src).expect_err("should reject incomplete record literal");
+}
+
+#[test]
+fn extra_field_still_rejects() {
+    let src = r#"
+type Pt = { x :: Int, y :: Int }
+
+fn id(p :: Pt) -> Pt { p }
+
+fn main() -> Pt { id({ x: 1, y: 2, z: 3 }) }
+"#;
+    check(src).expect_err("should reject record literal with extra field");
+}
+
+#[test]
+fn wrong_field_type_still_rejects() {
+    let src = r#"
+type Pt = { x :: Int, y :: Int }
+
+fn id(p :: Pt) -> Pt { p }
+
+fn main() -> Pt { id({ x: 1, y: "no" }) }
+"#;
+    check(src).expect_err("should reject wrong-typed field");
+}


### PR DESCRIPTION
Closes #79.

## Summary

Anonymous record literals now coerce to a matching nominal record alias at **every** position — function argument, nested record field, list element, let-binding type annotation, constructor payload, pattern — not only at function return like before. Two distinct nominal types with the same shape still stay nominally distinct, so the coercion doesn't silently merge `Apple` and `Box`.

The POC's `mk_*` workaround constructors are no longer needed. Field-declaration order was already structurally irrelevant; the test suite now pins that behavior.

## How

A new helper, `unify_with_record_coercion`, recursively walks both types and asymmetrically coerces at each level: when one side is `Ty::Record` and the other is `Ty::Con(alias)` whose alias is a record, the alias gets unfolded once, then unification proceeds on the unfolded pair. Internal recursion handles Record / List / Tuple; everything else falls through to plain `unify` so primitives and Functions are unchanged. The pre-existing return-position special-case in `check_fn` collapses to a single call.

10 unify sites that interact with user-written record literals now go through the helper:
- body vs return type
- let binding with type annotation
- match arm body
- list element
- lambda body vs return
- function call arguments
- constructor application (single + multi-arg)
- pattern unification (general, constructor, tuple)

Operator and primitive unifications stay on plain `self.u.unify` since records can't appear there.

## Test plan

- [x] `crates/lex-types/tests/record_coercion.rs` — 10 cases:
  - record literal at function-argument position (the core (a) case)
  - record literal as nested field of outer record literal (the (b) case)
  - record literal at function return (regression)
  - record literal in `let p :: Pt := { ... }`
  - record literal as list element
  - declared field order vs literal field order (the (c) case — it was always order-insensitive at the unify level; this pins the behavior)
  - regression: nominal-vs-nominal still rejects (Apple vs Box with same shape)
  - regression: missing field, extra field, wrong-typed field all still fail
- [x] `cargo test --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Smoke-tested the original failing programs from the issue against the release binary

https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s)_