### PR TITLE
feat: stdlib `std.map.fold` — three-arg HOF over Map entries

### DIFF
--- a/crates/lex-bytecode/src/compiler.rs
+++ b/crates/lex-bytecode/src/compiler.rs
@@ -563,7 +563,7 @@ impl<'a> FnCompiler<'a> {
         module: &str,
         op: &str,
         args: &[a::CExpr],
-        _node_id_idx: u32,
+        node_id_idx: u32,
     ) -> bool {
         match (module, op) {
             ("result", "map") => self.emit_variant_map(args, "Ok", true),
@@ -574,6 +574,7 @@ impl<'a> FnCompiler<'a> {
             ("list", "map") => self.emit_list_map(args),
             ("list", "filter") => self.emit_list_filter(args),
             ("list", "fold") => self.emit_list_fold(args),
+            ("map", "fold") => self.emit_map_fold(args, node_id_idx),
             ("flow", "sequential") => self.emit_flow_sequential(args),
             ("flow", "branch") => self.emit_flow_branch(args),
             ("flow", "retry") => self.emit_flow_retry(args),
@@ -748,6 +749,86 @@ impl<'a> FnCompiler<'a> {
         self.emit(Op::LoadLocal(i));
         self.emit(Op::GetListElemDyn);
         self.emit(Op::CallClosure { arity: 2, node_id_idx: nid });
+        self.emit(Op::StoreLocal(acc));
+
+        // i := i + 1
+        self.emit(Op::LoadLocal(i));
+        let one = self.pool.int(1);
+        self.emit(Op::PushConst(one));
+        self.emit(Op::NumAdd);
+        self.emit(Op::StoreLocal(i));
+
+        let jump_back = self.code.len();
+        let back = (loop_top as i32) - (jump_back as i32 + 1);
+        self.emit(Op::Jump(back));
+
+        let exit_target = self.code.len() as i32;
+        if let Op::JumpIfNot(off) = &mut self.code[j_exit] {
+            *off = exit_target - (j_exit as i32 + 1);
+        }
+        self.emit(Op::LoadLocal(acc));
+    }
+
+    /// `map.fold(m, init, f)` — left fold over `Map[K, V]` entries with a
+    /// three-arg combiner `f(acc, k, v)`. Iteration order matches
+    /// `map.entries` (BTreeMap-sorted by key). Materializes the entry
+    /// list once via the runtime's `("map", "entries")` op, then runs
+    /// the same inline loop as `list.fold`.
+    fn emit_map_fold(&mut self, args: &[a::CExpr], node_id_idx: u32) {
+        // xs := map.entries(m)
+        self.compile_expr(&args[0], false);
+        let map_kind = self.pool.str("map");
+        let entries_op = self.pool.str("entries");
+        self.emit(Op::EffectCall {
+            kind_idx: map_kind,
+            op_idx: entries_op,
+            arity: 1,
+            node_id_idx,
+        });
+        let xs = self.alloc_local("__mf_xs");
+        self.emit(Op::StoreLocal(xs));
+
+        // acc := init
+        self.compile_expr(&args[1], false);
+        let acc = self.alloc_local("__mf_acc");
+        self.emit(Op::StoreLocal(acc));
+
+        // f := <closure>
+        self.compile_expr(&args[2], false);
+        let f = self.alloc_local("__mf_f");
+        self.emit(Op::StoreLocal(f));
+
+        // i := 0
+        let zero = self.pool.int(0);
+        self.emit(Op::PushConst(zero));
+        let i = self.alloc_local("__mf_i");
+        self.emit(Op::StoreLocal(i));
+
+        // loop_top: while i < len(xs)
+        let loop_top = self.code.len();
+        self.emit(Op::LoadLocal(i));
+        self.emit(Op::LoadLocal(xs));
+        self.emit(Op::GetListLen);
+        self.emit(Op::NumLt);
+        let j_exit = self.code.len();
+        self.emit(Op::JumpIfNot(0));
+
+        // pair := xs[i]
+        self.emit(Op::LoadLocal(xs));
+        self.emit(Op::LoadLocal(i));
+        self.emit(Op::GetListElemDyn);
+        let pair = self.alloc_local("__mf_pair");
+        self.emit(Op::StoreLocal(pair));
+
+        // acc := f(acc, pair.0, pair.1)
+        let nid = self.pool.node_id("n_map_fold");
+        self.emit(Op::LoadLocal(f));
+        self.emit(Op::LoadLocal(acc));
+        self.emit(Op::LoadLocal(pair));
+        self.emit(Op::GetElem(0));
+        self.emit(Op::LoadLocal(pair));
+        self.emit(Op::GetElem(1));
+        self.emit(Op::CallClosure { arity: 3, node_id_idx: nid });
         self.emit(Op::StoreLocal(acc));
 
         // i := i + 1

--- a/crates/lex-runtime/tests/map_set.rs
+++ b/crates/lex-runtime/tests/map_set.rs
@@ -179,3 +179,95 @@ fn build() -> Map[Str, Int] { map.set(map.set(map.new(), "x", 7), "y", 11) }
     assert_eq!(m.get(&MapKey::Str("x".into())), Some(&Value::Int(7)));
     assert_eq!(m.get(&MapKey::Str("y".into())), Some(&Value::Int(11)));
 }
+
+#[test]
+fn map_fold_sums_values() {
+    // Combiner uses only `v`, ignores `k`. Smoke test the wiring.
+    let src = r#"
+import "std.map" as map
+fn sum_values() -> Int {
+  let m := map.set(map.set(map.set(map.new(), "a", 1), "b", 2), "c", 3)
+  map.fold(m, 0, fn (acc :: Int, k :: Str, v :: Int) -> Int { acc + v })
+}
+"#;
+    assert_eq!(run(src, "sum_values", vec![]), Value::Int(6));
+}
+
+#[test]
+fn map_fold_on_empty_returns_init() {
+    let src = r#"
+import "std.map" as map
+fn fold_empty() -> Int {
+  map.fold(map.new(), 42, fn (acc :: Int, k :: Str, v :: Int) -> Int { acc + v })
+}
+"#;
+    assert_eq!(run(src, "fold_empty", vec![]), Value::Int(42));
+}
+
+#[test]
+fn map_fold_passes_both_key_and_value_to_combiner() {
+    // Combiner uses both: `acc + parse(k) * v`. With keys "1","2","3"
+    // and values 10,20,30 → 1*10 + 2*20 + 3*30 = 140.
+    let src = r#"
+import "std.map" as map
+import "std.str" as str
+fn weighted_sum() -> Int {
+  let m := map.set(map.set(map.set(map.new(), "1", 10), "2", 20), "3", 30)
+  map.fold(m, 0, fn (acc :: Int, k :: Str, v :: Int) -> Int {
+    let kn := match str.to_int(k) { Some(n) => n, None => 0 }
+    acc + kn * v
+  })
+}
+"#;
+    assert_eq!(run(src, "weighted_sum", vec![]), Value::Int(140));
+}
+
+#[test]
+fn map_fold_iterates_in_btreemap_key_order() {
+    // BTreeMap iteration is sorted by key. Folding into a list shows
+    // the order: insertion was "z","a","m" but iteration is "a","m","z".
+    let src = r#"
+import "std.map" as map
+import "std.list" as list
+fn keys_in_iter_order() -> List[Str] {
+  let m := map.set(map.set(map.set(map.new(), "z", 1), "a", 2), "m", 3)
+  map.fold(m, [], fn (acc :: List[Str], k :: Str, v :: Int) -> List[Str] {
+    list.concat(acc, [k])
+  })
+}
+"#;
+    assert_eq!(
+        run(src, "keys_in_iter_order", vec![]),
+        Value::List(vec![
+            Value::Str("a".into()),
+            Value::Str("m".into()),
+            Value::Str("z".into()),
+        ])
+    );
+}
+
+#[test]
+fn map_fold_works_with_int_keys() {
+    let src = r#"
+import "std.map" as map
+fn sum_int_keys() -> Int {
+  let m := map.set(map.set(map.set(map.new(), 10, 100), 20, 200), 30, 300)
+  map.fold(m, 0, fn (acc :: Int, k :: Int, v :: Int) -> Int { acc + k + v })
+}
+"#;
+    // 10+100 + 20+200 + 30+300 = 660
+    assert_eq!(run(src, "sum_int_keys", vec![]), Value::Int(660));
+}
+
+#[test]
+fn map_fold_combiner_can_capture_outer_locals() {
+    let src = r#"
+import "std.map" as map
+fn weighted() -> Int {
+  let weight := 100
+  let m := map.set(map.set(map.new(), "a", 1), "b", 2)
+  map.fold(m, 0, fn (acc :: Int, k :: Str, v :: Int) -> Int { acc + v * weight })
+}
+"#;
+    assert_eq!(run(src, "weighted", vec![]), Value::Int(300));
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -499,10 +499,23 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
             // is_empty :: Map[K, V] -> Bool
             fields.insert("is_empty".into(), Ty::function(
                 vec![mt()], EffectSet::empty(), Ty::bool()));
-            // map.fold is a HOF — needs the same special-cased bytecode
-            // emit as `list.fold` to thread the closure through the
-            // VM's call protocol. Tracked as follow-up; not in this
-            // PR's scope.
+            // fold :: Map[K, V], A, (A, K, V) -> [E] A -> [E] A
+            // Iteration order matches `map.entries` (BTreeMap-sorted by
+            // key). Effect-polymorphic on the combiner like `list.fold`.
+            // Type variable 2 = A (accumulator), effect row 3.
+            fields.insert("fold".into(), Ty::function(
+                vec![
+                    mt(),
+                    Ty::Var(2),
+                    Ty::function(
+                        vec![Ty::Var(2), Ty::Var(0), Ty::Var(1)],
+                        EffectSet::open_var(3),
+                        Ty::Var(2),
+                    ),
+                ],
+                EffectSet::open_var(3),
+                Ty::Var(2),
+            ));
             Some(Ty::Record(fields))
         }
         "set" => {


### PR DESCRIPTION
## Summary

- Adds `map.fold(m, init, fn (acc, k, v) -> acc')` — three-arg left fold over `Map[K, V]` entries.
- Iteration order matches `map.entries` (BTreeMap-sorted by key); effect-polymorphic on the combiner like `list.fold`.
- Compiled inline (mirrors `list.fold`) so the closure flows through `CallClosure` rather than the runtime dispatcher.

## Implementation

The new `emit_map_fold` materializes the entry list once via the existing `("map", "entries")` runtime op, then runs the same `i < len(xs)` loop as `list.fold`, destructuring each pair via `GetElem(0)` / `GetElem(1)` to feed the three-arg combiner. No new opcodes required.

## Changes

- `crates/lex-types/src/builtins.rs` — type signature added to the `map` module record (replaces the carve-out comment).
- `crates/lex-bytecode/src/compiler.rs` — new `emit_map_fold` method + `("map", "fold")` dispatch arm; `try_emit_higher_order` now uses its `node_id_idx` parameter (previously prefixed `_`).
- `crates/lex-runtime/tests/map_set.rs` — 6 new tests appended.

## Test plan

- [x] `cargo test --test map_set` — 16/16 pass (6 new: sums values; empty returns init; combiner sees both K and V; iterates in BTreeMap key order; works with Int keys; combiner can capture outer locals)
- [x] `cargo test --workspace` — zero failures (no regressions)

Closes item 1 of #115.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRXRypmTju3ShcQ3ERJQSu)_