### PR TITLE
feat: stdlib `std.process` — streaming subprocess (closes #97)

### DIFF
--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -97,6 +97,198 @@ impl DefaultHandler {
         }
     }
 
+    fn dispatch_process(&mut self, op: &str, args: Vec<Value>) -> Result<Value, String> {
+        match op {
+            "spawn" => {
+                let cmd = expect_str(args.first())?.to_string();
+                let raw_args = match args.get(1) {
+                    Some(Value::List(items)) => items.clone(),
+                    _ => return Err("process.spawn: args must be List[Str]".into()),
+                };
+                let str_args: Result<Vec<String>, String> = raw_args.iter().map(|v| match v {
+                    Value::Str(s) => Ok(s.clone()),
+                    other => Err(format!("process.spawn: arg must be Str, got {other:?}")),
+                }).collect();
+                let str_args = str_args?;
+                let opts = match args.get(2) {
+                    Some(Value::Record(r)) => r.clone(),
+                    _ => return Err("process.spawn: missing or invalid opts record".into()),
+                };
+
+                // Allow-list check, mirroring the existing proc.spawn.
+                if !self.policy.allow_proc.is_empty() {
+                    let basename = std::path::Path::new(&cmd)
+                        .file_name()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or(&cmd);
+                    if !self.policy.allow_proc.iter().any(|a| a == basename) {
+                        return Ok(err(Value::Str(format!(
+                            "process.spawn: `{cmd}` not in --allow-proc {:?}",
+                            self.policy.allow_proc
+                        ))));
+                    }
+                }
+
+                let mut command = std::process::Command::new(&cmd);
+                command.args(&str_args);
+                command.stdin(std::process::Stdio::piped());
+                command.stdout(std::process::Stdio::piped());
+                command.stderr(std::process::Stdio::piped());
+
+                if let Some(Value::Variant { name, args: vargs }) = opts.get("cwd") {
+                    if name == "Some" {
+                        if let Some(Value::Str(s)) = vargs.first() {
+                            command.current_dir(s);
+                        }
+                    }
+                }
+                if let Some(Value::Map(env)) = opts.get("env") {
+                    for (k, v) in env {
+                        if let (lex_bytecode::MapKey::Str(ks), Value::Str(vs)) = (k, v) {
+                            command.env(ks, vs);
+                        }
+                    }
+                }
+
+                let stdin_payload: Option<Vec<u8>> = match opts.get("stdin") {
+                    Some(Value::Variant { name, args: vargs }) if name == "Some" => {
+                        match vargs.first() {
+                            Some(Value::Bytes(b)) => Some(b.clone()),
+                            _ => None,
+                        }
+                    }
+                    _ => None,
+                };
+
+                let mut child = match command.spawn() {
+                    Ok(c) => c,
+                    Err(e) => return Ok(err(Value::Str(format!("process.spawn `{cmd}`: {e}")))),
+                };
+
+                if let Some(payload) = stdin_payload {
+                    if let Some(mut stdin) = child.stdin.take() {
+                        use std::io::Write;
+                        let _ = stdin.write_all(&payload);
+                        // Drop closes stdin; the child sees EOF.
+                    }
+                }
+
+                let stdout = child.stdout.take().map(std::io::BufReader::new);
+                let stderr = child.stderr.take().map(std::io::BufReader::new);
+                let handle = next_process_handle();
+                process_registry().lock().unwrap().insert(handle, ProcessState {
+                    child,
+                    stdout,
+                    stderr,
+                });
+                Ok(ok(Value::Int(handle as i64)))
+            }
+            "read_stdout_line" => Self::read_line_op(args, true),
+            "read_stderr_line" => Self::read_line_op(args, false),
+            "wait" => {
+                let h = expect_process_handle(args.first())?;
+                let mut reg = process_registry().lock().unwrap();
+                let state = reg.get_mut(&h)
+                    .ok_or_else(|| "process.wait: closed or unknown ProcessHandle".to_string())?;
+                let status = state.child.wait().map_err(|e| format!("process.wait: {e}"))?;
+                let mut rec = indexmap::IndexMap::new();
+                rec.insert("code".into(), Value::Int(status.code().unwrap_or(-1) as i64));
+                #[cfg(unix)]
+                {
+                    use std::os::unix::process::ExitStatusExt;
+                    rec.insert("signaled".into(), Value::Bool(status.signal().is_some()));
+                }
+                #[cfg(not(unix))]
+                {
+                    rec.insert("signaled".into(), Value::Bool(false));
+                }
+                Ok(Value::Record(rec))
+            }
+            "kill" => {
+                let h = expect_process_handle(args.first())?;
+                let _signal = expect_str(args.get(1))?;
+                let mut reg = process_registry().lock().unwrap();
+                let state = reg.get_mut(&h)
+                    .ok_or_else(|| "process.kill: closed or unknown ProcessHandle".to_string())?;
+                // Cross-platform: only `kill` (SIGKILL-equivalent on
+                // Windows). Signal-name dispatch is a v1.5 follow-up.
+                match state.child.kill() {
+                    Ok(_) => Ok(ok(Value::Unit)),
+                    Err(e) => Ok(err(Value::Str(format!("process.kill: {e}")))),
+                }
+            }
+            "run" => {
+                let cmd = expect_str(args.first())?.to_string();
+                let raw_args = match args.get(1) {
+                    Some(Value::List(items)) => items.clone(),
+                    _ => return Err("process.run: args must be List[Str]".into()),
+                };
+                let str_args: Result<Vec<String>, String> = raw_args.iter().map(|v| match v {
+                    Value::Str(s) => Ok(s.clone()),
+                    other => Err(format!("process.run: arg must be Str, got {other:?}")),
+                }).collect();
+                let str_args = str_args?;
+                if !self.policy.allow_proc.is_empty() {
+                    let basename = std::path::Path::new(&cmd)
+                        .file_name()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or(&cmd);
+                    if !self.policy.allow_proc.iter().any(|a| a == basename) {
+                        return Ok(err(Value::Str(format!(
+                            "process.run: `{cmd}` not in --allow-proc {:?}",
+                            self.policy.allow_proc
+                        ))));
+                    }
+                }
+                match std::process::Command::new(&cmd).args(&str_args).output() {
+                    Ok(o) => {
+                        let mut rec = indexmap::IndexMap::new();
+                        rec.insert("stdout".into(), Value::Str(
+                            String::from_utf8_lossy(&o.stdout).to_string()));
+                        rec.insert("stderr".into(), Value::Str(
+                            String::from_utf8_lossy(&o.stderr).to_string()));
+                        rec.insert("exit_code".into(), Value::Int(
+                            o.status.code().unwrap_or(-1) as i64));
+                        Ok(ok(Value::Record(rec)))
+                    }
+                    Err(e) => Ok(err(Value::Str(format!("process.run `{cmd}`: {e}")))),
+                }
+            }
+            other => Err(format!("unsupported process.{other}")),
+        }
+    }
+
+    /// Read one line from the child's stdout (`is_stdout = true`) or
+    /// stderr. Returns `None` (Lex `Option`) at EOF; subsequent calls
+    /// keep returning `None`.
+    fn read_line_op(args: Vec<Value>, is_stdout: bool) -> Result<Value, String> {
+        let h = expect_process_handle(args.first())?;
+        let mut reg = process_registry().lock().unwrap();
+        let state = reg.get_mut(&h)
+            .ok_or_else(|| format!(
+                "process.read_{}_line: closed or unknown ProcessHandle",
+                if is_stdout { "stdout" } else { "stderr" }))?;
+        let reader_opt = if is_stdout {
+            state.stdout.as_mut().map(|r| -> &mut dyn std::io::BufRead { r })
+        } else {
+            state.stderr.as_mut().map(|r| -> &mut dyn std::io::BufRead { r })
+        };
+        let reader = match reader_opt {
+            Some(r) => r,
+            None => return Ok(none()),
+        };
+        let mut line = String::new();
+        match reader.read_line(&mut line) {
+            Ok(0) => Ok(none()),
+            Ok(_) => {
+                if line.ends_with('\n') { line.pop(); }
+                if line.ends_with('\r') { line.pop(); }
+                Ok(some(Value::Str(line)))
+            }
+            Err(e) => Err(format!("process.read_*_line: {e}")),
+        }
+    }
+
     fn dispatch_fs(&mut self, op: &str, args: Vec<Value>) -> Result<Value, String> {
         match op {
             "exists" => {
@@ -319,6 +511,10 @@ impl EffectHandler for DefaultHandler {
         // `std.fs` ops use the fine-grained `[fs_walk]` and `[fs_write]`
         // effect kinds (distinct from the module name `fs`); the
         // policy check uses the per-op kind, not the module's.
+        if kind == "process" {
+            self.ensure_kind_allowed("proc")?;
+            return self.dispatch_process(op, args);
+        }
         if kind == "fs" {
             let effect_kind = match op {
                 "exists" | "is_file" | "is_dir" | "stat"
@@ -826,6 +1022,30 @@ fn expect_kv_handle(v: Option<&Value>) -> Result<u64, String> {
         Some(Value::Int(n)) if *n >= 0 => Ok(*n as u64),
         Some(other) => Err(format!("expected Kv handle (Int), got {other:?}")),
         None => Err("missing Kv argument".into()),
+    }
+}
+
+struct ProcessState {
+    child: std::process::Child,
+    stdout: Option<std::io::BufReader<std::process::ChildStdout>>,
+    stderr: Option<std::io::BufReader<std::process::ChildStderr>>,
+}
+
+fn process_registry() -> &'static Mutex<HashMap<u64, ProcessState>> {
+    static REGISTRY: OnceLock<Mutex<HashMap<u64, ProcessState>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn next_process_handle() -> u64 {
+    static COUNTER: AtomicU64 = AtomicU64::new(1);
+    COUNTER.fetch_add(1, Ordering::SeqCst)
+}
+
+fn expect_process_handle(v: Option<&Value>) -> Result<u64, String> {
+    match v {
+        Some(Value::Int(n)) if *n >= 0 => Ok(*n as u64),
+        Some(other) => Err(format!("expected ProcessHandle (Int), got {other:?}")),
+        None => Err("missing ProcessHandle argument".into()),
     }
 }
 

--- a/crates/lex-runtime/tests/std_process.rs
+++ b/crates/lex-runtime/tests/std_process.rs
@@ -1,0 +1,176 @@
+//! Integration tests for `std.process`. Closes #97.
+//!
+//! Tests use POSIX `printf`, `cat`, and `false` — kept to coreutils
+//! that ship with every CI image. Skipped on Windows since the
+//! commands aren't there.
+
+#![cfg(unix)]
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+fn policy_with_proc() -> Policy {
+    let mut p = Policy::pure();
+    p.allow_effects = ["proc".to_string()].into_iter().collect::<BTreeSet<_>>();
+    p
+}
+
+fn run_with_policy(src: &str, fn_name: &str, args: Vec<Value>, policy: Policy) -> Value {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors:\n{errs:#?}");
+    }
+    let bc = Arc::new(compile_program(&stages));
+    let handler = DefaultHandler::new(policy).with_program(Arc::clone(&bc));
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(fn_name, args).unwrap_or_else(|e| panic!("call {fn_name}: {e}"))
+}
+
+const SRC: &str = r#"
+import "std.process" as process
+import "std.list" as list
+import "std.map" as map
+import "std.option" as option
+
+# Empty opts — no cwd, no env, no stdin.
+fn empty_opts() -> { cwd :: Option[Str], env :: Map[Str, Str], stdin :: Option[Bytes] } {
+  { cwd: None, env: map.new(), stdin: None }
+}
+
+# Run and read all of stdout line-by-line, return the line count.
+fn run_and_count_stdout(cmd :: Str, args :: List[Str]) -> [proc] Int {
+  match process.spawn(cmd, args, empty_opts()) {
+    Ok(h) => count_lines(h, 0),
+    Err(_) => 0 - 1,
+  }
+}
+
+# Recursive line-counter; tail-recursive on TCO-capable runtimes,
+# stack-friendly for the small line counts in tests.
+fn count_lines(h :: ProcessHandle, acc :: Int) -> [proc] Int {
+  match process.read_stdout_line(h) {
+    Some(_) => count_lines(h, acc + 1),
+    None    => match process.wait(h) {
+      _ => acc,
+    },
+  }
+}
+
+# Run and return the first stdout line.
+fn first_stdout_line(cmd :: Str, args :: List[Str]) -> [proc] Str {
+  match process.spawn(cmd, args, empty_opts()) {
+    Ok(h) => match process.read_stdout_line(h) {
+      Some(line) => line,
+      None       => "<no output>",
+    },
+    Err(_) => "<spawn failed>",
+  }
+}
+
+# Use process.run for the blocking convenience case.
+fn run_capture_stdout(cmd :: Str, args :: List[Str]) -> [proc] Str {
+  match process.run(cmd, args) {
+    Ok(o)  => o.stdout,
+    Err(_) => "<run failed>",
+  }
+}
+
+fn run_capture_exit(cmd :: Str, args :: List[Str]) -> [proc] Int {
+  match process.run(cmd, args) {
+    Ok(o)  => o.exit_code,
+    Err(_) => 0 - 1,
+  }
+}
+"#;
+
+fn s(v: Value) -> String {
+    match v {
+        Value::Str(s) => s,
+        other => panic!("expected Str, got {other:?}"),
+    }
+}
+
+#[test]
+fn streaming_spawn_and_read_lines() {
+    // printf "a\nb\nc\n" — three lines via the streaming API.
+    let v = run_with_policy(
+        SRC,
+        "run_and_count_stdout",
+        vec![
+            Value::Str("printf".into()),
+            Value::List(vec![Value::Str("a\nb\nc\n".into())]),
+        ],
+        policy_with_proc(),
+    );
+    assert_eq!(v, Value::Int(3));
+}
+
+#[test]
+fn first_stdout_line_returns_first_line() {
+    let v = run_with_policy(
+        SRC,
+        "first_stdout_line",
+        vec![
+            Value::Str("printf".into()),
+            Value::List(vec![Value::Str("alpha\nbeta\ngamma\n".into())]),
+        ],
+        policy_with_proc(),
+    );
+    assert_eq!(s(v), "alpha");
+}
+
+#[test]
+fn run_capture_returns_full_stdout() {
+    let v = run_with_policy(
+        SRC,
+        "run_capture_stdout",
+        vec![
+            Value::Str("printf".into()),
+            Value::List(vec![Value::Str("hello, world".into())]),
+        ],
+        policy_with_proc(),
+    );
+    assert_eq!(s(v), "hello, world");
+}
+
+#[test]
+fn run_capture_exit_for_failing_command() {
+    // `false` always exits 1.
+    let v = run_with_policy(
+        SRC,
+        "run_capture_exit",
+        vec![Value::Str("false".into()), Value::List(vec![])],
+        policy_with_proc(),
+    );
+    assert_eq!(v, Value::Int(1));
+}
+
+#[test]
+fn run_capture_exit_for_succeeding_command() {
+    let v = run_with_policy(
+        SRC,
+        "run_capture_exit",
+        vec![Value::Str("true".into()), Value::List(vec![])],
+        policy_with_proc(),
+    );
+    assert_eq!(v, Value::Int(0));
+}
+
+#[test]
+fn allow_proc_basename_blocks_unlisted() {
+    let mut p = policy_with_proc();
+    p.allow_proc = ["allowed_command_zzz".to_string()].into_iter().collect();
+    let v = run_with_policy(
+        SRC,
+        "run_capture_stdout",
+        vec![Value::Str("printf".into()), Value::List(vec![Value::Str("x".into())])],
+        p,
+    );
+    // The Err case in the Lex match returns "<run failed>".
+    assert_eq!(s(v), "<run failed>");
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -687,6 +687,65 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 Ty::List(Box::new(Ty::Var(0)))));
             Some(Ty::Record(fields))
         }
+        "process" => {
+            // Streaming subprocess. The opaque `ProcessHandle` type
+            // is an Int handle into a process-wide registry holding
+            // the `Child` plus its stdout/stderr `BufReader`s.
+            let ph = || Ty::Con("ProcessHandle".into(), vec![]);
+            let result_str = |t: Ty| Ty::Con("Result".into(), vec![t, Ty::str()]);
+            let opts_t = || {
+                let mut fs = IndexMap::new();
+                fs.insert("cwd".into(),
+                    Ty::Con("Option".into(), vec![Ty::str()]));
+                fs.insert("env".into(),
+                    Ty::Con("Map".into(), vec![Ty::str(), Ty::str()]));
+                fs.insert("stdin".into(),
+                    Ty::Con("Option".into(), vec![Ty::bytes()]));
+                Ty::Record(fs)
+            };
+            let exit_t = || {
+                let mut fs = IndexMap::new();
+                fs.insert("code".into(), Ty::int());
+                fs.insert("signaled".into(), Ty::bool());
+                Ty::Record(fs)
+            };
+            let output_t = || {
+                let mut fs = IndexMap::new();
+                fs.insert("stdout".into(), Ty::str());
+                fs.insert("stderr".into(), Ty::str());
+                fs.insert("exit_code".into(), Ty::int());
+                Ty::Record(fs)
+            };
+            let mut fields = IndexMap::new();
+            // spawn :: Str, List[Str], Opts -> [proc] Result[ProcessHandle, Str]
+            fields.insert("spawn".into(), Ty::function(
+                vec![Ty::str(), Ty::List(Box::new(Ty::str())), opts_t()],
+                EffectSet::singleton("proc"),
+                result_str(ph())));
+            // read_stdout_line / read_stderr_line :: ProcessHandle -> [proc] Option[Str]
+            for n in &["read_stdout_line", "read_stderr_line"] {
+                fields.insert((*n).into(), Ty::function(
+                    vec![ph()], EffectSet::singleton("proc"),
+                    Ty::Con("Option".into(), vec![Ty::str()])));
+            }
+            // wait :: ProcessHandle -> [proc] ProcessExit
+            fields.insert("wait".into(), Ty::function(
+                vec![ph()], EffectSet::singleton("proc"), exit_t()));
+            // kill :: ProcessHandle, Str -> [proc] Result[Nil, Str]
+            fields.insert("kill".into(), Ty::function(
+                vec![ph(), Ty::str()],
+                EffectSet::singleton("proc"),
+                result_str(Ty::Unit)));
+            // run :: Str, List[Str] -> [proc] Result[ProcessOutput, Str]
+            // Blocking convenience that captures stdout/stderr fully
+            // and returns once the child exits. For programs that
+            // need streaming, use spawn + read_*_line + wait.
+            fields.insert("run".into(), Ty::function(
+                vec![Ty::str(), Ty::List(Box::new(Ty::str()))],
+                EffectSet::singleton("proc"),
+                result_str(output_t())));
+            Some(Ty::Record(fields))
+        }
         "fs" => {
             // Filesystem walk + mutate. Walk-style ops (exists, walk,
             // glob, …) declare [fs_walk] — distinct from [fs_read]
@@ -860,6 +919,7 @@ pub fn module_for_import(reference: &str) -> Option<&'static str> {
         "deque" => "deque",
         "kv" => "kv",
         "fs" => "fs",
+        "process" => "process",
         _ => return None,
     })
 }


### PR DESCRIPTION
Closes #97. Sixth module from the top-10 stdlib roadmap (#106) — and the one I argued was the single biggest agent-tool unblocker (the OSS-Auditor proposal had it at v1.5; I bumped it to top-10 for exactly this reason).

## Summary

`process.spawn` returns a handle the caller can stream stdout/stderr from line-by-line, instead of the existing `proc.spawn`'s blocking-and-buffering (which can't watch a build in progress or pipe `git log | head`). Plus a `process.run` convenience that mimics the old shape for the easy case.

