### PR TITLE
fix: lex run decodes `{$variant, args}` JSON for variant args (closes #93)

### DIFF
--- a/crates/lex-api/src/handlers.rs
+++ b/crates/lex-api/src/handlers.rs
@@ -347,33 +347,7 @@ fn diff_handler(state: &State, query: &str) -> Response<std::io::Cursor<Vec<u8>>
     }
 }
 
-fn json_to_value(v: &serde_json::Value) -> Value {
-    use serde_json::Value as J;
-    match v {
-        J::Null => Value::Unit,
-        J::Bool(b) => Value::Bool(*b),
-        J::Number(n) => {
-            if let Some(i) = n.as_i64() { Value::Int(i) }
-            else if let Some(f) = n.as_f64() { Value::Float(f) }
-            else { Value::Unit }
-        }
-        J::String(s) => Value::Str(s.clone()),
-        J::Array(items) => Value::List(items.iter().map(json_to_value).collect()),
-        J::Object(map) => {
-            if let (Some(J::String(name)), Some(J::Array(args))) =
-                (map.get("$variant"), map.get("args"))
-            {
-                return Value::Variant {
-                    name: name.clone(),
-                    args: args.iter().map(json_to_value).collect(),
-                };
-            }
-            let mut out = IndexMap::new();
-            for (k, v) in map { out.insert(k.clone(), json_to_value(v)); }
-            Value::Record(out)
-        }
-    }
-}
+fn json_to_value(v: &serde_json::Value) -> Value { Value::from_json(v) }
 
 fn value_to_json(v: &Value) -> serde_json::Value { v.to_json() }
 

--- a/crates/lex-bytecode/src/value.rs
+++ b/crates/lex-bytecode/src/value.rs
@@ -151,4 +151,48 @@ impl Value {
                 s.iter().map(|k| k.as_value().to_json()).collect()),
         }
     }
+
+    /// Decode a `serde_json::Value` into a `Value`. The inverse of
+    /// [`to_json`](Self::to_json) for the shapes Lex round-trips:
+    ///
+    /// - `{"$variant": "Name", "args": [...]}` → `Value::Variant`
+    /// - JSON object → `Value::Record`
+    /// - JSON array → `Value::List`
+    /// - JSON null → `Value::Unit`
+    /// - JSON string / bool / number → the corresponding scalar
+    ///
+    /// Bytes (hex), Map, Set, F64Array, and Closure don't round-trip
+    /// — they decode as their natural JSON shape (Str / Object / Array
+    /// / Object / Str respectively), since the CLI / HTTP / VM
+    /// callers building Values from JSON don't have those shapes in
+    /// their input vocabulary.
+    pub fn from_json(v: &serde_json::Value) -> Value {
+        use serde_json::Value as J;
+        match v {
+            J::Null => Value::Unit,
+            J::Bool(b) => Value::Bool(*b),
+            J::Number(n) => {
+                if let Some(i) = n.as_i64() { Value::Int(i) }
+                else if let Some(f) = n.as_f64() { Value::Float(f) }
+                else { Value::Unit }
+            }
+            J::String(s) => Value::Str(s.clone()),
+            J::Array(items) => Value::List(items.iter().map(Value::from_json).collect()),
+            J::Object(map) => {
+                if let (Some(J::String(name)), Some(J::Array(args))) =
+                    (map.get("$variant"), map.get("args"))
+                {
+                    return Value::Variant {
+                        name: name.clone(),
+                        args: args.iter().map(Value::from_json).collect(),
+                    };
+                }
+                let mut out = indexmap::IndexMap::new();
+                for (k, v) in map {
+                    out.insert(k.clone(), Value::from_json(v));
+                }
+                Value::Record(out)
+            }
+        }
+    }
 }

