### PR TITLE
example: `agent_sprint` — sandboxed agent loop with effects as the security boundary

### DIFF
--- a/bench/RECORDING_AGENT_SPRINT.md
+++ b/bench/RECORDING_AGENT_SPRINT.md
@@ -1,0 +1,212 @@
+# Recording the `agent_sprint` security-perimeter demo
+
+The fourth recording in the series, alongside [`RECORDING.md`](RECORDING.md)
+(agent-tool security), [`RECORDING_VC.md`](RECORDING_VC.md) (agent-
+native VC), and [`RECORDING_PROC.md`](RECORDING_PROC.md) (`[proc]`
+escape hatch). This one shows a **multi-stage pipeline** where each
+stage's effect signature contributes to the orchestrator's perimeter,
+and the host policy is the entire trust budget.
+
+The story is the inverse of `RECORDING.md`: instead of one agent-
+emitted body type-checking against a single declared effect, this
+shows a four-stage DAG where every stage has its own narrower
+contract and the verdict is a real runtime outcome (PASS / FAIL),
+not just compile-time.
+
+## What you need
+
+- `asciinema` installed.
+- The release-mode binary: `cargo build --release` so output isn't
+  cluttered with `Compiling …` lines.
+- The lex binary on `$PATH` so `which lex` resolves (the dogfood
+  beat below uses `lex` as the agent CLI).
+
+The recording does **not** need an `ANTHROPIC_API_KEY` — we use
+`lex` itself as the agent, which makes the take deterministic and
+reproducible. Anyone re-running the script gets the same transcript.
+
+## Pre-recording setup
+
+```bash
+cargo build --release
+export PATH="$(pwd)/target/release:$PATH"
+which lex                 # confirm release binary is found
+cd examples/agent_sprint
+stty cols 100 rows 30
+clear
+```
+
+## Recording flow
+
+```bash
+asciinema rec ../../bench/agent_sprint_demo.cast \
+  --idle-time-limit 1.5 \
+  --title "Lex agent_sprint: effect types as the security perimeter"
+```
+
+Inside the session, the **four beats** below. Each is a punchline.
+Read each "Punchline" line out loud to yourself before typing the
+command — that's the slide title for that frame of the recording.
+
+### Beat 1 — The pipeline shape
+
+```bash
+# 1. Four stages, four files, four effect sets. The orchestrator
+#    composes them; its signature is the union.
+ls stages/
+cat sprint.lex
+```
+
+> **Punchline**: every stage has its own effect signature. Read the
+> directory tree and you've read the security model.
+
+### Beat 2 — Static check + happy dogfood run
+
+```bash
+# 2a. The type checker reports exactly which effects the host needs
+#     to grant.
+lex check sprint.lex
+
+# 2b. Run the dogfood task. The "agent" is lex itself, type-checking
+#     the verifier's source. PASS because lex check prints "ok" on
+#     a clean type-check.
+lex run sprint.lex sprint \
+  '"./tasks/dogfood.json"' "$(printf '%q' "$(which lex)")" '"./sprint.db"' \
+  --allow-effects io,proc,kv,fs_write,log \
+  --allow-fs-read  ./tasks \
+  --allow-fs-write ./sprint.db \
+  --allow-proc     lex
+# → Ok("dogfood-check-verify-stage => PASS")
+```
+
+> **Punchline**: `lex check` told us the exact policy. We supplied
+> exactly that, and the language type-checked itself end-to-end.
+
+### Beat 3 — Failing input, verifier rejects
+
+```bash
+# 3. Same pipeline, different task: lex check on a non-Lex file.
+#    stdout is empty, "ok" not contained, verdict flips to FAIL.
+lex run sprint.lex sprint \
+  '"./tasks/broken.json"' "$(printf '%q' "$(which lex)")" '"./sprint.db"' \
+  --allow-effects io,proc,kv,fs_write,log \
+  --allow-fs-read  ./tasks \
+  --allow-fs-write ./sprint.db \
+  --allow-proc     lex
+# → Ok("dogfood-check-nonexistent => FAIL")
+```
+
+> **Punchline**: the agent stage *always* returns Ok for a
+> successfully-spawned process. "Agent ran" vs. "agent ran
+> *correctly*" is the verifier's job, by signature.
+
+### Beat 4 — Adversarial: host policy + type checker
+
+Three rejections in quick succession. Type at the same pace as the
+happy run so the rhythm makes the contrast land.
+
+```bash
+# 4a. Try to invoke a binary not on --allow-proc. Runtime gate
+#     refuses; the orchestrator catches the error.
+lex run sprint.lex sprint \
+  '"./tasks/dogfood.json"' '"rm"' '"./sprint.db"' \
+  --allow-effects io,proc,kv,fs_write,log \
+  --allow-fs-read  ./tasks \
+  --allow-fs-write ./sprint.db \
+  --allow-proc     lex
+# → Err("process.run: `rm` not in --allow-proc [\"lex\"]")
+
+# 4b. Read a path outside --allow-fs-read, even though [io] is
+#     granted. Per-path scope wins.
+lex run sprint.lex sprint \
+  '"/etc/passwd"' "$(printf '%q' "$(which lex)")" '"./sprint.db"' \
+  --allow-effects io,proc,kv,fs_write,log \
+  --allow-fs-read  ./tasks \
+  --allow-fs-write ./sprint.db \
+  --allow-proc     lex
+# → effect handler error: read of `/etc/passwd` outside --allow-fs-read
+
+# 4c. Drop `proc` from --allow-effects entirely. Static rejection
+#     before *any* stage executes — note the {"kind":"effect_not_allowed"}
+#     output happens before the "info: sprint starting" log line.
+lex run sprint.lex sprint \
+  '"./tasks/dogfood.json"' "$(printf '%q' "$(which lex)")" '"./sprint.db"' \
+  --allow-effects io,kv,fs_write,log \
+  --allow-fs-read  ./tasks \
+  --allow-fs-write ./sprint.db \
+  --allow-proc     lex
+# → effect_not_allowed at invoke_agent.run, at sprint
+```
+
+> **Punchline**: three different rejection points — the runtime
+> handler, the path scope, and the static type checker — all from
+> the same source program by changing only the host policy line.
+> No process sandbox involved.
+
+End the session with `Ctrl-D` (or `exit`). The cast file is small
+(~12–25 KB).
+
+## Sharing
+
+```bash
+# Upload to asciinema.org for an embeddable player.
+asciinema upload bench/agent_sprint_demo.cast
+# → returns https://asciinema.org/a/<id>
+
+# Or convert to a GIF for the README / Twitter / LinkedIn.
+brew install agg          # https://github.com/asciinema/agg
+agg bench/agent_sprint_demo.cast bench/agent_sprint_demo.gif \
+  --theme monokai --font-size 14 --speed 1.5
+```
+
+Drop the URL or GIF into the README under "Sandboxing agent-
+generated code", next to the `agent-tool` recording. The two
+together tell a complete story: `agent-tool` is the
+**single-function** case (one body, one effect contract);
+`agent_sprint` is the **multi-stage** case (four files, four
+contracts, one perimeter).
+
+## Tips for the take
+
+- Run the four happy / failing / adversarial cases **once** before
+  recording so `cargo build --release` is hot and there's no
+  mid-take spinner. Delete `examples/agent_sprint/sprint.db`
+  between rehearsal and the real take so the recording's first
+  `kv.open` is fresh.
+- Make the terminal a clean 100×30 (`stty cols 100 rows 30`) and
+  `clear` before starting.
+- Type at human speed; `--idle-time-limit 1.5` collapses awkward
+  pauses on playback.
+- The release binary is much faster than debug — total recording
+  is ~90s end-to-end. Don't speed up the agg conversion past 1.5×
+  or beat 4's three rejections blur into one frame.
+
+## Reproducibility note
+
+Unlike [`RECORDING.md`](RECORDING.md), which uses a real LLM and
+gets non-byte-identical takes per run, **this recording is fully
+deterministic**: `lex check` produces the same stdout for the same
+input, every time. Anyone with a checkout can reproduce the exact
+transcript by following the four beats above. The `sprint.db`
+artifact is the only side-effect; `rm -rf examples/agent_sprint/sprint.db`
+between takes resets it.
+
+## Why a separate recording (and not just an extension of `RECORDING.md`)
+
+`RECORDING.md` shows the **point case** — a single agent-emitted
+body, a single declared effect, the type checker rejecting one
+escape attempt. That's the easy version of the pitch.
+
+`agent_sprint` is the **composed case** — four stages, four
+narrower contracts, the orchestrator's perimeter as the *union*.
+This is what production agent loops actually look like, and it's
+where you can see capabilities that don't exist in the point case:
+per-stage audit (`lex audit --effect proc sprint.lex`), `lex
+blame stages/invoke_agent.lex` showing when the trust budget
+last changed, and the verifier as a **pure function** that can't
+do anything observable even if its inputs are hostile.
+
+The two recordings together answer the two questions a security-
+minded reviewer asks: "can a single function be sandboxed?"
+(yes — `RECORDING.md`) and "does the sandbox compose across a
+real pipeline?" (yes — this one).

