### PR TITLE
feat: stdlib `std.log` — structured logging behind a `[log]` effect (closes #103)

### DIFF
--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -97,6 +97,64 @@ impl DefaultHandler {
         }
     }
 
+    fn dispatch_log(&mut self, op: &str, args: Vec<Value>) -> Result<Value, String> {
+        match op {
+            "debug" | "info" | "warn" | "error" => {
+                let msg = expect_str(args.first())?;
+                let level = match op {
+                    "debug" => LogLevel::Debug,
+                    "info" => LogLevel::Info,
+                    "warn" => LogLevel::Warn,
+                    _ => LogLevel::Error,
+                };
+                emit_log(level, msg);
+                Ok(Value::Unit)
+            }
+            "set_level" => {
+                let s = expect_str(args.first())?;
+                match parse_log_level(s) {
+                    Some(l) => {
+                        log_state().lock().unwrap().level = l;
+                        Ok(ok(Value::Unit))
+                    }
+                    None => Ok(err(Value::Str(format!(
+                        "log.set_level: unknown level `{s}`; expected debug|info|warn|error")))),
+                }
+            }
+            "set_format" => {
+                let s = expect_str(args.first())?;
+                let fmt = match s {
+                    "text" => LogFormat::Text,
+                    "json" => LogFormat::Json,
+                    other => return Ok(err(Value::Str(format!(
+                        "log.set_format: unknown format `{other}`; expected text|json")))),
+                };
+                log_state().lock().unwrap().format = fmt;
+                Ok(ok(Value::Unit))
+            }
+            "set_sink" => {
+                let path = expect_str(args.first())?;
+                if path == "-" {
+                    log_state().lock().unwrap().sink = LogSink::Stderr;
+                    return Ok(ok(Value::Unit));
+                }
+                if let Err(e) = self.ensure_fs_write_path(path) {
+                    return Ok(err(Value::Str(e)));
+                }
+                match std::fs::OpenOptions::new()
+                    .create(true).append(true).open(path)
+                {
+                    Ok(f) => {
+                        log_state().lock().unwrap().sink = LogSink::File(std::sync::Arc::new(Mutex::new(f)));
+                        Ok(ok(Value::Unit))
+                    }
+                    Err(e) => Ok(err(Value::Str(format!("log.set_sink `{path}`: {e}")))),
+                }
+            }
+            other => Err(format!("unsupported log.{other}")),
+        }
+    }
+
     fn dispatch_process(&mut self, op: &str, args: Vec<Value>) -> Result<Value, String> {
         match op {
             "spawn" => {
@@ -514,6 +572,22 @@ impl EffectHandler for DefaultHandler {
         if kind == "process" {
             self.ensure_kind_allowed("proc")?;
             return self.dispatch_process(op, args);
+        }
+        if kind == "log" {
+            // Emit ops are [log]; config ops are [io] (set_sink also
+            // [fs_write]). The dispatch picks the right kind per op.
+            let effect_kind = match op {
+                "debug" | "info" | "warn" | "error" => "log",
+                "set_level" | "set_format" => "io",
+                "set_sink" => {
+                    self.ensure_kind_allowed("io")?;
+                    self.ensure_kind_allowed("fs_write")?;
+                    return self.dispatch_log(op, args);
+                }
+                other => return Err(format!("unsupported log.{other}")),
+            };
+            self.ensure_kind_allowed(effect_kind)?;
+            return self.dispatch_log(op, args);
         }
         if kind == "fs" {
             let effect_kind = match op {
@@ -1030,6 +1104,93 @@ fn expect_kv_handle(v: Option<&Value>) -> Result<u64, String> {
         Some(Value::Int(n)) if *n >= 0 => Ok(*n as u64),
         Some(other) => Err(format!("expected Kv handle (Int), got {other:?}")),
         None => Err("missing Kv argument".into()),
+    }
+}
+
+// -- log state (process-wide; configurable via log.set_*) --
+
+#[derive(Clone, Copy, PartialEq, PartialOrd)]
+enum LogLevel { Debug, Info, Warn, Error }
+
+#[derive(Clone, Copy, PartialEq)]
+enum LogFormat { Text, Json }
+
+#[derive(Clone)]
+enum LogSink {
+    Stderr,
+    File(std::sync::Arc<Mutex<std::fs::File>>),
+}
+
+struct LogState {
+    level: LogLevel,
+    format: LogFormat,
+    sink: LogSink,
+}
+
+fn log_state() -> &'static Mutex<LogState> {
+    static STATE: OnceLock<Mutex<LogState>> = OnceLock::new();
+    STATE.get_or_init(|| Mutex::new(LogState {
+        level: LogLevel::Info,
+        format: LogFormat::Text,
+        sink: LogSink::Stderr,
+    }))
+}
+
+fn parse_log_level(s: &str) -> Option<LogLevel> {
+    match s {
+        "debug" => Some(LogLevel::Debug),
+        "info" => Some(LogLevel::Info),
+        "warn" => Some(LogLevel::Warn),
+        "error" => Some(LogLevel::Error),
+        _ => None,
+    }
+}
+
+fn level_label(l: LogLevel) -> &'static str {
+    match l {
+        LogLevel::Debug => "debug",
+        LogLevel::Info => "info",
+        LogLevel::Warn => "warn",
+        LogLevel::Error => "error",
+    }
+}
+
+fn emit_log(level: LogLevel, msg: &str) {
+    let state = log_state().lock().unwrap();
+    if level < state.level {
+        return;
+    }
+    let ts = chrono::Utc::now().to_rfc3339();
+    let line = match state.format {
+        LogFormat::Text => format!("[{}] {}: {}\n", ts, level_label(level), msg),
+        LogFormat::Json => {
+            // Hand-rolled JSON to avoid pulling serde_json into the
+            // hot path; msg gets minimal escaping (the four common
+            // cases that break a JSON line).
+            let escaped = msg
+                .replace('\\', "\\\\")
+                .replace('"',  "\\\"")
+                .replace('\n', "\\n")
+                .replace('\r', "\\r");
+            format!(
+                "{{\"ts\":\"{ts}\",\"level\":\"{}\",\"msg\":\"{escaped}\"}}\n",
+                level_label(level),
+            )
+        }
+    };
+    let sink = state.sink.clone();
+    drop(state);
+    match sink {
+        LogSink::Stderr => {
+            use std::io::Write;
+            let _ = std::io::stderr().write_all(line.as_bytes());
+        }
+        LogSink::File(f) => {
+            use std::io::Write;
+            if let Ok(mut g) = f.lock() {
+                let _ = g.write_all(line.as_bytes());
+            }
+        }
     }
 }
 

--- a/crates/lex-runtime/tests/std_log.rs
+++ b/crates/lex-runtime/tests/std_log.rs
@@ -1,0 +1,200 @@
+//! Integration tests for `std.log`. Closes #103.
+//!
+//! Tests redirect the global sink to a tempfile, exercise the emit
+//! ops at each level, and assert the file contents. Each test uses a
+//! fresh sink path; the global sink is process-wide, so tests use a
+//! mutex to serialize.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::collections::BTreeSet;
+use std::sync::{Arc, Mutex, OnceLock};
+
+fn test_lock() -> &'static Mutex<()> {
+    static M: OnceLock<Mutex<()>> = OnceLock::new();
+    M.get_or_init(|| Mutex::new(()))
+}
+
+fn policy_for_log(write_root: &std::path::Path) -> Policy {
+    let mut p = Policy::pure();
+    p.allow_effects = ["log".to_string(), "io".to_string(), "fs_write".to_string()]
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    p.allow_fs_write = vec![write_root.to_path_buf()];
+    p
+}
+
+fn run(src: &str, fn_name: &str, args: Vec<Value>, policy: Policy) -> Value {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors:\n{errs:#?}");
+    }
+    let bc = Arc::new(compile_program(&stages));
+    let handler = DefaultHandler::new(policy).with_program(Arc::clone(&bc));
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(fn_name, args).unwrap_or_else(|e| panic!("call {fn_name}: {e}"))
+}
+
+fn unique_log_path(name: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "lex-log-{}-{}-{}",
+        std::process::id(),
+        name,
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir.join("log.txt")
+}
+
+const SRC: &str = r#"
+import "std.log" as log
+
+fn setup_text(path :: Str) -> [io, fs_write] Bool {
+  match log.set_sink(path) {
+    Ok(_) => match log.set_format("text") {
+      Ok(_) => match log.set_level("debug") {
+        Ok(_)  => true,
+        Err(_) => false,
+      },
+      Err(_) => false,
+    },
+    Err(_) => false,
+  }
+}
+
+fn setup_json(path :: Str) -> [io, fs_write] Bool {
+  match log.set_sink(path) {
+    Ok(_) => match log.set_format("json") {
+      Ok(_) => match log.set_level("info") {
+        Ok(_)  => true,
+        Err(_) => false,
+      },
+      Err(_) => false,
+    },
+    Err(_) => false,
+  }
+}
+
+fn setup_warn_threshold(path :: Str) -> [io, fs_write] Bool {
+  match log.set_sink(path) {
+    Ok(_) => match log.set_format("text") {
+      Ok(_) => match log.set_level("warn") {
+        Ok(_)  => true,
+        Err(_) => false,
+      },
+      Err(_) => false,
+    },
+    Err(_) => false,
+  }
+}
+
+fn emit_each_level() -> [log] Nil {
+  log.debug("d-msg")
+  log.info("i-msg")
+  log.warn("w-msg")
+  log.error("e-msg")
+}
+
+fn emit_one_info() -> [log] Nil { log.info("hello, world") }
+"#;
+
+#[test]
+fn text_format_includes_level_and_message() {
+    let _g = test_lock().lock().unwrap();
+    let path = unique_log_path("text_levels");
+    let policy = policy_for_log(path.parent().unwrap());
+
+    run(SRC, "setup_text",
+        vec![Value::Str(path.to_string_lossy().to_string())], policy.clone());
+    run(SRC, "emit_each_level", vec![], policy);
+
+    let contents = std::fs::read_to_string(&path).expect("read log");
+    assert!(contents.contains("debug: d-msg"), "got: {contents}");
+    assert!(contents.contains("info: i-msg"), "got: {contents}");
+    assert!(contents.contains("warn: w-msg"), "got: {contents}");
+    assert!(contents.contains("error: e-msg"), "got: {contents}");
+}
+
+#[test]
+fn json_format_emits_one_object_per_line() {
+    let _g = test_lock().lock().unwrap();
+    let path = unique_log_path("json_format");
+    let policy = policy_for_log(path.parent().unwrap());
+
+    run(SRC, "setup_json",
+        vec![Value::Str(path.to_string_lossy().to_string())], policy.clone());
+    run(SRC, "emit_one_info", vec![], policy);
+
+    let contents = std::fs::read_to_string(&path).expect("read log");
+    let parsed: serde_json::Value = serde_json::from_str(contents.trim())
+        .unwrap_or_else(|e| panic!("expected JSON line, got `{contents}`: {e}"));
+    assert_eq!(parsed["level"], "info");
+    assert_eq!(parsed["msg"], "hello, world");
+    assert!(parsed["ts"].is_string(), "missing ts: {parsed}");
+}
+
+#[test]
+fn level_threshold_drops_lower_levels() {
+    let _g = test_lock().lock().unwrap();
+    let path = unique_log_path("level_threshold");
+    let policy = policy_for_log(path.parent().unwrap());
+
+    run(SRC, "setup_warn_threshold",
+        vec![Value::Str(path.to_string_lossy().to_string())], policy.clone());
+    run(SRC, "emit_each_level", vec![], policy);
+
+    let contents = std::fs::read_to_string(&path).expect("read log");
+    // debug + info dropped; warn + error survive.
+    assert!(!contents.contains("d-msg"), "debug should be filtered: {contents}");
+    assert!(!contents.contains("i-msg"), "info should be filtered: {contents}");
+    assert!(contents.contains("w-msg"), "warn should pass: {contents}");
+    assert!(contents.contains("e-msg"), "error should pass: {contents}");
+}
+
+#[test]
+fn invalid_level_returns_err() {
+    let _g = test_lock().lock().unwrap();
+    let path = unique_log_path("bad_level");
+    let policy = policy_for_log(path.parent().unwrap());
+
+    let src = r#"
+import "std.log" as log
+fn try_bad_level() -> [io] Bool {
+  match log.set_level("trace") {
+    Ok(_)  => false,
+    Err(_) => true,
+  }
+}
+"#;
+    let v = run(src, "try_bad_level", vec![], policy);
+    assert_eq!(v, Value::Bool(true));
+}
+
+#[test]
+fn set_sink_outside_write_root_returns_err() {
+    let _g = test_lock().lock().unwrap();
+    let allowed = std::env::temp_dir().join(format!(
+        "lex-log-allowed-{}", std::process::id()));
+    std::fs::create_dir_all(&allowed).unwrap();
+    let outside = unique_log_path("outside_root");
+
+    let src = r#"
+import "std.log" as log
+fn setup(path :: Str) -> [io, fs_write] Bool {
+  match log.set_sink(path) {
+    Ok(_)  => true,
+    Err(_) => false,
+  }
+}
+"#;
+    let policy = policy_for_log(&allowed);
+    let v = run(src, "setup",
+        vec![Value::Str(outside.to_string_lossy().to_string())], policy);
+    assert_eq!(v, Value::Bool(false));
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -687,6 +687,40 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 Ty::List(Box::new(Ty::Var(0)))));
             Some(Ty::Record(fields))
         }
