### PR TITLE
docs: changelog + README pass for #93 (CLI variant-arg JSON)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,20 @@ bumps may carry breaking changes when justified).
   patterns, tuple patterns) — previously they were accepted in
   match arms / list / record literals only. (#84, closes #80)
 
+### Fixed
+
+- **`lex run` now decodes the `{"$variant": "Name", "args": [...]}`
+  JSON convention** for variant arguments. Three crates each had
+  their own copy of the JSON → `Value` decoder; only the CLI's was
+  missing the variant-detection branch, so `lex run path.lex fn
+  '{"$variant":"Red","args":[]}'` materialized as a `Value::Record`
+  and tripped `TestVariant on non-variant` at the first match arm.
+  Promoted the helper to `Value::from_json` in `lex-bytecode`
+  (alongside the existing `to_json` it inverts); CLI, runtime
+  (`json.parse`), and `lex serve` HTTP body all delegate. One
+  source of truth for the JSON ↔ `Value` convention. (#94, closes
+  #93)
+
 ### Dependencies
 
 - logos `0.14` → `0.16`, tungstenite `0.21` → `0.29`, ureq

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ lex check examples/c_echo.lex
 lex run examples/a_factorial.lex factorial 5
 # → 120
 
+# Variants are passed as `{"$variant": "Name", "args": [...]}` —
+# the same shape the runtime emits on output, so `lex run` results
+# can be piped back as inputs to other calls.
+lex run examples/b_parse_int.lex double_input '"21"'
+# → {"$variant":"Ok","args":[42]}
+
 # Run a program that uses effects (the runtime refuses without a grant).
 lex run examples/c_echo.lex echo '"hello, lex"'
 # → {"kind":"effect_not_allowed", ...}; exit 3


### PR DESCRIPTION
Catches up the docs to #94 (CLI variant-arg JSON decoding).

## Summary

- **CHANGELOG** `[Unreleased]` gains a `### Fixed` section with the #94 entry — `lex run` now decodes the `{"$variant", "args"}` convention via the consolidated `Value::from_json` helper in `lex-bytecode`.
- **README** Quickstart adds a short note on variant arguments showing the convention is the same shape the runtime emits, so output from one `lex run` can be piped back as input to another.
- **docs/index.html** intentionally untouched: CLI JSON arg shape isn't pitch material and adding it would dilute the security / agent-tool focus.

## Test plan

- [ ] Eyeball the rendered README on GitHub
- [x] No code changes; nothing to test

https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s)_