### PR TITLE
chore: gate `bench/REPORT.md` regeneration behind BENCH_WRITE_REPORT

### DIFF
--- a/crates/lex-cli/tests/agent_sandbox_bench.rs
+++ b/crates/lex-cli/tests/agent_sandbox_bench.rs
@@ -301,7 +301,7 @@ fn write_report(results: &[(&Case, CaseResult)]) {
     s.push_str("3. **Python (RestrictedPython)** — `bench/python_restricted_sandbox.py`. ");
     s.push_str("Uses `compile_restricted` + `safe_builtins` + `safer_getattr`; the ");
     s.push_str("most-reached-for credible Python sandbox library.\n\n");
-    s.push_str("Regenerate: `cargo test -p lex-cli --test agent_sandbox_bench`.\n\n");
+    s.push_str("Regenerate: `BENCH_WRITE_REPORT=1 cargo test -p lex-cli --test agent_sandbox_bench`.\n\n");
 
     let attacks: Vec<_> = results.iter()
         .filter(|(c, _)| c.intent == Intent::Adversarial).collect();
@@ -408,7 +408,15 @@ fn agent_sandbox_benchmark() {
         return;
     }
     let results = run_all();
-    write_report(&results);
+    // Writing the report is a side effect on `bench/REPORT.md`, which
+    // makes a routine `cargo test --workspace` mutate the working
+    // tree. Gate it behind an env var so the test is idempotent by
+    // default. Regenerate the published report with:
+    //
+    //     BENCH_WRITE_REPORT=1 cargo test -p lex-cli --test agent_sandbox_bench
+    if std::env::var("BENCH_WRITE_REPORT").is_ok() {
+        write_report(&results);
+    }
 
     // Per-case assertions: every adversarial case must be Blocked or Errored
     // by Lex. Benign cases must be Ran by Lex. Python's outcome is recorded


### PR DESCRIPTION
## Summary

The `agent_sandbox_benchmark` test wrote `bench/REPORT.md` as a side effect on every run, so a routine `cargo test --workspace` mutated the working tree.

## Why

The written numbers depend on the environment (whether RestrictedPython is installed, sandbox permissions, etc.), so the file diff churned between runs and bled into unrelated PR branches. Side-effecting tests should be opt-in.

## Change

Gate the write behind `BENCH_WRITE_REPORT=1`. The test still runs and the assertions still execute on every workspace test pass; only the file emission is opt-in.

The published report is now regenerated explicitly with:

```sh
BENCH_WRITE_REPORT=1 cargo test -p lex-cli --test agent_sandbox_bench
```

The `Regenerate:` line in the report itself is updated to reflect the new command.

## Test plan

- [x] `cargo test -p lex-cli --test agent_sandbox_bench` — passes; `bench/REPORT.md` unchanged afterwards.
- [x] `BENCH_WRITE_REPORT=1 cargo test -p lex-cli --test agent_sandbox_bench` — passes; `bench/REPORT.md` updated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRXRypmTju3ShcQ3ERJQSu)_