+        "log" => {
+            // Structured logging behind a [log] effect. Emit ops route
+            // through a runtime-configured sink (stderr by default;
+            // can be redirected via set_sink). Configuration ops
+            // mutate the global sink and so are gated [io].
+            let result_str = |t: Ty| Ty::Con("Result".into(), vec![t, Ty::str()]);
+            let mut fields = IndexMap::new();
+            for level in &["debug", "info", "warn", "error"] {
+                fields.insert((*level).into(), Ty::function(
+                    vec![Ty::str()],
+                    EffectSet::singleton("log"),
+                    Ty::Unit,
+                ));
+            }
+            // set_level :: Str -> [io] Result[Nil, Str]
+            fields.insert("set_level".into(), Ty::function(
+                vec![Ty::str()],
+                EffectSet::singleton("io"),
+                result_str(Ty::Unit)));
+            // set_format :: Str -> [io] Result[Nil, Str]
+            fields.insert("set_format".into(), Ty::function(
+                vec![Ty::str()],
+                EffectSet::singleton("io"),
+                result_str(Ty::Unit)));
+            // set_sink :: Str -> [io, fs_write] Result[Nil, Str]
+            fields.insert("set_sink".into(), Ty::function(
+                vec![Ty::str()],
+                EffectSet {
+                    concrete: ["io".to_string(), "fs_write".to_string()].into_iter().collect(),
+                    var: None,
+                },
+                result_str(Ty::Unit)));
+            Some(Ty::Record(fields))
+        }
         "datetime" => {
             // Instant and Duration are nominal opaque Ints under the
             // hood (nanoseconds-since-UTC-epoch and signed nanoseconds
@@ -970,6 +1004,7 @@ pub fn module_for_import(reference: &str) -> Option<&'static str> {
         "fs" => "fs",
         "process" => "process",
         "datetime" => "datetime",
+        "log" => "log",
         _ => return None,
     })
 }


