### PR TITLE
feat: lex-vcs write-time type-check gate (#130)

### DIFF
--- a/crates/lex-vcs/Cargo.toml
+++ b/crates/lex-vcs/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 lex-ast = { path = "../lex-ast" }
+lex-types = { path = "../lex-types" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/lex-vcs/src/gate.rs
+++ b/crates/lex-vcs/src/gate.rs
@@ -1,0 +1,206 @@
+//! Write-time type-check gate (#130).
+//!
+//! Wraps [`apply`](crate::apply::apply) with a type-checker pass.
+//! When this gate is the only path that advances a branch head,
+//! the store's invariant becomes "every accepted operation
+//! produces a program that typechecks." The cascading-breakage
+//! failure mode that breaks agentic workflows — agent A commits a
+//! typing-broken stage, agent B reads it and builds work
+//! assuming the broken stage, hours pass, CI catches the bug —
+//! becomes impossible by construction.
+//!
+//! Effect violations surface here too: `lex-types::check_program`
+//! reports an undeclared-effect call as a `TypeError` variant, so
+//! a single rejection envelope covers both type and effect bugs.
+//!
+//! ## Performance
+//!
+//! The gate runs `lex_types::check_program` against the *candidate*
+//! program — the sequence of `Stage`s that would exist after the
+//! op is applied. Computing that sequence is the caller's job
+//! (typically `Store::publish_program`, which already has it in
+//! memory). The gate itself does not load anything from disk; it
+//! just runs the type checker.
+//!
+//! Performance budget from #130: <50 ms p99 for a single-function
+//! op on a 1000-stage store. This module doesn't validate that —
+//! the budget belongs to the caller's candidate-assembly path
+//! plus `lex_types::check_program`. We'll measure once the gate
+//! is wired into a real `Store::publish_program` flow.
+
+use lex_ast::Stage;
+use lex_types::{check_program, TypeError};
+
+use crate::apply::{apply, ApplyError, NewHead};
+use crate::op_log::OpLog;
+use crate::operation::{OpId, Operation, StageTransition};
+
+#[derive(Debug, thiserror::Error)]
+pub enum GateError {
+    /// The operation's parent or merge structure is wrong.
+    /// Pass-through from [`ApplyError`]; same shape so callers
+    /// already handling stale-parent / unknown-merge-parent on the
+    /// raw apply path can keep their existing match arms.
+    #[error(transparent)]
+    Apply(#[from] ApplyError),
+    /// The candidate program — i.e. the state that would exist
+    /// after applying the op — doesn't typecheck. The op is *not*
+    /// persisted; the branch head is unchanged.
+    ///
+    /// `op_id` is the would-be op_id (computed before the apply
+    /// path persisted anything). Lets callers correlate the
+    /// rejection with the op they submitted, even though no
+    /// `<root>/ops/<op_id>.json` file exists.
+    ///
+    /// `errors` is the structured envelope `lex check` already
+    /// emits. Effect violations show up here as a `TypeError`
+    /// variant; the gate doesn't model them as a separate kind
+    /// because the type checker doesn't either.
+    #[error("type errors after applying op {op_id}: {} error(s)", errors.len())]
+    TypeError {
+        op_id: OpId,
+        errors: Vec<TypeError>,
+    },
+}
+
+/// Apply an operation only if the resulting candidate program
+/// typechecks. Otherwise return [`GateError::TypeError`] with the
+/// structured error envelope; nothing is persisted.
+///
+/// `candidate` is the sequence of `Stage`s that would exist after
+/// the op is applied. The caller computes it — typically by
+/// applying the op's [`StageTransition`] to the program it just
+/// loaded from source. The gate does not assemble it from the
+/// store; the cost of "load every stage" is on the caller, where
+/// it can be amortized across the full publish flow.
+pub fn check_and_apply(
+    op_log: &OpLog,
+    head_op: Option<&OpId>,
+    op: Operation,
+    transition: StageTransition,
+    candidate: &[Stage],
+) -> Result<NewHead, GateError> {
+    if let Err(errors) = check_program(candidate) {
+        return Err(GateError::TypeError {
+            op_id: op.op_id(),
+            errors,
+        });
+    }
+    Ok(apply(op_log, head_op, op, transition)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::operation::OperationKind;
+    use std::collections::BTreeSet;
+
+    fn fac_op_and_transition() -> (Operation, StageTransition) {
+        let op = Operation::new(
+            OperationKind::AddFunction {
+                sig_id: "fac".into(),
+                stage_id: "s1".into(),
+                effects: BTreeSet::new(),
+            },
+            [],
+        );
+        let t = StageTransition::Create {
+            sig_id: "fac".into(),
+            stage_id: "s1".into(),
+        };
+        (op, t)
+    }
+
+    fn parse(src: &str) -> Vec<Stage> {
+        let prog = lex_syntax::parse_source(src).expect("parse");
+        lex_ast::canonicalize_program(&prog)
+    }
+
+    #[test]
+    fn clean_program_is_accepted_and_persisted() {
+        let tmp = tempfile::tempdir().unwrap();
+        let log = OpLog::open(tmp.path()).unwrap();
+        let candidate = parse(
+            "fn factorial(n :: Int) -> Int { match n { 0 => 1, _ => n * factorial(n - 1) } }\n",
+        );
+        let (op, t) = fac_op_and_transition();
+        let head = check_and_apply(&log, None, op, t, &candidate).unwrap();
+        assert!(log.get(&head.op_id).unwrap().is_some());
+    }
+
+    #[test]
+    fn type_error_is_rejected_and_nothing_persisted() {
+        let tmp = tempfile::tempdir().unwrap();
+        let log = OpLog::open(tmp.path()).unwrap();
+        // `not_defined` is referenced but never declared — the type
+        // checker emits an `UnknownIdentifier` error.
+        let candidate =
+            parse("fn broken(x :: Int) -> Int { not_defined(x) }\n");
+        let (op, t) = fac_op_and_transition();
+        let expected_op_id = op.op_id();
+        let err = check_and_apply(&log, None, op, t, &candidate)
+            .expect_err("expected TypeError");
+        match err {
+            GateError::TypeError { op_id, errors } => {
+                assert_eq!(op_id, expected_op_id);
+                assert!(!errors.is_empty(), "expected at least one TypeError");
+            }
+            other => panic!("expected TypeError, got {other:?}"),
+        }
+        // The op record was NOT persisted on the rejection path —
+        // the store's "always-valid HEAD" invariant holds.
+        assert!(log.get(&expected_op_id).unwrap().is_none());
+    }
+
+    #[test]
+    fn arity_mismatch_is_rejected() {
+        // Calling `add` with one arg when it takes two should
+        // produce an `ArityMismatch`. Verifies that several
+        // `TypeError` variants flow through the gate, not just
+        // unknown-identifier.
+        let tmp = tempfile::tempdir().unwrap();
+        let log = OpLog::open(tmp.path()).unwrap();
+        let candidate = parse(
+            "fn add(x :: Int, y :: Int) -> Int { x + y }\nfn caller() -> Int { add(1) }\n",
+        );
+        let (op, t) = fac_op_and_transition();
+        let err = check_and_apply(&log, None, op, t, &candidate)
+            .expect_err("expected TypeError");
+        assert!(matches!(err, GateError::TypeError { .. }));
+    }
+
+    #[test]
+    fn parent_check_still_runs_when_program_is_clean() {
+        // Pass a clean candidate but a stale-parent op. The gate
+        // shouldn't accept it just because typechecking passed —
+        // structural rejection still wins.
+        let tmp = tempfile::tempdir().unwrap();
+        let log = OpLog::open(tmp.path()).unwrap();
+        let candidate = parse(
+            "fn factorial(n :: Int) -> Int { match n { 0 => 1, _ => n * factorial(n - 1) } }\n",
+        );
+        // First op lands cleanly so head_op is set.
+        let (op1, t1) = fac_op_and_transition();
+        let head1 = check_and_apply(&log, None, op1, t1, &candidate).unwrap();
+        // Second op declares a wrong parent.
+        let bogus = Operation::new(
+            OperationKind::ModifyBody {
+                sig_id: "fac".into(),
+                from_stage_id: "s1".into(),
+                to_stage_id: "s2".into(),
+            },
+            ["someone-else".into()],
+        );
+        let t = StageTransition::Replace {
+            sig_id: "fac".into(),
+            from: "s1".into(),
+            to: "s2".into(),
+        };
+        let err = check_and_apply(&log, Some(&head1.op_id), bogus, t, &candidate)
+            .expect_err("expected Apply(StaleParent)");
+        match err {
+            GateError::Apply(ApplyError::StaleParent { .. }) => {}
+            other => panic!("expected Apply(StaleParent), got {other:?}"),
+        }
+    }
+}

--- a/crates/lex-vcs/src/lib.rs
+++ b/crates/lex-vcs/src/lib.rs
@@ -33,6 +33,7 @@ mod canonical;
 mod compute_diff;
 pub mod diff_report;
 mod diff_to_ops;
+mod gate;
 mod merge;
 mod op_log;
 mod operation;
@@ -41,6 +42,7 @@ pub use apply::{apply, ApplyError, NewHead};
 pub use compute_diff::{compute_diff, effect_label, render_signature};
 pub use diff_report::DiffReport;
 pub use diff_to_ops::{diff_to_ops, DiffInputs, DiffMappingError, ImportMap};
+pub use gate::{check_and_apply, GateError};
 pub use merge::{merge, ConflictKind, MergeOutcome, MergeOutput};
 pub use op_log::OpLog;
 pub use operation::{


### PR DESCRIPTION
## Summary

Stacks on **#138** (the operation-log foundation). Adds the write-time type-check gate that closes the cascading-breakage failure mode flagged in #128's tier-2 design.

```rust
pub fn check_and_apply(
    op_log: &OpLog,
    head_op: Option<&OpId>,
    op: Operation,
    transition: StageTransition,
    candidate: &[Stage],
) -> Result<NewHead, GateError>;

pub enum GateError {
    Apply(ApplyError),               // pass-through: parent / merge structure
    TypeError {                      // candidate state didn't typecheck
        op_id: OpId,
        errors: Vec<TypeError>,
    },
}
```

The gate runs `lex_types::check_program` against the candidate program *before* persisting the op record. On a type or effect error it returns the structured envelope `lex check` already emits and the branch head is unchanged. When this becomes the only path that advances a head, the store's invariant becomes **every accepted operation produces a program that typechecks** — agent A can't commit a typing-broken stage that breaks agent B's later work.

## Design choices worth flagging in review

- **Caller passes the candidate; gate doesn't reconstruct it.** Trade-off: more cognitive load on callers, but avoids the "load every stage from disk on every write" cost. For the publish path this is free since the candidate is the in-memory program. Keeps the <50ms p99 budget I flagged in #128 review reachable.
- **One rejection variant for type *and* effect errors.** The issue spec lists `TypeError` and `EffectViolation` separately, but `lex_types::check_program` returns both under the `TypeError` enum (`UnknownIdentifier`, `ArityMismatch`, undeclared-effect, …). Mirroring that single envelope is cleaner than splitting at the gate boundary.
- **No store integration in this PR.** Adds the gate function only. Wiring it into `Store::publish_program` so it becomes the only branch-advance path is the "always-valid HEAD" claim — but it's a behavior change that deserves its own review. Splitting keeps each PR small and reviewable.

## Test plan

- [x] `cargo test -p lex-vcs gate` — 4/4 pass:
  - clean program accepted, op record persisted
  - `UnknownIdentifier` rejected, `op_id` matches the would-be id, nothing persisted
  - `ArityMismatch` rejected (verifies multiple variants flow, not just the first)
  - structural `Apply(StaleParent)` still wins when the candidate types-check but parents are wrong
- [x] `cargo test --workspace` — 564/564 pass (560 → 564).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Out of scope (deferred)

- Wiring the gate into `Store::publish_program` so it's the only branch-advance path. Separate PR; behavior change.
- HTTP API rejection envelope (`POST /v1/publish` → 422 with structured `TypeError`). Separate PR.
- Performance validation against a real ~1000-stage store. Validate once the gate is on the publish path and we have a representative store.
- Effect-specific error variants if `lex-types` ever splits them out from `TypeError`. The gate's rejection shape would need to gain a variant; not blocking for v1.

Refs #130. Foundation for the rest of tier-2 (#131-#134).

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRXRypmTju3ShcQ3ERJQSu)_