### PR TITLE
feat: stdlib `std.crypto` — sha/HMAC/base64/hex/secure-random (closes #102)

### DIFF
--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -9,6 +9,13 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
+sha2.workspace = true
+hmac = "0.13"
+md-5 = "0.11"
+base64 = "0.22"
+hex = "0.4"
+subtle = "2.6"
+rand = { version = "0.9", features = ["os_rng"] }
 tiny_http = { version = "0.12", features = ["ssl-rustls"] }
 tungstenite = "0.29"
 ureq = { version = "3.3", default-features = false, features = ["rustls", "platform-verifier"] }

--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -9,6 +9,10 @@ use std::collections::{BTreeMap, BTreeSet};
 /// `None` means "not handled here; fall through to effect dispatch".
 pub fn try_pure_builtin(kind: &str, op: &str, args: &[Value]) -> Option<Result<Value, String>> {
     if !is_pure_module(kind) { return None; }
+    // `crypto.random` is the lone effectful op in an otherwise-pure
+    // module; let the handler dispatch it under the `[random]` effect
+    // kind instead of the pure-builtin bypass.
+    if (kind, op) == ("crypto", "random") { return None; }
     Some(dispatch(kind, op, args))
 }
 
@@ -17,7 +21,7 @@ pub fn try_pure_builtin(kind: &str, op: &str, args: &[Value]) -> Option<Result<V
 pub fn is_pure_module(kind: &str) -> bool {
     matches!(kind, "str" | "int" | "float" | "bool" | "list"
         | "option" | "result" | "tuple" | "json" | "bytes" | "flow" | "math"
-        | "map" | "set")
+        | "map" | "set" | "crypto")
 }
 
 fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
@@ -509,6 +513,89 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             let a = expect_set(args.first())?;
             let b = expect_set(args.get(1))?;
             Ok(Value::Set(a.intersection(b).cloned().collect()))
