### PR TITLE
feat: stdlib `std.regex` — compile/match/capture/replace (closes #96)

### DIFF
--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -11,6 +11,7 @@ thiserror.workspace = true
 indexmap.workspace = true
 sha2.workspace = true
 hmac = "0.13"
+regex = "1"
 md-5 = "0.11"
 base64 = "0.22"
 hex = "0.4"

--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -3,7 +3,8 @@
 //! without policy gates (they have no observable side effects).
 
 use lex_bytecode::{MapKey, Value};
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::sync::{Mutex, OnceLock};
 
 /// Returns Some(...) if `(kind, op)` names a known pure builtin.
 /// `None` means "not handled here; fall through to effect dispatch".
@@ -21,7 +22,7 @@ pub fn try_pure_builtin(kind: &str, op: &str, args: &[Value]) -> Option<Result<V
 pub fn is_pure_module(kind: &str) -> bool {
     matches!(kind, "str" | "int" | "float" | "bool" | "list"
         | "option" | "result" | "tuple" | "json" | "bytes" | "flow" | "math"
-        | "map" | "set" | "crypto")
+        | "map" | "set" | "crypto" | "regex")
 }
 
 fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
@@ -598,8 +599,110 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             Ok(Value::Bool(eq))
         }
 
+        // -- regex (the compiled `Regex` is stored as the pattern
+        // string; the runtime caches the actual `regex::Regex` so
+        // ops don't re-compile on every call) --
+        ("regex", "compile") => {
+            let pat = expect_str(args.first())?;
+            match get_or_compile_regex(&pat) {
+                Ok(_) => Ok(ok_v(Value::Str(pat))),
+                Err(e) => Ok(err_v(Value::Str(e))),
+            }
+        }
+        ("regex", "is_match") => {
+            let pat = expect_str(args.first())?;
+            let s = expect_str(args.get(1))?;
+            let re = get_or_compile_regex(&pat).map_err(|e| format!("regex.is_match: {e}"))?;
+            Ok(Value::Bool(re.is_match(&s)))
+        }
+        ("regex", "find") => {
+            let pat = expect_str(args.first())?;
+            let s = expect_str(args.get(1))?;
+            let re = get_or_compile_regex(&pat).map_err(|e| format!("regex.find: {e}"))?;
+            match re.captures(&s) {
+                Some(caps) => Ok(Value::Variant {
+                    name: "Some".into(),
+                    args: vec![match_value(&caps)],
+                }),
+                None => Ok(Value::Variant { name: "None".into(), args: vec![] }),
+            }
+        }
+        ("regex", "find_all") => {
+            let pat = expect_str(args.first())?;
+            let s = expect_str(args.get(1))?;
+            let re = get_or_compile_regex(&pat).map_err(|e| format!("regex.find_all: {e}"))?;
+            let items: Vec<Value> = re.captures_iter(&s).map(|caps| match_value(&caps)).collect();
+            Ok(Value::List(items))
+        }
+        ("regex", "replace") => {
+            let pat = expect_str(args.first())?;
+            let s = expect_str(args.get(1))?;
+            let rep = expect_str(args.get(2))?;
+            let re = get_or_compile_regex(&pat).map_err(|e| format!("regex.replace: {e}"))?;
+            Ok(Value::Str(re.replace(&s, rep.as_str()).into_owned()))
+        }
+        ("regex", "replace_all") => {
+            let pat = expect_str(args.first())?;
+            let s = expect_str(args.get(1))?;
+            let rep = expect_str(args.get(2))?;
+            let re = get_or_compile_regex(&pat).map_err(|e| format!("regex.replace_all: {e}"))?;
+            Ok(Value::Str(re.replace_all(&s, rep.as_str()).into_owned()))
+        }
+        ("regex", "split") => {
+            let pat = expect_str(args.first())?;
+            let s = expect_str(args.get(1))?;
+            let re = get_or_compile_regex(&pat).map_err(|e| format!("regex.split: {e}"))?;
+            let parts: Vec<Value> = re.split(&s).map(|p| Value::Str(p.to_string())).collect();
+            Ok(Value::List(parts))
+        }
+
         _ => Err(format!("unknown pure builtin: {kind}.{op}")),
     }
