### PR TITLE
fix: bare record patterns match nominal record aliases (closes #89)

### DIFF
--- a/crates/lex-types/src/checker.rs
+++ b/crates/lex-types/src/checker.rs
@@ -681,7 +681,11 @@ impl Checker {
                 }
             }
             a::Pattern::PRecord { fields } => {
-                let resolved = self.u.resolve(ty);
+                // Unfold a record-aliased Con (`type Bands = { ... }`)
+                // so a structural `{ idea: pat, ... }` pattern can match
+                // a nominal-typed scrutinee, mirror of #79's literal
+                // coercion at every position.
+                let resolved = self.unfold_record_alias(self.u.resolve(ty));
                 let rec = match resolved {
                     Ty::Record(r) => r,
                     _ => return Err(TypeError::TypeMismatch {

--- a/crates/lex-types/tests/record_pattern_nominal.rs
+++ b/crates/lex-types/tests/record_pattern_nominal.rs
@@ -1,0 +1,96 @@
+//! Bare record patterns match nominal record types (closes #89).
+//! Mirror of #79's literal coercion: `match v :: Bands { { idea: ..., execution: ... } => ... }`
+//! should work even though the scrutinee is a `Ty::Con` aliasing a record.
+
+use lex_ast::canonicalize_program;
+use lex_syntax::parse_source;
+
+fn check(src: &str) -> Result<(), Vec<lex_types::TypeError>> {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    lex_types::check_program(&stages).map(|_| ())
+}
+
+#[test]
+fn bare_record_pattern_matches_nominal_record_alias() {
+    let src = r#"
+type Bands = { idea :: Str, execution :: Str }
+
+fn verdict(b :: Bands) -> Str {
+  match b {
+    { idea: "high", execution: "high" } => "ship",
+    _                                    => "iterate",
+  }
+}
+"#;
+    check(src).expect("structural pattern should match nominal record");
+}
+
+#[test]
+fn bare_record_pattern_with_bindings_matches_nominal() {
+    let src = r#"
+type Pt = { x :: Int, y :: Int }
+
+fn dist(p :: Pt) -> Int {
+  match p {
+    { x, y } => x + y,
+  }
+}
+"#;
+    check(src).expect("shorthand binders against nominal record");
+}
+
+#[test]
+fn nested_bare_record_pattern_matches_nominal_inner() {
+    let src = r#"
+type Inner = { v :: Int }
+type Outer = { inner :: Inner, name :: Str }
+
+fn pull(o :: Outer) -> Int {
+  match o {
+    { inner: { v }, name: _ } => v,
+  }
+}
+"#;
+    check(src).expect("nested bare record pattern should match nominal inner");
+}
+
+#[test]
+fn bare_record_pattern_still_works_on_anonymous_record() {
+    // Regression: don't break the existing structural-on-structural case.
+    let src = r#"
+fn pick(p :: { x :: Int, y :: Int }) -> Int {
+  match p {
+    { x, y: _ } => x,
+  }
+}
+"#;
+    check(src).expect("structural pattern on structural type");
+}
+
+#[test]
+fn bare_record_pattern_against_non_record_still_errors() {
+    let src = r#"
+fn nope(n :: Int) -> Int {
+  match n {
+    { x } => x,
+    _     => n,
+  }
+}
+"#;
+    check(src).expect_err("record pattern against Int should reject");
+}
+
+#[test]
+fn bare_record_pattern_unknown_field_against_nominal_still_errors() {
+    let src = r#"
+type Pt = { x :: Int, y :: Int }
+
+fn nope(p :: Pt) -> Int {
+  match p {
+    { z } => z,
+  }
+}
+"#;
+    check(src).expect_err("unknown field in record pattern should reject");
+}


### PR DESCRIPTION
Closes #89.

## Summary

PR #86 added structural→nominal coercion at every position in unify sites, but the `PRecord` pattern path bypassed unify entirely — it did `match resolved_ty { Ty::Record(r) => r, _ => mismatch }` before any coercion-aware step ran. So a structural `{ field: pat, ... }` pattern against a nominal-typed scrutinee was rejected as `expected: record, got: T`.

## Fix

One line in `crates/lex-types/src/checker.rs`'s `PRecord` arm: unfold the scrutinee through `unfold_record_alias` before extracting the record fields. Mirror of #79's literal coercion at every position.

Anything not record-aliased (Int, Str, etc.) still falls through to the mismatch error.

## Test plan

`crates/lex-types/tests/record_pattern_nominal.rs` — 6 cases:

- structural pattern matches nominal alias (the issue's repro)
- shorthand `{ x, y }` binders against nominal
- nested bare record pattern matches nominal inner type
- regression: structural pattern against structural type still works
- regression: record pattern against `Int` still rejects
- regression: unknown field on nominal record still rejects

Plus `cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Impact

Unblocks the flat decision-table pattern the OSS-Auditor POC wanted (`match b { { idea: High, execution: High } => "ship", ... }` instead of nested-match-per-axis).

https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s)_