### PR DESCRIPTION
Closes #103. Eighth module from the top-10 stdlib roadmap (#106).

## Summary

Process-wide configurable structured logger:

```lex
fn log.debug(msg) -> [log] Nil
fn log.info(msg)  -> [log] Nil
fn log.warn(msg)  -> [log] Nil
fn log.error(msg) -> [log] Nil

fn log.set_level(level :: Str)   -> [io] Result[Nil, Str]            # debug|info|warn|error
fn log.set_format(format :: Str) -> [io] Result[Nil, Str]            # text|json
fn log.set_sink(path :: Str)     -> [io, fs_write] Result[Nil, Str]  # "-" = stderr
```

Default sink is stderr; default level is `info`; default format is text.

## Implementation

- `LogState` (process-wide via `OnceLock<Mutex>`) holds level, format, and sink.
- `LogSink::File(Arc<Mutex<File>>)` — shared across threads. The Arc is cloned out of the state lock before the I/O write, so the state lock isn't held during slow disk operations.
- Level filtering happens before formatting (cheap drop on filtered messages).
- **Text format:** `[<rfc3339>] <level>: <msg>`
- **JSON format:** `{"ts":"...","level":"info","msg":"..."}` with minimal escaping (`\`, `"`, `\n`, `\r`). Hand-rolled to avoid pulling serde_json into the hot path.

## Skipped for v1

`log.with(fields, body)` — context propagation. Lex is pure-functional with no thread-locals; either the runtime stashes context (mutable state in the VM, against the grain) or every log call takes a ctx parameter (verbose). Deferred so we can ship structured logging now and design context propagation separately.

## Test plan (5 cases)

- text format includes level + message at each of debug/info/warn/error
- json format → one valid object per line, parseable by serde_json with the right fields
- level threshold drops lower-level messages (warn threshold → debug + info filtered, warn + error survive)
- invalid level string → `Err`
- `set_sink` outside `--allow-fs-write` → `Err`

Tests serialize via a process-wide test mutex (the log state is process-wide). `cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings` clean.

https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s

---
_Generated by [Claude Code](https://claude.ai/code/session_01FmvbSJTe9HXpFMamfxei6s)_