### PR TITLE
feat: bound `std.kv` registry with LRU cap + FIFO eviction

### DIFF
--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -777,14 +777,14 @@ impl EffectHandler for DefaultHandler {
             }
             ("kv", "close") => {
                 let h = expect_kv_handle(args.first())?;
-                kv_registry().lock().unwrap().remove(&h);
+                kv_registry().lock().unwrap().remove(h);
                 Ok(Value::Unit)
             }
             ("kv", "get") => {
                 let h = expect_kv_handle(args.first())?;
                 let key = expect_str(args.get(1))?;
-                let reg = kv_registry().lock().unwrap();
-                let db = reg.get(&h).ok_or_else(|| "kv.get: closed or unknown Kv handle".to_string())?;
+                let mut reg = kv_registry().lock().unwrap();
+                let db = reg.touch_get(h).ok_or_else(|| "kv.get: closed or unknown Kv handle".to_string())?;
                 match db.get(key.as_bytes()) {
                     Ok(Some(ivec)) => Ok(some(Value::Bytes(ivec.to_vec()))),
                     Ok(None) => Ok(none()),
@@ -795,8 +795,8 @@ impl EffectHandler for DefaultHandler {
                 let h = expect_kv_handle(args.first())?;
                 let key = expect_str(args.get(1))?.to_string();
                 let val = expect_bytes(args.get(2))?.clone();
-                let reg = kv_registry().lock().unwrap();
-                let db = reg.get(&h).ok_or_else(|| "kv.put: closed or unknown Kv handle".to_string())?;
+                let mut reg = kv_registry().lock().unwrap();
+                let db = reg.touch_get(h).ok_or_else(|| "kv.put: closed or unknown Kv handle".to_string())?;
                 match db.insert(key.as_bytes(), val) {
                     Ok(_) => Ok(ok(Value::Unit)),
                     Err(e) => Ok(err(Value::Str(format!("kv.put: {e}")))),
@@ -805,8 +805,8 @@ impl EffectHandler for DefaultHandler {
             ("kv", "delete") => {
                 let h = expect_kv_handle(args.first())?;
                 let key = expect_str(args.get(1))?;
-                let reg = kv_registry().lock().unwrap();
-                let db = reg.get(&h).ok_or_else(|| "kv.delete: closed or unknown Kv handle".to_string())?;
+                let mut reg = kv_registry().lock().unwrap();
+                let db = reg.touch_get(h).ok_or_else(|| "kv.delete: closed or unknown Kv handle".to_string())?;
                 match db.remove(key.as_bytes()) {
                     Ok(_) => Ok(ok(Value::Unit)),
                     Err(e) => Ok(err(Value::Str(format!("kv.delete: {e}")))),
@@ -815,8 +815,8 @@ impl EffectHandler for DefaultHandler {
             ("kv", "contains") => {
                 let h = expect_kv_handle(args.first())?;
                 let key = expect_str(args.get(1))?;
-                let reg = kv_registry().lock().unwrap();
-                let db = reg.get(&h).ok_or_else(|| "kv.contains: closed or unknown Kv handle".to_string())?;
+                let mut reg = kv_registry().lock().unwrap();
+                let db = reg.touch_get(h).ok_or_else(|| "kv.contains: closed or unknown Kv handle".to_string())?;
                 match db.contains_key(key.as_bytes()) {
                     Ok(present) => Ok(Value::Bool(present)),
                     Err(e) => Err(format!("kv.contains: {e}")),
@@ -825,8 +825,8 @@ impl EffectHandler for DefaultHandler {
             ("kv", "list_prefix") => {
                 let h = expect_kv_handle(args.first())?;
                 let prefix = expect_str(args.get(1))?;
-                let reg = kv_registry().lock().unwrap();
-                let db = reg.get(&h).ok_or_else(|| "kv.list_prefix: closed or unknown Kv handle".to_string())?;
+                let mut reg = kv_registry().lock().unwrap();
+                let db = reg.touch_get(h).ok_or_else(|| "kv.list_prefix: closed or unknown Kv handle".to_string())?;
                 let mut keys: Vec<Value> = Vec::new();
                 for kv in db.scan_prefix(prefix.as_bytes()) {
                     let (k, _) = kv.map_err(|e| format!("kv.list_prefix: {e}"))?;
@@ -1221,12 +1221,150 @@ fn expect_process_handle(v: Option<&Value>) -> Result<u64, String> {
 /// Process-wide registry of open `Kv` handles. Each `kv.open` allocates
 /// a new u64 handle via [`next_kv_handle`] and stores the `sled::Db`
 /// here; subsequent ops fetch by handle. `kv.close` removes the entry.
-fn kv_registry() -> &'static Mutex<HashMap<u64, sled::Db>> {
-    static REGISTRY: OnceLock<Mutex<HashMap<u64, sled::Db>>> = OnceLock::new();
-    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+///
+/// Capped at [`MAX_KV_HANDLES`] to prevent leaks from long-running
+/// programs that open many short-lived stores without calling
+/// `kv.close`. On insert at cap, the least-recently-used entry is
+/// dropped (closing its `sled::Db`); subsequent ops on the evicted
+/// handle return the standard "closed or unknown Kv handle" error.
+/// Any access (`get`, `put`, `delete`, `contains`, `list_prefix`)
+/// touches the LRU order.
+fn kv_registry() -> &'static Mutex<KvRegistry> {
+    static REGISTRY: OnceLock<Mutex<KvRegistry>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(KvRegistry::with_capacity(MAX_KV_HANDLES)))
+}
+
+/// Maximum number of `kv.open` handles kept alive at once. Past this
+/// cap, the least-recently-used handle is evicted on each new open.
+/// Sized so that pathological "open and forget" programs are bounded
+/// without breaking real-world programs that intentionally keep one or
+/// two long-lived stores open.
+const MAX_KV_HANDLES: usize = 256;
+
+/// LRU-bounded set of open `sled::Db` instances keyed by `u64` handle.
+/// Built on `IndexMap` for O(1) insert / remove / lookup with
+/// insertion-order traversal — touching an entry just shift-moves it
+/// to the back, evictions pop from the front.
+pub(crate) struct KvRegistry {
+    entries: indexmap::IndexMap<u64, sled::Db>,
+    cap: usize,
+}
+
+impl KvRegistry {
+    pub(crate) fn with_capacity(cap: usize) -> Self {
+        Self { entries: indexmap::IndexMap::new(), cap }
+    }
+
+    /// Insert a freshly-opened db. If we're already at cap, evict the
+    /// LRU entry first; the dropped `sled::Db` closes its files.
+    pub(crate) fn insert(&mut self, handle: u64, db: sled::Db) {
+        if self.entries.len() >= self.cap {
+            self.entries.shift_remove_index(0);
+        }
+        self.entries.insert(handle, db);
+    }
+
+    /// Look up a handle, marking it most-recently-used on hit.
+    pub(crate) fn touch_get(&mut self, handle: u64) -> Option<&sled::Db> {
+        let idx = self.entries.get_index_of(&handle)?;
+        self.entries.move_index(idx, self.entries.len() - 1);
+        self.entries.get(&handle)
+    }
+
+    /// Explicit `kv.close`: drop the handle if present.
+    pub(crate) fn remove(&mut self, handle: u64) {
+        self.entries.shift_remove(&handle);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize { self.entries.len() }
 }
 
 fn next_kv_handle() -> u64 {
     static COUNTER: AtomicU64 = AtomicU64::new(1);
     COUNTER.fetch_add(1, Ordering::SeqCst)
+}
+
+#[cfg(test)]
+mod kv_registry_tests {
+    use super::KvRegistry;
+
+    /// Spin up an isolated `sled::Db` in a temp dir. Each call gets a
+    /// unique path so concurrent tests don't collide on the lockfile.
+    fn fresh_db(tag: &str) -> sled::Db {
+        let dir = std::env::temp_dir().join(format!(
+            "lex-kv-reg-{}-{}-{}",
+            std::process::id(),
+            tag,
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        sled::open(&dir).expect("sled open")
+    }
+
+    #[test]
+    fn insert_and_get_round_trip() {
+        let mut r = KvRegistry::with_capacity(4);
+        r.insert(1, fresh_db("a"));
+        assert!(r.touch_get(1).is_some());
+        assert!(r.touch_get(2).is_none());
+    }
+
+    #[test]
+    fn cap_evicts_lru_on_overflow() {
+        // cap=2: insert 1, 2; touch 1 (now MRU); insert 3 → 2 evicted.
+        let mut r = KvRegistry::with_capacity(2);
+        r.insert(1, fresh_db("c1"));
+        r.insert(2, fresh_db("c2"));
+        let _ = r.touch_get(1);
+        r.insert(3, fresh_db("c3"));
+        assert!(r.touch_get(1).is_some(), "1 was MRU, should survive");
+        assert!(r.touch_get(2).is_none(), "2 was LRU, should be evicted");
+        assert!(r.touch_get(3).is_some(), "3 just inserted, should survive");
+        assert_eq!(r.len(), 2);
+    }
+
+    #[test]
+    fn cap_with_no_touches_evicts_in_insertion_order() {
+        // cap=2: insert 1, 2, 3 with no touches → 1 evicted (FIFO).
+        let mut r = KvRegistry::with_capacity(2);
+        r.insert(10, fresh_db("f1"));
+        r.insert(20, fresh_db("f2"));
+        r.insert(30, fresh_db("f3"));
+        assert!(r.touch_get(10).is_none());
+        assert!(r.touch_get(20).is_some());
+        assert!(r.touch_get(30).is_some());
+    }
+
+    #[test]
+    fn remove_drops_entry() {
+        let mut r = KvRegistry::with_capacity(4);
+        r.insert(1, fresh_db("r1"));
+        r.remove(1);
+        assert!(r.touch_get(1).is_none());
+        assert_eq!(r.len(), 0);
+    }
+
+    #[test]
+    fn remove_unknown_handle_is_noop() {
+        let mut r = KvRegistry::with_capacity(4);
+        r.insert(1, fresh_db("u1"));
+        r.remove(999);
+        assert!(r.touch_get(1).is_some());
+    }
+
+    #[test]
+    fn many_inserts_stay_bounded_at_cap() {
+        // Exhaust the cap to confirm the registry never grows past it,
+        // even under sustained churn.
+        let cap = 8;
+        let mut r = KvRegistry::with_capacity(cap);
+        for i in 0..(cap as u64 * 3) {
+            r.insert(i, fresh_db(&format!("b{i}")));
+            assert!(r.len() <= cap);
+        }
+        assert_eq!(r.len(), cap);
+    }
 }


### PR DESCRIPTION
## Summary

- Wraps the global `std.kv` registry in a new `KvRegistry` struct that enforces a process-wide cap of 256 open handles with LRU eviction.
- Every `kv.{get,put,delete,contains,list_prefix}` touches the LRU order; each `kv.open` past the cap drops the least-recently-used entry.
- Evicted handles return the standard `"closed or unknown Kv handle"` error on subsequent ops — same shape as a manual `kv.close`.

## Why

Item 3 of #115. Long-running programs that opened many short-lived stores without calling `kv.close` previously leaked `sled::Db` instances forever. The `sled::Db` `Drop` impl flushes and releases its file handles, so eviction is real cleanup, not just registry shrinkage.

## Implementation

Built on `IndexMap` for O(1) insert / lookup / remove with insertion-order traversal:
- `insert(handle, db)`: if at cap, `shift_remove_index(0)` (drops the LRU entry's `sled::Db`), then insert.
- `touch_get(handle)`: `move_index(idx, len-1)` to mark MRU, then return the `&Db`.
- `remove(handle)`: explicit `kv.close` path, unchanged shape.

The cap is a `const MAX_KV_HANDLES = 256` — high enough that real programs keeping a few long-lived stores never hit it, low enough that "open and forget" workloads stay bounded.

## Test plan

- [x] `cargo test -p lex-runtime --lib kv_registry_tests` — 6/6 pass: insert+get round-trip; LRU eviction respects touches; FIFO eviction without touches; remove drops entry; remove of unknown handle is no-op; many inserts stay bounded at cap.
- [x] `cargo test --test std_kv` — 6/6 pass (no regression in existing kv integration tests).
- [x] `cargo test --workspace` — zero failures.

Closes item 3 of #115.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRXRypmTju3ShcQ3ERJQSu)_