### PR TITLE
feat: typed `Tz` variant for `std.datetime`

### DIFF
--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -1021,12 +1021,6 @@ fn format_iso(n: i64) -> String {
     chrono_from_instant(n).to_rfc3339()
 }
 
-/// Materialize the `DateTime` record from an Instant under the named
-/// timezone. `tz_name` accepts:
-///   - "UTC"
-///   - "Local"
-///   - an IANA name like "America/New_York"
-///   - a fixed offset like "+05:30" or "-08:00"
 /// Parsed form of the user-side `Tz` variant. Mirrors the type
 /// registered in `TypeEnv::new_with_builtins`.
 enum TzArg {
@@ -1078,7 +1072,7 @@ fn resolve_tz_to_components(n: i64, tz: &TzArg) -> Result<Value, String> {
              d.nanosecond() as i32, off)
         }
         TzArg::Offset(off_min) => {
-            let off_secs = (*off_min as i32).saturating_mul(60);
+            let off_secs = off_min.saturating_mul(60);
             let fixed = chrono::FixedOffset::east_opt(off_secs)
                 .ok_or("to_components: offset out of range")?;
             let d = utc_dt.with_timezone(&fixed);

--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -776,8 +776,11 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
         }
         ("datetime", "to_components") => {
             let n = expect_int(args.first())?;
-            let tz_name = expect_str(args.get(1))?;
-            match resolve_tz_to_components(n, &tz_name) {
+            let tz = match parse_tz_arg(args.get(1)) {
+                Ok(t) => t,
+                Err(e) => return Ok(err_v(Value::Str(e))),
+            };
+            match resolve_tz_to_components(n, &tz) {
                 Ok(rec) => Ok(ok_v(rec)),
                 Err(e) => Ok(err_v(Value::Str(e))),
             }
@@ -1024,37 +1027,68 @@ fn format_iso(n: i64) -> String {
 ///   - "Local"
 ///   - an IANA name like "America/New_York"
 ///   - a fixed offset like "+05:30" or "-08:00"
-fn resolve_tz_to_components(n: i64, tz_name: &str) -> Result<Value, String> {
+/// Parsed form of the user-side `Tz` variant. Mirrors the type
+/// registered in `TypeEnv::new_with_builtins`.
+enum TzArg {
+    Utc,
+    Local,
+    /// Fixed offset in minutes east of UTC.
+    Offset(i32),
+    /// IANA name like `"America/New_York"`.
+    Iana(String),
+}
+
+fn parse_tz_arg(v: Option<&Value>) -> Result<TzArg, String> {
+    match v {
+        Some(Value::Variant { name, args }) => match (name.as_str(), args.as_slice()) {
+            ("Utc", []) => Ok(TzArg::Utc),
+            ("Local", []) => Ok(TzArg::Local),
+            ("Offset", [Value::Int(m)]) => {
+                let m = i32::try_from(*m).map_err(|_| {
+                    format!("Tz::Offset: minutes out of range: {m}")
+                })?;
+                Ok(TzArg::Offset(m))
+            }
+            ("Iana", [Value::Str(s)]) => Ok(TzArg::Iana(s.clone())),
+            (other, _) => Err(format!(
+                "expected Tz variant (Utc | Local | Offset(Int) | Iana(Str)), got `{other}` with {} arg(s)",
+                args.len()
+            )),
+        },
+        Some(other) => Err(format!("expected Tz variant, got {other:?}")),
+        None => Err("missing Tz argument".into()),
+    }
+}
+
+fn resolve_tz_to_components(n: i64, tz: &TzArg) -> Result<Value, String> {
     use chrono::{TimeZone, Datelike, Timelike, Offset};
     let utc_dt = chrono_from_instant(n);
-    let (y, m, d, hh, mm, ss, ns, off_min) = match tz_name {
-        "UTC" => {
+    let (y, m, d, hh, mm, ss, ns, off_min) = match tz {
+        TzArg::Utc => {
             let d = utc_dt;
             (d.year(), d.month() as i32, d.day() as i32,
              d.hour() as i32, d.minute() as i32, d.second() as i32,
              d.nanosecond() as i32, 0)
         }
-        "Local" => {
+        TzArg::Local => {
             let d = utc_dt.with_timezone(&chrono::Local);
             let off = d.offset().fix().local_minus_utc() / 60;
             (d.year(), d.month() as i32, d.day() as i32,
              d.hour() as i32, d.minute() as i32, d.second() as i32,
              d.nanosecond() as i32, off)
         }
-        name if name.starts_with('+') || name.starts_with('-') => {
-            // Fixed offset like "+05:30" / "-08:00".
-            let off_secs = parse_fixed_offset(name)
-                .ok_or_else(|| format!("to_components: bad offset `{name}`"))?;
+        TzArg::Offset(off_min) => {
+            let off_secs = (*off_min as i32).saturating_mul(60);
             let fixed = chrono::FixedOffset::east_opt(off_secs)
                 .ok_or("to_components: offset out of range")?;
             let d = utc_dt.with_timezone(&fixed);
             (d.year(), d.month() as i32, d.day() as i32,
              d.hour() as i32, d.minute() as i32, d.second() as i32,
-             d.nanosecond() as i32, off_secs / 60)
+             d.nanosecond() as i32, *off_min)
         }
-        iana => {
-            let tz: chrono_tz::Tz = iana.parse()
-                .map_err(|e| format!("to_components: unknown timezone `{iana}`: {e}"))?;
+        TzArg::Iana(name) => {
+            let tz: chrono_tz::Tz = name.parse()
+                .map_err(|e| format!("to_components: unknown timezone `{name}`: {e}"))?;
             let d = utc_dt.with_timezone(&tz);
             let off = d.offset().fix().local_minus_utc() / 60;
             (d.year(), d.month() as i32, d.day() as i32,
@@ -1075,14 +1109,6 @@ fn resolve_tz_to_components(n: i64, tz_name: &str) -> Result<Value, String> {
     Ok(Value::Record(rec))
 }
 
-fn parse_fixed_offset(s: &str) -> Option<i32> {
-    let sign: i32 = if s.starts_with('+') { 1 } else { -1 };
-    let rest = &s[1..];
-    let (h, m) = rest.split_once(':')?;
-    let h: i32 = h.parse().ok()?;
-    let m: i32 = m.parse().ok()?;
-    Some(sign * (h * 3600 + m * 60))
-}
 
 fn instant_from_components(rec: &indexmap::IndexMap<String, Value>) -> Result<i64, String> {
     use chrono::TimeZone;

--- a/crates/lex-runtime/tests/std_datetime.rs
+++ b/crates/lex-runtime/tests/std_datetime.rs
@@ -71,7 +71,7 @@ fn diff_is_45_minutes(start :: Str, end :: Str) -> Bool {
 
 fn year_in_utc(iso :: Str) -> Int {
   match datetime.parse_iso(iso) {
-    Ok(t) => match datetime.to_components(t, "UTC") {
+    Ok(t) => match datetime.to_components(t, Utc) {
       Ok(c)  => c.year,
       Err(_) => 0 - 1,
     },
@@ -79,7 +79,7 @@ fn year_in_utc(iso :: Str) -> Int {
   }
 }
 
-fn iana_offset(iso :: Str, tz :: Str) -> Int {
+fn tz_offset_for(iso :: Str, tz :: Tz) -> Int {
   match datetime.parse_iso(iso) {
     Ok(t) => match datetime.to_components(t, tz) {
       Ok(c)  => c.tz_offset_minutes,
@@ -91,12 +91,44 @@ fn iana_offset(iso :: Str, tz :: Str) -> Int {
 
 fn round_trip_components(iso :: Str) -> Str {
   match datetime.parse_iso(iso) {
-    Ok(t) => match datetime.to_components(t, "UTC") {
+    Ok(t) => match datetime.to_components(t, Utc) {
       Ok(c) => match datetime.from_components(c) {
         Ok(t2) => datetime.format_iso(t2),
         Err(_) => "<from_components fail>",
       },
       Err(_) => "<to_components fail>",
+    },
+    Err(_) => "<bad iso>",
+  }
+}
+
+# Tag-only summary of what each Tz variant carries — exercises a
+# match across every constructor.
+fn tz_tag(tz :: Tz) -> Str {
+  match tz {
+    Utc       => "utc",
+    Local     => "local",
+    Offset(_) => "offset",
+    Iana(_)   => "iana",
+  }
+}
+
+# Surface the IANA name back out — exercises constructor-with-payload
+# binding.
+fn iana_name_or(tz :: Tz, fallback :: Str) -> Str {
+  match tz {
+    Iana(s) => s,
+    _       => fallback,
+  }
+}
+
+# Exercises the failure path: an unrecognized IANA name now produces
+# the documented `Err` payload through the existing parse path.
+fn tz_offset_or_err(iso :: Str, tz :: Tz) -> Str {
+  match datetime.parse_iso(iso) {
+    Ok(t) => match datetime.to_components(t, tz) {
+      Ok(_)  => "<ok>",
+      Err(e) => e,
     },
     Err(_) => "<bad iso>",
   }
@@ -171,15 +203,29 @@ fn to_components_yields_year() {
     assert_eq!(v, Value::Int(2026));
 }
 
+fn iana(name: &str) -> Value {
+    Value::Variant {
+        name: "Iana".into(),
+        args: vec![Value::Str(name.into())],
+    }
+}
+
+fn offset_minutes(m: i64) -> Value {
+    Value::Variant {
+        name: "Offset".into(),
+        args: vec![Value::Int(m)],
+    }
+}
+
 #[test]
 fn iana_timezone_offset() {
     // 2026-01-15 (winter) New York is UTC-05:00 → -300 minutes.
     let v = run(
         SRC,
-        "iana_offset",
+        "tz_offset_for",
         vec![
             Value::Str("2026-01-15T12:00:00+00:00".into()),
-            Value::Str("America/New_York".into()),
+            iana("America/New_York"),
         ],
         Policy::pure(),
     );
@@ -191,10 +237,10 @@ fn iana_timezone_offset_dst() {
     // 2026-07-15 (summer) New York is UTC-04:00 → -240 minutes.
     let v = run(
         SRC,
-        "iana_offset",
+        "tz_offset_for",
         vec![
             Value::Str("2026-07-15T12:00:00+00:00".into()),
-            Value::Str("America/New_York".into()),
+            iana("America/New_York"),
         ],
         Policy::pure(),
     );
@@ -203,12 +249,13 @@ fn iana_timezone_offset_dst() {
 
 #[test]
 fn fixed_offset_components() {
+    // +05:30 → 330 minutes east.
     let v = run(
         SRC,
-        "iana_offset",
+        "tz_offset_for",
         vec![
             Value::Str("2026-05-03T12:00:00+00:00".into()),
-            Value::Str("+05:30".into()),
+            offset_minutes(330),
         ],
         Policy::pure(),
     );
@@ -241,4 +288,84 @@ fn now_iso() -> [time] Str { datetime.format_iso(datetime.now()) }
     let year: i32 = iso.get(..4).and_then(|y| y.parse().ok())
         .unwrap_or_else(|| panic!("could not parse year from {iso}"));
     assert!((2020..2100).contains(&year), "now()'s year out of range: {year}");
+}
+
+#[test]
+fn tz_match_returns_correct_tag_per_variant() {
+    let utc   = Value::Variant { name: "Utc".into(),   args: vec![] };
+    let local = Value::Variant { name: "Local".into(), args: vec![] };
+    assert_eq!(s(run(SRC, "tz_tag", vec![utc],   Policy::pure())), "utc");
+    assert_eq!(s(run(SRC, "tz_tag", vec![local], Policy::pure())), "local");
+    assert_eq!(
+        s(run(SRC, "tz_tag", vec![offset_minutes(60)], Policy::pure())),
+        "offset",
+    );
+    assert_eq!(
+        s(run(SRC, "tz_tag", vec![iana("UTC")], Policy::pure())),
+        "iana",
+    );
+}
+
+#[test]
+fn iana_payload_is_destructurable() {
+    let v = run(
+        SRC,
+        "iana_name_or",
+        vec![iana("Europe/Paris"), Value::Str("none".into())],
+        Policy::pure(),
+    );
+    assert_eq!(s(v), "Europe/Paris");
+    // Non-Iana variant falls through to fallback.
+    let v = run(
+        SRC,
+        "iana_name_or",
+        vec![
+            Value::Variant { name: "Utc".into(), args: vec![] },
+            Value::Str("none".into()),
+        ],
+        Policy::pure(),
+    );
+    assert_eq!(s(v), "none");
+}
+
+#[test]
+fn unknown_iana_name_returns_err_with_message() {
+    // The Tz variant statically guarantees the *shape* of the input,
+    // but an `Iana(...)` payload can still hold an invalid name.
+    let v = run(
+        SRC,
+        "tz_offset_or_err",
+        vec![
+            Value::Str("2026-05-03T12:00:00+00:00".into()),
+            iana("Not/Real_Place"),
+        ],
+        Policy::pure(),
+    );
+    let msg = s(v);
+    assert!(
+        msg.contains("Not/Real_Place") && msg.contains("unknown"),
+        "expected unknown-timezone error, got: {msg}",
+    );
+}
+
+#[test]
+fn local_variant_returns_components_without_panicking() {
+    // `Local` resolves against the host's current timezone; we don't
+    // know what offset that produces in CI, so just assert it
+    // returns a reasonable offset (within ±840 minutes — covers all
+    // real timezones on Earth).
+    let local = Value::Variant { name: "Local".into(), args: vec![] };
+    let v = run(
+        SRC,
+        "tz_offset_for",
+        vec![Value::Str("2026-05-03T12:00:00+00:00".into()), local],
+        Policy::pure(),
+    );
+    match v {
+        Value::Int(off) => assert!(
+            (-840..=840).contains(&off),
+            "Local offset out of plausible range: {off}",
+        ),
+        other => panic!("expected Int offset, got {other:?}"),
+    }
 }

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -725,11 +725,18 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
             // Instant and Duration are nominal opaque Ints under the
             // hood (nanoseconds-since-UTC-epoch and signed nanoseconds
             // respectively); the type checker tracks the distinction
-            // even though both values look like Int at runtime. Tz is
-            // a Str — "UTC", "Local", an IANA name like
-            // "America/New_York", or a fixed-offset like "+05:30".
+            // even though both values look like Int at runtime.
+            //
+            // Tz is the variant
+            //     Utc | Local | Offset(Int) | Iana(Str)
+            // registered as a built-in nominal type in
+            // `TypeEnv::new_with_builtins`. The pre-v1 stringly Tz
+            // ("UTC"/"Local"/IANA-name/"+05:30") is no longer accepted
+            // — passing a `Str` to `to_components` is now a type
+            // error.
             let inst   = || Ty::Con("Instant".into(), vec![]);
             let dur    = || Ty::Con("Duration".into(), vec![]);
+            let tz     = || Ty::Con("Tz".into(), vec![]);
             let result_str = |t: Ty| Ty::Con("Result".into(), vec![t, Ty::str()]);
             let dt_t = || {
                 let mut fs = IndexMap::new();
@@ -755,7 +762,7 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
             fields.insert("format".into(), Ty::function(
                 vec![inst(), Ty::str()], EffectSet::empty(), Ty::str()));
             fields.insert("to_components".into(), Ty::function(
-                vec![inst(), Ty::str()], EffectSet::empty(), result_str(dt_t())));
+                vec![inst(), tz()], EffectSet::empty(), result_str(dt_t())));
             fields.insert("from_components".into(), Ty::function(
                 vec![dt_t()], EffectSet::empty(), result_str(inst())));
             fields.insert("add".into(), Ty::function(

--- a/crates/lex-types/src/env.rs
+++ b/crates/lex-types/src/env.rs
@@ -62,6 +62,24 @@ impl TypeEnv {
         e.types.insert("Map".into(), TypeDef { params: vec!["K".into(), "V".into()], kind: TypeDefKind::Opaque });
         e.types.insert("Set".into(), TypeDef { params: vec!["T".into()], kind: TypeDefKind::Opaque });
 
+        // Tz = Utc | Local | Offset(Int) | Iana(Str).
+        // Used by std.datetime; the variant-typed alternative to the
+        // pre-v1 stringly Tz ("UTC" / "Local" / "+05:30" / IANA name).
+        // Registered globally so users don't have to import a module
+        // to mention `Utc` / `Iana("America/New_York")` etc.
+        let mut tz_variants = IndexMap::new();
+        tz_variants.insert("Utc".into(), None);
+        tz_variants.insert("Local".into(), None);
+        tz_variants.insert("Offset".into(), Some(Ty::int()));
+        tz_variants.insert("Iana".into(), Some(Ty::str()));
+        e.types.insert("Tz".into(), TypeDef {
+            params: vec![],
+            kind: TypeDefKind::Union(tz_variants),
+        });
+        for ctor in &["Utc", "Local", "Offset", "Iana"] {
+            e.ctor_to_type.insert((*ctor).into(), "Tz".into());
+        }
+
         // Matrix = { rows :: Int, cols :: Int, data :: List[Float] }.
         // Used by std.math; runtime values are the F64Array fast lane,
         // not a real record. The alias makes math.* signatures readable


### PR DESCRIPTION
## Summary

Promotes `Tz` from a stringly value to a real Lex variant:

```lex
type Tz = Utc | Local | Offset(Int) | Iana(Str)
```

- Registered as a built-in nominal type in `TypeEnv::new_with_builtins` so users mention `Utc` / `Iana("America/New_York")` without an import.
- `datetime.to_components`'s second param is now `Tz`; passing a `Str` is a type error.
- The previous fixed-offset string syntax `"+05:30"` is gone — programs use `Offset(330)` (minutes east of UTC).

## Why

Item 6 of #115. The v1 simplification used `Str` to avoid registering a new builtin variant in the env; the trade was type safety on tz parsing. This PR pays back that debt — a typo in `Utc` / `Local` is now caught at type-check time rather than producing a runtime "unknown timezone" error, and the host can't accidentally pass an unrelated `Str`.

## Behavior change to call out

This is a **breaking** API change for `datetime.to_components`. Migrating call sites:

| before | after |
|---|---|
| `datetime.to_components(t, "UTC")` | `datetime.to_components(t, Utc)` |
| `datetime.to_components(t, "Local")` | `datetime.to_components(t, Local)` |
| `datetime.to_components(t, "+05:30")` | `datetime.to_components(t, Offset(330))` |
| `datetime.to_components(t, "America/New_York")` | `datetime.to_components(t, Iana("America/New_York"))` |

The `Iana` payload still carries the IANA name verbatim; an unrecognized name continues to surface through the existing `Result[…, Str]` `Err` payload, so the runtime error message shape is unchanged for that case.

## Implementation

- `lex-types/src/env.rs` — registers `Tz` Union with constructors `Utc | Local | Offset(Int) | Iana(Str)`.
- `lex-types/src/builtins.rs` — `to_components` signature swaps `Str` for `Con("Tz", [])`.
- `lex-runtime/src/builtins.rs` — adds a `TzArg` enum + `parse_tz_arg` that destructures the runtime `Value::Variant`. Shape errors surface as the existing `Result` `Err` payload rather than a Rust panic. Removed the now-unused `parse_fixed_offset` helper.

## Test plan

- [x] `cargo test --test std_datetime` — 14/14 pass (10 migrated + 4 new):
   - `tz_match_returns_correct_tag_per_variant` — round-trips every constructor through a `match` on `Tz`.
   - `iana_payload_is_destructurable` — `match Iana(s) => s` binds the payload.
   - `unknown_iana_name_returns_err_with_message` — well-formed-`Tz`-but-unknown-IANA-name still produces the documented error.
   - `local_variant_returns_components_without_panicking` — `Local` resolves against the host clock and returns a plausible offset.
- [x] `cargo test --workspace` — zero failures (no regressions across spec-checker, conformance, etc.).

Closes item 6 of #115.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRXRypmTju3ShcQ3ERJQSu)_