### PR TITLE
feat: per-handle locks + bounded GC for `std.process` registry

### DIFF
--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -245,10 +245,20 @@ impl DefaultHandler {
             "read_stderr_line" => Self::read_line_op(args, false),
             "wait" => {
                 let h = expect_process_handle(args.first())?;
-                let mut reg = process_registry().lock().unwrap();
-                let state = reg.get_mut(&h)
+                // Look up the per-handle Arc, then release the global
+                // lock before the (slow) wait so unrelated handles
+                // can dispatch concurrently.
+                let arc = process_registry().lock().unwrap()
+                    .touch_get(h)
                     .ok_or_else(|| "process.wait: closed or unknown ProcessHandle".to_string())?;
-                let status = state.child.wait().map_err(|e| format!("process.wait: {e}"))?;
+                let status = {
+                    let mut state = arc.lock().unwrap();
+                    state.child.wait().map_err(|e| format!("process.wait: {e}"))?
+                };
+                // Wait completion makes the handle terminal; drop it
+                // from the registry so the cap doesn't fill up with
+                // exited children.
+                process_registry().lock().unwrap().remove(h);
                 let mut rec = indexmap::IndexMap::new();
                 rec.insert("code".into(), Value::Int(status.code().unwrap_or(-1) as i64));
                 #[cfg(unix)]
@@ -265,9 +275,10 @@ impl DefaultHandler {
             "kill" => {
                 let h = expect_process_handle(args.first())?;
                 let _signal = expect_str(args.get(1))?;
-                let mut reg = process_registry().lock().unwrap();
-                let state = reg.get_mut(&h)
+                let arc = process_registry().lock().unwrap()
+                    .touch_get(h)
                     .ok_or_else(|| "process.kill: closed or unknown ProcessHandle".to_string())?;
+                let mut state = arc.lock().unwrap();
                 // Cross-platform: only `kill` (SIGKILL-equivalent on
                 // Windows). Signal-name dispatch is a v1.5 follow-up.
                 match state.child.kill() {
@@ -318,14 +329,17 @@ impl DefaultHandler {
 
     /// Read one line from the child's stdout (`is_stdout = true`) or
     /// stderr. Returns `None` (Lex `Option`) at EOF; subsequent calls
-    /// keep returning `None`.
+    /// keep returning `None`. Holds only the per-handle mutex during
+    /// the (potentially blocking) read, so reads on one handle don't
+    /// block reads/waits on a different handle.
     fn read_line_op(args: Vec<Value>, is_stdout: bool) -> Result<Value, String> {
         let h = expect_process_handle(args.first())?;
-        let mut reg = process_registry().lock().unwrap();
-        let state = reg.get_mut(&h)
+        let arc = process_registry().lock().unwrap()
+            .touch_get(h)
             .ok_or_else(|| format!(
                 "process.read_{}_line: closed or unknown ProcessHandle",
                 if is_stdout { "stdout" } else { "stderr" }))?;
+        let mut state = arc.lock().unwrap();
         let reader_opt = if is_stdout {
             state.stdout.as_mut().map(|r| -> &mut dyn std::io::BufRead { r })
         } else {
@@ -1194,20 +1208,172 @@ fn emit_log(level: LogLevel, msg: &str) {
     }
 }
 
-struct ProcessState {
+pub(crate) struct ProcessState {
     child: std::process::Child,
     stdout: Option<std::io::BufReader<std::process::ChildStdout>>,
     stderr: Option<std::io::BufReader<std::process::ChildStderr>>,
 }
 
-fn process_registry() -> &'static Mutex<HashMap<u64, ProcessState>> {
-    static REGISTRY: OnceLock<Mutex<HashMap<u64, ProcessState>>> = OnceLock::new();
-    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+/// Process-wide registry of live `process.spawn` handles. Capped at
+/// [`MAX_PROCESS_HANDLES`] to bound long-running programs that spawn
+/// many short-lived children: on each `spawn` past the cap, the
+/// least-recently-used entry is dropped (which `Drop`s its
+/// `ProcessState`, leaving the child orphaned but the registry
+/// bounded). `process.wait` also drops the entry on completion since
+/// the handle becomes terminal once the child exits.
+///
+/// Each entry is wrapped in `Arc<Mutex<ProcessState>>` so the global
+/// lookup mutex is held only briefly during dispatch — once we have
+/// the per-handle `Arc`, the global lock is released and the slow
+/// op (`wait`, `read_*_line`) only contends on its own handle's
+/// mutex. Reads on different handles no longer block each other.
+fn process_registry() -> &'static Mutex<ProcessRegistry> {
+    static REGISTRY: OnceLock<Mutex<ProcessRegistry>> = OnceLock::new();
+    REGISTRY.get_or_init(|| Mutex::new(ProcessRegistry::with_capacity(MAX_PROCESS_HANDLES)))
+}
+
+const MAX_PROCESS_HANDLES: usize = 256;
+
+type SharedProcessState = Arc<Mutex<ProcessState>>;
+
+pub(crate) struct ProcessRegistry {
+    entries: indexmap::IndexMap<u64, SharedProcessState>,
+    cap: usize,
+}
+
+impl ProcessRegistry {
+    pub(crate) fn with_capacity(cap: usize) -> Self {
+        Self { entries: indexmap::IndexMap::new(), cap }
+    }
+
+    /// Insert a freshly-spawned child. If at cap, evict the LRU entry
+    /// first; the dropped `ProcessState`'s child stays alive (orphaned)
+    /// but its file descriptors are released.
+    pub(crate) fn insert(&mut self, handle: u64, state: ProcessState) {
+        if self.entries.len() >= self.cap {
+            self.entries.shift_remove_index(0);
+        }
+        self.entries.insert(handle, Arc::new(Mutex::new(state)));
+    }
+
+    /// Look up a handle, marking it most-recently-used on hit. Returns
+    /// a clone of the shared `Arc` — callers should release the global
+    /// registry lock before locking the per-handle mutex.
+    pub(crate) fn touch_get(&mut self, handle: u64) -> Option<SharedProcessState> {
+        let idx = self.entries.get_index_of(&handle)?;
+        self.entries.move_index(idx, self.entries.len() - 1);
+        self.entries.get(&handle).cloned()
+    }
+
+    /// Drop the registry entry. The underlying `Arc` may outlive the
+    /// removal if another op still holds it; that's intentional — the
+    /// in-flight op finishes against the existing `ProcessState`, and
+    /// only fresh lookups start failing.
+    pub(crate) fn remove(&mut self, handle: u64) {
+        self.entries.shift_remove(&handle);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize { self.entries.len() }
 }
 
 fn next_process_handle() -> u64 {
     static COUNTER: AtomicU64 = AtomicU64::new(1);
     COUNTER.fetch_add(1, Ordering::SeqCst)
+}
+
+#[cfg(all(test, unix))]
+mod process_registry_tests {
+    use super::{ProcessRegistry, ProcessState};
+
+    /// Spawn a trivial short-lived child for use as registry payload.
+    /// `true` exits immediately — we don't actually run the child for
+    /// real, we just need a valid `std::process::Child`.
+    fn fresh_state() -> ProcessState {
+        let child = std::process::Command::new("true")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn `true`");
+        ProcessState { child, stdout: None, stderr: None }
+    }
+
+    #[test]
+    fn insert_and_get_round_trip() {
+        let mut r = ProcessRegistry::with_capacity(4);
+        r.insert(1, fresh_state());
+        assert!(r.touch_get(1).is_some());
+        assert!(r.touch_get(2).is_none());
+    }
+
+    #[test]
+    fn touch_get_returns_distinct_arcs_for_distinct_handles() {
+        let mut r = ProcessRegistry::with_capacity(4);
+        r.insert(1, fresh_state());
+        r.insert(2, fresh_state());
+        let a = r.touch_get(1).unwrap();
+        let b = r.touch_get(2).unwrap();
+        // Different Arcs — pointer-equality check.
+        assert!(!std::sync::Arc::ptr_eq(&a, &b));
+    }
+
+    #[test]
+    fn cap_evicts_lru_on_overflow() {
+        let mut r = ProcessRegistry::with_capacity(2);
+        r.insert(1, fresh_state());
+        r.insert(2, fresh_state());
+        let _ = r.touch_get(1);
+        r.insert(3, fresh_state());
+        assert!(r.touch_get(1).is_some(), "1 was MRU, should survive");
+        assert!(r.touch_get(2).is_none(), "2 was LRU, should be evicted");
+        assert!(r.touch_get(3).is_some(), "3 just inserted, should survive");
+        assert_eq!(r.len(), 2);
+    }
+
+    #[test]
+    fn cap_with_no_touches_evicts_in_insertion_order() {
+        let mut r = ProcessRegistry::with_capacity(2);
+        r.insert(10, fresh_state());
+        r.insert(20, fresh_state());
+        r.insert(30, fresh_state());
+        assert!(r.touch_get(10).is_none());
+        assert!(r.touch_get(20).is_some());
+        assert!(r.touch_get(30).is_some());
+    }
+
+    #[test]
+    fn remove_drops_entry() {
+        let mut r = ProcessRegistry::with_capacity(4);
+        r.insert(1, fresh_state());
+        r.remove(1);
+        assert!(r.touch_get(1).is_none());
+        assert_eq!(r.len(), 0);
+    }
+
+    #[test]
+    fn many_inserts_stay_bounded_at_cap() {
+        let cap = 8;
+        let mut r = ProcessRegistry::with_capacity(cap);
+        for i in 0..(cap as u64 * 3) {
+            r.insert(i, fresh_state());
+            assert!(r.len() <= cap);
+        }
+        assert_eq!(r.len(), cap);
+    }
+
+    #[test]
+    fn outstanding_arc_outlives_remove() {
+        // Holding the per-handle Arc while another op removes the
+        // entry must not invalidate the in-flight op. Mirrors the
+        // wait-completes-then-removes pattern.
+        let mut r = ProcessRegistry::with_capacity(4);
+        r.insert(1, fresh_state());
+        let arc = r.touch_get(1).expect("entry exists");
+        r.remove(1);
+        // Registry forgot about it, but the Arc still works.
+        assert!(r.touch_get(1).is_none());
+        let _state = arc.lock().unwrap();
+    }
 }
 
 fn expect_process_handle(v: Option<&Value>) -> Result<u64, String> {

--- a/crates/lex-runtime/tests/std_process.rs
+++ b/crates/lex-runtime/tests/std_process.rs
@@ -162,6 +162,70 @@ fn run_capture_exit_for_succeeding_command() {
 }
 
 #[test]
+fn wait_evicts_handle_so_subsequent_read_fails() {
+    // After `process.wait` returns, the handle is terminal — the
+    // registry drops it. A read on the same handle should now hit
+    // the "closed or unknown ProcessHandle" path, surfaced here as
+    // a Rust-level VM error (the handler returns Err out-of-band).
+    //
+    // We probe that by comparing the success path (read-then-wait,
+    // with no post-wait read) against the failure path (read,
+    // wait, read again). The failure path produces a VM error
+    // which `vm.call` reports as Err.
+    let src = r#"
+import "std.process" as process
+import "std.map" as map
+import "std.option" as option
+
+fn empty_opts() -> { cwd :: Option[Str], env :: Map[Str, Str], stdin :: Option[Bytes] } {
+  { cwd: None, env: map.new(), stdin: None }
+}
+
+fn read_after_wait(cmd :: Str, args :: List[Str]) -> [proc] Bool {
+  match process.spawn(cmd, args, empty_opts()) {
+    Ok(h) => {
+      # Drain output, then wait.
+      let drained := drain(h)
+      let exited := process.wait(h)
+      # Try one more read; the registry has dropped `h` so this
+      # short-circuits to a runtime error before reaching the body.
+      match process.read_stdout_line(h) {
+        Some(_) => true,
+        None    => false,
+      }
+    },
+    Err(_) => false,
+  }
+}
+
+fn drain(h :: ProcessHandle) -> [proc] Int {
+  match process.read_stdout_line(h) {
+    Some(_) => drain(h),
+    None    => 0,
+  }
+}
+"#;
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors:\n{errs:#?}");
+    }
+    let bc = Arc::new(compile_program(&stages));
+    let handler = DefaultHandler::new(policy_with_proc()).with_program(Arc::clone(&bc));
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    let r = vm.call("read_after_wait", vec![
+        Value::Str("printf".into()),
+        Value::List(vec![Value::Str("a\n".into())]),
+    ]);
+    let err = r.expect_err("post-wait read should hit closed-or-unknown");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("closed or unknown ProcessHandle"),
+        "expected closed-or-unknown message, got {msg}"
+    );
+}
+
+#[test]
 fn allow_proc_basename_blocks_unlisted() {
     let mut p = policy_with_proc();
     p.allow_proc = ["allowed_command_zzz".to_string()].into_iter().collect();


### PR DESCRIPTION
## Summary

Two changes to the global `std.process` handle registry:

- **Per-handle locks.** Wraps each `ProcessState` in `Arc<Mutex<…>>`. Dispatch acquires the global registry mutex only briefly during lookup (and `Arc::clone`), then releases it before the slow per-handle op. Reads / waits on different handles no longer block each other.
- **Bounded GC.** Caps the registry at 256 entries with LRU eviction; subsequent ops on an evicted handle return the standard `"closed or unknown ProcessHandle"` error. `process.wait` also removes its entry on completion since the handle is terminal once the child exits.

## Why

Item 2 of #115. Previously every `process.{wait,read_*_line,kill}` call grabbed the same global mutex while interacting with the child, so a slow `wait` blocked unrelated reads. Long-running programs that spawned many short-lived children also leaked `ProcessState` indefinitely (no automatic cleanup; `kv.close`-style explicit close was the only path).

## Implementation

```rust
type SharedProcessState = Arc<Mutex<ProcessState>>;
pub(crate) struct ProcessRegistry {
    entries: indexmap::IndexMap<u64, SharedProcessState>,
    cap: usize,
}
```

Built on `IndexMap` for O(1) insert / lookup / remove with insertion-order traversal — same shape as the kv registry in #119. `touch_get` returns a `Clone` of the per-handle `Arc`, so callers release the global lock before locking the per-handle mutex.

## Behavior change to call out

`process.wait` now invalidates its handle on completion. Calling `read_stdout_line(h)` after `wait(h)` previously could drain remaining buffered output; now it returns the closed-handle error. Programs that need the buffered output should drain stdout to EOF before calling `wait` (the existing `count_lines` / `streaming_spawn_and_read_lines` test already does this and continues to pass).

## Test plan

- [x] `cargo test -p lex-runtime --lib process_registry_tests` — 7/7 pass: insert+get round-trip; distinct Arcs per handle; LRU eviction; FIFO fallback; remove drops entry; many inserts stay bounded; outstanding Arc outlives remove.
- [x] `cargo test --test std_process` — 7/7 pass (1 new: `wait_evicts_handle_so_subsequent_read_fails` — verifies post-wait read surfaces the closed-or-unknown error end-to-end through the VM).
- [x] `cargo test --test proc_effect` — 5/5 pass (no regression in the `proc.spawn` legacy effect).
- [x] `cargo test --workspace` — zero failures.

Closes item 2 of #115.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRXRypmTju3ShcQ3ERJQSu)_