--- a/crates/lex-bytecode/tests/from_json.rs
+++ b/crates/lex-bytecode/tests/from_json.rs
@@ -1,0 +1,151 @@
+//! `Value::from_json` round-trip and variant-detection tests.
+//! Closes #93's symmetry concern: every JSON shape `to_json` produces
+//! decodes back to a structurally-equal `Value`.
+
+use lex_bytecode::Value;
+use serde_json::json;
+
+fn roundtrip(v: Value) {
+    let j = v.to_json();
+    let back = Value::from_json(&j);
+    assert_eq!(v, back, "value did not round-trip; intermediate JSON: {j}");
+}
+
+#[test]
+fn variant_no_args_decodes_as_variant() {
+    let j = json!({ "$variant": "Red", "args": [] });
+    let v = Value::from_json(&j);
+    assert_eq!(
+        v,
+        Value::Variant {
+            name: "Red".into(),
+            args: vec![]
+        }
+    );
+}
+
+#[test]
+fn variant_with_args_decodes_as_variant() {
+    let j = json!({ "$variant": "Some", "args": [42] });
+    let v = Value::from_json(&j);
+    assert_eq!(
+        v,
+        Value::Variant {
+            name: "Some".into(),
+            args: vec![Value::Int(42)]
+        }
+    );
+}
+
+#[test]
+fn variant_with_nested_variant_arg_decodes_recursively() {
+    let j = json!({
+        "$variant": "Ok",
+        "args": [{ "$variant": "Some", "args": [7] }]
+    });
+    let v = Value::from_json(&j);
+    assert_eq!(
+        v,
+        Value::Variant {
+            name: "Ok".into(),
+            args: vec![Value::Variant {
+                name: "Some".into(),
+                args: vec![Value::Int(7)]
+            }]
+        }
+    );
+}
+
+#[test]
+fn plain_object_without_variant_keys_stays_record() {
+    let j = json!({ "x": 1, "y": 2 });
+    let v = Value::from_json(&j);
+    let expected = {
+        let mut m = indexmap::IndexMap::new();
+        m.insert("x".into(), Value::Int(1));
+        m.insert("y".into(), Value::Int(2));
+        Value::Record(m)
+    };
+    assert_eq!(v, expected);
+}
+
+#[test]
+fn object_with_only_variant_key_stays_record() {
+    // Both `$variant` AND `args` are required for the variant decode.
+    let j = json!({ "$variant": "Red" });
+    let v = Value::from_json(&j);
+    let expected = {
+        let mut m = indexmap::IndexMap::new();
+        m.insert("$variant".into(), Value::Str("Red".into()));
+        Value::Record(m)
+    };
+    assert_eq!(v, expected);
+}
+
+#[test]
+fn variant_round_trip() {
+    roundtrip(Value::Variant {
+        name: "Healthy".into(),
+        args: vec![],
+    });
+    roundtrip(Value::Variant {
+        name: "Some".into(),
+        args: vec![Value::Int(42)],
+    });
+    roundtrip(Value::Variant {
+        name: "Pair".into(),
+        args: vec![Value::Str("a".into()), Value::Bool(true)],
+    });
+}
+
+#[test]
+fn record_round_trip() {
+    let mut m = indexmap::IndexMap::new();
+    m.insert("name".into(), Value::Str("alice".into()));
+    m.insert("age".into(), Value::Int(30));
+    roundtrip(Value::Record(m));
+}
+
+#[test]
+fn nested_variant_in_record_round_trip() {
+    let mut m = indexmap::IndexMap::new();
+    m.insert(
+        "result".into(),
+        Value::Variant {
+            name: "Ok".into(),
+            args: vec![Value::Int(7)],
+        },
+    );
+    roundtrip(Value::Record(m));
+}
+
+#[test]
+fn list_round_trip() {
+    roundtrip(Value::List(vec![
+        Value::Int(1),
+        Value::Int(2),
+        Value::Int(3),
+    ]));
+}
+
+#[test]
+fn list_of_variants_round_trips() {
+    roundtrip(Value::List(vec![
+        Value::Variant {
+            name: "Red".into(),
+            args: vec![],
+        },
+        Value::Variant {
+            name: "Green".into(),
+            args: vec![],
+        },
+    ]));
+}
+
+#[test]
+fn primitives_round_trip() {
+    roundtrip(Value::Int(42));
+    roundtrip(Value::Bool(true));
+    roundtrip(Value::Str("hi".into()));
+    roundtrip(Value::Unit);
+}

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -634,24 +634,12 @@ fn stage_name(s: &Stage) -> &str {
     }
 }
 