+        }
+
+        // -- crypto (pure ops; crypto.random is effectful and routes
+        // through the handler under [random], see try_pure_builtin) --
+        ("crypto", "sha256") => {
+            use sha2::{Digest, Sha256};
+            let data = expect_bytes(args.first())?;
+            let mut h = Sha256::new();
+            h.update(data);
+            Ok(Value::Bytes(h.finalize().to_vec()))
+        }
+        ("crypto", "sha512") => {
+            use sha2::{Digest, Sha512};
+            let data = expect_bytes(args.first())?;
+            let mut h = Sha512::new();
+            h.update(data);
+            Ok(Value::Bytes(h.finalize().to_vec()))
+        }
+        ("crypto", "md5") => {
+            use md5::{Digest, Md5};
+            let data = expect_bytes(args.first())?;
+            let mut h = Md5::new();
+            h.update(data);
+            Ok(Value::Bytes(h.finalize().to_vec()))
+        }
+        ("crypto", "hmac_sha256") => {
+            use hmac::{Hmac, KeyInit, Mac};
+            type HmacSha256 = Hmac<sha2::Sha256>;
+            let key = expect_bytes(args.first())?;
+            let data = expect_bytes(args.get(1))?;
+            let mut mac = HmacSha256::new_from_slice(key)
+                .map_err(|e| format!("hmac_sha256 key: {e}"))?;
+            mac.update(data);
+            Ok(Value::Bytes(mac.finalize().into_bytes().to_vec()))
+        }
+        ("crypto", "hmac_sha512") => {
+            use hmac::{Hmac, KeyInit, Mac};
+            type HmacSha512 = Hmac<sha2::Sha512>;
+            let key = expect_bytes(args.first())?;
+            let data = expect_bytes(args.get(1))?;
+            let mut mac = HmacSha512::new_from_slice(key)
+                .map_err(|e| format!("hmac_sha512 key: {e}"))?;
+            mac.update(data);
+            Ok(Value::Bytes(mac.finalize().into_bytes().to_vec()))
+        }
+        ("crypto", "base64_encode") => {
+            use base64::{Engine, engine::general_purpose::STANDARD};
+            let data = expect_bytes(args.first())?;
+            Ok(Value::Str(STANDARD.encode(data)))
+        }
+        ("crypto", "base64_decode") => {
+            use base64::{Engine, engine::general_purpose::STANDARD};
+            let s = expect_str(args.first())?;
+            match STANDARD.decode(s) {
+                Ok(b)  => Ok(ok_v(Value::Bytes(b))),
+                Err(e) => Ok(err_v(Value::Str(format!("base64: {e}")))),
+            }
+        }
+        ("crypto", "hex_encode") => {
+            let data = expect_bytes(args.first())?;
+            Ok(Value::Str(hex::encode(data)))
+        }
+        ("crypto", "hex_decode") => {
+            let s = expect_str(args.first())?;
+            match hex::decode(s) {
+                Ok(b)  => Ok(ok_v(Value::Bytes(b))),
+                Err(e) => Ok(err_v(Value::Str(format!("hex: {e}")))),
+            }
+        }
+        ("crypto", "constant_time_eq") => {
+            use subtle::ConstantTimeEq;
+            let a = expect_bytes(args.first())?;
+            let b = expect_bytes(args.get(1))?;
+            // `subtle` returns Choice; comparison only meaningful when
+            // lengths match. For mismatched lengths return false in
+            // constant time (length itself isn't secret, but we want
+            // a single comparison shape).
+            let eq = if a.len() == b.len() {
+                a.ct_eq(b).into()
+            } else {
+                false
+            };
+            Ok(Value::Bool(eq))
         }
 
         _ => Err(format!("unknown pure builtin: {kind}.{op}")),

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -131,6 +131,22 @@ impl EffectHandler for DefaultHandler {
         if let Some(r) = try_pure_builtin(kind, op, &args) {
             return r;
         }
+        // `crypto.random` is the lone effectful op in `std.crypto`. Its
+        // declared effect kind is `random` (fine-grained on purpose so
+        // `lex audit --effect random` flags every token-generating
+        // call), distinct from the `crypto` module name.
+        if kind == "crypto" && op == "random" {
+            self.ensure_kind_allowed("random")?;
+            let n = expect_int(args.first())?;
+            if !(0..=1_048_576).contains(&n) {
+                return Err("crypto.random: n must be in 0..=1048576".into());
+            }
+            use rand::{rngs::OsRng, TryRngCore};
+            let mut buf = vec![0u8; n as usize];
+            OsRng.try_fill_bytes(&mut buf)
+                .map_err(|e| format!("crypto.random: OS RNG: {e}"))?;
+            return Ok(Value::Bytes(buf));
+        }
         self.ensure_kind_allowed(kind)?;
         match (kind, op) {
             ("io", "print") => {

--- a/crates/lex-runtime/tests/std_crypto.rs
+++ b/crates/lex-runtime/tests/std_crypto.rs
@@ -1,0 +1,264 @@
+//! Integration tests for `std.crypto`. Closes #102.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+fn run_with_policy(src: &str, fn_name: &str, args: Vec<Value>, policy: Policy) -> Value {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors:\n{errs:#?}");
+    }
+    let bc = Arc::new(compile_program(&stages));
+    let handler = DefaultHandler::new(policy).with_program(Arc::clone(&bc));
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(fn_name, args).unwrap_or_else(|e| panic!("call {fn_name}: {e}"))
+}
+
+fn run(src: &str, fn_name: &str, args: Vec<Value>) -> Value {
+    run_with_policy(src, fn_name, args, Policy::pure())
+}
+
+fn bytes(v: Value) -> Vec<u8> {
+    match v {
+        Value::Bytes(b) => b,
+        other => panic!("expected Bytes, got {other:?}"),
+    }
+}
+
+fn s(v: Value) -> String {
+    match v {
+        Value::Str(s) => s,
+        other => panic!("expected Str, got {other:?}"),
+    }
+}
+
+const HASH_SRC: &str = r#"
+import "std.crypto" as crypto
+fn h_sha256(x :: Bytes) -> Bytes { crypto.sha256(x) }
+fn h_sha512(x :: Bytes) -> Bytes { crypto.sha512(x) }
+fn h_md5(x :: Bytes) -> Bytes { crypto.md5(x) }
+fn h_sha256_hex(x :: Bytes) -> Str { crypto.hex_encode(crypto.sha256(x)) }
+"#;
+
+#[test]
+fn sha256_known_vector() {
+    // SHA-256("hello") = 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
+    let v = run(HASH_SRC, "h_sha256_hex", vec![Value::Bytes(b"hello".to_vec())]);
+    assert_eq!(
+        s(v),
+        "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+    );
+}
+
+#[test]
+fn sha256_empty_input() {
+    let v = run(HASH_SRC, "h_sha256", vec![Value::Bytes(vec![])]);
+    let b = bytes(v);
+    assert_eq!(b.len(), 32);
+    // SHA-256("") known prefix
+    assert_eq!(b[0], 0xe3);
+    assert_eq!(b[1], 0xb0);
+}
+
+#[test]
+fn sha512_length() {
+    let v = run(HASH_SRC, "h_sha512", vec![Value::Bytes(b"hello".to_vec())]);
+    assert_eq!(bytes(v).len(), 64);
+}
+
+#[test]
+fn md5_length() {
+    let v = run(HASH_SRC, "h_md5", vec![Value::Bytes(b"hello".to_vec())]);
+    assert_eq!(bytes(v).len(), 16);
+}
+
+const HMAC_SRC: &str = r#"
+import "std.crypto" as crypto
+fn mac256(key :: Bytes, data :: Bytes) -> Str {
+  crypto.hex_encode(crypto.hmac_sha256(key, data))
+}
+"#;
+
+#[test]
+fn hmac_sha256_known_vector() {
+    // RFC 4231 test 1:
+    //   key  = 0b * 20
+    //   data = "Hi There"
+    //   mac  = b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7
+    let key = vec![0x0b; 20];
+    let v = run(
+        HMAC_SRC,
+        "mac256",
+        vec![Value::Bytes(key), Value::Bytes(b"Hi There".to_vec())],
+    );
+    assert_eq!(
+        s(v),
+        "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7"
+    );
+}
+
+const ENCODE_SRC: &str = r#"
+import "std.crypto" as crypto
+fn b64(x :: Bytes) -> Str { crypto.base64_encode(x) }
+fn unb64(s :: Str) -> Result[Bytes, Str] { crypto.base64_decode(s) }
+fn h(x :: Bytes) -> Str { crypto.hex_encode(x) }
+fn unh(s :: Str) -> Result[Bytes, Str] { crypto.hex_decode(s) }
+"#;
+
+#[test]
+fn base64_round_trip() {
+    let input = b"hello, world!".to_vec();
+    let encoded = run(ENCODE_SRC, "b64", vec![Value::Bytes(input.clone())]);
+    assert_eq!(s(encoded.clone()), "aGVsbG8sIHdvcmxkIQ==");
+    let decoded = run(ENCODE_SRC, "unb64", vec![encoded]);
+    match decoded {
+        Value::Variant { name, args } => {
+            assert_eq!(name, "Ok");
+            match &args[0] {
+                Value::Bytes(b) => assert_eq!(b, &input),
+                other => panic!("expected Bytes inside Ok, got {other:?}"),
+            }
+        }
+        other => panic!("expected Result variant, got {other:?}"),
+    }
+}
+
+#[test]
+fn base64_decode_invalid() {
+    let v = run(ENCODE_SRC, "unb64", vec![Value::Str("not!@#valid".into())]);
+    match v {
+        Value::Variant { name, .. } => assert_eq!(name, "Err"),
+        other => panic!("expected Err variant, got {other:?}"),
+    }
+}
+
+#[test]
+fn hex_round_trip() {
+    let input = vec![0xde, 0xad, 0xbe, 0xef];
+    let encoded = run(ENCODE_SRC, "h", vec![Value::Bytes(input.clone())]);
+    assert_eq!(s(encoded.clone()), "deadbeef");
+    let decoded = run(ENCODE_SRC, "unh", vec![encoded]);
+    if let Value::Variant { name, args } = decoded {
+        assert_eq!(name, "Ok");
+        if let Value::Bytes(b) = &args[0] {
+            assert_eq!(b, &input);
+            return;
+        }
+    }
+    panic!("hex round-trip failed");
+}
+
+#[test]
+fn hex_decode_invalid_length() {
+    let v = run(ENCODE_SRC, "unh", vec![Value::Str("abc".into())]);
+    match v {
+        Value::Variant { name, .. } => assert_eq!(name, "Err"),
+        other => panic!("expected Err variant, got {other:?}"),
+    }
+}
+
+const CTEQ_SRC: &str = r#"
+import "std.crypto" as crypto
+fn cmp(a :: Bytes, b :: Bytes) -> Bool { crypto.constant_time_eq(a, b) }
+"#;
+
+#[test]
+fn constant_time_eq_match() {
+    let v = run(
+        CTEQ_SRC,
+        "cmp",
+        vec![Value::Bytes(b"abcd".to_vec()), Value::Bytes(b"abcd".to_vec())],
+    );
+    assert_eq!(v, Value::Bool(true));
+}
+
+#[test]
+fn constant_time_eq_mismatch() {
+    let v = run(
+        CTEQ_SRC,
+        "cmp",
+        vec![Value::Bytes(b"abcd".to_vec()), Value::Bytes(b"abce".to_vec())],
+    );
+    assert_eq!(v, Value::Bool(false));
+}
+
+#[test]
+fn constant_time_eq_length_mismatch_returns_false() {
+    let v = run(
+        CTEQ_SRC,
+        "cmp",
+        vec![Value::Bytes(b"abc".to_vec()), Value::Bytes(b"abcd".to_vec())],
+    );
+    assert_eq!(v, Value::Bool(false));
+}
+
+const RANDOM_SRC: &str = r#"
+import "std.crypto" as crypto
+fn make_token(n :: Int) -> [random] Bytes { crypto.random(n) }
+"#;
+
+fn random_policy() -> Policy {
+    let mut p = Policy::pure();
+    p.allow_effects = ["random".to_string()].into_iter().collect::<BTreeSet<_>>();
+    p
+}
+
+#[test]
+fn random_returns_requested_length() {
+    let v = run_with_policy(
+        RANDOM_SRC,
+        "make_token",
+        vec![Value::Int(32)],
+        random_policy(),
+    );
+    assert_eq!(bytes(v).len(), 32);
+}
+
+#[test]
+fn random_zero_length_is_allowed() {
+    let v = run_with_policy(
+        RANDOM_SRC,
+        "make_token",
+        vec![Value::Int(0)],
+        random_policy(),
+    );
+    assert_eq!(bytes(v).len(), 0);
+}
+
+#[test]
+fn random_two_calls_differ() {
+    let a = bytes(run_with_policy(
+        RANDOM_SRC,
+        "make_token",
+        vec![Value::Int(32)],
+        random_policy(),
+    ));
+    let b = bytes(run_with_policy(
+        RANDOM_SRC,
+        "make_token",
+        vec![Value::Int(32)],
+        random_policy(),
+    ));
+    // 1 in 2^256 chance of false failure; effectively impossible.
+    assert_ne!(a, b);
+}
+
+#[test]
+fn random_without_grant_is_rejected_by_static_policy_walk() {
+    use lex_runtime::policy::check_program;
+    let prog = parse_source(RANDOM_SRC).expect("parse");
+    let stages = canonicalize_program(&prog);
+    lex_types::check_program(&stages).expect("type-check");
+    let bc = compile_program(&stages);
+    let policy = Policy::pure(); // no [random] grant
+    let result = check_program(&bc, &policy);
+    assert!(
+        result.is_err(),
+        "expected static policy walk to reject [random] without grant"
+    );
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -581,6 +581,50 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
             ));
             Some(Ty::Record(fields))
         }