--- a/examples/agent_sprint/README.md
+++ b/examples/agent_sprint/README.md
@@ -30,8 +30,12 @@ fs_write, log]` — exactly the union.
 
 ## Run it
 
-The example task uses `echo` as the "agent" so the demo runs
-without claude-code / cursor / etc. installed:
+### Smoke test (`echo` as the agent)
+
+The simplest task uses `echo` so the demo runs without
+claude-code / cursor / etc. installed. The criteria is "haiku"
+and the prompt contains "haiku", so the verifier returns true.
+This is purely a wires-work check.
 
 ```sh
 cd examples/agent_sprint
@@ -41,12 +45,57 @@ lex run sprint.lex sprint \
   --allow-fs-read  ./tasks \
   --allow-fs-write ./sprint.db \
   --allow-proc     echo
+# → Ok("demo-haiku-1 => PASS")
 ```
 
-Swap `"echo"` and `--allow-proc echo` for `"claude-code"` (or
-`cursor-cli` / `gemini-cli` / `codex-cli`) once the agent CLI is
-installed and on `$PATH`. The sprint script doesn't change — only
-the host policy.
+### Dogfood (the language type-checks itself)
+
+A more substantive run: use the lex CLI itself as the "agent."
+The task says "run `lex check ./stages/verify.lex`," and the
+verifier checks for "ok" in the output. Lex type-checks the
+verifier's source via the same Lex compiler the sprint is
+running on; on success, `lex check` prints `ok` and verify
+returns true.
+
+```sh
+lex run sprint.lex sprint \
+  '"./tasks/dogfood.json"' "$(which lex)" '"./sprint.db"' \
+  --allow-effects io,proc,kv,fs_write,log \
+  --allow-fs-read  ./tasks \
+  --allow-fs-write ./sprint.db \
+  --allow-proc     lex
+# → Ok("dogfood-check-verify-stage => PASS")
+```
+
+Swap `dogfood.json`'s `args` field to point at a file that
+isn't valid Lex (e.g. `./tasks/example.json`) and the verdict
+flips:
+
+```sh
+# tasks/broken.json sets args=["./tasks/example.json"]
+lex run sprint.lex sprint \
+  '"./tasks/broken.json"' "$(which lex)" '"./sprint.db"' \
+  --allow-effects io,proc,kv,fs_write,log \
+  --allow-fs-read  ./tasks \
+  --allow-fs-write ./sprint.db \
+  --allow-proc     lex
+# → Ok("dogfood-check-nonexistent => FAIL")
+```
+
+The `=> PASS` / `=> FAIL` suffix in the result string comes from
+the `verdict :: Bool` that `verify.run` produced. The persist
+stage logs the verdict (`info: PASS: ...` / `info: FAIL: ...`)
+and threads it into the final return value. The agent stage
+*always* returns `Ok` for a successfully-spawned process — the
+distinction between "agent ran" and "agent ran *correctly*" is
+made by the verifier, by signature.
+
+### Real agents
+
+Swap the second argument and `--allow-proc` for any installed
+agent CLI (`claude-code`, `cursor-cli`, `gemini-cli`,
+`codex-cli`, ...). The sprint script doesn't change — only the
+host policy.
 
 ## Why this is interesting
 
@@ -165,5 +214,7 @@ examples/agent_sprint/
 │   ├── verify.lex       ← pure
 │   └── persist.lex      ← [kv, fs_write, log]
 └── tasks/
-    └── example.json     ← sample input
+    ├── example.json     ← echo smoke test
+    ├── dogfood.json     ← lex check verify.lex (passes)
+    └── broken.json      ← lex check example.json (fails)
 ```

