### PR TITLE
feat: stdlib `std.kv` — embedded key-value persistence (closes #100)

### DIFF
--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -12,6 +12,7 @@ indexmap.workspace = true
 sha2.workspace = true
 hmac = "0.13"
 regex = "1"
+sled = "0.34"
 md-5 = "0.11"
 base64 = "0.22"
 hex = "0.4"

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -7,7 +7,10 @@
 use lex_bytecode::vm::{EffectHandler, Vm};
 use lex_bytecode::{Program, Value};
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -273,6 +276,87 @@ impl EffectHandler for DefaultHandler {
                 let body = expect_str(args.get(1))?;
                 Ok(Value::Bool(crate::ws::chat_send(registry, conn_id, body)))
             }
+            ("kv", "open") => {
+                let path = expect_str(args.first())?.to_string();
+                // Honor write-allowlist: opening a Kv writes its
+                // backing files at `path`, so the same scoping that
+                // applies to `io.write` applies here.
+                if !self.policy.allow_fs_write.is_empty() {
+                    let p = std::path::Path::new(&path);
+                    if !self.policy.allow_fs_write.iter().any(|a| p.starts_with(a)) {
+                        return Ok(err(Value::Str(format!(
+                            "kv.open: `{path}` outside --allow-fs-write"))));
+                    }
+                }
+                match sled::open(&path) {
+                    Ok(db) => {
+                        let handle = next_kv_handle();
+                        kv_registry().lock().unwrap().insert(handle, db);
+                        Ok(ok(Value::Int(handle as i64)))
+                    }
+                    Err(e) => Ok(err(Value::Str(format!("kv.open: {e}")))),
+                }
+            }
+            ("kv", "close") => {
+                let h = expect_kv_handle(args.first())?;
+                kv_registry().lock().unwrap().remove(&h);
+                Ok(Value::Unit)
+            }
+            ("kv", "get") => {
+                let h = expect_kv_handle(args.first())?;
+                let key = expect_str(args.get(1))?;
+                let reg = kv_registry().lock().unwrap();
+                let db = reg.get(&h).ok_or_else(|| "kv.get: closed or unknown Kv handle".to_string())?;
+                match db.get(key.as_bytes()) {
+                    Ok(Some(ivec)) => Ok(some(Value::Bytes(ivec.to_vec()))),
+                    Ok(None) => Ok(none()),
+                    Err(e) => Err(format!("kv.get: {e}")),
+                }
+            }
+            ("kv", "put") => {
+                let h = expect_kv_handle(args.first())?;
+                let key = expect_str(args.get(1))?.to_string();
+                let val = expect_bytes(args.get(2))?.clone();
+                let reg = kv_registry().lock().unwrap();
+                let db = reg.get(&h).ok_or_else(|| "kv.put: closed or unknown Kv handle".to_string())?;
+                match db.insert(key.as_bytes(), val) {
+                    Ok(_) => Ok(ok(Value::Unit)),
+                    Err(e) => Ok(err(Value::Str(format!("kv.put: {e}")))),
+                }
+            }
+            ("kv", "delete") => {
+                let h = expect_kv_handle(args.first())?;
+                let key = expect_str(args.get(1))?;
+                let reg = kv_registry().lock().unwrap();
+                let db = reg.get(&h).ok_or_else(|| "kv.delete: closed or unknown Kv handle".to_string())?;
+                match db.remove(key.as_bytes()) {
+                    Ok(_) => Ok(ok(Value::Unit)),
+                    Err(e) => Ok(err(Value::Str(format!("kv.delete: {e}")))),
+                }
+            }
+            ("kv", "contains") => {
+                let h = expect_kv_handle(args.first())?;
+                let key = expect_str(args.get(1))?;
+                let reg = kv_registry().lock().unwrap();
+                let db = reg.get(&h).ok_or_else(|| "kv.contains: closed or unknown Kv handle".to_string())?;
+                match db.contains_key(key.as_bytes()) {
+                    Ok(present) => Ok(Value::Bool(present)),
+                    Err(e) => Err(format!("kv.contains: {e}")),
+                }
+            }
+            ("kv", "list_prefix") => {
+                let h = expect_kv_handle(args.first())?;
+                let prefix = expect_str(args.get(1))?;
+                let reg = kv_registry().lock().unwrap();
+                let db = reg.get(&h).ok_or_else(|| "kv.list_prefix: closed or unknown Kv handle".to_string())?;
+                let mut keys: Vec<Value> = Vec::new();
+                for kv in db.scan_prefix(prefix.as_bytes()) {
+                    let (k, _) = kv.map_err(|e| format!("kv.list_prefix: {e}"))?;
+                    let s = String::from_utf8_lossy(&k).to_string();
+                    keys.push(Value::Str(s));
+                }
+                Ok(Value::List(keys))
+            }
             ("proc", "spawn") => {
                 // The escape hatch effect. Spawns a child process,
                 // collects its stdout/stderr, returns a structured
@@ -520,4 +604,40 @@ fn ok(v: Value) -> Value {
 }
 fn err(v: Value) -> Value {
     Value::Variant { name: "Err".into(), args: vec![v] }
+}
+
+fn some(v: Value) -> Value {
+    Value::Variant { name: "Some".into(), args: vec![v] }
+}
+fn none() -> Value {
+    Value::Variant { name: "None".into(), args: vec![] }
+}
+
+fn expect_bytes(v: Option<&Value>) -> Result<&Vec<u8>, String> {
+    match v {
+        Some(Value::Bytes(b)) => Ok(b),
+        Some(other) => Err(format!("expected Bytes arg, got {other:?}")),
+        None => Err("missing argument".into()),
+    }
+}
+
+fn expect_kv_handle(v: Option<&Value>) -> Result<u64, String> {
+    match v {
+        Some(Value::Int(n)) if *n >= 0 => Ok(*n as u64),
+        Some(other) => Err(format!("expected Kv handle (Int), got {other:?}")),
+        None => Err("missing Kv argument".into()),
+    }
+}
+
+/// Process-wide registry of open `Kv` handles. Each `kv.open` allocates
+/// a new u64 handle via [`next_kv_handle`] and stores the `sled::Db`
+/// here; subsequent ops fetch by handle. `kv.close` removes the entry.
+fn kv_registry() -> &'static Mutex<HashMap<u64, sled::Db>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<u64, sled::Db>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn next_kv_handle() -> u64 {
+    static COUNTER: AtomicU64 = AtomicU64::new(1);
+    COUNTER.fetch_add(1, Ordering::SeqCst)
 }

--- a/crates/lex-runtime/tests/std_kv.rs
+++ b/crates/lex-runtime/tests/std_kv.rs
@@ -1,0 +1,229 @@
+//! Integration tests for `std.kv`. Closes #100.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+fn policy_with_kv(write_root: &std::path::Path) -> Policy {
+    let mut p = Policy::pure();
+    p.allow_effects = ["kv".to_string(), "fs_write".to_string()]
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    p.allow_fs_write = vec![write_root.to_path_buf()];
+    p
+}
+
+fn run_with_policy(src: &str, fn_name: &str, args: Vec<Value>, policy: Policy) -> Value {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors:\n{errs:#?}");
+    }
+    let bc = Arc::new(compile_program(&stages));
+    let handler = DefaultHandler::new(policy).with_program(Arc::clone(&bc));
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(fn_name, args).unwrap_or_else(|e| panic!("call {fn_name}: {e}"))
+}
+
+fn unique_db_path(name: &str) -> std::path::PathBuf {
+    // Each test gets a fresh dir so tests don't share state and the
+    // sled lockfile doesn't collide.
+    let dir = std::env::temp_dir().join(format!(
+        "lex-kv-{}-{}-{}",
+        std::process::id(),
+        name,
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+const SRC: &str = r#"
+import "std.kv" as kv
+
+# Round-trip: open, put, get, return Some payload as Bytes.
+fn put_then_get(path :: Str, key :: Str, val :: Bytes) -> [kv, fs_write] Option[Bytes] {
+  match kv.open(path) {
+    Ok(db) => match kv.put(db, key, val) {
+      Ok(_)  => kv.get(db, key),
+      Err(_) => None,
+    },
+    Err(_) => None,
+  }
+}
+
+fn get_missing(path :: Str, key :: Str) -> [kv, fs_write] Option[Bytes] {
+  match kv.open(path) {
+    Ok(db) => kv.get(db, key),
+    Err(_) => None,
+  }
+}
+
+fn put_then_contains(path :: Str, key :: Str, val :: Bytes) -> [kv, fs_write] Bool {
+  match kv.open(path) {
+    Ok(db) => match kv.put(db, key, val) {
+      Ok(_)  => kv.contains(db, key),
+      Err(_) => false,
+    },
+    Err(_) => false,
+  }
+}
+
+fn delete_then_contains(path :: Str, key :: Str, val :: Bytes) -> [kv, fs_write] Bool {
+  match kv.open(path) {
+    Ok(db) => match kv.put(db, key, val) {
+      Ok(_)  => match kv.delete(db, key) {
+        Ok(_)  => kv.contains(db, key),
+        Err(_) => true,
+      },
+      Err(_) => true,
+    },
+    Err(_) => true,
+  }
+}
+
+fn list_prefix_keys(path :: Str) -> [kv, fs_write] List[Str] {
+  match kv.open(path) {
+    Ok(db) => match kv.put(db, "user:1", b"a") {
+      Ok(_) => match kv.put(db, "user:2", b"b") {
+        Ok(_) => match kv.put(db, "session:x", b"c") {
+          Ok(_) => kv.list_prefix(db, "user:"),
+          Err(_) => [],
+        },
+        Err(_) => [],
+      },
+      Err(_) => [],
+    },
+    Err(_) => [],
+  }
+}
+"#;
+
+#[test]
+fn put_then_get_round_trips() {
+    let path = unique_db_path("put_then_get");
+    let policy = policy_with_kv(&path);
+    let v = run_with_policy(
+        SRC,
+        "put_then_get",
+        vec![
+            Value::Str(path.to_string_lossy().to_string()),
+            Value::Str("k1".into()),
+            Value::Bytes(b"hello".to_vec()),
+        ],
+        policy,
+    );
+    assert_eq!(
+        v,
+        Value::Variant {
+            name: "Some".into(),
+            args: vec![Value::Bytes(b"hello".to_vec())],
+        },
+    );
+}
+
+#[test]
+fn get_missing_returns_none() {
+    let path = unique_db_path("get_missing");
+    let policy = policy_with_kv(&path);
+    let v = run_with_policy(
+        SRC,
+        "get_missing",
+        vec![
+            Value::Str(path.to_string_lossy().to_string()),
+            Value::Str("never_set".into()),
+        ],
+        policy,
+    );
+    assert_eq!(v, Value::Variant { name: "None".into(), args: vec![] });
+}
+
+#[test]
+fn contains_after_put() {
+    let path = unique_db_path("contains_after_put");
+    let policy = policy_with_kv(&path);
+    let v = run_with_policy(
+        SRC,
+        "put_then_contains",
+        vec![
+            Value::Str(path.to_string_lossy().to_string()),
+            Value::Str("a".into()),
+            Value::Bytes(b"x".to_vec()),
+        ],
+        policy,
+    );
+    assert_eq!(v, Value::Bool(true));
+}
+
+#[test]
+fn delete_removes_key() {
+    let path = unique_db_path("delete");
+    let policy = policy_with_kv(&path);
+    let v = run_with_policy(
+        SRC,
+        "delete_then_contains",
+        vec![
+            Value::Str(path.to_string_lossy().to_string()),
+            Value::Str("a".into()),
+            Value::Bytes(b"x".to_vec()),
+        ],
+        policy,
+    );
+    assert_eq!(v, Value::Bool(false));
+}
+
+#[test]
+fn list_prefix_returns_only_matching_keys() {
+    let path = unique_db_path("list_prefix");
+    let policy = policy_with_kv(&path);
+    let v = run_with_policy(SRC, "list_prefix_keys", vec![
+        Value::Str(path.to_string_lossy().to_string()),
+    ], policy);
+
+    let keys: Vec<String> = match v {
+        Value::List(items) => items
+            .into_iter()
+            .map(|i| match i {
+                Value::Str(s) => s,
+                other => panic!("expected Str in list, got {other:?}"),
+            })
+            .collect(),
+        other => panic!("expected List, got {other:?}"),
+    };
+    assert_eq!(
+        keys.iter().filter(|k| k.starts_with("user:")).count(),
+        2
+    );
+    assert!(!keys.iter().any(|k| k.starts_with("session:")));
+}
+
+#[test]
+fn open_outside_fs_write_root_returns_err() {
+    // The static policy walk only checks effect kinds, not paths;
+    // path scoping is enforced at the runtime dispatch site.
+    let allowed = unique_db_path("open_scope_allowed");
+    let outside = unique_db_path("open_scope_outside");
+    let mut policy = policy_with_kv(&allowed);
+    // Re-scope to *only* `allowed` (overwriting the default from the
+    // helper, which adds `outside` implicitly through the test setup).
+    policy.allow_fs_write = vec![allowed.clone()];
+
+    let v = run_with_policy(
+        SRC,
+        "put_then_get",
+        vec![
+            Value::Str(outside.to_string_lossy().to_string()),
+            Value::Str("k".into()),
+            Value::Bytes(b"v".to_vec()),
+        ],
+        policy,
+    );
+    // The outer match in put_then_get returns None on the open Err.
+    assert_eq!(v, Value::Variant { name: "None".into(), args: vec![] });
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -687,6 +687,51 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 Ty::List(Box::new(Ty::Var(0)))));
             Some(Ty::Record(fields))
         }
+        "kv" => {
+            // Embedded key-value store. The opaque `Kv` type is
+            // backed by an Int handle into a process-wide registry.
+            let kv_t = || Ty::Con("Kv".into(), vec![]);
+            let mut fields = IndexMap::new();
+            // open :: Str -> [kv, fs_write] Result[Kv, Str]
+            fields.insert("open".into(), Ty::function(
+                vec![Ty::str()],
+                EffectSet {
+                    concrete: ["kv".to_string(), "fs_write".to_string()].into_iter().collect(),
+                    var: None,
+                },
+                Ty::Con("Result".into(), vec![kv_t(), Ty::str()])));
+            // close :: Kv -> [kv] Nil
+            fields.insert("close".into(), Ty::function(
+                vec![kv_t()],
+                EffectSet::singleton("kv"),
+                Ty::Unit));
+            // get :: Kv, Str -> [kv] Option[Bytes]
+            fields.insert("get".into(), Ty::function(
+                vec![kv_t(), Ty::str()],
+                EffectSet::singleton("kv"),
+                Ty::Con("Option".into(), vec![Ty::bytes()])));
+            // put :: Kv, Str, Bytes -> [kv] Result[Nil, Str]
+            fields.insert("put".into(), Ty::function(
+                vec![kv_t(), Ty::str(), Ty::bytes()],
+                EffectSet::singleton("kv"),
+                Ty::Con("Result".into(), vec![Ty::Unit, Ty::str()])));
+            // delete :: Kv, Str -> [kv] Result[Nil, Str]
+            fields.insert("delete".into(), Ty::function(
+                vec![kv_t(), Ty::str()],
+                EffectSet::singleton("kv"),
+                Ty::Con("Result".into(), vec![Ty::Unit, Ty::str()])));
+            // contains :: Kv, Str -> [kv] Bool
+            fields.insert("contains".into(), Ty::function(
+                vec![kv_t(), Ty::str()],
+                EffectSet::singleton("kv"),
+                Ty::bool()));
+            // list_prefix :: Kv, Str -> [kv] List[Str]
+            fields.insert("list_prefix".into(), Ty::function(
+                vec![kv_t(), Ty::str()],
+                EffectSet::singleton("kv"),
+                Ty::List(Box::new(Ty::str()))));
+            Some(Ty::Record(fields))
+        }
         "regex" => {
             // The compiled `Regex` is stored as a `Str` at runtime
             // (the pattern source) plus a process-wide cache of the
@@ -759,6 +804,7 @@ pub fn module_for_import(reference: &str) -> Option<&'static str> {
         "crypto" => "crypto",
         "regex" => "regex",
         "deque" => "deque",
+        "kv" => "kv",
         _ => return None,
     })
 }