+}
+
+/// Process-wide cache of compiled regexes, keyed by the pattern
+/// string. Compilation is the only cost we want to amortize; matching
+/// the same `Regex` from multiple threads is safe (`regex::Regex` is
+/// `Send + Sync`).
+fn regex_cache() -> &'static Mutex<HashMap<String, regex::Regex>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, regex::Regex>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn get_or_compile_regex(pattern: &str) -> Result<regex::Regex, String> {
+    let cache = regex_cache();
+    {
+        let guard = cache.lock().unwrap();
+        if let Some(re) = guard.get(pattern) {
+            return Ok(re.clone());
+        }
+    }
+    let re = regex::Regex::new(pattern).map_err(|e| format!("invalid regex: {e}"))?;
+    let mut guard = cache.lock().unwrap();
+    guard.insert(pattern.to_string(), re.clone());
+    Ok(re)
+}
+
+/// Build a `Match` record value: `{ text, start, end, groups }` where
+/// `groups` is the captured groups in order (group 0 is the full match).
+/// Missing optional groups become empty strings.
+fn match_value(caps: &regex::Captures) -> Value {
+    let m0 = caps.get(0).expect("regex match always has group 0");
+    let mut rec = indexmap::IndexMap::new();
+    rec.insert("text".into(), Value::Str(m0.as_str().to_string()));
+    rec.insert("start".into(), Value::Int(m0.start() as i64));
+    rec.insert("end".into(), Value::Int(m0.end() as i64));
+    let groups: Vec<Value> = (1..caps.len())
+        .map(|i| {
+            Value::Str(
+                caps.get(i)
+                    .map(|m| m.as_str().to_string())
+                    .unwrap_or_default(),
+            )
+        })
+        .collect();
+    rec.insert("groups".into(), Value::List(groups));
+    Value::Record(rec)
 }
 
 fn expect_map(v: Option<&Value>) -> Result<&BTreeMap<MapKey, Value>, String> {

--- a/crates/lex-runtime/tests/std_regex.rs
+++ b/crates/lex-runtime/tests/std_regex.rs
@@ -1,0 +1,204 @@
+//! Integration tests for `std.regex`. Closes #96.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::sync::Arc;
+
+fn run(src: &str, fn_name: &str, args: Vec<Value>) -> Value {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors:\n{errs:#?}");
+    }
+    let bc = Arc::new(compile_program(&stages));
+    let handler = DefaultHandler::new(Policy::pure()).with_program(Arc::clone(&bc));
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(fn_name, args).unwrap_or_else(|e| panic!("call {fn_name}: {e}"))
+}
+
+fn s(v: Value) -> String {
+    match v {
+        Value::Str(s) => s,
+        other => panic!("expected Str, got {other:?}"),
+    }
+}
+
+fn b(v: Value) -> bool {
+    match v {
+        Value::Bool(b) => b,
+        other => panic!("expected Bool, got {other:?}"),
+    }
+}
+
+fn list_of_strs(v: Value) -> Vec<String> {
+    match v {
+        Value::List(items) => items
+            .into_iter()
+            .map(|i| match i {
+                Value::Str(s) => s,
+                other => panic!("expected Str in list, got {other:?}"),
+            })
+            .collect(),
+        other => panic!("expected List, got {other:?}"),
+    }
+}
+
+const SRC: &str = r#"
+import "std.regex" as regex
+import "std.list" as list
+
+# Each helper takes the pattern + input, compiles inline, and either
+# returns a sensible default on Err or matches the test contract.
+
+fn match_p(pat :: Str, s :: Str) -> Bool {
+  match regex.compile(pat) {
+    Ok(r)  => regex.is_match(r, s),
+    Err(_) => false,
+  }
+}
+
+fn replace_p(pat :: Str, s :: Str, rep :: Str) -> Str {
+  match regex.compile(pat) {
+    Ok(r)  => regex.replace_all(r, s, rep),
+    Err(_) => s,
+  }
+}
+
+fn split_p(pat :: Str, s :: Str) -> List[Str] {
+  match regex.compile(pat) {
+    Ok(r)  => regex.split(r, s),
+    Err(_) => [s],
+  }
+}
+
+fn first_match_text(pat :: Str, s :: Str) -> Str {
+  match regex.compile(pat) {
+    Ok(r)  => match regex.find(r, s) {
+      Some(m) => m.text,
+      None    => "<no match>",
+    },
+    Err(_) => "<bad pattern>",
+  }
+}
+
+fn first_capture(pat :: Str, s :: Str) -> Str {
+  match regex.compile(pat) {
+    Ok(r)  => match regex.find(r, s) {
+      Some(m) => match list.head(m.groups) {
+        Some(g) => g,
+        None    => "<no group>",
+      },
+      None => "<no match>",
+    },
+    Err(_) => "<bad pattern>",
+  }
+}
+
+fn count_matches(pat :: Str, s :: Str) -> Int {
+  match regex.compile(pat) {
+    Ok(r)  => list.len(regex.find_all(r, s)),
+    Err(_) => 0 - 1,
+  }
+}
+
+fn compile_validates(pat :: Str) -> Bool {
+  match regex.compile(pat) {
+    Ok(_)  => true,
+    Err(_) => false,
+  }
+}
+"#;
+
+#[test]
+fn is_match_basic() {
+    assert!(b(run(SRC, "match_p", vec![
+        Value::Str(r"\d+".into()),
+        Value::Str("abc 123 def".into()),
+    ])));
+    assert!(!b(run(SRC, "match_p", vec![
+        Value::Str(r"^\d+$".into()),
+        Value::Str("abc 123 def".into()),
+    ])));
+}
+
+#[test]
+fn replace_all_substitutes_every_occurrence() {
+    let v = run(SRC, "replace_p", vec![
+        Value::Str(r"\d+".into()),
+        Value::Str("a 1 b 22 c 333".into()),
+        Value::Str("N".into()),
+    ]);
+    assert_eq!(s(v), "a N b N c N");
+}
+
+#[test]
+fn split_returns_pieces() {
+    let v = run(SRC, "split_p", vec![
+        Value::Str(r"\s*,\s*".into()),
+        Value::Str("a,  b,c , d".into()),
+    ]);
+    assert_eq!(list_of_strs(v), vec!["a", "b", "c", "d"]);
+}
+
+#[test]
+fn find_returns_first_match_text() {
+    let v = run(SRC, "first_match_text", vec![
+        Value::Str(r"[A-Z][a-z]+".into()),
+        Value::Str("alpha Beta gamma Delta".into()),
+    ]);
+    assert_eq!(s(v), "Beta");
+}
+
+#[test]
+fn find_returns_none_when_no_match() {
+    let v = run(SRC, "first_match_text", vec![
+        Value::Str(r"\d+".into()),
+        Value::Str("only letters here".into()),
+    ]);
+    assert_eq!(s(v), "<no match>");
+}
+
+#[test]
+fn find_all_count_matches() {
+    let v = run(SRC, "count_matches", vec![
+        Value::Str(r"\b[a-z]+\b".into()),
+        Value::Str("one TWO three FOUR five".into()),
+    ]);
+    assert_eq!(v, Value::Int(3));
+}
+
+#[test]
+fn find_returns_capture_groups() {
+    let v = run(SRC, "first_capture", vec![
+        Value::Str(r"name=(\w+)".into()),
+        Value::Str("user name=alice end".into()),
+    ]);
+    assert_eq!(s(v), "alice");
+}
+
+#[test]
+fn compile_succeeds_for_valid_pattern() {
+    assert!(b(run(SRC, "compile_validates", vec![
+        Value::Str(r"^\d+$".into()),
+    ])));
+}
+
+#[test]
+fn compile_returns_err_for_invalid_pattern() {
+    // Unbalanced bracket — invalid regex.
+    assert!(!b(run(SRC, "compile_validates", vec![
+        Value::Str(r"[abc".into()),
+    ])));
+}
+
+#[test]
+fn replace_with_backrefs() {
+    let v = run(SRC, "replace_p", vec![
+        Value::Str(r"(\w+)@(\w+)".into()),
+        Value::Str("alice@example bob@test".into()),
+        Value::Str("$2.$1".into()),
+    ]);
+    assert_eq!(s(v), "example.alice test.bob");
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -625,6 +625,48 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
             ));
             Some(Ty::Record(fields))
         }