--- a/examples/agent_sprint/README.md
+++ b/examples/agent_sprint/README.md
@@ -1,0 +1,169 @@
+# `agent_sprint` — a sandboxed agent loop with effects as the
+# security boundary
+
+A four-stage pipeline that fetches a task, dispatches it to an LLM
+CLI, verifies the result, and persists it. Every stage declares
+exactly what it can do; the orchestrator's signature is the union;
+the host's CLI policy is the entire perimeter.
+
+The interesting bit is the threat model: there is **no process
+sandbox** here. No bubblewrap, no seccomp, no Docker. The whole
+demo runs unprivileged in the host shell. The thing that makes it
+safe to run code an LLM emitted is that the type checker rejects
+out-of-policy stages **before** they execute.
+
+## Pipeline shape
+
+```
+            ┌─────────────┐    ┌──────────────┐    ┌────────┐    ┌──────────────┐
+task.json ──► fetch_task  ├────► invoke_agent ├────► verify ├────►   persist    │
+            │    [io]     │    │    [proc]    │    │ (pure) │    │ [kv, fs_write,
+            └─────────────┘    └──────────────┘    └────────┘    │      log]    │
+                                                                  └──────────────┘
+```
+
+Each box is a separate `.lex` file under `stages/`. The label
+under each box is its declared effect set — the only thing that
+stage can do at runtime. The orchestrator (`sprint.lex`) composes
+them with `match`, and its own signature is `[io, proc, kv,
+fs_write, log]` — exactly the union.
+
+## Run it
+
+The example task uses `echo` as the "agent" so the demo runs
+without claude-code / cursor / etc. installed:
+
+```sh
+cd examples/agent_sprint
+lex run sprint.lex sprint \
+  '"./tasks/example.json"' '"echo"' '"./sprint.db"' \
+  --allow-effects io,proc,kv,fs_write,log \
+  --allow-fs-read  ./tasks \
+  --allow-fs-write ./sprint.db \
+  --allow-proc     echo
+```
+
+Swap `"echo"` and `--allow-proc echo` for `"claude-code"` (or
+`cursor-cli` / `gemini-cli` / `codex-cli`) once the agent CLI is
+installed and on `$PATH`. The sprint script doesn't change — only
+the host policy.
+
+## Why this is interesting
+
+### 1. The security perimeter is the policy line, not the source
+
+Read the four invocation flags in the run command above. That's
+the entire trust budget. A reviewer auditing this deployment
+checks one place — the `lex run` invocation — to know what *any*
+stage in this pipeline can possibly do. Compare to a process
+sandbox where the analogous question is "what syscalls did
+bubblewrap actually block, given my distro's config and the
+agent's `unshare`-evasion attempts."
+
+### 2. New stages can't smuggle capabilities
+
+If someone adds `import "std.net" as net` and a `net.get(...)`
+call into `verify.lex`, `lex check sprint.lex` fails:
+
+    error: effect `net` not declared at <verify.run>
+        verify.run's signature said pure, body wants [net]
+
+The stage doesn't compile. No execution happens. Compare to a
+process sandbox where the analogous bug is "the bwrap policy
+forgot to deny outbound TCP, so the verifier is now exfiltrating."
+
+### 3. Per-path / per-host scopes compose
+
+Granting `[io]` doesn't grant unrestricted filesystem access —
+`--allow-fs-read ./tasks` means *any* `io.read` call in *any*
+stage can only see files under `./tasks/`. A prompt-injected
+agent that emits `io.read("/etc/passwd")` fails at the policy
+gate, on the line that tries to read, with a clear error.
+
+### 4. The DAG is auditable by capability
+
+```sh
+lex audit --effect proc sprint.lex
+```
+
+…lists every stage that can spawn a subprocess. `lex audit
+--effect io` lists every stage that touches the filesystem.
+You read the pipeline by capability, not by trawling source.
+
+### 5. Stages are content-addressed
+
+`lex publish stages/invoke_agent.lex` records the stage's
+canonical AST hash + effect signature in the store. `lex blame
+stages/invoke_agent.lex` shows when the effects last changed —
+which is when the trust budget last changed. That's the audit
+log a reviewer actually wants.
+
+## Adversarial walkthrough
+
+To convince yourself, try the rejections live:
+
+```sh
+# 1. Try to invoke a binary not on the allow-list:
+lex run sprint.lex sprint \
+  '"./tasks/example.json"' '"rm"' '"./sprint.db"' \
+  --allow-effects io,proc,kv,fs_write,log \
+  --allow-fs-read  ./tasks \
+  --allow-fs-write ./sprint.db \
+  --allow-proc     echo
+# → Err("process.run: `rm` not in --allow-proc [\"echo\"]")
+
+# 2. Edit verify.lex to add `import "std.io" as io` and an
+#    io.read call, then `lex check sprint.lex`:
+# → effect `io` not declared at <verify.run>
+
+# 3. Remove `proc` from --allow-effects:
+lex run sprint.lex sprint \
+  '"./tasks/example.json"' '"echo"' '"./sprint.db"' \
+  --allow-effects io,kv,fs_write,log \
+  --allow-fs-read  ./tasks \
+  --allow-fs-write ./sprint.db \
+  --allow-proc     echo
+# → effect `proc` not in --allow-effects (at invoke_agent.run, at sprint)
+
+# 4. Path-scope refuses to read outside --allow-fs-read, even
+#    though [io] is granted:
+lex run sprint.lex sprint \
+  '"/etc/passwd"' '"echo"' '"./sprint.db"' \
+  --allow-effects io,proc,kv,fs_write,log \
+  --allow-fs-read  ./tasks \
+  --allow-fs-write ./sprint.db \
+  --allow-proc     echo
+# → effect handler error: read of `/etc/passwd` outside --allow-fs-read
+```
+
+## Caveats called out
+
+- **Sequential.** This v1 runs one stage at a time. Concurrent
+  agents (`flow.race`, `flow.timeout`, `parallel_list` of
+  effectful actions) need a true thread pool + `time.sleep` —
+  language-level prereqs that aren't shipped yet. Tracked
+  separately.
+- **Single agent per sprint.** A multi-agent dispatcher that
+  abstracts over claude-code / cursor / gemini calling
+  conventions is one more file (~30 lines per agent). Skipped
+  here to keep the demo focused on the security pitch.
+- **No git / Gitea integration.** Caloron-Noether (the project
+  this demo is inspired by) wires the sprint loop into a Gitea
+  issue tracker. That belongs in a `std.git` module wrapping
+  `std.http`; out of scope for the demo.
+
+## Layout
+
+```
+examples/agent_sprint/
+├── README.md            ← you are here
+├── sprint.lex           ← orchestrator (entry)
+├── types.lex            ← shared `Task` type
+├── stages/
+│   ├── fetch_task.lex   ← [io]
+│   ├── invoke_agent.lex ← [proc]
+│   ├── verify.lex       ← pure
+│   └── persist.lex      ← [kv, fs_write, log]
+└── tasks/
+    └── example.json     ← sample input
+```