### PR DESCRIPTION
Closes #100. Fourth module from the top-10 stdlib roadmap (#106).

## Summary

Adds `std.kv`, the embedded key-value persistence layer:

```lex
fn kv.open(path)              -> [kv, fs_write] Result[Kv, Str]
fn kv.close(db)               -> [kv] Nil
fn kv.get(db, key)            -> [kv] Option[Bytes]
fn kv.put(db, key, val)       -> [kv] Result[Nil, Str]
fn kv.delete(db, key)         -> [kv] Result[Nil, Str]
fn kv.contains(db, key)       -> [kv] Bool
fn kv.list_prefix(db, prefix) -> [kv] List[Str]
```

Backed by `sled`. The opaque `Kv` type at the language level is an `Int` handle at the runtime level — points into a process-wide registry. No new `Value` variant.

## Design choices

- **Process-wide registry:** `OnceLock<Mutex<HashMap<u64, sled::Db>>>` + atomic counter. Each `kv.open` allocates a new handle; subsequent ops fetch by handle. `kv.close` removes the entry; subsequent ops on a closed handle return a clear "closed or unknown Kv handle" error.
- **Path scoping:** `kv.open` enforces both `[kv]` (effect kind) and the existing `--allow-fs-write` path scoping — the same scoping that applies to `io.write` applies here, since opening a Kv writes its backing files at the path.
- **Handle GC:** handles aren't reclaimed when their Lex value goes out of scope; long-running programs that open many stores leak `sled::Db` instances. Documented as v1 limitation; `kv.close` is the explicit cleanup path.

## Test plan (6 cases)

- put-then-get round trip
- get on missing key → `None`
- contains after put → `true`
- delete then contains → `false`
- list_prefix returns only matching keys (excludes other prefixes)
- open outside `--allow-fs-write` returns `Err`

`cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings` clean.

https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s)_