+/// Decode a CLI argument's JSON into a `Value`. Delegates to
+/// `Value::from_json` so the CLI, the `lex serve` HTTP API, and
+/// in-program `json.parse` all share the same convention — including
+/// `{"$variant": "Name", "args": [...]}` for variants. (Closes #93.)
 fn json_to_value(v: &serde_json::Value) -> Value {
-    use serde_json::Value as J;
-    match v {
-        J::Null => Value::Unit,
-        J::Bool(b) => Value::Bool(*b),
-        J::Number(n) => {
-            if let Some(i) = n.as_i64() { Value::Int(i) }
-            else if let Some(f) = n.as_f64() { Value::Float(f) }
-            else { Value::Unit }
-        }
-        J::String(s) => Value::Str(s.clone()),
-        J::Array(items) => Value::List(items.iter().map(json_to_value).collect()),
-        J::Object(map) => {
-            let mut out = indexmap::IndexMap::new();
-            for (k, v) in map { out.insert(k.clone(), json_to_value(v)); }
-            Value::Record(out)
-        }
-    }
+    Value::from_json(v)
 }
 
 fn value_to_json_string(v: &Value) -> String {

--- a/crates/lex-cli/tests/run_variant_args.rs
+++ b/crates/lex-cli/tests/run_variant_args.rs
@@ -1,0 +1,125 @@
+//! `lex run` accepts `{"$variant": ..., "args": [...]}` for variant
+//! arguments (closes #93).
+
+use std::process::{Command, Stdio};
+
+fn lex_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_lex")
+}
+
+fn run(args: &[&str]) -> (i32, String) {
+    let out = Command::new(lex_bin())
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn lex");
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+    )
+}
+
+fn write_to_tempfile(name: &str, src: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("lex-run-variant-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(name);
+    std::fs::write(&path, src).unwrap();
+    path
+}
+
+#[test]
+fn lex_run_decodes_tag_only_variant_arg() {
+    let path = write_to_tempfile(
+        "color.lex",
+        r#"type Color = Red | Green | Blue
+
+fn name(c :: Color) -> Str {
+  match c {
+    Red   => "red",
+    Green => "green",
+    Blue  => "blue",
+  }
+}
+"#,
+    );
+    let (code, stdout) = run(&[
+        "run",
+        path.to_str().unwrap(),
+        "name",
+        r#"{"$variant":"Red","args":[]}"#,
+    ]);
+    assert_eq!(code, 0, "exit code; stdout: {stdout}");
+    assert!(stdout.contains("red"), "stdout: {stdout}");
+}
+
+#[test]
+fn lex_run_decodes_variant_with_payload() {
+    let path = write_to_tempfile(
+        "opt.lex",
+        r#"fn unwrap_or(o :: Option[Int], default :: Int) -> Int {
+  match o {
+    Some(n) => n,
+    None    => default,
+  }
+}
+"#,
+    );
+    let (code, stdout) = run(&[
+        "run",
+        path.to_str().unwrap(),
+        "unwrap_or",
+        r#"{"$variant":"Some","args":[42]}"#,
+        "0",
+    ]);
+    assert_eq!(code, 0, "exit code; stdout: {stdout}");
+    assert!(stdout.trim() == "42", "stdout: {stdout}");
+}
+
+#[test]
+fn lex_run_decodes_nested_variant_in_record() {
+    let path = write_to_tempfile(
+        "nested.lex",
+        r#"type Status = Healthy | Sick
+type Report = { score :: Int, status :: Status }
+
+fn label(r :: Report) -> Str {
+  match r.status {
+    Healthy => "ok",
+    Sick    => "nope",
+  }
+}
+"#,
+    );
+    let (code, stdout) = run(&[
+        "run",
+        path.to_str().unwrap(),
+        "label",
+        r#"{"score":7,"status":{"$variant":"Healthy","args":[]}}"#,
+    ]);
+    assert_eq!(code, 0, "exit code; stdout: {stdout}");
+    assert!(stdout.contains("ok"), "stdout: {stdout}");
+}
+
+#[test]
+fn lex_run_round_trips_variant_output() {
+    // The function returns a variant; it should serialize with the
+    // same convention so it can be piped back as input.
+    let path = write_to_tempfile(
+        "echo_variant.lex",
+        r#"type Color = Red | Green | Blue
+fn echo(c :: Color) -> Color { c }
+"#,
+    );
+    let (code, stdout) = run(&[
+        "run",
+        path.to_str().unwrap(),
+        "echo",
+        r#"{"$variant":"Green","args":[]}"#,
+    ]);
+    assert_eq!(code, 0, "exit code; stdout: {stdout}");
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("expected JSON output, got {stdout:?}: {e}"));
+    assert_eq!(parsed["$variant"], "Green");
+    assert!(parsed["args"].is_array());
+}