--- a/examples/agent_sprint/sprint.lex
+++ b/examples/agent_sprint/sprint.lex
@@ -1,0 +1,44 @@
+# Agent-sprint orchestrator: a deliberately small pipeline that
+# shows the effect-typed security perimeter end-to-end.
+#
+#   fetch_task  ──► invoke_agent  ──► verify  ──► persist
+#       [io]            [proc]        (pure)    [kv, fs_write, log]
+#
+# The `sprint` fn's signature lists the *union* of every stage's
+# effects. The host's `--allow-effects` set must cover that union
+# at the entry point, and `--allow-fs-read` / `--allow-fs-write` /
+# `--allow-proc` then narrow each individual capability.
+#
+# Read the README for the threat model and run instructions.
+
+import "./types"               as t
+import "./stages/fetch_task"   as fetch
+import "./stages/invoke_agent" as agent
+import "./stages/verify"       as verify
+import "./stages/persist"      as persist
+import "std.log"               as log
+import "std.str"               as str
+
+fn sprint(
+  task_path :: Str,
+  agent_cmd :: Str,
+  db_path   :: Str,
+) -> [io, proc, kv, fs_write, log] Result[Str, Str] {
+  log.info(str.concat("sprint starting: ", task_path))
+  match fetch.run(task_path) {
+    Ok(task) => match agent.run(agent_cmd, task) {
+      Ok(output) => {
+        let verdict := verify.run(task, output)
+        persist.run(db_path, task, output, verdict)
+      },
+      Err(e) => {
+        log.error(str.concat("agent failed: ", e))
+        Err(e)
+      },
+    },
+    Err(e) => {
+      log.error(str.concat("fetch failed: ", e))
+      Err(e)
+    },
+  }
+}