+        "crypto" => {
+            let mut fields = IndexMap::new();
+            // Hashes: Bytes -> Bytes (digest as raw bytes)
+            for name in &["sha256", "sha512", "md5"] {
+                fields.insert((*name).into(), Ty::function(
+                    vec![Ty::bytes()],
+                    EffectSet::empty(),
+                    Ty::bytes(),
+                ));
+            }
+            // HMAC: (key :: Bytes, data :: Bytes) -> Bytes
+            for name in &["hmac_sha256", "hmac_sha512"] {
+                fields.insert((*name).into(), Ty::function(
+                    vec![Ty::bytes(), Ty::bytes()],
+                    EffectSet::empty(),
+                    Ty::bytes(),
+                ));
+            }
+            // base64 / hex
+            fields.insert("base64_encode".into(), Ty::function(
+                vec![Ty::bytes()], EffectSet::empty(), Ty::str()));
+            fields.insert("base64_decode".into(), Ty::function(
+                vec![Ty::str()], EffectSet::empty(),
+                Ty::Con("Result".into(), vec![Ty::bytes(), Ty::str()])));
+            fields.insert("hex_encode".into(), Ty::function(
+                vec![Ty::bytes()], EffectSet::empty(), Ty::str()));
+            fields.insert("hex_decode".into(), Ty::function(
+                vec![Ty::str()], EffectSet::empty(),
+                Ty::Con("Result".into(), vec![Ty::bytes(), Ty::str()])));
+            // constant-time equality (for HMAC verification etc.)
+            fields.insert("constant_time_eq".into(), Ty::function(
+                vec![Ty::bytes(), Ty::bytes()], EffectSet::empty(), Ty::bool()));
+            // Cryptographically-secure random bytes — OS RNG, not the
+            // deterministic `rand.int_in` stub. The new `[random]`
+            // effect is fine-grained on purpose so reviewers can find
+            // every token-generating call via `lex audit --effect
+            // random`.
+            fields.insert("random".into(), Ty::function(
+                vec![Ty::int()],
+                EffectSet::singleton("random"),
+                Ty::bytes(),
+            ));
+            Some(Ty::Record(fields))
+        }
         _ => None,
     }
 }
