### PR TITLE
feat: stdlib `std.flow.parallel_list` — variadic counterpart to `parallel`

### DIFF
--- a/crates/lex-bytecode/src/compiler.rs
+++ b/crates/lex-bytecode/src/compiler.rs
@@ -578,6 +578,7 @@ impl<'a> FnCompiler<'a> {
             ("flow", "branch") => self.emit_flow_branch(args),
             ("flow", "retry") => self.emit_flow_retry(args),
             ("flow", "parallel") => self.emit_flow_parallel(args),
+            ("flow", "parallel_list") => self.emit_flow_parallel_list(args),
             _ => return false,
         }
         true
@@ -898,6 +899,68 @@ impl<'a> FnCompiler<'a> {
         ];
         let fn_id = self.install_trampoline("__flow_parallel", 2, 2, code);
         self.emit(Op::MakeClosure { fn_id, capture_count: 2 });
+    }
+
+    /// `flow.parallel_list(actions)` runs each 0-arg closure in `actions`
+    /// and returns the results as a list in input order. Variadic
+    /// counterpart to `flow.parallel`. Sequential under the hood — the
+    /// spec (§11.2) reserves true threading for a future scheduler.
+    /// Compiled inline (mirrors `list.map`) so closure args can flow
+    /// through `CallClosure` without a heap-allocated trampoline.
+    fn emit_flow_parallel_list(&mut self, args: &[a::CExpr]) {
+        // xs := actions
+        self.compile_expr(&args[0], false);
+        let xs = self.alloc_local("__fpl_xs");
+        self.emit(Op::StoreLocal(xs));
+
+        // out := []
+        self.emit(Op::MakeList(0));
+        let out = self.alloc_local("__fpl_out");
+        self.emit(Op::StoreLocal(out));
+
+        // i := 0
+        let zero = self.pool.int(0);
+        self.emit(Op::PushConst(zero));
+        let i = self.alloc_local("__fpl_i");
+        self.emit(Op::StoreLocal(i));
+
+        // loop_top: while i < len(xs) { ... }
+        let loop_top = self.code.len();
+        self.emit(Op::LoadLocal(i));
+        self.emit(Op::LoadLocal(xs));
+        self.emit(Op::GetListLen);
+        self.emit(Op::NumLt);
+        let j_exit = self.code.len();
+        self.emit(Op::JumpIfNot(0));
+
+        // body: out := out ++ [xs[i]()]
+        let nid = self.pool.node_id("n_flow_parallel_list");
+        self.emit(Op::LoadLocal(out));
+        self.emit(Op::LoadLocal(xs));
+        self.emit(Op::LoadLocal(i));
+        self.emit(Op::GetListElemDyn);
+        self.emit(Op::CallClosure { arity: 0, node_id_idx: nid });
+        self.emit(Op::ListAppend);
+        self.emit(Op::StoreLocal(out));
+
+        // i := i + 1
+        self.emit(Op::LoadLocal(i));
+        let one = self.pool.int(1);
+        self.emit(Op::PushConst(one));
+        self.emit(Op::NumAdd);
+        self.emit(Op::StoreLocal(i));
+
+        // jump back
+        let jump_back = self.code.len();
+        let back = (loop_top as i32) - (jump_back as i32 + 1);
+        self.emit(Op::Jump(back));
+
+        // exit: patch j_exit, push out
+        let exit_target = self.code.len() as i32;
+        if let Op::JumpIfNot(off) = &mut self.code[j_exit] {
+            *off = exit_target - (j_exit as i32 + 1);
+        }
+        self.emit(Op::LoadLocal(out));
     }
 
     /// `flow.branch(cond, t, f)` returns a closure `(x) -> if cond(x) then t(x) else f(x)`.

