### PR TITLE
feat: lex-vcs RenameSymbol apply — close the NotYetImplemented gap (#129 cont'd)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,21 @@ bumps may carry breaking changes when justified).
   `AddImport` / `RemoveImport`, `AddType` / `RemoveType` /
   `ModifyType`. Two agents producing the same logical change against
   the same parent state get the same `OpId` — the automatic-dedup
-  property the rest of tier-2 (#130-#134) relies on. This slice is
-  data-model only; subsequent slices add the apply pass, the
-  store-write gate, intent linkage, attestations, predicate branches,
-  and the programmatic merge API.
+  property the rest of tier-2 (#130-#134) relies on.
+- **`lex-vcs` apply pass (#129 cont'd).** `apply_operation(store, op)`
+  bridges typed deltas to the existing content-addressed `lex-store`
+  by validating preconditions atomically (stage exists, stale-parent
+  check, no-duplicate-add), flipping lifecycle states, and
+  persisting the resulting `OperationRecord` under
+  `<root>/ops/<OpId>.json`. Dry-run preview via
+  `compute_transition(store, &op)` returns the would-be
+  `StageTransition` without mutating anything. Supports 9 of 10
+  operation kinds; `RenameSymbol` requires a small follow-up to the
+  op enum (separate `from_stage_id` / `to_stage_id` fields, since
+  lex-store's StageId hash includes the symbol name) and currently
+  surfaces `ApplyError::NotYetImplemented` rather than corrupting
+  state. CLI surface, `diff_to_ops`, and the `lex publish` refactor
+  remain ahead.
 - **`std.sql` — embedded SQL (SQLite).** Second of the OSS-Auditor
   stdlib follow-ups. Wraps `rusqlite` with the bundled SQLite
   feature so no system lib is required. Surface:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,13 +26,17 @@ bumps may carry breaking changes when justified).
   persisting the resulting `OperationRecord` under
   `<root>/ops/<OpId>.json`. Dry-run preview via
   `compute_transition(store, &op)` returns the would-be
-  `StageTransition` without mutating anything. Supports 9 of 10
-  operation kinds; `RenameSymbol` requires a small follow-up to the
-  op enum (separate `from_stage_id` / `to_stage_id` fields, since
-  lex-store's StageId hash includes the symbol name) and currently
-  surfaces `ApplyError::NotYetImplemented` rather than corrupting
-  state. CLI surface, `diff_to_ops`, and the `lex publish` refactor
-  remain ahead.
+  `StageTransition` without mutating anything.
+- **`lex-vcs` `RenameSymbol` apply (#129 cont'd).** Tightens the
+  op enum: the `RenameSymbol` variant now carries `from_sig` /
+  `from_stage_id` / `to_sig` / `to_stage_id` (the
+  pre-rename hand-wave around a single `body_stage_id` couldn't
+  represent the recursive-rename case where call-site references
+  to the new name produce distinct stage hashes). Apply walks
+  the rename in one transition: activate the TO stage, then
+  Active → Deprecated → Tombstone the FROM stage. `lex blame`
+  sees one causal event rather than `delete + add`. The
+  `StageTransition::Rename` payload mirrors the new shape.
 - **`std.sql` — embedded SQL (SQLite).** Second of the OSS-Auditor
   stdlib follow-ups. Wraps `rusqlite` with the bundled SQLite
   feature so no system lib is required. Surface:

--- a/README.md
+++ b/README.md
@@ -514,7 +514,7 @@ lex/
 | LLM-agnostic discovery | ✅ — full [ACLI](https://github.com/alpibrusl/acli) compliance: `lex introspect` / `lex skill` / `lex version`, `--output text\|json\|table` on every subcommand, `--dry-run` on state-modifying ones, error envelopes with semantic exit codes |
 | Hardening | [`SECURITY.md`](SECURITY.md) threat model ✅ ; parser-recursion DoS gate (`MAX_DEPTH=96`) ✅ ; **VM call-stack depth gate (`MAX_CALL_DEPTH=1024`) ✅** ; libFuzzer CI for parser + type checker ✅ ; VM-level memory bounds remain delegated to the host (container memory caps) |
 
-**Workspace test count:** 527 passing, 0 failing, 5 ignored (WS chat example + handful of slow examples, flaky on CI runners — pass locally with `--ignored`). `cargo clippy --workspace --all-targets -- -D warnings` clean. Fuzz CI: 60 s/PR, 5 min nightly across both targets.
+**Workspace test count:** 537 passing, 0 failing, 5 ignored (WS chat example + handful of slow examples, flaky on CI runners — pass locally with `--ignored`). `cargo clippy --workspace --all-targets -- -D warnings` clean. Fuzz CI: 60 s/PR, 5 min nightly across both targets.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -514,7 +514,7 @@ lex/
 | LLM-agnostic discovery | ✅ — full [ACLI](https://github.com/alpibrusl/acli) compliance: `lex introspect` / `lex skill` / `lex version`, `--output text\|json\|table` on every subcommand, `--dry-run` on state-modifying ones, error envelopes with semantic exit codes |
 | Hardening | [`SECURITY.md`](SECURITY.md) threat model ✅ ; parser-recursion DoS gate (`MAX_DEPTH=96`) ✅ ; **VM call-stack depth gate (`MAX_CALL_DEPTH=1024`) ✅** ; libFuzzer CI for parser + type checker ✅ ; VM-level memory bounds remain delegated to the host (container memory caps) |
 
-**Workspace test count:** 537 passing, 0 failing, 5 ignored (WS chat example + handful of slow examples, flaky on CI runners — pass locally with `--ignored`). `cargo clippy --workspace --all-targets -- -D warnings` clean. Fuzz CI: 60 s/PR, 5 min nightly across both targets.
+**Workspace test count:** 540 passing, 0 failing, 5 ignored (WS chat example + handful of slow examples, flaky on CI runners — pass locally with `--ignored`). `cargo clippy --workspace --all-targets -- -D warnings` clean. Fuzz CI: 60 s/PR, 5 min nightly across both targets.
 
 ## Install
 

--- a/crates/lex-vcs/Cargo.toml
+++ b/crates/lex-vcs/Cargo.toml
@@ -10,5 +10,9 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
+lex-store = { path = "../lex-store" }
 
 [dev-dependencies]
+lex-ast = { path = "../lex-ast" }
+lex-syntax = { path = "../lex-syntax" }
+tempfile = "3"

--- a/crates/lex-vcs/src/apply.rs
+++ b/crates/lex-vcs/src/apply.rs
@@ -1,0 +1,281 @@
+//! Apply an [`Operation`] to a [`Store`], producing the resulting
+//! [`OperationRecord`] and a side-effected store state.
+//!
+//! The apply pass is the bridge from the *typed-delta* world of
+//! `lex-vcs` to the *content-addressed-stage* world of `lex-store`.
+//! It assumes the caller has already published any new stages
+//! (via `Store::publish`) and now wants to advance the store's
+//! lifecycle / op log to reflect the change.
+//!
+//! # Contract
+//!
+//! - **Stages must exist before the op is applied.** `apply_operation`
+//!   does not create stages from source — it only flips lifecycle
+//!   states and writes the op record. If the operation references a
+//!   `stage_id` that isn't in the store, [`ApplyError::StageMissing`]
+//!   is returned and nothing is written.
+//! - **Preconditions are checked atomically.** A `ModifyBody` op
+//!   whose `from_stage_id` doesn't match the current head returns
+//!   [`ApplyError::StaleParent`] without mutating anything.
+//! - **The op record is written last.** Any earlier failure
+//!   (precondition, lifecycle transition error) leaves no
+//!   `<root>/ops/<OpId>.json` file behind.
+//!
+//! # Persistence layout
+//!
+//! ```text
+//! <root>/
+//! ├── ops/
+//! │   └── <OpId>.json        ← OperationRecord (this PR)
+//! └── stages/...              ← unchanged from lex-store
+//! ```
+//!
+//! Branch heads (`<root>/refs/heads/<branch>`) and the predicate-
+//! branch view (#133) are deliberately not touched here. Today's
+//! tier-1 branches map `SigId → StageId` and are updated implicitly
+//! through `Store::activate` — that path keeps working. The op log
+//! is purely additive on top.
+//!
+//! # What's not here
+//!
+//! - **`RenameSymbol` apply.** The op enum carries a single
+//!   `body_stage_id`, but a rename involves *two* stages (the old
+//!   `from`-keyed one and the new `to`-keyed one) because lex-store's
+//!   StageId hash includes the function name. Tightening this needs
+//!   a small follow-up to the operation enum (separate `from_stage_id`
+//!   / `to_stage_id` fields). Until that lands, applying a
+//!   `RenameSymbol` returns [`ApplyError::NotYetImplemented`] so
+//!   callers don't silently get the wrong store state.
+//! - **`diff_to_ops`** — turning an `lex ast-diff` result into a
+//!   minimal sequence of operations. Lands with the `lex publish`
+//!   refactor.
+//! - **The CLI surface** (`lex op show`, `lex op log`, `lex op
+//!   apply`). Separate PR.
+
+use std::fs;
+use std::path::PathBuf;
+
+use lex_store::{Store, StoreError};
+
+use crate::operation::{
+    Operation, OperationKind, OperationRecord, OpId, SigId, StageId, StageTransition,
+};
+
+#[derive(Debug, thiserror::Error)]
+pub enum ApplyError {
+    #[error("store error: {0}")]
+    Store(#[from] StoreError),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("serialization error: {0}")]
+    Serde(#[from] serde_json::Error),
+    /// A required stage isn't in the store. Caller forgot to
+    /// `Store::publish` before applying.
+    #[error("stage `{0}` not found in store; publish it first")]
+    StageMissing(StageId),
+    /// `ModifyBody` / `ChangeEffectSig` / `RemoveFunction` etc.
+    /// expected a specific head stage and found something else.
+    /// Surfaces concurrent-write conflicts as a clean error.
+    #[error("stale parent for `{sig_id}`: expected head `{expected}`, found `{actual}`")]
+    StaleParent { sig_id: SigId, expected: StageId, actual: String },
+    /// `AddFunction` / `AddType` against a `SigId` that already has
+    /// an active stage.
+    #[error("`{sig_id}` already has an active stage `{existing}`; use ModifyBody to replace")]
+    DuplicateAdd { sig_id: SigId, existing: StageId },
+    /// Operation kind that the apply pass doesn't yet implement.
+    /// Tracked separately so callers can surface a clear "v1.5"
+    /// message rather than a generic store error.
+    #[error("operation kind not yet implemented in this slice: {0}")]
+    NotYetImplemented(&'static str),
+}
+
+/// Apply an operation to the store. Returns the resulting
+/// [`OperationRecord`] (op id + computed stage transition) and
+/// persists it under `<root>/ops/<OpId>.json`.
+///
+/// See the module docs for the contract: stages must exist;
+/// preconditions are checked atomically; the op record is written
+/// last so failures leave no footprint.
+pub fn apply_operation(store: &Store, op: Operation) -> Result<OperationRecord, ApplyError> {
+    let transition = compute_transition(store, &op)?;
+    apply_lifecycle(store, &op)?;
+    let record = OperationRecord::new(op, transition);
+    persist_record(store, &record)?;
+    Ok(record)
+}
+
+/// Compute the [`StageTransition`] for an op without mutating
+/// anything. Pulled out separately so callers (e.g., a future "dry
+/// run" mode) can preview the effect.
+pub fn compute_transition(
+    store: &Store,
+    op: &Operation,
+) -> Result<StageTransition, ApplyError> {
+    match &op.kind {
+        OperationKind::AddFunction { sig_id, stage_id, .. }
+        | OperationKind::AddType { sig_id, stage_id } => {
+            ensure_stage_present(store, stage_id)?;
+            ensure_no_active(store, sig_id)?;
+            Ok(StageTransition::Create {
+                sig_id: sig_id.clone(),
+                stage_id: stage_id.clone(),
+            })
+        }
+        OperationKind::RemoveFunction { sig_id, last_stage_id }
+        | OperationKind::RemoveType { sig_id, last_stage_id } => {
+            ensure_active_matches(store, sig_id, last_stage_id)?;
+            Ok(StageTransition::Remove {
+                sig_id: sig_id.clone(),
+                last: last_stage_id.clone(),
+            })
+        }
+        OperationKind::ModifyBody { sig_id, from_stage_id, to_stage_id }
+        | OperationKind::ModifyType { sig_id, from_stage_id, to_stage_id }
+        | OperationKind::ChangeEffectSig {
+            sig_id, from_stage_id, to_stage_id, ..
+        } => {
+            ensure_stage_present(store, to_stage_id)?;
+            ensure_active_matches(store, sig_id, from_stage_id)?;
+            Ok(StageTransition::Replace {
+                sig_id: sig_id.clone(),
+                from: from_stage_id.clone(),
+                to: to_stage_id.clone(),
+            })
+        }
+        OperationKind::AddImport { .. } | OperationKind::RemoveImport { .. } => {
+            // Imports don't have a SigId in the store taxonomy
+            // today; they live in source files. The op log records
+            // them so causal history is complete, but the apply
+            // pass has no stage-level work to do.
+            Ok(StageTransition::ImportOnly)
+        }
+        OperationKind::RenameSymbol { from, to, body_stage_id } => {
+            // body_stage_id is the FROM stage (lex-store's StageId
+            // hash includes the symbol name, so rename produces two
+            // stages with different ids). Tightening the op enum to
+            // carry both is a small follow-up; until then, surface
+            // a clean error rather than silently corrupting state.
+            let _ = (from, to, body_stage_id);
+            Err(ApplyError::NotYetImplemented("RenameSymbol"))
+        }
+    }
+}
+
+fn apply_lifecycle(store: &Store, op: &Operation) -> Result<(), ApplyError> {
+    match &op.kind {
+        OperationKind::AddFunction { stage_id, .. }
+        | OperationKind::AddType { stage_id, .. } => {
+            store.activate(stage_id)?;
+        }
+        OperationKind::RemoveFunction { last_stage_id, .. }
+        | OperationKind::RemoveType { last_stage_id, .. } => {
+            // Lex-store enforces the lifecycle ordering Active →
+            // Deprecated → Tombstone (a direct Active→Tombstone is
+            // rejected). Step through Deprecated first so callers
+            // get the same end-state regardless of where they
+            // started.
+            if store.get_status(last_stage_id)? == lex_store::StageStatus::Active {
+                store.deprecate(last_stage_id, "removed")?;
+            }
+            store.tombstone(last_stage_id)?;
+        }
+        OperationKind::ModifyBody { to_stage_id, .. }
+        | OperationKind::ModifyType { to_stage_id, .. } => {
+            // `Store::activate` already demotes the current Active
+            // to Deprecated as part of the same lifecycle write —
+            // no separate `deprecate` call needed (and a redundant
+            // one would error with `Deprecated ⇒ Deprecated`).
+            store.activate(to_stage_id)?;
+        }
+        OperationKind::ChangeEffectSig {
+            from_stage_id, to_stage_id, from_effects, to_effects, ..
+        } => {
+            // Same single-call pattern as ModifyBody. The
+            // effect-set diff is captured in the `OperationRecord`
+            // for #130's write-time gate; we don't need to
+            // re-encode it as a deprecate reason on the old stage.
+            let _ = (from_stage_id, from_effects, to_effects);
+            store.activate(to_stage_id)?;
+        }
+        OperationKind::AddImport { .. } | OperationKind::RemoveImport { .. } => {
+            // No store-level mutation.
+        }
+        OperationKind::RenameSymbol { .. } => {
+            // Unreachable — `compute_transition` already returned
+            // NotYetImplemented and short-circuited.
+            return Err(ApplyError::NotYetImplemented("RenameSymbol"));
+        }
+    }
+    Ok(())
+}
+
+fn persist_record(store: &Store, record: &OperationRecord) -> Result<(), ApplyError> {
+    let dir = ops_dir(store);
+    fs::create_dir_all(&dir)?;
+    let path = dir.join(format!("{}.json", record.op_id));
+    let bytes = serde_json::to_vec_pretty(record)?;
+    fs::write(path, bytes)?;
+    Ok(())
+}
+
+/// Read an op record from disk. Returns `Ok(None)` if the file
+/// doesn't exist (the more common precondition than a bare error).
+pub fn load_record(store: &Store, op_id: &OpId) -> Result<Option<OperationRecord>, ApplyError> {
+    let path = ops_dir(store).join(format!("{op_id}.json"));
+    if !path.exists() {
+        return Ok(None);
+    }
+    let bytes = fs::read(path)?;
+    Ok(Some(serde_json::from_slice(&bytes)?))
+}
+
+fn ops_dir(store: &Store) -> PathBuf {
+    store.root().join("ops")
+}
+
+fn ensure_stage_present(store: &Store, stage_id: &StageId) -> Result<(), ApplyError> {
+    match store.get_ast(stage_id) {
+        Ok(_) => Ok(()),
+        Err(StoreError::UnknownStage(_)) => Err(ApplyError::StageMissing(stage_id.clone())),
+        Err(e) => Err(ApplyError::Store(e)),
+    }
+}
+
+fn ensure_no_active(store: &Store, sig_id: &SigId) -> Result<(), ApplyError> {
+    match store.resolve_sig(sig_id) {
+        Ok(Some(existing)) => Err(ApplyError::DuplicateAdd {
+            sig_id: sig_id.clone(),
+            existing,
+        }),
+        Ok(None) => Ok(()),
+        Err(StoreError::UnknownSig(_)) => Ok(()),
+        Err(e) => Err(ApplyError::Store(e)),
+    }
+}
+
+fn ensure_active_matches(
+    store: &Store,
+    sig_id: &SigId,
+    expected: &StageId,
+) -> Result<(), ApplyError> {
+    match store.resolve_sig(sig_id) {
+        Ok(Some(actual)) if &actual == expected => Ok(()),
+        Ok(Some(actual)) => Err(ApplyError::StaleParent {
+            sig_id: sig_id.clone(),
+            expected: expected.clone(),
+            actual,
+        }),
+        Ok(None) => Err(ApplyError::StaleParent {
+            sig_id: sig_id.clone(),
+            expected: expected.clone(),
+            actual: "<no active stage>".into(),
+        }),
+        Err(StoreError::UnknownSig(_)) => Err(ApplyError::StaleParent {
+            sig_id: sig_id.clone(),
+            expected: expected.clone(),
+            actual: "<unknown sig>".into(),
+        }),
+        Err(e) => Err(ApplyError::Store(e)),
+    }
+}
+

--- a/crates/lex-vcs/src/apply.rs
+++ b/crates/lex-vcs/src/apply.rs
@@ -149,14 +149,26 @@ pub fn compute_transition(
             // pass has no stage-level work to do.
             Ok(StageTransition::ImportOnly)
         }
-        OperationKind::RenameSymbol { from, to, body_stage_id } => {
-            // body_stage_id is the FROM stage (lex-store's StageId
-            // hash includes the symbol name, so rename produces two
-            // stages with different ids). Tightening the op enum to
-            // carry both is a small follow-up; until then, surface
-            // a clean error rather than silently corrupting state.
-            let _ = (from, to, body_stage_id);
-            Err(ApplyError::NotYetImplemented("RenameSymbol"))
+        OperationKind::RenameSymbol {
+            from_sig,
+            from_stage_id,
+            to_sig,
+            to_stage_id,
+        } => {
+            // The TO stage must already exist (caller `Store::publish`d
+            // it before applying); the FROM stage must currently be
+            // the active head for `from_sig`. The rename collapses
+            // both into a single causal event — `lex blame` walks
+            // it as one transition rather than `delete + add`.
+            ensure_stage_present(store, to_stage_id)?;
+            ensure_active_matches(store, from_sig, from_stage_id)?;
+            ensure_no_active(store, to_sig)?;
+            Ok(StageTransition::Rename {
+                from_sig: from_sig.clone(),
+                from_stage_id: from_stage_id.clone(),
+                to_sig: to_sig.clone(),
+                to_stage_id: to_stage_id.clone(),
+            })
         }
     }
 }
@@ -200,10 +212,15 @@ fn apply_lifecycle(store: &Store, op: &Operation) -> Result<(), ApplyError> {
         OperationKind::AddImport { .. } | OperationKind::RemoveImport { .. } => {
             // No store-level mutation.
         }
-        OperationKind::RenameSymbol { .. } => {
-            // Unreachable — `compute_transition` already returned
-            // NotYetImplemented and short-circuited.
-            return Err(ApplyError::NotYetImplemented("RenameSymbol"));
+        OperationKind::RenameSymbol { from_stage_id, to_stage_id, .. } => {
+            // Activate the new TO stage (no auto-deprecate kicks in
+            // because it has a different SigId than the FROM stage).
+            // Then walk the FROM stage Active → Deprecated → Tombstone
+            // since the rename retires it. The `from_stage_id` is
+            // guaranteed Active by the precondition check.
+            store.activate(to_stage_id)?;
+            store.deprecate(from_stage_id, "renamed")?;
+            store.tombstone(from_stage_id)?;
         }
     }
     Ok(())

--- a/crates/lex-vcs/src/lib.rs
+++ b/crates/lex-vcs/src/lib.rs
@@ -28,9 +28,11 @@
 //! mentions Blake3; if that becomes load-bearing for performance we
 //! can swap with a one-line crate change since `OpId` is opaque.
 
+mod apply;
 mod canonical;
 mod operation;
 
+pub use apply::{apply_operation, compute_transition, load_record, ApplyError};
 pub use operation::{
     EffectSet, ModuleRef, OpId, Operation, OperationRecord, OperationKind, SigId, StageId,
     StageTransition,

--- a/crates/lex-vcs/src/operation.rs
+++ b/crates/lex-vcs/src/operation.rs
@@ -49,8 +49,16 @@ pub enum StageTransition {
     Replace { sig_id: SigId, from: StageId, to: StageId },
     /// SigId removed; no head stage afterwards.
     Remove { sig_id: SigId, last: StageId },
-    /// SigId renamed; same body hash, different signature identity.
-    Rename { from: SigId, to: SigId, body_stage_id: StageId },
+    /// SigId renamed. Two stages produced with different `StageId`s
+    /// because the SigId hash includes the symbol name, even when
+    /// the body bytes are identical (the typical non-recursive
+    /// rename case).
+    Rename {
+        from_sig: SigId,
+        from_stage_id: StageId,
+        to_sig: SigId,
+        to_stage_id: StageId,
+    },
     /// Import-only change; doesn't touch any stage.
     ImportOnly,
 }
@@ -84,14 +92,18 @@ pub enum OperationKind {
         from_stage_id: StageId,
         to_stage_id: StageId,
     },
-    /// Symbol renamed. The body hash is preserved (`body_stage_id`)
-    /// so two renames of the same body collapse to the same OpId
-    /// and `lex blame` walks the rename as a single causal event
+    /// Symbol renamed. The body bytes are preserved (a non-recursive
+    /// rename produces the same `Stage` AST modulo the symbol name),
+    /// but the SigId hash includes the symbol name so the FROM and
+    /// TO stages have different `StageId`s. Both are recorded so
+    /// the apply pass can flip lifecycle state on each independently
+    /// and `lex blame` can walk the rename as a single causal event
     /// rather than `delete + add`.
     RenameSymbol {
-        from: SigId,
-        to: SigId,
-        body_stage_id: StageId,
+        from_sig: SigId,
+        from_stage_id: StageId,
+        to_sig: SigId,
+        to_stage_id: StageId,
     },
     /// Effect signature changed. Captures both old and new effect
     /// sets so the write-time gate (#130) can verify importers
@@ -271,15 +283,16 @@ mod tests {
     }
 
     #[test]
-    fn rename_with_same_body_hashes_equal_across_runs() {
+    fn rename_with_same_stages_hashes_equal_across_runs() {
         // Two independent runs producing the same rename against the
-        // same parent should produce the same OpId — this is the
+        // same parent should produce the same OpId — the
         // automatic-dedup property #129 relies on for distributed
         // agents.
         let kind = OperationKind::RenameSymbol {
-            from: "parse::Str->Int".into(),
-            to: "parse_int::Str->Int".into(),
-            body_stage_id: "abc123".into(),
+            from_sig: "parse::Str->Int".into(),
+            from_stage_id: "abc-from".into(),
+            to_sig: "parse_int::Str->Int".into(),
+            to_stage_id: "def-to".into(),
         };
         let a = Operation::new(kind.clone(), ["op-parent".into()]);
         let b = Operation::new(kind, ["op-parent".into()]);
@@ -293,23 +306,24 @@ mod tests {
         // AddFunction` pair. Causal history sees one event, not two.
         let rename = Operation::new(
             OperationKind::RenameSymbol {
-                from: "parse::Str->Int".into(),
-                to: "parse_int::Str->Int".into(),
-                body_stage_id: "abc123".into(),
+                from_sig: "parse::Str->Int".into(),
+                from_stage_id: "abc-from".into(),
+                to_sig: "parse_int::Str->Int".into(),
+                to_stage_id: "def-to".into(),
             },
             ["op-parent".into()],
         );
         let remove = Operation::new(
             OperationKind::RemoveFunction {
                 sig_id: "parse::Str->Int".into(),
-                last_stage_id: "abc123".into(),
+                last_stage_id: "abc-from".into(),
             },
             ["op-parent".into()],
         );
         let add = Operation::new(
             OperationKind::AddFunction {
                 sig_id: "parse_int::Str->Int".into(),
-                stage_id: "abc123".into(),
+                stage_id: "def-to".into(),
                 effects: BTreeSet::new(),
             },
             ["op-parent".into()],

--- a/crates/lex-vcs/tests/apply.rs
+++ b/crates/lex-vcs/tests/apply.rs
@@ -1,0 +1,347 @@
+//! Integration tests for the `lex-vcs` apply pass against a real
+//! `lex-store::Store` rooted in a tempdir. Each test publishes one
+//! or two real stages from parsed Lex source, applies an
+//! `Operation` against them, and verifies the resulting store
+//! state plus the persisted `OperationRecord`.
+
+use std::collections::BTreeSet;
+
+use lex_ast::{canonicalize_program, sig_id, Stage};
+use lex_store::{StageStatus, Store};
+use lex_syntax::parse_source;
+use lex_vcs::{
+    apply_operation, compute_transition, load_record, ApplyError, Operation, OperationKind,
+    StageTransition,
+};
+use tempfile::TempDir;
+
+fn one_stage(src: &str, name: &str) -> Stage {
+    let prog = parse_source(src).unwrap();
+    let stages = canonicalize_program(&prog);
+    stages
+        .into_iter()
+        .find(|s| match s {
+            Stage::FnDecl(fd) => fd.name == name,
+            Stage::TypeDecl(td) => td.name == name,
+            _ => false,
+        })
+        .expect("stage not found")
+}
+
+const ADD_V1: &str = "fn add(x :: Int, y :: Int) -> Int { x + y }\n";
+const ADD_V2: &str = "fn add(x :: Int, y :: Int) -> Int { y + x }\n";
+const FACTORIAL: &str =
+    "fn factorial(n :: Int) -> Int { match n { 0 => 1, _ => n * factorial(n - 1) } }\n";
+
+// ---- AddFunction --------------------------------------------------
+
+#[test]
+fn add_function_activates_published_stage_and_persists_record() {
+    let tmp = TempDir::new().unwrap();
+    let store = Store::open(tmp.path()).unwrap();
+    let s = one_stage(FACTORIAL, "factorial");
+    let stage = store.publish(&s).unwrap();
+    let sig = sig_id(&s).unwrap();
+
+    let op = Operation::new(
+        OperationKind::AddFunction {
+            sig_id: sig.clone(),
+            stage_id: stage.clone(),
+            effects: BTreeSet::new(),
+        },
+        [],
+    );
+    let expected_id = op.op_id();
+
+    let record = apply_operation(&store, op).expect("apply_operation");
+
+    assert_eq!(record.op_id, expected_id);
+    assert_eq!(
+        record.produces,
+        StageTransition::Create {
+            sig_id: sig.clone(),
+            stage_id: stage.clone(),
+        },
+    );
+    assert_eq!(store.get_status(&stage).unwrap(), StageStatus::Active);
+    assert_eq!(store.resolve_sig(&sig).unwrap(), Some(stage.clone()));
+
+    // Persisted under <root>/ops/<OpId>.json.
+    let on_disk = load_record(&store, &expected_id).expect("load_record").expect("record exists");
+    assert_eq!(on_disk, record);
+}
+
+#[test]
+fn add_function_against_existing_active_returns_duplicate_add() {
+    let tmp = TempDir::new().unwrap();
+    let store = Store::open(tmp.path()).unwrap();
+    let s = one_stage(FACTORIAL, "factorial");
+    let stage = store.publish(&s).unwrap();
+    let sig = sig_id(&s).unwrap();
+    store.activate(&stage).unwrap();
+
+    let op = Operation::new(
+        OperationKind::AddFunction {
+            sig_id: sig.clone(),
+            stage_id: stage.clone(),
+            effects: BTreeSet::new(),
+        },
+        [],
+    );
+    let expected_id = op.op_id();
+    let err = apply_operation(&store, op).expect_err("expected DuplicateAdd");
+    match err {
+        ApplyError::DuplicateAdd { sig_id: s, existing } => {
+            assert_eq!(s, sig);
+            assert_eq!(existing, stage);
+        }
+        other => panic!("expected DuplicateAdd, got {other:?}"),
+    }
+    // No record persisted on the failure path.
+    assert!(load_record(&store, &expected_id).unwrap().is_none());
+}
+
+#[test]
+fn add_function_against_unpublished_stage_returns_stage_missing() {
+    let tmp = TempDir::new().unwrap();
+    let store = Store::open(tmp.path()).unwrap();
+    let op = Operation::new(
+        OperationKind::AddFunction {
+            sig_id: "nonexistent::Int->Int".into(),
+            stage_id: "fakestage123".into(),
+            effects: BTreeSet::new(),
+        },
+        [],
+    );
+    let err = apply_operation(&store, op).expect_err("expected StageMissing");
+    assert!(matches!(err, ApplyError::StageMissing(s) if s == "fakestage123"));
+}
+
+// ---- ModifyBody ---------------------------------------------------
+
+#[test]
+fn modify_body_swaps_active_head() {
+    let tmp = TempDir::new().unwrap();
+    let store = Store::open(tmp.path()).unwrap();
+
+    let v1 = one_stage(ADD_V1, "add");
+    let v2 = one_stage(ADD_V2, "add");
+    let id1 = store.publish(&v1).unwrap();
+    let id2 = store.publish(&v2).unwrap();
+    let sig = sig_id(&v1).unwrap();
+
+    // Bring v1 to Active.
+    store.activate(&id1).unwrap();
+    assert_eq!(store.resolve_sig(&sig).unwrap(), Some(id1.clone()));
+
+    // Now apply ModifyBody to swap to v2.
+    let op = Operation::new(
+        OperationKind::ModifyBody {
+            sig_id: sig.clone(),
+            from_stage_id: id1.clone(),
+            to_stage_id: id2.clone(),
+        },
+        [],
+    );
+    let record = apply_operation(&store, op).expect("apply");
+
+    assert_eq!(
+        record.produces,
+        StageTransition::Replace {
+            sig_id: sig.clone(),
+            from: id1.clone(),
+            to: id2.clone(),
+        },
+    );
+    assert_eq!(store.resolve_sig(&sig).unwrap(), Some(id2.clone()));
+    assert_eq!(store.get_status(&id1).unwrap(), StageStatus::Deprecated);
+    assert_eq!(store.get_status(&id2).unwrap(), StageStatus::Active);
+}
+
+#[test]
+fn modify_body_with_stale_parent_is_rejected() {
+    let tmp = TempDir::new().unwrap();
+    let store = Store::open(tmp.path()).unwrap();
+
+    let v1 = one_stage(ADD_V1, "add");
+    let v2 = one_stage(ADD_V2, "add");
+    let id1 = store.publish(&v1).unwrap();
+    let id2 = store.publish(&v2).unwrap();
+    let sig = sig_id(&v1).unwrap();
+    store.activate(&id1).unwrap();
+
+    // Submit a ModifyBody whose `from` doesn't match the current
+    // active head — simulates a concurrent writer that already
+    // moved to v2.
+    let op = Operation::new(
+        OperationKind::ModifyBody {
+            sig_id: sig.clone(),
+            from_stage_id: "wrong-parent-id".into(),
+            to_stage_id: id2.clone(),
+        },
+        [],
+    );
+    let err = apply_operation(&store, op).expect_err("expected StaleParent");
+    match err {
+        ApplyError::StaleParent { sig_id: s, expected, actual } => {
+            assert_eq!(s, sig);
+            assert_eq!(expected, "wrong-parent-id");
+            assert_eq!(actual, id1);
+        }
+        other => panic!("expected StaleParent, got {other:?}"),
+    }
+    // Active head is unchanged.
+    assert_eq!(store.resolve_sig(&sig).unwrap(), Some(id1));
+}
+
+// ---- ChangeEffectSig ---------------------------------------------
+
+#[test]
+fn change_effect_sig_records_old_and_new_effects() {
+    // Same store-level effect as ModifyBody (activate new, deprecate
+    // old), but the OperationRecord retains the effect-set diff so
+    // the future write-time gate (#130) can verify importers.
+    let tmp = TempDir::new().unwrap();
+    let store = Store::open(tmp.path()).unwrap();
+    let v1 = one_stage(ADD_V1, "add");
+    let v2 = one_stage(ADD_V2, "add");
+    let id1 = store.publish(&v1).unwrap();
+    let id2 = store.publish(&v2).unwrap();
+    let sig = sig_id(&v1).unwrap();
+    store.activate(&id1).unwrap();
+
+    let mut new_effects = BTreeSet::new();
+    new_effects.insert("io".to_string());
+
+    let op = Operation::new(
+        OperationKind::ChangeEffectSig {
+            sig_id: sig.clone(),
+            from_stage_id: id1.clone(),
+            to_stage_id: id2.clone(),
+            from_effects: BTreeSet::new(),
+            to_effects: new_effects.clone(),
+        },
+        [],
+    );
+    let record = apply_operation(&store, op).expect("apply");
+    assert_eq!(
+        record.produces,
+        StageTransition::Replace { sig_id: sig.clone(), from: id1, to: id2 },
+    );
+
+    // The OperationRecord on disk preserves the effect diff.
+    let on_disk = load_record(&store, &record.op_id).unwrap().unwrap();
+    match on_disk.op.kind {
+        OperationKind::ChangeEffectSig { from_effects, to_effects, .. } => {
+            assert!(from_effects.is_empty());
+            assert_eq!(to_effects, new_effects);
+        }
+        other => panic!("expected ChangeEffectSig, got {other:?}"),
+    }
+}
+
+// ---- RemoveFunction ----------------------------------------------
+
+#[test]
+fn remove_function_tombstones_the_active_head() {
+    let tmp = TempDir::new().unwrap();
+    let store = Store::open(tmp.path()).unwrap();
+    let s = one_stage(FACTORIAL, "factorial");
+    let stage = store.publish(&s).unwrap();
+    let sig = sig_id(&s).unwrap();
+    store.activate(&stage).unwrap();
+
+    let op = Operation::new(
+        OperationKind::RemoveFunction {
+            sig_id: sig.clone(),
+            last_stage_id: stage.clone(),
+        },
+        [],
+    );
+    let record = apply_operation(&store, op).expect("apply");
+    assert_eq!(
+        record.produces,
+        StageTransition::Remove { sig_id: sig.clone(), last: stage.clone() },
+    );
+    assert_eq!(store.get_status(&stage).unwrap(), StageStatus::Tombstone);
+    // After tombstoning, resolve_sig has no Active head.
+    assert_eq!(store.resolve_sig(&sig).unwrap(), None);
+}
+
+// ---- AddImport / RemoveImport ------------------------------------
+
+#[test]
+fn add_import_persists_record_without_touching_stages() {
+    let tmp = TempDir::new().unwrap();
+    let store = Store::open(tmp.path()).unwrap();
+    let op = Operation::new(
+        OperationKind::AddImport {
+            in_file: "src/main.lex".into(),
+            module: "std.io".into(),
+        },
+        [],
+    );
+    let record = apply_operation(&store, op).expect("apply");
+    assert_eq!(record.produces, StageTransition::ImportOnly);
+    assert!(load_record(&store, &record.op_id).unwrap().is_some());
+    // No stages directory should have been created.
+    let stages_dir = tmp.path().join("stages");
+    let entries: Vec<_> = std::fs::read_dir(&stages_dir)
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    assert!(entries.is_empty(), "no stage directories should be created");
+}
+
+// ---- RenameSymbol (deferred) -------------------------------------
+
+#[test]
+fn rename_symbol_returns_not_yet_implemented() {
+    // Documented limitation: the op enum carries a single
+    // `body_stage_id`, but lex-store's StageId hash includes the
+    // symbol name, so a rename involves two stages with different
+    // ids. Tightening the op enum is a follow-up; until then the
+    // apply pass surfaces a clean error rather than silently
+    // corrupting state.
+    let tmp = TempDir::new().unwrap();
+    let store = Store::open(tmp.path()).unwrap();
+    let op = Operation::new(
+        OperationKind::RenameSymbol {
+            from: "parse::Str->Int".into(),
+            to: "parse_int::Str->Int".into(),
+            body_stage_id: "abc123".into(),
+        },
+        [],
+    );
+    let err = apply_operation(&store, op).expect_err("expected NotYetImplemented");
+    assert!(matches!(err, ApplyError::NotYetImplemented("RenameSymbol")));
+}
+
+// ---- compute_transition (preview / dry-run) ----------------------
+
+#[test]
+fn compute_transition_does_not_mutate_the_store() {
+    let tmp = TempDir::new().unwrap();
+    let store = Store::open(tmp.path()).unwrap();
+    let s = one_stage(FACTORIAL, "factorial");
+    let stage = store.publish(&s).unwrap();
+    let sig = sig_id(&s).unwrap();
+
+    let op = Operation::new(
+        OperationKind::AddFunction {
+            sig_id: sig.clone(),
+            stage_id: stage.clone(),
+            effects: BTreeSet::new(),
+        },
+        [],
+    );
+    let preview = compute_transition(&store, &op).expect("preview");
+    assert_eq!(
+        preview,
+        StageTransition::Create { sig_id: sig.clone(), stage_id: stage.clone() },
+    );
+    // The published stage is still Draft, not Active.
+    assert_eq!(store.get_status(&stage).unwrap(), StageStatus::Draft);
+    // No op record should be persisted by a preview.
+    assert!(load_record(&store, &op.op_id()).unwrap().is_none());
+}

--- a/crates/lex-vcs/tests/apply.rs
+++ b/crates/lex-vcs/tests/apply.rs
@@ -293,28 +293,153 @@ fn add_import_persists_record_without_touching_stages() {
     assert!(entries.is_empty(), "no stage directories should be created");
 }
 
-// ---- RenameSymbol (deferred) -------------------------------------
+// ---- RenameSymbol ------------------------------------------------
+
+// Recursive functions get distinct StageIds across renames because
+// the call-site references the new name (lex-store §4.6 acceptance).
+// Use them so `from_stage_id` and `to_stage_id` are guaranteed
+// distinct and `Store::activate` is unambiguous about which
+// (sig, stage) pair it's flipping.
+const FAC_FROM: &str =
+    "fn fac(n :: Int) -> Int { match n { 0 => 1, _ => n * fac(n - 1) } }\n";
+const FAC_TO: &str =
+    "fn factorial(n :: Int) -> Int { match n { 0 => 1, _ => n * factorial(n - 1) } }\n";
 
 #[test]
-fn rename_symbol_returns_not_yet_implemented() {
-    // Documented limitation: the op enum carries a single
-    // `body_stage_id`, but lex-store's StageId hash includes the
-    // symbol name, so a rename involves two stages with different
-    // ids. Tightening the op enum is a follow-up; until then the
-    // apply pass surfaces a clean error rather than silently
-    // corrupting state.
+fn rename_symbol_retires_from_sig_and_activates_to_sig() {
+    // Recursive rename: the body's `fac(n - 1)` becomes
+    // `factorial(n - 1)`, so the body bytes differ and the two
+    // stages have distinct StageIds. The apply walks the rename
+    // as a single causal event nonetheless.
     let tmp = TempDir::new().unwrap();
     let store = Store::open(tmp.path()).unwrap();
+    let s_from = one_stage(FAC_FROM, "fac");
+    let s_to = one_stage(FAC_TO, "factorial");
+    let from_sig = sig_id(&s_from).unwrap();
+    let to_sig = sig_id(&s_to).unwrap();
+    assert_ne!(from_sig, to_sig, "SigId includes the symbol name");
+    let from_stage = store.publish(&s_from).unwrap();
+    let to_stage = store.publish(&s_to).unwrap();
+    assert_ne!(
+        from_stage, to_stage,
+        "recursive rename produces distinct StageIds",
+    );
+    store.activate(&from_stage).unwrap();
+
     let op = Operation::new(
         OperationKind::RenameSymbol {
-            from: "parse::Str->Int".into(),
-            to: "parse_int::Str->Int".into(),
-            body_stage_id: "abc123".into(),
+            from_sig: from_sig.clone(),
+            from_stage_id: from_stage.clone(),
+            to_sig: to_sig.clone(),
+            to_stage_id: to_stage.clone(),
         },
         [],
     );
-    let err = apply_operation(&store, op).expect_err("expected NotYetImplemented");
-    assert!(matches!(err, ApplyError::NotYetImplemented("RenameSymbol")));
+    let record = apply_operation(&store, op).expect("apply rename");
+    assert_eq!(
+        record.produces,
+        StageTransition::Rename {
+            from_sig: from_sig.clone(),
+            from_stage_id: from_stage.clone(),
+            to_sig: to_sig.clone(),
+            to_stage_id: to_stage.clone(),
+        },
+    );
+
+    // FROM sig retired; TO sig now Active.
+    assert_eq!(store.resolve_sig(&from_sig).unwrap(), None);
+    assert_eq!(store.resolve_sig(&to_sig).unwrap(), Some(to_stage.clone()));
+    // FROM stage walked Active → Deprecated → Tombstone in one apply.
+    assert_eq!(store.get_status(&from_stage).unwrap(), StageStatus::Tombstone);
+    assert_eq!(store.get_status(&to_stage).unwrap(), StageStatus::Active);
+}
+
+#[test]
+fn rename_symbol_with_stale_from_is_rejected() {
+    let tmp = TempDir::new().unwrap();
+    let store = Store::open(tmp.path()).unwrap();
+    let s_to = one_stage(FAC_TO, "factorial");
+    let to_sig = sig_id(&s_to).unwrap();
+    let to_stage = store.publish(&s_to).unwrap();
+
+    let op = Operation::new(
+        OperationKind::RenameSymbol {
+            from_sig: "nonexistent::Int,Int->Int".into(),
+            from_stage_id: "wrong-from".into(),
+            to_sig,
+            to_stage_id: to_stage,
+        },
+        [],
+    );
+    let err = apply_operation(&store, op).expect_err("expected StaleParent");
+    assert!(matches!(err, ApplyError::StaleParent { .. }));
+}
+
+#[test]
+fn rename_symbol_against_an_already_active_to_sig_is_rejected() {
+    // If the TO sig already has an active stage, the rename would
+    // collide — surface as DuplicateAdd rather than silently
+    // overwriting.
+    let tmp = TempDir::new().unwrap();
+    let store = Store::open(tmp.path()).unwrap();
+    let s_from = one_stage(FAC_FROM, "fac");
+    let s_to = one_stage(FAC_TO, "factorial");
+    let from_sig = sig_id(&s_from).unwrap();
+    let to_sig = sig_id(&s_to).unwrap();
+    let from_stage = store.publish(&s_from).unwrap();
+    let to_stage = store.publish(&s_to).unwrap();
+    store.activate(&from_stage).unwrap();
+    store.activate(&to_stage).unwrap();
+
+    let op = Operation::new(
+        OperationKind::RenameSymbol {
+            from_sig,
+            from_stage_id: from_stage,
+            to_sig,
+            to_stage_id: to_stage,
+        },
+        [],
+    );
+    let err = apply_operation(&store, op).expect_err("expected DuplicateAdd");
+    assert!(matches!(err, ApplyError::DuplicateAdd { .. }));
+}
+
+#[test]
+fn rename_symbol_op_record_persists_with_correct_transition() {
+    let tmp = TempDir::new().unwrap();
+    let store = Store::open(tmp.path()).unwrap();
+    let s_from = one_stage(FAC_FROM, "fac");
+    let s_to = one_stage(FAC_TO, "factorial");
+    let from_sig = sig_id(&s_from).unwrap();
+    let to_sig = sig_id(&s_to).unwrap();
+    let from_stage = store.publish(&s_from).unwrap();
+    let to_stage = store.publish(&s_to).unwrap();
+    store.activate(&from_stage).unwrap();
+
+    let op = Operation::new(
+        OperationKind::RenameSymbol {
+            from_sig: from_sig.clone(),
+            from_stage_id: from_stage.clone(),
+            to_sig: to_sig.clone(),
+            to_stage_id: to_stage.clone(),
+        },
+        [],
+    );
+    let expected_id = op.op_id();
+    let record = apply_operation(&store, op).expect("apply");
+    let on_disk = load_record(&store, &expected_id).unwrap().unwrap();
+    assert_eq!(on_disk, record);
+    match on_disk.op.kind {
+        OperationKind::RenameSymbol {
+            from_sig: f, from_stage_id: fs, to_sig: t, to_stage_id: ts,
+        } => {
+            assert_eq!(f, from_sig);
+            assert_eq!(fs, from_stage);
+            assert_eq!(t, to_sig);
+            assert_eq!(ts, to_stage);
+        }
+        other => panic!("expected RenameSymbol, got {other:?}"),
+    }
 }
 
 // ---- compute_transition (preview / dry-run) ----------------------


### PR DESCRIPTION
## Summary

Stacks on **#136** (the apply pass for the other 9 op kinds — currently in CI). Closes the known limitation flagged in #136's description: `RenameSymbol`'s op enum couldn't represent the recursive-rename case where call-site references to the new name produce distinct stage hashes (the same StageId-includes-symbol-name property that lex-store §4.6 documents).

> **Stack note**: until #136 merges, the diff shown here includes the apply-pass commit. Once #136 lands, this PR's diff will collapse to just the rename work after a rebase.

## Op enum tightening

`RenameSymbol` and `StageTransition::Rename` both now carry separate `from_sig` / `from_stage_id` / `to_sig` / `to_stage_id`. The single-`body_stage_id` shape was a hand-wave that worked for non-recursive renames (where body bytes don't include the symbol name, so FROM and TO share a StageId) but couldn't represent the recursive case at all.

Breaking change to the op enum, but no external code uses `RenameSymbol` yet — doing it now means the data model is fully shipped and the next slice (`diff_to_ops` + CLI surface) builds on a stable shape.

## Apply behavior

```text
RenameSymbol { from_sig, from_stage_id, to_sig, to_stage_id }
  ⇒ activate(to_stage_id);
    deprecate(from_stage_id, "renamed");
    tombstone(from_stage_id);
```

`lex blame` walks the rename as a single causal event rather than `delete + add`. Preconditions:
- TO stage must already exist (`Store::publish` first).
- FROM stage must currently be the active head for FROM sig.
- TO sig must NOT already have an active stage (otherwise `DuplicateAdd`, since the rename would silently overwrite).

## Test plan

- [x] `cargo test -p lex-vcs` — 28/28 pass (15 unit + 13 integration; +3 net new since #136 by removing the `NotYetImplemented` stub and adding 4 rename tests).
- [x] `cargo test --workspace` — 540/540 pass (537 → 540).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.

The four new rename tests use recursive `fac` / `factorial` so the FROM and TO stages have distinct hashes (the lex-store §4.6 non-recursive-rename body-collapse case is documented but not what we want to exercise here):
- happy path: retires FROM sig, activates TO sig, FROM stage walks Active → Deprecated → Tombstone in one apply
- stale-from rejection
- duplicate-add rejection (TO sig already active)
- record-persistence round-trip

Refs #129. With this in, #129's data model + apply pass are complete; remaining slices are `diff_to_ops`, the CLI surface, the `lex publish` refactor, and `lex store migrate v1→v2`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRXRypmTju3ShcQ3ERJQSu)_