@@ -608,6 +652,7 @@ pub fn module_for_import(reference: &str) -> Option<&'static str> {
         "map" => "map",
         "set" => "set",
         "proc" => "proc",
+        "crypto" => "crypto",
         _ => return None,
     })
 }


### PR DESCRIPTION
Closes #102. First module from the top-10 stdlib roadmap (#106).

## Summary

Adds `std.crypto`:
- Hashes: `crypto.sha256`, `sha512`, `md5` — `Bytes -> Bytes`
- HMAC: `crypto.hmac_sha256`, `hmac_sha512` — `(key, data) -> Bytes`
- Encodings: `crypto.base64_encode`/`decode`, `hex_encode`/`decode`
- Constant-time equality: `crypto.constant_time_eq` (`subtle` crate)
- Cryptographically-secure random: `crypto.random :: (Int) -> [random] Bytes` (OS RNG)

Pure ops route through `try_pure_builtin` (no policy check; no declared effect). `crypto.random` is the lone effectful op; its declared kind is the fine-grained `[random]`, distinct from the module name `crypto` — so reviewers can spot every token-generating call via `lex audit --effect random`.

## Why a separate `[random]` effect

`crypto.random` consumes OS entropy, which is a security-relevant property worth surfacing as its own effect kind. The runtime dispatch handles the module/effect-kind asymmetry in `handler.rs::dispatch`: pure `crypto.*` ops bypass the policy gate via `try_pure_builtin`; `crypto.random` falls through and explicitly checks `ensure_kind_allowed("random")`.

## Test plan (16 cases, all known vectors)

- SHA-256 against the published `"hello"` → `2cf24dba...` vector
- HMAC-SHA-256 against RFC 4231 test 1
- Empty-input hashing; output lengths for SHA-512 / MD5
- Base64 + hex round trips, decode-invalid → `Err(...)`
- Constant-time eq: match / mismatch / length-mismatch-returns-false
- `crypto.random`: requested length, zero-length, two calls differ, static policy walk rejects `[random]` without `--allow-effects` grant

`cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Bytes-via-CLI-arg gap (separate concern)

`Value::from_json` maps `J::String → Value::Str`, so `lex run path.lex fn '"deadbeef"'` produces a `Str` not a `Bytes`. Bytes-via-JSON has no canonical wire shape today (`to_json` encodes them as hex strings, which is lossy — a 64-char hex string is ambiguously bytes or a string-that-happens-to-be-hex). Out of scope for this module; happy to file separately if it actually blocks anything.

https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s)_