### PR TITLE
fix: diamond imports collapse to one nominal type per file (closes #88)

### DIFF
--- a/crates/lex-syntax/Cargo.toml
+++ b/crates/lex-syntax/Cargo.toml
@@ -10,6 +10,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 logos.workspace = true
 indexmap.workspace = true
+sha2.workspace = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/lex-syntax/src/loader.rs
+++ b/crates/lex-syntax/src/loader.rs
@@ -2,15 +2,22 @@
 //! `import "/abs/..."` statements relative to the importer, recursively
 //! parses, and produces a single [`Program`] with all stages merged.
 //!
-//! Names that are local to an imported file are mangled with the alias
-//! path so they don't collide with the importer's names. Stdlib imports
-//! (`import "std.foo" as bar`) pass through unchanged.
+//! Names that are local to an imported file are mangled with a
+//! **per-file-path** prefix, so the same module imported via multiple
+//! aliases (or from multiple parents in a diamond shape) collapses to
+//! one set of mangled names — same SigId, same nominal identity.
+//! Stdlib imports (`import "std.foo" as bar`) pass through unchanged.
 //!
 //! ## Mangling
 //!
-//! Each loaded file has an "alias path" — empty for the root file, `f`
-//! for `import "./X" as f` from the root, `f.g` for `import "./Y" as g`
-//! inside X, etc. Within a file at alias path `P`:
+//! Each loaded file gets a prefix derived from its canonical filesystem
+//! path. The entry file's prefix is empty (so `lex run main.lex
+//! process` works unchanged). Imported files use `<stem>_<hash>`
+//! where `hash` is the first 8 hex chars of SHA-256 of the canonical
+//! path string. The hash disambiguates same-stem files in different
+//! directories without forcing a project manifest.
+//!
+//! Within a file at prefix `P`:
 //!
 //! - `fn foo` declared in this file becomes `<P>.foo` (just `foo` at root).
 //! - `type T` declared in this file becomes `<P>.T`.
@@ -18,23 +25,36 @@
 //!   name is shadowed by a binder (let, fn param, lambda param, or
 //!   pattern binder) in scope.
 //! - `m.foo` where `m` is a path-import alias is rewritten to the
-//!   imported file's alias-path-qualified name.
+//!   imported file's prefix-qualified name. Two parents importing the
+//!   same file see the same prefix → calls and types unify.
 //! - `m.foo` where `m` is a stdlib alias is unchanged.
 //!
 //! Variant constructors are **not** mangled — they live in a global
 //! namespace, and a collision between two imported types' constructors
 //! surfaces later as a type-check error. Same for record field names.
 //!
+//! ## Diamond imports
+//!
+//! `main.lex` imports `./left` and `./right`, both of which import
+//! `./shared`. `shared.lex` is parsed once per resolution, but its
+//! mangled items are merged into the output exactly once (subsequent
+//! loads from the same canonical path return an empty Program). This
+//! is what makes `s.build_report(...)` and `v.read_score(...)` agree
+//! on `Report`'s nominal identity.
+//!
 //! ## Limitations (tracked separately)
 //!
-//! Mangling means the SigId / StageId of an imported function depends
-//! on the alias chain the importer chose. `lex blame` across imports
-//! is not stable yet — see the future-work tracker for store-native
-//! imports (`import "stage:..."`).
+//! The mangling key is the canonical filesystem path. Moving a file
+//! changes its SigId; renaming changes the file-stem half of the
+//! prefix. The eventual fix — content-addressed identity decoupled
+//! from filesystem layout — lives with store-native imports
+//! (`import "stage:..."`); see the corresponding follow-up tracker.
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use thiserror::Error;
+
+use sha2::{Digest, Sha256};
 
 use crate::syntax::*;
 use crate::{parse_source, SyntaxError};
@@ -64,10 +84,19 @@ pub enum LoadError {
 /// Load a multi-file Lex program, expanding local imports relative to
 /// the entry path. Stdlib imports (`std.*`) pass through unchanged.
 pub fn load_program(entry: &Path) -> Result<Program, LoadError> {
+    let entry_canonical = entry.canonicalize().map_err(|source| LoadError::Io {
+        path: entry.display().to_string(),
+        source,
+    })?;
     let mut state = LoaderState {
         in_progress: Vec::new(),
+        loaded: HashSet::new(),
+        prefixes: HashMap::new(),
     };
-    state.load(entry, "")
+    // Entry file's prefix is empty so `lex run main.lex process` works
+    // without users typing the hashed prefix.
+    state.prefixes.insert(entry_canonical.clone(), String::new());
+    state.load(&entry_canonical)
 }
 
 /// Load a Lex program from a string source. Local-path imports are
@@ -89,15 +118,36 @@ pub fn load_program_from_str(src: &str) -> Result<Program, LoadError> {
 
 struct LoaderState {
     in_progress: Vec<PathBuf>,
+    /// Canonical paths that have already been merged into the output.
+    /// A second `import "./shared"` from a different parent skips
+    /// re-merging — the file's mangled items are already there.
+    loaded: HashSet<PathBuf>,
+    /// Stable mangling prefix per canonical path. Computed lazily;
+    /// the entry file is seeded with an empty prefix.
+    prefixes: HashMap<PathBuf, String>,
 }
 
 impl LoaderState {
-    fn load(&mut self, path: &Path, alias_path: &str) -> Result<Program, LoadError> {
-        let canonical = path.canonicalize().map_err(|source| LoadError::Io {
-            path: path.display().to_string(),
-            source,
-        })?;
-        if self.in_progress.contains(&canonical) {
+    fn prefix_for(&mut self, canonical: &Path) -> String {
+        if let Some(p) = self.prefixes.get(canonical) {
+            return p.clone();
+        }
+        let stem = canonical
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("module");
+        let mut hasher = Sha256::new();
+        hasher.update(canonical.to_string_lossy().as_bytes());
+        let digest = hasher.finalize();
+        let prefix = format!("{stem}_{:08x}", u32::from_be_bytes([
+            digest[0], digest[1], digest[2], digest[3],
+        ]));
+        self.prefixes.insert(canonical.to_path_buf(), prefix.clone());
+        prefix
+    }
+
+    fn load(&mut self, canonical: &Path) -> Result<Program, LoadError> {
+        if self.in_progress.contains(&canonical.to_path_buf()) {
             let mut chain: Vec<String> = self
                 .in_progress
                 .iter()
@@ -108,9 +158,18 @@ impl LoaderState {
                 chain: chain.join(" -> "),
             });
         }
-        self.in_progress.push(canonical.clone());
+        // Diamond dedupe: if this file was already merged on another
+        // path through the import graph, its items are already in the
+        // output Vec — return an empty Program so the caller's
+        // `merged_children.extend(...)` is a no-op for items, but the
+        // call still resolves so the parent's `path_imports` map gets
+        // populated below.
+        if self.loaded.contains(canonical) {
+            return Ok(Program { items: Vec::new() });
+        }
+        self.in_progress.push(canonical.to_path_buf());
 
-        let src = std::fs::read_to_string(&canonical).map_err(|source| LoadError::Io {
+        let src = std::fs::read_to_string(canonical).map_err(|source| LoadError::Io {
             path: canonical.display().to_string(),
             source,
         })?;
@@ -129,6 +188,7 @@ impl LoaderState {
             })
             .collect();
 
+        // alias used by this file → mangling prefix of the imported file
         let mut path_imports: HashMap<String, String> = HashMap::new();
         let mut merged_children: Vec<Item> = Vec::new();
         let mut std_imports: Vec<Item> = Vec::new();
@@ -137,14 +197,10 @@ impl LoaderState {
         for item in prog.items {
             match item {
                 Item::Import(ref imp) if is_path_import(&imp.reference) => {
-                    let resolved = resolve_import(&canonical, &imp.reference)?;
-                    let child_alias_path = if alias_path.is_empty() {
-                        imp.alias.clone()
-                    } else {
-                        format!("{alias_path}.{}", imp.alias)
-                    };
-                    path_imports.insert(imp.alias.clone(), child_alias_path.clone());
-                    let child_prog = self.load(&resolved, &child_alias_path)?;
+                    let resolved = resolve_import(canonical, &imp.reference)?;
+                    let child_prefix = self.prefix_for(&resolved);
+                    path_imports.insert(imp.alias.clone(), child_prefix);
+                    let child_prog = self.load(&resolved)?;
                     merged_children.extend(child_prog.items);
                 }
                 Item::Import(_) => std_imports.push(item),
@@ -152,8 +208,9 @@ impl LoaderState {
             }
         }
 
+        let my_prefix = self.prefix_for(canonical);
         let mangler = Mangler {
-            alias_path: alias_path.to_string(),
+            prefix: my_prefix,
             local_names: &local_names,
             path_imports: &path_imports,
         };
@@ -163,6 +220,7 @@ impl LoaderState {
             .collect();
 
         self.in_progress.pop();
+        self.loaded.insert(canonical.to_path_buf());
 
         // Output order: std imports first (deduped against children's),
         // then merged children's items, then this file's items.
@@ -202,18 +260,22 @@ fn resolve_import(importer: &Path, reference: &str) -> Result<PathBuf, LoadError
 }
 
 struct Mangler<'a> {
-    alias_path: String,
+    /// Mangling prefix for items declared in this file. Empty for the
+    /// entry file, `<stem>_<hash8>` for imported files.
+    prefix: String,
     local_names: &'a HashSet<String>,
-    /// Map from local alias to the imported file's alias path.
+    /// Map from local alias to the imported file's mangling prefix.
+    /// `m.foo` rewrites to `<imported_prefix>.foo` regardless of which
+    /// alias `m` was, so two parents importing the same module agree.
     path_imports: &'a HashMap<String, String>,
 }
 
 impl<'a> Mangler<'a> {
     fn qualify(&self, name: &str) -> String {
-        if self.alias_path.is_empty() {
+        if self.prefix.is_empty() {
             name.to_string()
         } else {
-            format!("{}.{}", self.alias_path, name)
+            format!("{}.{}", self.prefix, name)
         }
     }
 

--- a/crates/lex-syntax/tests/loader_smoke.rs
+++ b/crates/lex-syntax/tests/loader_smoke.rs
@@ -1,6 +1,6 @@
 //! Multi-file loader smoke tests: two-file project, transitive imports,
-//! diamond, cycle detection, missing file, m.Type qualified types,
-//! shadowing.
+//! diamond (now deduped), cycle detection, missing file, m.Type
+//! qualified types, shadowing.
 
 use lex_syntax::syntax::*;
 use lex_syntax::{load_program, load_program_from_str, LoadError};
@@ -28,6 +28,40 @@ fn type_names(prog: &Program) -> Vec<String> {
             _ => None,
         })
         .collect()
+}
+
+/// Find the unique fn whose mangled name ends with `.<suffix>` (an
+/// imported fn) or equals `<suffix>` (a root-file fn). Asserts
+/// uniqueness.
+fn unique_fn<'a>(prog: &'a Program, suffix: &str) -> &'a FnDecl {
+    let matches: Vec<&FnDecl> = prog
+        .items
+        .iter()
+        .filter_map(|i| match i {
+            Item::FnDecl(fd) if fd.name == suffix || fd.name.ends_with(&format!(".{suffix}")) => {
+                Some(fd)
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        matches.len(),
+        1,
+        "expected exactly one fn matching `{suffix}`, found {}: {:?}",
+        matches.len(),
+        matches.iter().map(|f| &f.name).collect::<Vec<_>>(),
+    );
+    matches[0]
+}
+
+fn count_with_suffix(prog: &Program, suffix: &str) -> usize {
+    prog.items
+        .iter()
+        .filter(|i| match i {
+            Item::FnDecl(fd) => fd.name == suffix || fd.name.ends_with(&format!(".{suffix}")),
+            _ => false,
+        })
+        .count()
 }
 
 #[test]
@@ -58,11 +92,17 @@ fn main(s :: m.Status) -> Str { m.label(s) }
     let fns = fn_names(&prog);
     let types = type_names(&prog);
 
-    // Imported fn is mangled with the alias.
-    assert!(fns.contains(&"m.label".to_string()), "got fns: {fns:?}");
-    // Imported type is mangled.
-    assert!(types.contains(&"m.Status".to_string()), "got types: {types:?}");
-    // Root fn is unmangled.
+    // Imported fn is mangled (some prefix, ending in .label).
+    assert!(
+        fns.iter().any(|n| n.ends_with(".label") && n.contains('_')),
+        "expected mangled fn ending in `.label` with `_` separator, got: {fns:?}",
+    );
+    // Imported type likewise.
+    assert!(
+        types.iter().any(|n| n.ends_with(".Status") && n.contains('_')),
+        "expected mangled type ending in `.Status`, got: {types:?}",
+    );
+    // Root fn stays unmangled.
     assert!(fns.contains(&"main".to_string()), "got fns: {fns:?}");
 }
 
@@ -84,19 +124,15 @@ fn main(x :: Int) -> Int { h.double(x) }
     );
 
     let prog = load_program(&dir.path().join("main.lex")).expect("load");
-    // The call site `h.double(x)` should have been rewritten to `Var("h.double")`.
-    let main_fn = prog
-        .items
-        .iter()
-        .find_map(|i| match i {
-            Item::FnDecl(fd) if fd.name == "main" => Some(fd),
-            _ => None,
-        })
-        .expect("main fn present");
+    let main_fn = unique_fn(&prog, "main");
+    let imported = unique_fn(&prog, "double");
 
     if let Expr::Call { callee, .. } = &*main_fn.body.result {
         if let Expr::Var(name) = &**callee {
-            assert_eq!(name, "h.double");
+            assert_eq!(
+                name, &imported.name,
+                "main's call should reference the imported fn's mangled name"
+            );
             return;
         }
     }
@@ -106,8 +142,6 @@ fn main(x :: Int) -> Int { h.double(x) }
 #[test]
 fn unqualified_local_call_inside_imported_file_is_mangled() {
     let dir = tempfile::tempdir().unwrap();
-    // helpers.lex defines `inner` and calls it from `outer`. After the
-    // loader pass, both should live under the `h` alias path.
     write(
         dir.path(),
         "helpers.lex",
@@ -124,29 +158,21 @@ fn main(x :: Int) -> Int { h.outer(x) }
     );
 
     let prog = load_program(&dir.path().join("main.lex")).expect("load");
-    let outer = prog
-        .items
-        .iter()
-        .find_map(|i| match i {
-            Item::FnDecl(fd) if fd.name == "h.outer" => Some(fd),
-            _ => None,
-        })
-        .expect("h.outer present");
-    // Inside h.outer, the call to `inner(x)` should now be `h.inner(x)`.
+    let outer = unique_fn(&prog, "outer");
+    let inner = unique_fn(&prog, "inner");
+
     if let Expr::Call { callee, .. } = &*outer.body.result {
         if let Expr::Var(name) = &**callee {
-            assert_eq!(name, "h.inner");
+            assert_eq!(name, &inner.name, "outer's body should call inner via mangled name");
             return;
         }
     }
-    panic!("h.outer body not rewritten: {:?}", outer.body.result);
+    panic!("outer body not rewritten: {:?}", outer.body.result);
 }
 
 #[test]
 fn shadowed_let_binding_is_not_mangled() {
     let dir = tempfile::tempdir().unwrap();
-    // `inner` is a top-level fn AND a let binding inside `caller`.
-    // The let binding should win inside the body — no mangling.
     write(
         dir.path(),
         "helpers.lex",
@@ -166,22 +192,12 @@ fn main(x :: Int) -> Int { h.caller(x) }
     );
 
     let prog = load_program(&dir.path().join("main.lex")).expect("load");
-    let caller = prog
-        .items
-        .iter()
-        .find_map(|i| match i {
-            Item::FnDecl(fd) if fd.name == "h.caller" => Some(fd),
-            _ => None,
-        })
-        .expect("h.caller present");
+    let caller = unique_fn(&prog, "caller");
     if let Expr::Var(name) = &*caller.body.result {
-        // The let-bound `inner` shadows the top-level `h.inner`,
-        // so the result expression should reference the unmangled
-        // local binder.
         assert_eq!(name, "inner", "let-bound var should not be mangled");
         return;
     }
-    panic!("h.caller result not a Var: {:?}", caller.body.result);
+    panic!("caller result not a Var: {:?}", caller.body.result);
 }
 
 #[test]
@@ -206,8 +222,8 @@ fn main(x :: Int) -> Int { b.y(x) }
     let prog = load_program(&dir.path().join("a.lex")).expect("load");
     let fns = fn_names(&prog);
     assert!(fns.contains(&"main".to_string()));
-    assert!(fns.contains(&"b.y".to_string()));
-    assert!(fns.contains(&"b.c.z".to_string()), "got: {fns:?}");
+    assert_eq!(count_with_suffix(&prog, "y"), 1);
+    assert_eq!(count_with_suffix(&prog, "z"), 1);
 }
 
 #[test]
@@ -261,7 +277,10 @@ fn string_source_accepts_std_imports() {
 }
 
 #[test]
-fn diamond_keeps_shared_module_once() {
+fn diamond_imports_share_one_module_identity() {
+    // Closes #88: two parents importing the same file produce one
+    // (deduped) set of mangled items, so `s.util` and `r.util` both
+    // resolve to the same fn under the same mangled name.
     let dir = tempfile::tempdir().unwrap();
     write(
         dir.path(),
@@ -288,15 +307,81 @@ fn main(x :: Int) -> Int { l.lhs(x) + r.rhs(x) }
     );
 
     let prog = load_program(&dir.path().join("main.lex")).expect("load");
-    let fns = fn_names(&prog);
-    // We accept duplication of `shared.util` under each parent's path
-    // for the MVP. The test documents current behavior:
-    // - `l.s.util` and `r.s.util` both appear.
-    // (See follow-up tracker for store-native imports / SigId stability.)
-    let l_util = fns.iter().filter(|n| n == &"l.s.util").count();
-    let r_util = fns.iter().filter(|n| n == &"r.s.util").count();
-    assert_eq!(l_util, 1, "got fns: {fns:?}");
-    assert_eq!(r_util, 1, "got fns: {fns:?}");
+
+    // util appears exactly once under its mangled name (regardless of
+    // which parent's alias chain we'd have walked).
+    assert_eq!(
+        count_with_suffix(&prog, "util"),
+        1,
+        "shared.util should appear once after dedupe; got fns: {:?}",
+        fn_names(&prog),
+    );
+
+    // Both lhs and rhs call sites resolve to that same name.
+    let util = unique_fn(&prog, "util");
+    let lhs = unique_fn(&prog, "lhs");
+    let rhs = unique_fn(&prog, "rhs");
+
+    fn callee_name(body: &Block) -> &str {
+        if let Expr::Call { callee, .. } = &*body.result {
+            if let Expr::Var(name) = &**callee {
+                return name;
+            }
+        }
+        panic!("body result not a Call(Var): {:?}", body.result);
+    }
+    assert_eq!(callee_name(&lhs.body), util.name);
+    assert_eq!(callee_name(&rhs.body), util.name);
+}
+
+#[test]
+fn diamond_with_imported_type_unifies_across_branches() {
+    // The user's repro from #88: scorer builds Report, verdict
+    // consumes Report, both reach Report via different aliases.
+    let dir = tempfile::tempdir().unwrap();
+    write(dir.path(), "models.lex", "type Report = { score :: Int }\n");
+    write(
+        dir.path(),
+        "scorer.lex",
+        "import \"./models\" as m\nfn build_report(s :: Int) -> m.Report { { score: s } }\n",
+    );
+    write(
+        dir.path(),
+        "verdict.lex",
+        "import \"./models\" as m\nfn read_score(r :: m.Report) -> Int { r.score }\n",
+    );
+    write(
+        dir.path(),
+        "main.lex",
+        r#"import "./scorer" as s
+import "./verdict" as v
+
+fn main() -> Int {
+  let r := s.build_report(7)
+  v.read_score(r)
+}
+"#,
+    );
+
+    let prog = load_program(&dir.path().join("main.lex")).expect("load");
+
+    // The build_report and read_score signatures should reference the
+    // same mangled `Report` name, so a downstream type-check unifies.
+    let builder = unique_fn(&prog, "build_report");
+    let reader = unique_fn(&prog, "read_score");
+
+    let builder_ret = match &builder.return_type {
+        TypeExpr::Named { name, .. } => name.clone(),
+        other => panic!("expected Named return type, got {other:?}"),
+    };
+    let reader_param = match &reader.params[0].ty {
+        TypeExpr::Named { name, .. } => name.clone(),
+        other => panic!("expected Named param type, got {other:?}"),
+    };
+    assert_eq!(
+        builder_ret, reader_param,
+        "diamond branches should resolve to the same nominal type",
+    );
 }
 
 #[test]
@@ -326,19 +411,11 @@ fn main(s :: Str) -> [io] Nil { h.say(s) }
             _ => None,
         })
         .collect();
-    // The std.io import should appear exactly once, even though both
-    // files would have included it.
     assert_eq!(std_imports.len(), 1, "got: {std_imports:?}");
     assert_eq!(std_imports[0].reference, "std.io");
-    // io.print inside h.say should NOT have been rewritten.
-    let say = prog
-        .items
-        .iter()
-        .find_map(|i| match i {
-            Item::FnDecl(fd) if fd.name == "h.say" => Some(fd),
-            _ => None,
-        })
-        .expect("h.say present");
+
+    // io.print inside say should NOT have been rewritten.
+    let say = unique_fn(&prog, "say");
     if let Expr::Call { callee, .. } = &*say.body.result {
         if let Expr::Field { value, field } = &**callee {
             if let Expr::Var(alias) = &**value {
@@ -348,5 +425,5 @@ fn main(s :: Str) -> [io] Nil { h.say(s) }
             }
         }
     }
-    panic!("h.say body not preserving io.print: {:?}", say.body.result);
+    panic!("say body not preserving io.print: {:?}", say.body.result);
 }


### PR DESCRIPTION
Closes #88.

## Summary

The loader's mangling key is now the file's canonical filesystem path, not the alias chain the importer used. Each loaded file gets a stable prefix `<stem>_<8hex of sha256(canonical_path)>`; two parents importing the same file see the same prefix, so call sites and types unify across diamond shapes. The user's repro from #88 (`s.build_report → m.Report` vs `v.read_score(r :: m.Report)`) now type-checks.

## How

- `LoaderState` gains `loaded: HashSet<PathBuf>` (dedupe) and `prefixes: HashMap<PathBuf, String>` (canonical-path → mangle prefix).
- A second load of the same canonical path returns an empty Program — its mangled items are already in the output, so no duplicate-fn-decl errors.
- The entry file is special-cased to an empty prefix, so `lex run main.lex process 5` keeps working without users typing the hashed prefix.
- `Mangler.alias_path: String` becomes `Mangler.prefix: String`; `path_imports` now stores the imported file's prefix (not alias-chain string), so `m.foo` rewrites to `<imported_prefix>.foo` regardless of which alias `m` was.

Adds `sha2.workspace = true` to `lex-syntax` (already in workspace deps).

## Test plan

- [x] `crates/lex-syntax/tests/loader_smoke.rs`:
  - flipped `diamond_keeps_shared_module_once` → `diamond_imports_share_one_module_identity`. Asserts `util` appears exactly once after dedupe, and both parents' call sites resolve to the same mangled name.
  - added `diamond_with_imported_type_unifies_across_branches` — direct port of the issue's repro
  - other tests switched from hardcoded `m.label` / `b.c.z`-style assertions to suffix-matching, since the exact prefix is now an implementation detail
- [x] `cargo test --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Issue's repro verified against the release binary: `lex check /tmp/diamond/main.lex` → `ok`

## #82 still on the table

The mangling key is the canonical filesystem path, so moving or renaming a file changes the prefix. Content-addressed identity that survives filesystem layout changes is what #82 (store-native imports) eventually solves.

https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s)_