--- a/crates/lex-runtime/tests/std_flow_extensions.rs
+++ b/crates/lex-runtime/tests/std_flow_extensions.rs
@@ -1,0 +1,110 @@
+//! std.flow extensions: `parallel_list` (variadic counterpart to
+//! `parallel`). Spec §11.2 — sequential under the hood; threading is
+//! reserved for a future scheduler.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+
+fn run(src: &str, func: &str, args: Vec<Value>) -> Value {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors: {errs:#?}");
+    }
+    let bc = compile_program(&stages);
+    let handler = DefaultHandler::new(Policy::permissive());
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(func, args).expect("vm")
+}
+
+#[test]
+fn parallel_list_runs_three_actions_in_input_order() {
+    let src = r#"
+import "std.flow" as flow
+fn run3() -> List[Int] {
+  flow.parallel_list([
+    fn () -> Int { 7 },
+    fn () -> Int { 11 },
+    fn () -> Int { 13 }
+  ])
+}
+"#;
+    let r = run(src, "run3", vec![]);
+    assert_eq!(
+        r,
+        Value::List(vec![Value::Int(7), Value::Int(11), Value::Int(13)])
+    );
+}
+
+#[test]
+fn parallel_list_empty_returns_empty_list() {
+    let src = r#"
+import "std.flow" as flow
+fn run0() -> List[Int] {
+  flow.parallel_list([])
+}
+"#;
+    let r = run(src, "run0", vec![]);
+    assert_eq!(r, Value::List(vec![]));
+}
+
+#[test]
+fn parallel_list_single_action_returns_singleton() {
+    let src = r#"
+import "std.flow" as flow
+fn run1() -> List[Int] {
+  flow.parallel_list([fn () -> Int { 42 }])
+}
+"#;
+    let r = run(src, "run1", vec![]);
+    assert_eq!(r, Value::List(vec![Value::Int(42)]));
+}
+
+#[test]
+fn parallel_list_preserves_captured_locals() {
+    // Each closure captures a distinct local from the enclosing scope.
+    // Verifies captures are read at call time without aliasing.
+    let src = r#"
+import "std.flow" as flow
+fn run_caps() -> List[Int] {
+  let a := 1
+  let b := 2
+  let c := 3
+  flow.parallel_list([
+    fn () -> Int { a + 10 },
+    fn () -> Int { b + 20 },
+    fn () -> Int { c + 30 }
+  ])
+}
+"#;
+    let r = run(src, "run_caps", vec![]);
+    assert_eq!(
+        r,
+        Value::List(vec![Value::Int(11), Value::Int(22), Value::Int(33)])
+    );
+}
+
+#[test]
+fn parallel_list_works_with_string_return_type() {
+    let src = r#"
+import "std.flow" as flow
+fn run_strs() -> List[Str] {
+  flow.parallel_list([
+    fn () -> Str { "alpha" },
+    fn () -> Str { "beta" },
+    fn () -> Str { "gamma" }
+  ])
+}
+"#;
+    let r = run(src, "run_strs", vec![]);
+    assert_eq!(
+        r,
+        Value::List(vec![
+            Value::Str("alpha".into()),
+            Value::Str("beta".into()),
+            Value::Str("gamma".into()),
+        ])
+    );
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -598,6 +598,22 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 Ty::function(vec![], EffectSet::empty(),
                     Ty::Tuple(vec![Ty::Var(0), Ty::Var(1)])),
             ));
+            // parallel_list[T](actions: List[() -> T]) -> List[T]
+            // Variadic counterpart to `parallel`. Runs each action and
+            // collects results in input order. Sequential under the
+            // hood (same caveat as `parallel`); spec §11.2 reserves
+            // true threading for a future scheduler. Unlike `parallel`,
+            // this returns the result list directly rather than a
+            // closure, since the input arity is dynamic.
+            fields.insert("parallel_list".into(), Ty::function(
+                vec![
+                    Ty::List(Box::new(
+                        Ty::function(vec![], EffectSet::empty(), Ty::Var(0)),
+                    )),
+                ],
+                EffectSet::empty(),
+                Ty::List(Box::new(Ty::Var(0))),
+            ));
             Some(Ty::Record(fields))
         }
         "crypto" => {


### PR DESCRIPTION
## Summary

- Adds `flow.parallel_list[T](actions: List[() -> T]) -> List[T]` — runs each 0-arg closure in input order and returns the results as a list.
- Sequential under the hood (same caveat as `flow.parallel`); spec §11.2 reserves true threading for a future scheduler.
- Compiled inline mirroring `list.map` rather than via a heap-allocated trampoline so closures flow directly through `CallClosure`. Unlike `parallel`, the result is the list itself (not a closure), since input arity is dynamic.

## Changes

- `crates/lex-types/src/builtins.rs` — type signature added to the `flow` module record.
- `crates/lex-bytecode/src/compiler.rs` — new `emit_flow_parallel_list` method + `("flow", "parallel_list")` dispatch arm.
- `crates/lex-runtime/tests/std_flow_extensions.rs` — 5 tests (3 actions in order, empty list, singleton, captured locals, `Str` return type).

## Recovery context

Refs #105. The previous session's branch (`feat/std-flow-extensions-105`) was lost before commit/push; this branch recreates the implementation from the plan documented in the #105 comment. `race` / `timeout` / `retry_backoff` remain deferred to v1.5 pending true parallelism + `time.sleep`.

## Test plan

- [x] `cargo test --test std_flow_extensions` — 5/5 pass
- [x] `cargo test --test flow` — 10/10 pass (no regression)
- [x] `cargo test --test list_higher_order` — 9/9 pass (no regression)
- [x] `cargo test -p lex-types` — pass (no regression from builtins change)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRXRypmTju3ShcQ3ERJQSu)_