### PR TITLE
docs: changelog + README + landing-page pass for #88 and #89

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,12 @@ bumps may carry breaking changes when justified).
 
 - **Local file imports** between `.lex` modules
   (`import "./helpers" as h`, `../`, `/abs/`). Imported files'
-  top-level fns and types are mangled with the alias path so they
-  don't collide with the importer's names; references — including
-  `m.foo(...)` calls and `m.Type` annotations — get rewritten in
-  place. Cycle detection reports the full path chain. Stdlib
-  imports unchanged. Multi-file programs no longer collapse into a
-  single file. (#83, closes #78)
+  top-level fns and types are mangled with a stable per-file prefix
+  so they don't collide with the importer's names; references —
+  including `m.foo(...)` calls and `m.Type` annotations — get
+  rewritten in place. Cycle detection reports the full path chain.
+  Stdlib imports unchanged. Multi-file programs no longer collapse
+  into a single file. (#83, closes #78)
 - **`lex check` surfaces required `--allow-effects` grants** in
   both text and JSON output. The text mode adds a one-line summary
   plus a ready-to-run `lex run --allow-effects ...` suggestion;
@@ -29,6 +29,16 @@ bumps may carry breaking changes when justified).
 
 ### Changed
 
+- **Diamond imports collapse to one nominal identity per file.**
+  The loader's mangling key is now the canonical filesystem path
+  (`<stem>_<8hex of sha256>`) rather than the alias chain, and the
+  loader dedupes second loads of the same path. The natural
+  `types/ + behavior/ + runner/` layout — where two siblings each
+  import the same `models.lex` — now works: `Report` resolved
+  through `scorer.m` and `verdict.m` is the same nominal type. The
+  entry file is special-cased to an empty prefix so
+  `lex run main.lex process` keeps working without users typing the
+  hash. (#91, closes #88)
 - **Anonymous record literals coerce to nominal record aliases at
   every position** — function argument, nested record field, list
   element, `let p :: T := { ... }`, constructor payload, pattern.
@@ -36,6 +46,11 @@ bumps may carry breaking changes when justified).
   POCs to write explicit `mk_*` constructor functions for every
   nominal record type. Two distinct nominal types with the same
   shape stay nominally distinct. (#86, closes #79)
+- **Bare record patterns now match nominal record aliases.**
+  `match v { { idea: pat, ... } => … }` works when `v` has a
+  `type T = { ... }` annotation — mirror of the literal-coercion
+  fix above. Unblocks the flat decision-table pattern (otherwise
+  forced into a nested-match-per-axis tree). (#90, closes #89)
 - **Trailing commas** are now allowed in every comma-separated
   list (fn params, call args, lambda params, type args, effects,
   function type params, constructor type payloads, constructor

--- a/README.md
+++ b/README.md
@@ -106,13 +106,19 @@ lex run main.lex describe '{"$variant":"Healthy","args":[]}'
 
 Path imports are resolved relative to the importer's directory; the
 `.lex` extension is auto-appended. `../`, `/abs/path.lex`, and
-multi-level nesting (`f.g.h`) all work, with cycle detection that
-reports the full path chain. Stdlib imports are unchanged.
+multi-level nesting all work, with cycle detection that reports the
+full path chain. Stdlib imports are unchanged.
 
-> Each imported function is currently identified by its alias path,
-> so `lex blame` doesn't yet follow a function across imports — see
-> [`#82`](https://github.com/alpibrusl/lex-lang/issues/82) for the
-> store-native sharing model that will fix this.
+The natural `types/ + behavior/ + runner/` layout works too: when
+two siblings each `import "./models" as m`, both reach the same
+`Report` nominal type — the loader keys mangling on the canonical
+filesystem path and dedupes second loads, so diamond-shaped imports
+collapse to one identity.
+
+> Identity is per-file-path today: moving or renaming a `.lex` file
+> changes the prefix used in mangled names. The future
+> [store-native imports](https://github.com/alpibrusl/lex-lang/issues/82)
+> tracker is where content-addressed identity will eventually live.
 
 ### Quickstart: agent-native tooling
 
@@ -226,6 +232,21 @@ fn area(s :: Shape) -> Float {
   match s {
     Circle({ radius }) => 3.14159 * radius * radius,
     Rect({ width, height }) => width * height,
+  }
+}
+```
+
+A bare record pattern matches a nominal record alias too — useful
+for flat decision tables over a fixed set of fields:
+
+```
+type Bands = { idea :: Str, execution :: Str }
+
+fn verdict(b :: Bands) -> Str {
+  match b {
+    { idea: "high", execution: "high" } => "ship",
+    { idea: "high", execution: _      } => "iterate",
+    _                                   => "park",
   }
 }
 ```

--- a/docs/index.html
+++ b/docs/index.html
@@ -423,6 +423,8 @@ lex check examples/c_echo.lex
 #   import "./helpers" as h
 # Sibling .lex files are loaded and merged. Cycle detection,
 # transitive imports, and `m.Type` qualified types all work.
+# Diamond imports (two siblings importing the same module) collapse
+# to one nominal identity, so `types/ + behavior/ + runner/` works.
 
 # Reject a malicious tool without an API key:
 lex agent-tool --allow-effects net --input x \


### PR DESCRIPTION
Catches up the docs to #90 (bare record patterns) and #91 (diamond imports).

## Summary

- **CHANGELOG** `[Unreleased]` adds entries for #91 and #90. Updates the local-imports entry to drop the alias-chain framing (now per-file-path) and the record-coercion entry to mention its pattern-side sibling.
- **README** Multi-file Projects subsection drops the stale "alias path identity" caveat (which #91 fixed), gains a paragraph on the diamond-shape `types/ + behavior/ + runner/` pattern, and updates the SigId-stability callout to reflect that identity is per-file-path now. Example 3 (records) gets a flat decision-table snippet showing bare record patterns against a nominal alias.
- **docs/index.html** gets one extra comment line in the multi-file block about diamond imports collapsing — kept tight so the security pitch stays the focus.

## Test plan

- [ ] Eyeball the rendered README on GitHub
- [ ] Eyeball docs/index.html on GitHub Pages once main lands
- [x] No code changes; nothing to test

https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s)_