### PR TITLE
docs: changelog + README + landing-page pass for the recent feature work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,53 @@ bumps may carry breaking changes when justified).
 
 ### Added
 
+- **Local file imports** between `.lex` modules
+  (`import "./helpers" as h`, `../`, `/abs/`). Imported files'
+  top-level fns and types are mangled with the alias path so they
+  don't collide with the importer's names; references — including
+  `m.foo(...)` calls and `m.Type` annotations — get rewritten in
+  place. Cycle detection reports the full path chain. Stdlib
+  imports unchanged. Multi-file programs no longer collapse into a
+  single file. (#83, closes #78)
+- **`lex check` surfaces required `--allow-effects` grants** in
+  both text and JSON output. The text mode adds a one-line summary
+  plus a ready-to-run `lex run --allow-effects ...` suggestion;
+  the JSON adds `required_effects`, `required_fs_read`,
+  `required_fs_write`, and `required_net_host`. Pure programs
+  stay silent on effects to keep the existing single-line `ok`
+  clean. (#85, closes #81)
 - `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, GitHub issue / PR
   templates, Dependabot config — open-source housekeeping.
+
+### Changed
+
+- **Anonymous record literals coerce to nominal record aliases at
+  every position** — function argument, nested record field, list
+  element, `let p :: T := { ... }`, constructor payload, pattern.
+  Previously this only worked at function-return position, forcing
+  POCs to write explicit `mk_*` constructor functions for every
+  nominal record type. Two distinct nominal types with the same
+  shape stay nominally distinct. (#86, closes #79)
+- **Trailing commas** are now allowed in every comma-separated
+  list (fn params, call args, lambda params, type args, effects,
+  function type params, constructor type payloads, constructor
+  patterns, tuple patterns) — previously they were accepted in
+  match arms / list / record literals only. (#84, closes #80)
+
+### Dependencies
+
+- logos `0.14` → `0.16`, tungstenite `0.21` → `0.29`, ureq
+  `2.10` → `3.3`, sha2 `0.10` → `0.11`, thiserror `1` → `2`.
+  Source changes for tungstenite (`Message::Text` now wraps
+  `Utf8Bytes`) and ureq (full API rewrite — `Agent::config_builder`,
+  `body_mut().read_to_string()`, `Error::StatusCode`). For ureq,
+  `http_status_as_error(false)` preserves the prior
+  `Err("status NNN: <body>")` shape. Features renamed to
+  `rustls,platform-verifier`. (#75, #76)
+- `actions/checkout@v4` → `@v6`, `actions/upload-artifact@v4`
+  → `@v7`, `actions/download-artifact@v4` → `@v8`. (#84 build,
+  bumped together because v8 download validates the
+  upload side's content-type.)
 
 ### Documentation
 
@@ -18,6 +63,9 @@ bumps may carry breaking changes when justified).
   Rust MSRV).
 - Worked `lex serve` example with `curl /v1/check` and `/v1/run`
   in the Quickstart.
+- Multi-file project example in the Quickstart, demonstrating
+  local imports.
+- `lex check` examples updated to show the effect summary.
 
 ## [0.1.0] — 2026-05
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,15 @@ cargo build --release
 # Add the binary to your path (or invoke ./target/release/lex directly).
 export PATH="$(pwd)/target/release:$PATH"
 
-# Type-check a program.
+# Type-check a program. Pure programs print `ok`; non-pure ones add
+# the effects you'll need to grant when running, plus a suggested
+# `lex run` command.
 lex check examples/a_factorial.lex
+# → ok
+lex check examples/c_echo.lex
+# → ok
+#   required effects: io
+#   hint: lex run --allow-effects io examples/c_echo.lex <fn> [args]
 
 # Run a function with JSON arguments.
 lex run examples/a_factorial.lex factorial 5
@@ -74,6 +81,38 @@ curl -sX POST http://localhost:4040/v1/run \
        "fn":"add", "args":[2,3], "policy":{"allow_effects":[]}}'
 # → {"run_id":"...","output":5}
 ```
+
+### Multi-file projects
+
+Local imports work the same way as `std.*`, just with a path:
+
+```bash
+# models.lex
+type Status = Healthy | Sick
+fn label(s :: Status) -> Str {
+  match s { Healthy => "ok", Sick => "nope" }
+}
+
+# main.lex
+import "./models" as m
+
+fn describe(s :: m.Status) -> Str { m.label(s) }
+```
+
+```bash
+lex check main.lex   # ok — both files are loaded and merged
+lex run main.lex describe '{"$variant":"Healthy","args":[]}'
+```
+
+Path imports are resolved relative to the importer's directory; the
+`.lex` extension is auto-appended. `../`, `/abs/path.lex`, and
+multi-level nesting (`f.g.h`) all work, with cycle detection that
+reports the full path chain. Stdlib imports are unchanged.
+
+> Each imported function is currently identified by its alias path,
+> so `lex blame` doesn't yet follow a function across imports — see
+> [`#82`](https://github.com/alpibrusl/lex-lang/issues/82) for the
+> store-native sharing model that will fix this.
 
 ### Quickstart: agent-native tooling
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -412,6 +412,18 @@ $ lex ast-merge --json base.lex ours.lex theirs.lex
 cargo build --release
 export PATH="$(pwd)/target/release:$PATH"
 
+# Type-check a program. Effects you'll need at run time are surfaced
+# alongside `ok` so the first run doesn't trip on `effect_not_allowed`:
+lex check examples/c_echo.lex
+# → ok
+#   required effects: io
+#   hint: lex run --allow-effects io examples/c_echo.lex &lt;fn&gt; [args]
+
+# Multi-file projects work like std imports, with a path:
+#   import "./helpers" as h
+# Sibling .lex files are loaded and merged. Cycle detection,
+# transitive imports, and `m.Type` qualified types all work.
+
 # Reject a malicious tool without an API key:
 lex agent-tool --allow-effects net --input x \
   --body 'match io.read("/etc/passwd") { Ok(s) =&gt; s, Err(e) =&gt; e }'


### PR DESCRIPTION
Catches up the docs to the recently merged feature work.

## Summary

- **CHANGELOG** `[Unreleased]` now lists every shipped change since the prior entry: local imports (#83), `lex check` effect surfacing (#85), record-literal coercion (#86), trailing commas (#84), and the dependency + actions overhaul (#75, #76). Grouped by Added / Changed / Dependencies / Documentation.
- **README** adds a new "Multi-file projects" subsection in the Quickstart with a worked two-file example, the path-resolution rules, and a small callout pointing at #82 for the SigId-stability follow-up. The `lex check` example is updated to show the new effect summary + run-command hint.
- **docs/index.html** (landing page) gets one tight block in the "Try it" section showing the new `lex check` output and a one-line note that multi-file projects work the same way as `std.*` imports — kept minimal so the security pitch isn't diluted.

## Test plan

- [ ] Eyeball the rendered README on GitHub
- [ ] Eyeball the rendered docs/index.html on GitHub Pages once main lands
- [x] No code changes; nothing to test

https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s)_