+        "regex" => {
+            // The compiled `Regex` is stored as a `Str` at runtime
+            // (the pattern source) plus a process-wide cache of the
+            // actual `regex::Regex`. So `Regex` is a nominal type at
+            // the language level but its value is just the pattern.
+            let regex_t = || Ty::Con("Regex".into(), vec![]);
+            let match_t = || {
+                let mut fs = IndexMap::new();
+                fs.insert("text".into(), Ty::str());
+                fs.insert("start".into(), Ty::int());
+                fs.insert("end".into(), Ty::int());
+                fs.insert("groups".into(), Ty::List(Box::new(Ty::str())));
+                Ty::Record(fs)
+            };
+            let mut fields = IndexMap::new();
+            // compile :: Str -> Result[Regex, Str]
+            fields.insert("compile".into(), Ty::function(
+                vec![Ty::str()], EffectSet::empty(),
+                Ty::Con("Result".into(), vec![regex_t(), Ty::str()])));
+            // is_match :: Regex, Str -> Bool
+            fields.insert("is_match".into(), Ty::function(
+                vec![regex_t(), Ty::str()], EffectSet::empty(), Ty::bool()));
+            // find :: Regex, Str -> Option[Match]
+            fields.insert("find".into(), Ty::function(
+                vec![regex_t(), Ty::str()], EffectSet::empty(),
+                Ty::Con("Option".into(), vec![match_t()])));
+            // find_all :: Regex, Str -> List[Match]
+            fields.insert("find_all".into(), Ty::function(
+                vec![regex_t(), Ty::str()], EffectSet::empty(),
+                Ty::List(Box::new(match_t()))));
+            // replace :: Regex, Str, Str -> Str
+            fields.insert("replace".into(), Ty::function(
+                vec![regex_t(), Ty::str(), Ty::str()], EffectSet::empty(), Ty::str()));
+            // replace_all :: Regex, Str, Str -> Str
+            fields.insert("replace_all".into(), Ty::function(
+                vec![regex_t(), Ty::str(), Ty::str()], EffectSet::empty(), Ty::str()));
+            // split :: Regex, Str -> List[Str]
+            fields.insert("split".into(), Ty::function(
+                vec![regex_t(), Ty::str()], EffectSet::empty(),
+                Ty::List(Box::new(Ty::str()))));
+            Some(Ty::Record(fields))
+        }
         _ => None,
     }
 }