--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -2,7 +2,6 @@
 //! ops dispatched via the same `EffectHandler` interface as effects, but
 //! without policy gates (they have no observable side effects).
 
-use indexmap::IndexMap;
 use lex_bytecode::{MapKey, Value};
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -628,30 +627,4 @@ fn err_v(v: Value) -> Value { Value::Variant { name: "Err".into(), args: vec![v]
 
 fn value_to_json(v: &Value) -> serde_json::Value { v.to_json() }
 
-fn json_to_value(v: &serde_json::Value) -> Value {
-    use serde_json::Value as J;
-    match v {
-        J::Null => Value::Unit,
-        J::Bool(b) => Value::Bool(*b),
-        J::Number(n) => {
-            if let Some(i) = n.as_i64() { Value::Int(i) }
-            else if let Some(f) = n.as_f64() { Value::Float(f) }
-            else { Value::Unit }
-        }
-        J::String(s) => Value::Str(s.clone()),
-        J::Array(items) => Value::List(items.iter().map(json_to_value).collect()),
-        J::Object(map) => {
-            if let (Some(J::String(name)), Some(J::Array(args))) =
-                (map.get("$variant"), map.get("args"))
-            {
-                return Value::Variant {
-                    name: name.clone(),
-                    args: args.iter().map(json_to_value).collect(),
-                };
-            }
-            let mut out = IndexMap::new();
-            for (k, v) in map { out.insert(k.clone(), json_to_value(v)); }
-            Value::Record(out)
-        }
-    }
-}
+fn json_to_value(v: &serde_json::Value) -> Value { Value::from_json(v) }


### PR DESCRIPTION
Closes #93.

## Summary

`lex run path.lex fn '{"$variant":"Name","args":[...]}'` now decodes the variant correctly. Before, the CLI built a `Value::Record({"$variant", "args"})` and tripped `TestVariant on non-variant` on the first match arm, blocking every cross-language caller (Python, shell, HTTP) from passing any variant-typed argument without writing a primitive-only adapter.

## Root cause

Three crates each had their own copy of `json_to_value`. The runtime's (`json.parse`) and `lex-api`'s (HTTP `POST /v1/run`) had the `{"$variant", "args"}` detection branch; the CLI's didn't. The CLI's copy was extracted before the convention was added to the others and never caught up.

## Fix

Promoted the helper to `Value::from_json` in `crates/lex-bytecode/src/value.rs`, alongside the existing `to_json` it inverts. The three callers now delegate to it:

- `crates/lex-cli/src/main.rs::cmd_run`
- `crates/lex-runtime/src/builtins.rs` (`json.parse`)
- `crates/lex-api/src/handlers.rs` (`POST /v1/run`, `/v1/replay`)

One source of truth for the JSON ↔ `Value` convention. Future shape changes update one helper, not three independent copies.

## Test plan

- [x] `crates/lex-bytecode/tests/from_json.rs` — 11 cases: variant decode (no args / with args / nested), boundary case where a record happens to have only `$variant` and stays a Record, full `to_json` ↔ `from_json` round-trips for variant / record / list-of-variants / nested / primitives
- [x] `crates/lex-cli/tests/run_variant_args.rs` — 4 cases shelling out to the binary: tag-only variant arg (the issue's repro), variant with payload, variant-inside-record, variant → variant round-trip through stdout
- [x] `cargo test --workspace` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Issue's exact repro verified against the release binary

```
$ lex run /tmp/variant_arg.lex name '{"$variant":"Red","args":[]}'
"red"
```

https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s)_