### PR TITLE
feat: round-trip `Value::Bytes` through JSON via `$bytes` marker

### DIFF
--- a/crates/lex-bytecode/src/value.rs
+++ b/crates/lex-bytecode/src/value.rs
@@ -225,7 +225,7 @@ impl Value {
 /// Lowercase-hex → bytes. Returns `None` for odd length or non-hex chars
 /// (callers fall through to a record decode rather than erroring).
 fn decode_hex(s: &str) -> Option<Vec<u8>> {
-    if s.len() % 2 != 0 { return None; }
+    if !s.len().is_multiple_of(2) { return None; }
     let mut out = Vec::with_capacity(s.len() / 2);
     let bytes = s.as_bytes();
     for pair in bytes.chunks(2) {

--- a/crates/lex-bytecode/src/value.rs
+++ b/crates/lex-bytecode/src/value.rs
@@ -99,7 +99,10 @@ impl Value {
     /// - `Variant { name, args }` → `{"$variant": name, "args": [...]}`
     /// - `F64Array { ... }` → `{"$f64_array": true, rows, cols, data}`
     /// - `Closure { fn_id, .. }` → `"<closure fn_N>"`
-    /// - `Bytes` → lowercase hex string
+    /// - `Bytes` → `{"$bytes": "deadbeef"}` (lowercase hex). Round-trips
+    ///   through `from_json`. Bare hex strings decode as `Str`, so the
+    ///   marker is required to disambiguate bytes from a string that
+    ///   happens to look like hex.
     /// - `Map` with all-`Str` keys → JSON object; otherwise array of
     ///   `[key, value]` pairs (Int keys can't be JSON-object keys)
     /// - `Set` → JSON array of elements
@@ -114,7 +117,12 @@ impl Value {
             Value::Float(f) => J::from(*f),
             Value::Bool(b) => J::Bool(*b),
             Value::Str(s) => J::String(s.clone()),
-            Value::Bytes(b) => J::String(b.iter().map(|b| format!("{:02x}", b)).collect()),
+            Value::Bytes(b) => {
+                let hex: String = b.iter().map(|b| format!("{:02x}", b)).collect();
+                let mut m = serde_json::Map::new();
+                m.insert("$bytes".into(), J::String(hex));
+                J::Object(m)
+            }
             Value::Unit => J::Null,
             Value::List(items) => J::Array(items.iter().map(Value::to_json).collect()),
             Value::Tuple(items) => J::Array(items.iter().map(Value::to_json).collect()),
@@ -164,16 +172,18 @@ impl Value {
     /// [`to_json`](Self::to_json) for the shapes Lex round-trips:
     ///
     /// - `{"$variant": "Name", "args": [...]}` → `Value::Variant`
+    /// - `{"$bytes": "deadbeef"}` → `Value::Bytes` (lowercase hex; an
+    ///   odd-length string or non-hex character falls through to
+    ///   `Value::Record`, matching the malformed-`$variant` fallback)
     /// - JSON object → `Value::Record`
     /// - JSON array → `Value::List`
     /// - JSON null → `Value::Unit`
     /// - JSON string / bool / number → the corresponding scalar
     ///
-    /// Bytes (hex), Map, Set, F64Array, and Closure don't round-trip
-    /// — they decode as their natural JSON shape (Str / Object / Array
-    /// / Object / Str respectively), since the CLI / HTTP / VM
-    /// callers building Values from JSON don't have those shapes in
-    /// their input vocabulary.
+    /// Map, Set, F64Array, and Closure don't round-trip — they decode
+    /// as their natural JSON shape (Object / Array / Object / Str
+    /// respectively), since the CLI / HTTP / VM callers building Values
+    /// from JSON don't have those shapes in their input vocabulary.
     pub fn from_json(v: &serde_json::Value) -> Value {
         use serde_json::Value as J;
         match v {
@@ -195,6 +205,13 @@ impl Value {
                         args: args.iter().map(Value::from_json).collect(),
                     };
                 }
+                if map.len() == 1 {
+                    if let Some(J::String(hex)) = map.get("$bytes") {
+                        if let Some(bytes) = decode_hex(hex) {
+                            return Value::Bytes(bytes);
+                        }
+                    }
+                }
                 let mut out = indexmap::IndexMap::new();
                 for (k, v) in map {
                     out.insert(k.clone(), Value::from_json(v));
@@ -203,4 +220,18 @@ impl Value {
             }
         }
     }
+}
+
+/// Lowercase-hex → bytes. Returns `None` for odd length or non-hex chars
+/// (callers fall through to a record decode rather than erroring).
+fn decode_hex(s: &str) -> Option<Vec<u8>> {
+    if s.len() % 2 != 0 { return None; }
+    let mut out = Vec::with_capacity(s.len() / 2);
+    let bytes = s.as_bytes();
+    for pair in bytes.chunks(2) {
+        let hi = (pair[0] as char).to_digit(16)?;
+        let lo = (pair[1] as char).to_digit(16)?;
+        out.push(((hi << 4) | lo) as u8);
+    }
+    Some(out)
 }

--- a/crates/lex-bytecode/tests/from_json.rs
+++ b/crates/lex-bytecode/tests/from_json.rs
@@ -149,3 +149,59 @@ fn primitives_round_trip() {
     roundtrip(Value::Str("hi".into()));
     roundtrip(Value::Unit);
 }
+
+#[test]
+fn bytes_round_trip_via_dollar_bytes_marker() {
+    // The marker disambiguates bytes from a string-that-happens-to-be-hex.
+    roundtrip(Value::Bytes(vec![]));
+    roundtrip(Value::Bytes(vec![0xde, 0xad, 0xbe, 0xef]));
+    roundtrip(Value::Bytes((0..=255u8).collect()));
+}
+
+#[test]
+fn bytes_encode_uses_dollar_bytes_object() {
+    let j = Value::Bytes(vec![0xde, 0xad, 0xbe, 0xef]).to_json();
+    assert_eq!(j, json!({ "$bytes": "deadbeef" }));
+}
+
+#[test]
+fn dollar_bytes_decodes_as_bytes() {
+    let j = json!({ "$bytes": "deadbeef" });
+    assert_eq!(Value::from_json(&j), Value::Bytes(vec![0xde, 0xad, 0xbe, 0xef]));
+}
+
+#[test]
+fn bare_hex_string_still_decodes_as_str() {
+    // No marker → no bytes. Avoids accidentally classifying user strings
+    // that happen to be valid hex.
+    let j = json!("deadbeef");
+    assert_eq!(Value::from_json(&j), Value::Str("deadbeef".into()));
+}
+
+#[test]
+fn dollar_bytes_with_invalid_hex_falls_through_to_record() {
+    // Odd length → invalid hex → record fallback (parallels the
+    // malformed-`$variant` fallback above).
+    let j = json!({ "$bytes": "abc" });
+    let v = Value::from_json(&j);
+    let expected = {
+        let mut m = indexmap::IndexMap::new();
+        m.insert("$bytes".into(), Value::Str("abc".into()));
+        Value::Record(m)
+    };
+    assert_eq!(v, expected);
+}
+
+#[test]
+fn dollar_bytes_with_extra_keys_stays_record() {
+    // Extra keys signal it's not the marker shape.
+    let j = json!({ "$bytes": "dead", "note": "x" });
+    let v = Value::from_json(&j);
+    let expected = {
+        let mut m = indexmap::IndexMap::new();
+        m.insert("$bytes".into(), Value::Str("dead".into()));
+        m.insert("note".into(), Value::Str("x".into()));
+        Value::Record(m)
+    };
+    assert_eq!(v, expected);
+}


### PR DESCRIPTION
## Summary

- `Value::to_json` now encodes `Value::Bytes` as `{"$bytes": "deadbeef"}` instead of a bare lowercase-hex string.
- `Value::from_json` decodes the marker back to `Value::Bytes`. Bare strings continue to decode as `Value::Str`, so user strings that happen to be valid hex aren't reclassified.
- Malformed marker objects (odd-length hex, non-hex chars, extra keys) fall through to the `Record` decode — paralleling the existing `$variant` fallback.

## Why

Item 5 of #115. JSON has no canonical bytes wire shape, and `to_json` previously emitted bytes as a hex string indistinguishable from a string-that-happens-to-be-hex. Round-tripping `Value::Bytes` through Lex's JSON pipeline silently lost the bytes-ness, returning `Value::Str`. The opt-in `$bytes` marker mirrors the existing `$variant` / `$f64_array` shapes and makes `Bytes` round-trippable.

So a CLI invocation like:
```sh
lex run path.lex fn '{"$bytes": "deadbeef"}'
```
now produces `Value::Bytes(vec![0xde, 0xad, 0xbe, 0xef])` rather than `Value::Str("deadbeef")`.

## Test plan

- [x] `cargo test -p lex-bytecode --test from_json` — 17/17 pass (6 new tests covering: round-trip via marker, encoder shape, decoder shape, bare-hex-string-stays-Str, invalid-hex falls through, extra-keys stays Record)
- [x] `cargo test --workspace` — zero failures (no regressions in `std_crypto`, `bytes_and_net`, lex-trace recorder, lex-cli, lex-api, conformance, etc.)

Refs #115.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRXRypmTju3ShcQ3ERJQSu)_