### PR TITLE
feat: lex-vcs crate skeleton — Operation type + content-addressed OpId (#129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ bumps may carry breaking changes when justified).
 
 ### Added
 
+- **`lex-vcs` crate — foundation for agent-native VCS tier-2 (#129).**
+  New workspace crate at `crates/lex-vcs/`. Defines `Operation` (the
+  typed-delta unit replacing snapshot-of-tree) plus content-addressed
+  `OpId` (SHA-256 over canonical-form `(kind, payload, sorted parents)`).
+  Initial operation kinds match #129's spec: `AddFunction`,
+  `RemoveFunction`, `ModifyBody`, `RenameSymbol`, `ChangeEffectSig`,
+  `AddImport` / `RemoveImport`, `AddType` / `RemoveType` /
+  `ModifyType`. Two agents producing the same logical change against
+  the same parent state get the same `OpId` — the automatic-dedup
+  property the rest of tier-2 (#130-#134) relies on. This slice is
+  data-model only; subsequent slices add the apply pass, the
+  store-write gate, intent linkage, attestations, predicate branches,
+  and the programmatic merge API.
 - **`std.sql` — embedded SQL (SQLite).** Second of the OSS-Auditor
   stdlib follow-ups. Wraps `rusqlite` with the bundled SQLite
   feature so no system lib is required. Surface:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/lex-types",
     "crates/lex-bytecode",
     "crates/lex-store",
+    "crates/lex-vcs",
     "crates/lex-trace",
     "crates/lex-runtime",
     "crates/lex-stdlib",

--- a/README.md
+++ b/README.md
@@ -514,7 +514,7 @@ lex/
 | LLM-agnostic discovery | ✅ — full [ACLI](https://github.com/alpibrusl/acli) compliance: `lex introspect` / `lex skill` / `lex version`, `--output text\|json\|table` on every subcommand, `--dry-run` on state-modifying ones, error envelopes with semantic exit codes |
 | Hardening | [`SECURITY.md`](SECURITY.md) threat model ✅ ; parser-recursion DoS gate (`MAX_DEPTH=96`) ✅ ; **VM call-stack depth gate (`MAX_CALL_DEPTH=1024`) ✅** ; libFuzzer CI for parser + type checker ✅ ; VM-level memory bounds remain delegated to the host (container memory caps) |
 
-**Workspace test count:** 512 passing, 0 failing, 5 ignored (WS chat example + handful of slow examples, flaky on CI runners — pass locally with `--ignored`). `cargo clippy --workspace --all-targets -- -D warnings` clean. Fuzz CI: 60 s/PR, 5 min nightly across both targets.
+**Workspace test count:** 527 passing, 0 failing, 5 ignored (WS chat example + handful of slow examples, flaky on CI runners — pass locally with `--ignored`). `cargo clippy --workspace --all-targets -- -D warnings` clean. Fuzz CI: 60 s/PR, 5 min nightly across both targets.
 
 ## Install
 

--- a/crates/lex-vcs/Cargo.toml
+++ b/crates/lex-vcs/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "lex-vcs"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+thiserror.workspace = true
+indexmap.workspace = true
+
+[dev-dependencies]

--- a/crates/lex-vcs/src/canonical.rs
+++ b/crates/lex-vcs/src/canonical.rs
@@ -1,0 +1,72 @@
+//! Canonical JSON serialization for hashing.
+//!
+//! The contract is narrow: given any `Serialize` value, produce a byte
+//! sequence such that two values that *should* hash equal produce
+//! identical bytes. We get there by:
+//!
+//! 1. **Field order from the struct/enum declaration.** `serde_json`
+//!    emits struct fields in the order they appear in the type. Since
+//!    we control the operation enum, this gives us a stable layout
+//!    without sorting at serialize time. The risk is that *changing*
+//!    the type's field order silently rewrites every `OpId`; the
+//!    operation tests below pin a few golden hashes so a refactor
+//!    that breaks identity surfaces as a test failure.
+//!
+//! 2. **`BTreeSet` / `BTreeMap` for unordered collections.** Effect
+//!    sets are `BTreeSet<String>` so iteration is sorted. If we ever
+//!    add a map-shaped field (e.g. for variant payloads), it should
+//!    use `BTreeMap` for the same reason.
+//!
+//! 3. **`serde_json` compact emit.** No pretty-printing, no trailing
+//!    whitespace. The compact form is canonical because it has no
+//!    formatting choices.
+//!
+//! The only thing we explicitly *don't* do here is recursive key
+//! sorting on arbitrary `serde_json::Value` trees. We don't need it:
+//! every type that contributes to an [`OpId`] is concrete and uses
+//! one of the three patterns above. If you find yourself wanting to
+//! hash a `serde_json::Value` directly, route it through a typed
+//! struct first.
+
+use sha2::{Digest, Sha256};
+
+/// Hash a serializable value to a 64-char lowercase hex digest.
+pub(crate) fn hash<T: serde::Serialize>(value: &T) -> String {
+    let bytes = serde_json::to_vec(value).expect("canonical serialization");
+    let digest = Sha256::digest(&bytes);
+    let mut out = String::with_capacity(digest.len() * 2);
+    for b in digest.iter() {
+        out.push_str(&format!("{b:02x}"));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::hash;
+    use serde::Serialize;
+
+    #[derive(Serialize)]
+    struct Point { x: i32, y: i32 }
+
+    #[test]
+    fn identical_values_hash_equal() {
+        let a = Point { x: 1, y: 2 };
+        let b = Point { x: 1, y: 2 };
+        assert_eq!(hash(&a), hash(&b));
+    }
+
+    #[test]
+    fn different_values_hash_differently() {
+        let a = Point { x: 1, y: 2 };
+        let b = Point { x: 2, y: 1 };
+        assert_ne!(hash(&a), hash(&b));
+    }
+
+    #[test]
+    fn hash_is_64_char_lowercase_hex() {
+        let h = hash(&Point { x: 0, y: 0 });
+        assert_eq!(h.len(), 64);
+        assert!(h.chars().all(|c| c.is_ascii_hexdigit() && (c.is_ascii_digit() || c.is_lowercase())));
+    }
+}

--- a/crates/lex-vcs/src/lib.rs
+++ b/crates/lex-vcs/src/lib.rs
@@ -1,0 +1,37 @@
+//! Agent-native version control for Lex (#128 tier-2).
+//!
+//! The unit of writing is an [`Operation`] — a typed delta on the AST
+//! identified by `(kind, payload, parents)`. Two agents producing the
+//! same logical change against the same parent state get the same
+//! [`OpId`], so the store can dedup automatically and surface "we
+//! agree" without a merge.
+//!
+//! This crate is the foundation slice of #129. It defines the
+//! operation enum and content-addressed identity. Subsequent slices
+//! add: applying ops to a store state (#129 cont'd), the write-time
+//! type-check gate (#130), intent linkage (#131), attestations
+//! (#132), predicate branches (#133), and the programmatic merge API
+//! (#134).
+//!
+//! # Identity
+//!
+//! [`OpId`] is the lowercase-hex SHA-256 of the canonical JSON form
+//! of `(kind, payload, parents)`. The serializer is deterministic
+//! by construction (struct fields are emitted in declaration order;
+//! [`EffectSet`] is a `BTreeSet`; parents are sorted before
+//! hashing), so two independent runs producing the same logical
+//! operation produce byte-identical canonical bytes.
+//!
+//! `lex-store` already uses SHA-256 (via the `sha2` crate) for stage
+//! and signature identity, so we reuse that here for consistency
+//! and to avoid pulling in a second hash dependency. The issue text
+//! mentions Blake3; if that becomes load-bearing for performance we
+//! can swap with a one-line crate change since `OpId` is opaque.
+
+mod canonical;
+mod operation;
+
+pub use operation::{
+    EffectSet, ModuleRef, OpId, Operation, OperationRecord, OperationKind, SigId, StageId,
+    StageTransition,
+};

--- a/crates/lex-vcs/src/operation.rs
+++ b/crates/lex-vcs/src/operation.rs
@@ -1,0 +1,402 @@
+//! The `Operation` enum + `OperationRecord` (operation plus its
+//! causal parents and resulting `OpId`).
+//!
+//! See `lib.rs` for the design context and #129 for the issue.
+
+use indexmap::IndexSet;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+
+use crate::canonical;
+
+/// Signature identity of a function or type — the part that stays
+/// stable across body edits. Wraps the same string identity
+/// `lex-store` uses; we keep it as `String` here so this crate has
+/// no dependency on `lex-store`'s internals.
+pub type SigId = String;
+
+/// Content hash of a single stage (function body, type def, ...).
+/// Same string identity as the file under `<root>/stages/<SigId>/
+/// implementations/<StageId>.ast.json`.
+pub type StageId = String;
+
+/// Identity of an operation. `(kind, payload, parents)` SHA-256 in
+/// lowercase hex (64 chars). Two operations with identical payloads
+/// and parent sets produce identical `OpId`s; the store dedupes on
+/// this.
+pub type OpId = String;
+
+/// Sorted set of effect-kind strings (e.g. `["fs_write", "io"]`).
+/// `BTreeSet` so the canonical form is order-independent for
+/// hashing.
+pub type EffectSet = BTreeSet<String>;
+
+/// Reference to an imported module — either a stdlib name
+/// (`std.io`) or a local path (`./helpers`). Kept as a string so
+/// this crate doesn't pull in `lex-syntax`'s parser.
+pub type ModuleRef = String;
+
+/// Effect of applying an operation on a stage's content-addressed
+/// identity. Used as the `produces` field of an [`OperationRecord`]
+/// so consumers can answer "after this op, what's the head stage
+/// for this SigId?" without rerunning the apply step.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum StageTransition {
+    /// New SigId; produces a stage that didn't exist before.
+    Create { sig_id: SigId, stage_id: StageId },
+    /// Existing SigId; replaces its head stage.
+    Replace { sig_id: SigId, from: StageId, to: StageId },
+    /// SigId removed; no head stage afterwards.
+    Remove { sig_id: SigId, last: StageId },
+    /// SigId renamed; same body hash, different signature identity.
+    Rename { from: SigId, to: SigId, body_stage_id: StageId },
+    /// Import-only change; doesn't touch any stage.
+    ImportOnly,
+}
+
+/// The kinds of operations that produce stage transitions. Mirrors
+/// the initial set in #129; new kinds (`MoveBetweenFiles`,
+/// `SplitFunction`, `ExtractType`) can be added later as long as
+/// they're appended at the end of this enum or use explicit
+/// `#[serde(rename = "...")]` tags so existing `OpId`s stay stable.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum OperationKind {
+    /// New function published. `effects` is the effect set declared
+    /// in the signature; tracked here (not just inside the stage)
+    /// so #130's write-time gate has a cheap path to check effect
+    /// changes without rehydrating the AST.
+    AddFunction {
+        sig_id: SigId,
+        stage_id: StageId,
+        effects: EffectSet,
+    },
+    /// Function removed; `last_stage_id` is the head before the
+    /// remove (so blame can walk the predecessor without scanning).
+    RemoveFunction {
+        sig_id: SigId,
+        last_stage_id: StageId,
+    },
+    /// Function body changed; signature unchanged.
+    ModifyBody {
+        sig_id: SigId,
+        from_stage_id: StageId,
+        to_stage_id: StageId,
+    },
+    /// Symbol renamed. The body hash is preserved (`body_stage_id`)
+    /// so two renames of the same body collapse to the same OpId
+    /// and `lex blame` walks the rename as a single causal event
+    /// rather than `delete + add`.
+    RenameSymbol {
+        from: SigId,
+        to: SigId,
+        body_stage_id: StageId,
+    },
+    /// Effect signature changed. Captures both old and new effect
+    /// sets so the write-time gate (#130) can verify importers
+    /// haven't silently broken.
+    ChangeEffectSig {
+        sig_id: SigId,
+        from_stage_id: StageId,
+        to_stage_id: StageId,
+        from_effects: EffectSet,
+        to_effects: EffectSet,
+    },
+    /// Import added to a file. `in_file` is the canonical path
+    /// (relative to the repo root, forward-slashes) so two
+    /// machines hashing the same edit get the same OpId.
+    AddImport {
+        in_file: String,
+        module: ModuleRef,
+    },
+    RemoveImport {
+        in_file: String,
+        module: ModuleRef,
+    },
+    AddType {
+        sig_id: SigId,
+        stage_id: StageId,
+    },
+    RemoveType {
+        sig_id: SigId,
+        last_stage_id: StageId,
+    },
+    ModifyType {
+        sig_id: SigId,
+        from_stage_id: StageId,
+        to_stage_id: StageId,
+    },
+}
+
+/// The operation as a whole — its kind and the causal predecessors
+/// it assumes. The `OpId` is computed from this plus a sorted view
+/// of `parents`.
+///
+/// Operations without parents are valid and represent "applies to
+/// the empty repository" or "applies to the synthetic genesis
+/// state." `lex store migrate v1→v2` will produce parentless ops
+/// for stages it can't trace back to a clear predecessor.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Operation {
+    #[serde(flatten)]
+    pub kind: OperationKind,
+    /// Operations whose `produces` this op assumes. Sorted before
+    /// hashing for canonical form. Empty for ops against the empty
+    /// repo.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub parents: Vec<OpId>,
+}
+
+impl Operation {
+    /// Construct an operation against zero or more parents. Caller
+    /// supplies parents in any order; canonicalization sorts them
+    /// before hashing.
+    pub fn new(kind: OperationKind, parents: impl IntoIterator<Item = OpId>) -> Self {
+        let mut parents: Vec<OpId> = parents.into_iter().collect();
+        parents.sort();
+        parents.dedup();
+        Self { kind, parents }
+    }
+
+    /// Compute this operation's content-addressed identity.
+    ///
+    /// Stable across runs and machines: same `(kind, payload,
+    /// sorted parents)` produces the same `OpId`. This is the
+    /// invariant #129's automatic-dedup behavior relies on.
+    pub fn op_id(&self) -> OpId {
+        // Build a transient hashable view rather than hashing
+        // `self` directly so the parent ordering is canonical
+        // even if a caller hand-constructs an `Operation` with
+        // unsorted parents.
+        let canonical = CanonicalView {
+            kind: &self.kind,
+            parents: self.parents.iter().collect::<IndexSet<_>>().into_iter().collect::<BTreeSet<_>>(),
+        };
+        canonical::hash(&canonical)
+    }
+}
+
+/// Hashable shadow of [`Operation`] with parents in a `BTreeSet` so
+/// the serialization is order-independent regardless of how the
+/// caller constructed the live operation. Never persisted; lives
+/// only as a transient for hashing.
+#[derive(Serialize)]
+struct CanonicalView<'a> {
+    #[serde(flatten)]
+    kind: &'a OperationKind,
+    parents: BTreeSet<&'a OpId>,
+}
+
+/// An operation paired with its computed `OpId` and the resulting
+/// stage transition. This is what gets persisted under
+/// `<root>/ops/<OpId>.json` once `apply.rs` (next slice of #129)
+/// lands.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OperationRecord {
+    pub op_id: OpId,
+    #[serde(flatten)]
+    pub op: Operation,
+    pub produces: StageTransition,
+}
+
+impl OperationRecord {
+    pub fn new(op: Operation, produces: StageTransition) -> Self {
+        let op_id = op.op_id();
+        Self { op_id, op, produces }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn add_factorial() -> OperationKind {
+        OperationKind::AddFunction {
+            sig_id: "fac::Int->Int".into(),
+            stage_id: "abc123".into(),
+            effects: BTreeSet::new(),
+        }
+    }
+
+    #[test]
+    fn identical_operations_have_identical_op_ids() {
+        let a = Operation::new(add_factorial(), []);
+        let b = Operation::new(add_factorial(), []);
+        assert_eq!(a.op_id(), b.op_id());
+    }
+
+    #[test]
+    fn different_operations_have_different_op_ids() {
+        let a = Operation::new(add_factorial(), []);
+        let b = Operation::new(
+            OperationKind::AddFunction {
+                sig_id: "double::Int->Int".into(),
+                stage_id: "abc123".into(),
+                effects: BTreeSet::new(),
+            },
+            [],
+        );
+        assert_ne!(a.op_id(), b.op_id());
+    }
+
+    #[test]
+    fn parent_set_changes_op_id() {
+        let no_parent = Operation::new(add_factorial(), []);
+        let with_parent = Operation::new(add_factorial(), ["op-parent-1".into()]);
+        assert_ne!(no_parent.op_id(), with_parent.op_id());
+    }
+
+    #[test]
+    fn parent_order_does_not_affect_op_id() {
+        let a = Operation::new(add_factorial(), ["b".into(), "a".into(), "c".into()]);
+        let b = Operation::new(add_factorial(), ["c".into(), "a".into(), "b".into()]);
+        assert_eq!(a.op_id(), b.op_id());
+        // and the stored form is sorted.
+        assert_eq!(a.parents, vec!["a".to_string(), "b".to_string(), "c".to_string()]);
+    }
+
+    #[test]
+    fn duplicate_parents_are_deduped() {
+        let with_dups = Operation::new(
+            add_factorial(),
+            ["a".into(), "a".into(), "b".into()],
+        );
+        let no_dups = Operation::new(
+            add_factorial(),
+            ["a".into(), "b".into()],
+        );
+        assert_eq!(with_dups.op_id(), no_dups.op_id());
+        assert_eq!(with_dups.parents, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn rename_with_same_body_hashes_equal_across_runs() {
+        // Two independent runs producing the same rename against the
+        // same parent should produce the same OpId — this is the
+        // automatic-dedup property #129 relies on for distributed
+        // agents.
+        let kind = OperationKind::RenameSymbol {
+            from: "parse::Str->Int".into(),
+            to: "parse_int::Str->Int".into(),
+            body_stage_id: "abc123".into(),
+        };
+        let a = Operation::new(kind.clone(), ["op-parent".into()]);
+        let b = Operation::new(kind, ["op-parent".into()]);
+        assert_eq!(a.op_id(), b.op_id());
+    }
+
+    #[test]
+    fn rename_does_not_collide_with_delete_plus_add() {
+        // The whole point of `RenameSymbol` is that it's a different
+        // OpId from the (semantically-equivalent) `RemoveFunction +
+        // AddFunction` pair. Causal history sees one event, not two.
+        let rename = Operation::new(
+            OperationKind::RenameSymbol {
+                from: "parse::Str->Int".into(),
+                to: "parse_int::Str->Int".into(),
+                body_stage_id: "abc123".into(),
+            },
+            ["op-parent".into()],
+        );
+        let remove = Operation::new(
+            OperationKind::RemoveFunction {
+                sig_id: "parse::Str->Int".into(),
+                last_stage_id: "abc123".into(),
+            },
+            ["op-parent".into()],
+        );
+        let add = Operation::new(
+            OperationKind::AddFunction {
+                sig_id: "parse_int::Str->Int".into(),
+                stage_id: "abc123".into(),
+                effects: BTreeSet::new(),
+            },
+            ["op-parent".into()],
+        );
+        assert_ne!(rename.op_id(), remove.op_id());
+        assert_ne!(rename.op_id(), add.op_id());
+    }
+
+    #[test]
+    fn effect_set_order_does_not_affect_op_id() {
+        // Effects are a BTreeSet so iteration is sorted. Build two
+        // ops via different insertion orders and confirm the
+        // canonical form is identical.
+        let a_effects: EffectSet = ["io".into(), "fs_write".into()].into_iter().collect();
+        let b_effects: EffectSet = ["fs_write".into(), "io".into()].into_iter().collect();
+        let a = Operation::new(
+            OperationKind::AddFunction {
+                sig_id: "x".into(), stage_id: "s".into(), effects: a_effects,
+            },
+            [],
+        );
+        let b = Operation::new(
+            OperationKind::AddFunction {
+                sig_id: "x".into(), stage_id: "s".into(), effects: b_effects,
+            },
+            [],
+        );
+        assert_eq!(a.op_id(), b.op_id());
+    }
+
+    #[test]
+    fn op_id_is_64_char_lowercase_hex() {
+        let id = Operation::new(add_factorial(), []).op_id();
+        assert_eq!(id.len(), 64);
+        assert!(id.chars().all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)));
+    }
+
+    #[test]
+    fn round_trip_through_serde_json() {
+        let op = Operation::new(
+            OperationKind::ChangeEffectSig {
+                sig_id: "f".into(),
+                from_stage_id: "old".into(),
+                to_stage_id: "new".into(),
+                from_effects: BTreeSet::new(),
+                to_effects: ["io".into()].into_iter().collect(),
+            },
+            ["op-parent".into()],
+        );
+        let json = serde_json::to_string(&op).expect("serialize");
+        let back: Operation = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(op, back);
+        assert_eq!(op.op_id(), back.op_id());
+    }
+
+    #[test]
+    fn operation_record_carries_op_id() {
+        let op = Operation::new(add_factorial(), []);
+        let expected = op.op_id();
+        let rec = OperationRecord::new(
+            op,
+            StageTransition::Create {
+                sig_id: "fac::Int->Int".into(),
+                stage_id: "abc123".into(),
+            },
+        );
+        assert_eq!(rec.op_id, expected);
+    }
+
+    /// Golden hash. If this changes, the canonical form has shifted
+    /// and *every* op_id in every existing store has changed too —
+    /// that's a major-version event for the data model and should
+    /// be a deliberate decision, not an accident from reordering
+    /// fields. Update with care.
+    #[test]
+    fn canonical_form_is_stable_for_a_known_input() {
+        let op = Operation::new(
+            OperationKind::AddFunction {
+                sig_id: "fac::Int->Int".into(),
+                stage_id: "abc123".into(),
+                effects: BTreeSet::new(),
+            },
+            [],
+        );
+        assert_eq!(
+            op.op_id(),
+            "f112990d31ef2a63f3e5ca5680637ed36a54bc7e8230510ae0c0e93fcb39d104"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Foundation slice of the agent-native VCS tier-2 (#128). The unit of writing in `lex-store` will move from **stage** (snapshot of a single function) to **operation** (typed delta on the AST identified by `(kind, payload, parents)` SHA-256). This PR ships **only the data model**; subsequent slices add the apply pass, the write-time type/effect gate (#130), intent linkage (#131), the attestation graph (#132), predicate branches (#133), and the programmatic conflict-resolution API (#134).

Splitting the data-model review off keeps it small. The next PR can land the apply pass against a real `Store` without re-litigating the operation enum's shape.

## What's in

- **`crates/lex-vcs/`** — new workspace crate.
- **`OperationKind`** matching #129's initial set: `AddFunction` / `RemoveFunction` / `ModifyBody` / `RenameSymbol` / `ChangeEffectSig` / `AddImport` / `RemoveImport` / `AddType` / `RemoveType` / `ModifyType`.
- **`Operation { kind, parents }`** + `op_id()` — SHA-256 over canonical JSON of `(kind, payload, sorted parents)` via a transient `CanonicalView` so unsorted caller input still produces canonical output.
- **`OperationRecord`** — operation + computed OpId + resulting `StageTransition` (`Create | Replace | Remove | Rename | ImportOnly`). The shape that will get persisted under `<root>/ops/<OpId>.json` once the apply pass lands.

## Identity decisions worth flagging in review

| decision | rationale |
|---|---|
| **SHA-256, not Blake3** | Matches `lex-store`'s existing hashes; avoids a second hash dep. `OpId` is opaque, so swapping later is a one-line change. |
| **`EffectSet = BTreeSet<String>`** | Canonical form is order-independent. Verified by test. |
| **Parents sorted + deduped at construction** | Same op + same parents → same OpId regardless of caller-supplied order. Verified by test. |
| **`RenameSymbol` is its own kind** | Two agents independently producing the same rename get the same OpId; history shows one event, not `Remove + Add`. The whole point of #129 over a stage-only model. Verified by test. |
| **Golden-hash test pinning a known input** | Future refactors that reorder fields can't silently rewrite every existing `OpId` — that's a major-version event for the data model and should be a deliberate decision. |

## Test plan

- [x] `cargo test -p lex-vcs` — 15/15 pass.
- [x] `cargo test --workspace` — 527/527 pass (512 → 527; +15 new from `lex-vcs`).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.

## Out of scope (deferred)

Tracked on the #128 review comment; recap here:
- `apply.rs` — applying an op to a Store to produce a new head. Comes next; needs the Store API extension.
- `diff_to_ops.rs` — turning an `ast-diff` result into a minimal operation sequence. Lands with the `lex publish` refactor.
- CLI surface (`lex op show`, `lex op log`, `lex op apply`).
- `lex store migrate v1→v2` for upgrading tier-1 stores.
- Op-DAG GC policy.

Refs #129. Foundation for #130-#134.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRXRypmTju3ShcQ3ERJQSu)_