```lex
fn process.spawn(cmd, args, opts) -> [proc] Result[ProcessHandle, Str]
fn process.read_stdout_line(p)    -> [proc] Option[Str]   # None = EOF
fn process.read_stderr_line(p)    -> [proc] Option[Str]
fn process.wait(p)                -> [proc] ProcessExit
fn process.kill(p, signal)        -> [proc] Result[Nil, Str]
fn process.run(cmd, args)         -> [proc] Result[ProcessOutput, Str]

type SpawnOpts     = { cwd :: Option[Str], env :: Map[Str, Str], stdin :: Option[Bytes] }
type ProcessExit   = { code :: Int, signaled :: Bool }
type ProcessOutput = { stdout :: Str, stderr :: Str, exit_code :: Int }
```

## Implementation

- `ProcessHandle` is `Int` at runtime — points into a process-wide registry (same shape as `std.kv`'s handle pattern).
- `ProcessState` holds `Child` + `BufReader<ChildStdout>` + `BufReader<ChildStderr>`. `take_stdout`/`take_stderr` wrap into the readers at spawn time.
- Effect kind `[proc]` matches the existing `proc.spawn` convention so `lex audit --effect proc` continues to flag every subprocess site.
- Allow-proc basename check honored on both `spawn` and `run`.
- `signaled` uses `ExitStatusExt::signal()` on Unix; always false on non-Unix.
- `process.kill` uses `Child::kill` for cross-platform termination; signal-name dispatch is a v1.5 follow-up.

## Known v1 limitations

- Per-line reads block on the registry mutex while waiting on the child. A slow process delays other ops on different handles. Per-handle locks are a v1.5 follow-up.
- ProcessHandles aren't garbage-collected; long-running programs that spawn many short-lived children leak `Child` entries. `process.wait` could evict on completion — left for v1.5.

## Test plan (6 cases, unix-gated via `#![cfg(unix)]`)

- streaming spawn + line-by-line read via `printf "a\nb\nc\n"` (3 lines)
- first stdout line returned correctly
- `process.run` full-capture stdout
- exit codes: `true` → 0, `false` → 1
- `--allow-proc` basename allowlist blocks unlisted commands

`cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings` clean.

https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s)_