@@ -653,6 +695,7 @@ pub fn module_for_import(reference: &str) -> Option<&'static str> {
         "set" => "set",
         "proc" => "proc",
         "crypto" => "crypto",
+        "regex" => "regex",
         _ => return None,
     })
 }


### PR DESCRIPTION
Closes #96. Second module from the top-10 stdlib roadmap (#106).

## Summary

`std.regex` wraps the Rust `regex` crate.

```lex
fn regex.compile(pat :: Str)    -> Result[Regex, Str]
fn regex.is_match(r, s)         -> Bool
fn regex.find(r, s)             -> Option[Match]
fn regex.find_all(r, s)         -> List[Match]
fn regex.replace(r, s, rep)     -> Str
fn regex.replace_all(r, s, rep) -> Str
fn regex.split(r, s)            -> List[Str]

type Match = { text :: Str, start :: Int, end :: Int, groups :: List[Str] }
```

## Design choice: compile-as-cache, not opaque resource

The compiled `Regex` is represented at runtime as the pattern `String`; a process-wide `OnceLock<Mutex<HashMap<String, Regex>>>` caches the actual `regex::Regex` so subsequent ops reuse the compiled FSM. The alternative — adding `Value::Regex(regex::Regex)` to `lex-bytecode` — would force the bytecode crate to depend on `regex`, violating the layer boundary. Keeping `Regex` as `Str` at the runtime level lets `lex-types` track the nominal `Regex` type while `lex-bytecode` stays agnostic.

`regex.compile` validates the pattern (so bad regexes return `Err` early) and seeds the cache.

## Test plan (10 cases)

- `is_match` basic + anchored
- `replace_all` with `$1` / `$2` backrefs
- `split` with whitespace-tolerant separator
- `find` returning `None` when no match
- `find_all` counting matches
- `compile` rejecting unbalanced brackets
- Capture groups extracted as `List[Str]`

`cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings` clean.

https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s)_