--- a/examples/agent_sprint/stages/fetch_task.lex
+++ b/examples/agent_sprint/stages/fetch_task.lex
@@ -1,0 +1,15 @@
+# Stage 1: read a Task from disk. The only effect is `[io]` —
+# narrowed at the host invocation by `--allow-fs-read ./tasks`, so
+# this stage cannot read anything outside the tasks directory even
+# though it has the bare `[io]` capability.
+
+import "../types" as t
+import "std.io"   as io
+import "std.json" as json
+
+fn run(path :: Str) -> [io] Result[t.Task, Str] {
+  match io.read(path) {
+    Ok(s)  => json.parse(s),
+    Err(e) => Err(e),
+  }
+}

--- a/examples/agent_sprint/stages/invoke_agent.lex
+++ b/examples/agent_sprint/stages/invoke_agent.lex
@@ -1,0 +1,17 @@
+# Stage 2: dispatch the prompt to a sub-agent (claude-code,
+# cursor-cli, gemini-cli, ... or `echo` for the demo). The only
+# effect is `[proc]`. This stage cannot read the filesystem, cannot
+# reach the network, cannot persist anything. The runtime rejects
+# any binary not on `--allow-proc` even when `[proc]` is granted, so
+# a prompt-injected agent that emits `process.run("rm", ["-rf",
+# "/"])` fails at the policy gate, not in user-space.
+
+import "../types"     as t
+import "std.process"  as process
+
+fn run(agent_cmd :: Str, task :: t.Task) -> [proc] Result[Str, Str] {
+  match process.run(agent_cmd, [task.prompt]) {
+    Ok(o)  => Ok(o.stdout),
+    Err(e) => Err(e),
+  }
+}

--- a/examples/agent_sprint/stages/invoke_agent.lex
+++ b/examples/agent_sprint/stages/invoke_agent.lex
@@ -6,11 +6,13 @@
 # a prompt-injected agent that emits `process.run("rm", ["-rf",
 # "/"])` fails at the policy gate, not in user-space.
 
-import "../types"     as t
-import "std.process"  as process
+import "../types"    as t
+import "std.process" as process
+import "std.list"    as list
 
 fn run(agent_cmd :: Str, task :: t.Task) -> [proc] Result[Str, Str] {
-  match process.run(agent_cmd, [task.prompt]) {
+  let all_args := list.concat([task.prompt], task.args)
+  match process.run(agent_cmd, all_args) {
     Ok(o)  => Ok(o.stdout),
     Err(e) => Err(e),
   }

--- a/examples/agent_sprint/stages/persist.lex
+++ b/examples/agent_sprint/stages/persist.lex
@@ -17,11 +17,12 @@ fn run(
   output  :: Str,
   verdict :: Bool,
 ) -> [kv, fs_write, log] Result[Str, Str] {
+  let tag := if verdict { "PASS" } else { "FAIL" }
   match kv.open(db_path) {
     Ok(db) => match kv.put(db, task.id, bytes.from_str(output)) {
       Ok(_) => {
-        log.info(str.concat("persisted ", task.id))
-        Ok(task.id)
+        log.info(str.concat(str.concat(tag, ": "), task.id))
+        Ok(str.concat(str.concat(task.id, " => "), tag))
       },
       Err(e) => Err(e),
     },

--- a/examples/agent_sprint/stages/persist.lex
+++ b/examples/agent_sprint/stages/persist.lex
@@ -1,0 +1,30 @@
+# Stage 4: persist the agent's output keyed by task id and emit a
+# structured log line. Effect set is `[kv, fs_write, log]` — the
+# `fs_write` comes from `kv.open` declaring it (the embedded sled
+# store writes its own files), so the host's `--allow-fs-write
+# ./sprint.db` scope gates *both* the kv store creation and any
+# stray `io.write` calls anywhere else in the program.
+
+import "../types"  as t
+import "std.kv"    as kv
+import "std.bytes" as bytes
+import "std.log"   as log
+import "std.str"   as str
+
+fn run(
+  db_path :: Str,
+  task    :: t.Task,
+  output  :: Str,
+  verdict :: Bool,
+) -> [kv, fs_write, log] Result[Str, Str] {
+  match kv.open(db_path) {
+    Ok(db) => match kv.put(db, task.id, bytes.from_str(output)) {
+      Ok(_) => {
+        log.info(str.concat("persisted ", task.id))
+        Ok(task.id)
+      },
+      Err(e) => Err(e),
+    },
+    Err(e) => Err(e),
+  }
+}

--- a/examples/agent_sprint/stages/verify.lex
+++ b/examples/agent_sprint/stages/verify.lex
@@ -1,0 +1,13 @@
+# Stage 3: judge whether the agent's output satisfies the task. The
+# function has *no* declared effects — it's pure, by signature. You
+# can run this on a hostile output and the worst it can do is
+# return `false`. The type checker will reject any future edit that
+# tries to log, write to disk, or call out to the network from
+# inside the verifier.
+
+import "../types" as t
+import "std.str"  as str
+
+fn run(task :: t.Task, output :: Str) -> Bool {
+  str.contains(output, task.criteria)
+}

--- a/examples/agent_sprint/tasks/broken.json
+++ b/examples/agent_sprint/tasks/broken.json
@@ -1,0 +1,6 @@
+{
+  "id": "dogfood-check-nonexistent",
+  "prompt": "check",
+  "args": ["./tasks/example.json"],
+  "criteria": "ok"
+}

--- a/examples/agent_sprint/tasks/dogfood.json
+++ b/examples/agent_sprint/tasks/dogfood.json
@@ -1,0 +1,6 @@
+{
+  "id": "dogfood-check-verify-stage",
+  "prompt": "check",
+  "args": ["./stages/verify.lex"],
+  "criteria": "ok"
+}

--- a/examples/agent_sprint/tasks/example.json
+++ b/examples/agent_sprint/tasks/example.json
@@ -1,0 +1,5 @@
+{
+  "id": "demo-haiku-1",
+  "prompt": "Write a haiku about effect types in programming languages.",
+  "criteria": "haiku"
+}

--- a/examples/agent_sprint/tasks/example.json
+++ b/examples/agent_sprint/tasks/example.json
@@ -1,5 +1,6 @@
 {
   "id": "demo-haiku-1",
   "prompt": "Write a haiku about effect types in programming languages.",
+  "args": [],
   "criteria": "haiku"
 }

--- a/examples/agent_sprint/types.lex
+++ b/examples/agent_sprint/types.lex
@@ -6,5 +6,6 @@
 type Task = {
   id :: Str,
   prompt :: Str,
+  args :: List[Str],
   criteria :: Str,
 }

--- a/examples/agent_sprint/types.lex
+++ b/examples/agent_sprint/types.lex
@@ -1,0 +1,10 @@
+# Shared types for the agent-sprint demo. Both the orchestrator and
+# every stage import this file so the type checker sees a single
+# nominal `Task` flowing through the pipeline rather than four
+# structurally-equal-but-distinct shapes.
+
+type Task = {
+  id :: Str,
+  prompt :: Str,
+  criteria :: Str,
+}


### PR DESCRIPTION
## Summary

Adds `examples/agent_sprint/` — a four-stage pipeline (fetch_task → invoke_agent → verify → persist) that demonstrates Lex's effect-typed security pitch end-to-end. Inspired by [Caloron-Noether](https://github.com/alpibrusl/caloron-noether) (sprint-style autonomous agent orchestration), but the sandboxing layer is *the type system* rather than bubblewrap.

```
            ┌─────────────┐    ┌──────────────┐    ┌────────┐    ┌──────────────┐
task.json ──► fetch_task  ├────► invoke_agent ├────► verify ├────►   persist    │
            │    [io]     │    │    [proc]    │    │ (pure) │    │ [kv, fs_write,
            └─────────────┘    └──────────────┘    └────────┘    │      log]    │
                                                                  └──────────────┘
```

The orchestrator's signature is the **union** of every stage's effects (`[io, proc, kv, fs_write, log]`); the host's `--allow-effects` set must cover that union before any stage runs. Per-path / per-host scopes (`--allow-fs-read`, `--allow-proc`) narrow individual capabilities further.

## Why this demo

- **Discoverable** — lives in `examples/` next to `weather_app`, `gateway_app`, etc., so anyone evaluating Lex finds it immediately.
- **Runs out of the box** — uses `echo` as the "agent" so the demo works without claude-code / cursor / etc. installed. Swap one CLI flag (`--allow-proc echo` → `--allow-proc claude-code`) to use a real agent.
- **No process sandbox involved** — no bubblewrap, no Docker, no seccomp. The whole demo runs unprivileged in the host shell, and the thing that makes it safe to run code an LLM emitted is that the type checker rejects out-of-policy stages **before** they execute.

## Verified live

| Scenario | Outcome |
|---|---|
| Happy path (`echo` as agent) | `Ok("demo-haiku-1")` returned, kv store populated, structured log emitted |
| Spawn `rm` (not on `--allow-proc echo`) | Policy gate refusal: `process.run: 'rm' not in --allow-proc ["echo"]` |
| Drop `proc` from `--allow-effects` | Static `effect_not_allowed` error at `invoke_agent.run` and `sprint`, no execution |
| Read `/etc/passwd` (outside `--allow-fs-read ./tasks`) | Handler-level refusal: `read of '/etc/passwd' outside --allow-fs-read` |
| Future edit adds undeclared effect to `verify.lex` | `lex check` refuses to compile (documented in README, not in the test) |

## Caveats called out in the README

- **Sequential only.** Concurrent agents need true threading + `time.sleep` (language-level prereqs not yet shipped).
- **Single-agent dispatcher.** A multi-framework abstraction over claude-code / cursor / gemini calling conventions is ~30 lines per agent, deferred.
- **No git / Gitea integration.** Caloron uses Gitea; that belongs in a future `std.git` module wrapping `std.http`.

## Test plan

- [x] `lex check sprint.lex` — passes; surfaces `required effects: fs_write, io, kv, log, proc`.
- [x] `lex run sprint.lex sprint ... --allow-effects io,proc,kv,fs_write,log ...` — happy path returns `Ok("demo-haiku-1")` end-to-end.
- [x] All four adversarial cases above produce the expected refusals.
- [x] `cargo test --workspace` — zero failures (no regression).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRXRypmTju3ShcQ3ERJQSu)_