### PR TITLE
feat: lex-vcs Intent — first-class provenance for ops (#131)

### DIFF
--- a/crates/lex-vcs/src/intent.rs
+++ b/crates/lex-vcs/src/intent.rs
@@ -1,0 +1,374 @@
+//! First-class `Intent` object linked to operations (#131).
+//!
+//! Today the op log records *what* changed (typed deltas on the
+//! AST). Intent captures *why* — the prompt that caused an agent
+//! to make the change, the model that interpreted it, and the
+//! session that grouped it with sibling ops.
+//!
+//! This matters for two reasons:
+//! 1. **Audit.** When an agent commits a regression, the maintainer
+//!    needs the prompt that led to it. The commit message can be
+//!    made up; the prompt is the actual causal event.
+//! 2. **Coordination.** When multiple agents work in parallel,
+//!    knowing which operations belong to which intent lets the
+//!    harness group them — agent A's work on intent-X is
+//!    independent of agent B's work on intent-Y.
+//!
+//! # Identity
+//!
+//! [`IntentId`] is the SHA-256 of the canonical form of
+//! `(prompt, session_id, model, parent_intent)` — `created_at` is
+//! deliberately *not* part of the hash, so two runs of the same
+//! prompt at different times still dedupe. The
+//! "same `(prompt, model, session)` → same `intent_id`" invariant
+//! is what #131's audit story rests on.
+//!
+//! # Storage
+//!
+//! `<root>/intents/<IntentId>.json` — same shape as `<root>/ops/`
+//! and `<root>/stages/`. Atomic writes via tempfile + rename;
+//! idempotent on existing IDs.
+//!
+//! # Privacy boundary
+//!
+//! Prompts may contain sensitive data. Keeping intents in their
+//! own addressable namespace (rather than inlining the prompt on
+//! every op) makes per-intent ACLs tractable as a follow-up
+//! without touching the op log itself.
+
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::canonical;
+
+/// Content-addressed identity of an intent. Lowercase-hex SHA-256
+/// of the canonical form of `(prompt, session_id, model,
+/// parent_intent)`. Excludes `created_at` so two runs of the same
+/// prompt produce the same id.
+pub type IntentId = String;
+
+/// Groups intents from the same agent session. Free-form string
+/// so callers can use whatever session model their harness has.
+pub type SessionId = String;
+
+/// Which model produced the intent. Tracked so audit / blame can
+/// answer "what model wrote this?" without joining against an
+/// external table.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModelDescriptor {
+    /// Vendor / origin: `"anthropic"`, `"openai"`, `"local"`, etc.
+    pub provider: String,
+    /// The model name: `"claude-opus-4-7"`, `"gpt-5"`, etc.
+    pub name: String,
+    /// Optional version pin. `None` means "whatever the provider
+    /// served"; `Some("2026-04-01")` lets the harness record an
+    /// exact API revision.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+}
+
+/// The persisted intent. Carries the prompt that caused some
+/// operations to be produced, the model that interpreted it, and
+/// the session that grouped them. Many ops can share one intent;
+/// duplicating the prompt on each would be wasteful and break the
+/// "two equal ops hash equal" invariant.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Intent {
+    pub intent_id: IntentId,
+    pub prompt: String,
+    pub session_id: SessionId,
+    pub model: ModelDescriptor,
+    /// For refinement chains ("the user said X, then said 'now also
+    /// handle Y'"). `None` for top-level intents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_intent: Option<IntentId>,
+    /// Wall-clock seconds since epoch when this intent was first
+    /// created. Excluded from `intent_id` so the dedup property
+    /// holds across runs.
+    pub created_at: u64,
+}
+
+impl Intent {
+    /// Build an intent and compute its content-addressed id.
+    /// `created_at` is filled in from the current wall clock; pass
+    /// to [`Intent::with_timestamp`] if you want to control it
+    /// explicitly (e.g. in tests).
+    pub fn new(
+        prompt: impl Into<String>,
+        session_id: impl Into<SessionId>,
+        model: ModelDescriptor,
+        parent_intent: Option<IntentId>,
+    ) -> Self {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        Self::with_timestamp(prompt, session_id, model, parent_intent, now)
+    }
+
+    /// Build an intent with a caller-controlled `created_at`. Used
+    /// in tests to keep golden hashes stable; production code uses
+    /// [`Intent::new`].
+    pub fn with_timestamp(
+        prompt: impl Into<String>,
+        session_id: impl Into<SessionId>,
+        model: ModelDescriptor,
+        parent_intent: Option<IntentId>,
+        created_at: u64,
+    ) -> Self {
+        let prompt = prompt.into();
+        let session_id = session_id.into();
+        let intent_id = compute_intent_id(&prompt, &session_id, &model, parent_intent.as_deref());
+        Self {
+            intent_id,
+            prompt,
+            session_id,
+            model,
+            parent_intent,
+            created_at,
+        }
+    }
+}
+
+fn compute_intent_id(
+    prompt: &str,
+    session_id: &str,
+    model: &ModelDescriptor,
+    parent_intent: Option<&str>,
+) -> IntentId {
+    let view = CanonicalIntentView {
+        prompt,
+        session_id,
+        model,
+        parent_intent,
+    };
+    canonical::hash(&view)
+}
+
+/// Hashable shadow of [`Intent`] omitting `intent_id` (we're
+/// computing it) and `created_at` (timestamp drift would break
+/// dedup). Lives only as a transient for hashing.
+#[derive(Serialize)]
+struct CanonicalIntentView<'a> {
+    prompt: &'a str,
+    session_id: &'a str,
+    model: &'a ModelDescriptor,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parent_intent: Option<&'a str>,
+}
+
+// ---- Persistence -------------------------------------------------
+
+/// Persistent log of [`Intent`] records. Mirrors [`crate::OpLog`]'s
+/// shape: one canonical-JSON file per intent, atomic writes via
+/// tempfile + rename, idempotent on re-puts.
+pub struct IntentLog {
+    dir: PathBuf,
+}
+
+impl IntentLog {
+    pub fn open(root: &Path) -> io::Result<Self> {
+        let dir = root.join("intents");
+        fs::create_dir_all(&dir)?;
+        Ok(Self { dir })
+    }
+
+    fn path(&self, id: &IntentId) -> PathBuf {
+        self.dir.join(format!("{id}.json"))
+    }
+
+    /// Persist an intent. Idempotent on existing ids — the bytes
+    /// must match by content addressing, so re-putting the same
+    /// intent is a no-op.
+    pub fn put(&self, intent: &Intent) -> io::Result<()> {
+        let path = self.path(&intent.intent_id);
+        if path.exists() {
+            return Ok(());
+        }
+        let bytes = serde_json::to_vec(intent)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let tmp = path.with_extension("json.tmp");
+        let mut f = fs::File::create(&tmp)?;
+        f.write_all(&bytes)?;
+        f.sync_all()?;
+        fs::rename(&tmp, &path)?;
+        Ok(())
+    }
+
+    pub fn get(&self, id: &IntentId) -> io::Result<Option<Intent>> {
+        let path = self.path(id);
+        if !path.exists() {
+            return Ok(None);
+        }
+        let bytes = fs::read(&path)?;
+        let intent: Intent = serde_json::from_slice(&bytes)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        Ok(Some(intent))
+    }
+}
+
+// ---- Tests --------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn anthropic() -> ModelDescriptor {
+        ModelDescriptor {
+            provider: "anthropic".into(),
+            name: "claude-opus-4-7".into(),
+            version: None,
+        }
+    }
+
+    #[test]
+    fn same_prompt_session_model_hashes_equal() {
+        // The load-bearing dedup invariant: the same logical
+        // intent (same prompt, same session, same model) should
+        // produce the same `intent_id` regardless of which agent
+        // session re-recorded it. `created_at` differs but is not
+        // in the hash.
+        let a = Intent::with_timestamp(
+            "fix the auth bug", "ses_abc", anthropic(), None, 1000,
+        );
+        let b = Intent::with_timestamp(
+            "fix the auth bug", "ses_abc", anthropic(), None, 99999,
+        );
+        assert_eq!(a.intent_id, b.intent_id);
+        assert_ne!(a.created_at, b.created_at);
+    }
+
+    #[test]
+    fn different_prompts_hash_differently() {
+        let a = Intent::with_timestamp(
+            "fix the auth bug", "ses_abc", anthropic(), None, 0,
+        );
+        let b = Intent::with_timestamp(
+            "fix the cache bug", "ses_abc", anthropic(), None, 0,
+        );
+        assert_ne!(a.intent_id, b.intent_id);
+    }
+
+    #[test]
+    fn different_sessions_hash_differently() {
+        let a = Intent::with_timestamp(
+            "fix the auth bug", "ses_abc", anthropic(), None, 0,
+        );
+        let b = Intent::with_timestamp(
+            "fix the auth bug", "ses_xyz", anthropic(), None, 0,
+        );
+        assert_ne!(a.intent_id, b.intent_id);
+    }
+
+    #[test]
+    fn different_models_hash_differently() {
+        let a = Intent::with_timestamp(
+            "fix the auth bug", "ses_abc", anthropic(), None, 0,
+        );
+        let mut model = anthropic();
+        model.name = "claude-sonnet-4-6".into();
+        let b = Intent::with_timestamp(
+            "fix the auth bug", "ses_abc", model, None, 0,
+        );
+        assert_ne!(a.intent_id, b.intent_id);
+    }
+
+    #[test]
+    fn refinement_chain_distinguishes_parent_intent() {
+        let a = Intent::with_timestamp(
+            "now also handle Y", "ses_abc", anthropic(), None, 0,
+        );
+        let b = Intent::with_timestamp(
+            "now also handle Y", "ses_abc", anthropic(),
+            Some("parent-intent-id".into()), 0,
+        );
+        assert_ne!(
+            a.intent_id, b.intent_id,
+            "an intent with a parent is causally distinct from one without",
+        );
+    }
+
+    #[test]
+    fn intent_id_is_64_char_lowercase_hex() {
+        let i = Intent::with_timestamp(
+            "test", "ses_abc", anthropic(), None, 0,
+        );
+        assert_eq!(i.intent_id.len(), 64);
+        assert!(i.intent_id.chars().all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)));
+    }
+
+    #[test]
+    fn round_trip_through_serde_json() {
+        let i = Intent::with_timestamp(
+            "fix the auth bug", "ses_abc", anthropic(),
+            Some("parent".into()), 12345,
+        );
+        let json = serde_json::to_string(&i).unwrap();
+        let back: Intent = serde_json::from_str(&json).unwrap();
+        assert_eq!(i, back);
+    }
+
+    /// Golden hash. If this changes, the canonical form has shifted
+    /// — every `IntentId` in every existing store has changed too.
+    /// That's a major-version event for the data model and should
+    /// be a deliberate decision; update with care. Same protective
+    /// shape as the operation.rs golden test.
+    #[test]
+    fn canonical_form_is_stable_for_a_known_input() {
+        let i = Intent::with_timestamp(
+            "fix the auth bug",
+            "ses_abc",
+            ModelDescriptor {
+                provider: "anthropic".into(),
+                name: "claude-opus-4-7".into(),
+                version: None,
+            },
+            None,
+            0,
+        );
+        assert_eq!(
+            i.intent_id,
+            "5ede62683a249cd00afff49fdf56e8f659fe878a668c8b61e36f5fbc1de7c734",
+        );
+    }
+
+    // ---- IntentLog ----
+
+    #[test]
+    fn intent_log_round_trips_through_disk() {
+        let tmp = tempfile::tempdir().unwrap();
+        let log = IntentLog::open(tmp.path()).unwrap();
+        let i = Intent::with_timestamp(
+            "fix the auth bug", "ses_abc", anthropic(), None, 100,
+        );
+        log.put(&i).unwrap();
+        let read_back = log.get(&i.intent_id).unwrap().unwrap();
+        assert_eq!(i, read_back);
+    }
+
+    #[test]
+    fn intent_log_get_unknown_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let log = IntentLog::open(tmp.path()).unwrap();
+        assert!(log.get(&"nonexistent".to_string()).unwrap().is_none());
+    }
+
+    #[test]
+    fn intent_log_put_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let log = IntentLog::open(tmp.path()).unwrap();
+        let i = Intent::with_timestamp(
+            "fix the auth bug", "ses_abc", anthropic(), None, 100,
+        );
+        log.put(&i).unwrap();
+        // Second put with the same content is a no-op (the file
+        // already exists; content addressing guarantees the bytes
+        // match).
+        log.put(&i).unwrap();
+        let read_back = log.get(&i.intent_id).unwrap().unwrap();
+        assert_eq!(i, read_back);
+    }
+}

--- a/crates/lex-vcs/src/lib.rs
+++ b/crates/lex-vcs/src/lib.rs
@@ -34,6 +34,7 @@ mod compute_diff;
 pub mod diff_report;
 mod diff_to_ops;
 mod gate;
+mod intent;
 mod merge;
 mod op_log;
 mod operation;
@@ -43,6 +44,7 @@ pub use compute_diff::{compute_diff, effect_label, render_signature};
 pub use diff_report::DiffReport;
 pub use diff_to_ops::{diff_to_ops, DiffInputs, DiffMappingError, ImportMap};
 pub use gate::{check_and_apply, GateError};
+pub use intent::{Intent, IntentId, IntentLog, ModelDescriptor, SessionId};
 pub use merge::{merge, ConflictKind, MergeOutcome, MergeOutput};
 pub use op_log::OpLog;
 pub use operation::{

--- a/crates/lex-vcs/src/operation.rs
+++ b/crates/lex-vcs/src/operation.rs
@@ -160,6 +160,19 @@ pub struct Operation {
     /// repo.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub parents: Vec<OpId>,
+    /// The intent that caused this op, if known. Optional because
+    /// operations produced outside an agent harness (e.g. a human
+    /// running `lex publish` directly) don't have one.
+    ///
+    /// Including the intent in the canonical hash means the same
+    /// logical change made under different intents produces
+    /// different `OpId`s — causally distinct events should hash
+    /// distinctly. Ops with `intent_id: None` keep their existing
+    /// hashes (the field is omitted from the canonical JSON via
+    /// `skip_serializing_if`), so this is backwards-compatible
+    /// for stores written before #131.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub intent_id: Option<crate::intent::IntentId>,
 }
 
 impl Operation {
@@ -170,13 +183,22 @@ impl Operation {
         let mut parents: Vec<OpId> = parents.into_iter().collect();
         parents.sort();
         parents.dedup();
-        Self { kind, parents }
+        Self { kind, parents, intent_id: None }
+    }
+
+    /// Tag this operation with the intent that produced it. The
+    /// builder shape keeps existing call sites untouched; agent
+    /// harnesses that record intent call this once before
+    /// applying the op.
+    pub fn with_intent(mut self, intent_id: impl Into<crate::intent::IntentId>) -> Self {
+        self.intent_id = Some(intent_id.into());
+        self
     }
 
     /// Compute this operation's content-addressed identity.
     ///
     /// Stable across runs and machines: same `(kind, payload,
-    /// sorted parents)` produces the same `OpId`. This is the
+    /// sorted parents, intent_id)` produces the same `OpId`. The
     /// invariant #129's automatic-dedup behavior relies on.
     pub fn op_id(&self) -> OpId {
         // Build a transient hashable view rather than hashing
@@ -186,6 +208,7 @@ impl Operation {
         let canonical = CanonicalView {
             kind: &self.kind,
             parents: self.parents.iter().collect::<IndexSet<_>>().into_iter().collect::<BTreeSet<_>>(),
+            intent_id: self.intent_id.as_deref(),
         };
         canonical::hash(&canonical)
     }
@@ -200,6 +223,11 @@ struct CanonicalView<'a> {
     #[serde(flatten)]
     kind: &'a OperationKind,
     parents: BTreeSet<&'a OpId>,
+    /// `skip_serializing_if = "Option::is_none"` keeps existing
+    /// `OpId`s stable for ops without an intent — the field is
+    /// omitted from the canonical JSON entirely.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    intent_id: Option<&'a str>,
 }
 
 /// An operation paired with its computed `OpId` and the resulting
@@ -391,6 +419,46 @@ mod tests {
             },
         );
         assert_eq!(rec.op_id, expected);
+    }
+
+    #[test]
+    fn intent_id_is_part_of_op_id_canonical_hash() {
+        // The dedup property: same `(kind, parents, intent_id)`
+        // produces the same OpId. Different intent_ids on
+        // otherwise-identical ops produce different OpIds, so
+        // causally distinct events (different prompts) hash
+        // distinctly.
+        let no_intent = Operation::new(add_factorial(), []);
+        let with_intent_a = Operation::new(add_factorial(), [])
+            .with_intent("intent-a");
+        let with_intent_b = Operation::new(add_factorial(), [])
+            .with_intent("intent-b");
+        let with_intent_a_again = Operation::new(add_factorial(), [])
+            .with_intent("intent-a");
+
+        // No-intent op is distinct from any intent-tagged variant.
+        assert_ne!(no_intent.op_id(), with_intent_a.op_id());
+        // Different intents → different OpIds.
+        assert_ne!(with_intent_a.op_id(), with_intent_b.op_id());
+        // Same intent → same OpId (the load-bearing dedup invariant).
+        assert_eq!(with_intent_a.op_id(), with_intent_a_again.op_id());
+    }
+
+    #[test]
+    fn op_without_intent_keeps_pre_intent_op_id() {
+        // Backwards-compat invariant: an op constructed without an
+        // intent must hash to the same value as it would have
+        // before #131 added the field. The golden test below pins
+        // the exact hash; this one asserts that adding then
+        // resetting to None doesn't drift.
+        let mut op = Operation::new(add_factorial(), []);
+        let baseline = op.op_id();
+        op.intent_id = Some("transient".into());
+        let with_intent = op.op_id();
+        assert_ne!(baseline, with_intent);
+        op.intent_id = None;
+        let back = op.op_id();
+        assert_eq!(baseline, back);
     }
 
     /// Golden hash. If this changes, the canonical form has shifted


### PR DESCRIPTION
## Summary

Adds the *why* alongside #129's *what*. `Intent` captures the prompt, model, and agent session that caused some operations to be produced — the **causal seed**, not the execution trace (which already lives in `lex-trace`).

```rust
pub struct Intent {
    pub intent_id: IntentId,             // SHA-256 over canonical form
    pub prompt: String,
    pub session_id: SessionId,
    pub model: ModelDescriptor,          // {provider, name, version}
    pub parent_intent: Option<IntentId>, // for refinement chains
    pub created_at: u64,                 // wall-clock; not in hash
}
```

`Operation` gains an optional `intent_id` plus a builder shim:

```rust
let op = Operation::new(kind, parents).with_intent("intent-id");
```

## Identity

`intent_id` is SHA-256 of `(prompt, session_id, model, parent_intent)`. `created_at` is **not** in the hash — two runs of the same logical intent at different wall-clock times still dedupe. The "same `(prompt, model, session)` → same `intent_id`" invariant the issue calls out is the load-bearing property; verified by test.

`OpId` now also includes `intent_id` in its canonical hash. Causally distinct events (different prompts) hash distinctly even when the underlying code change is byte-identical.

## Backwards compat

Ops with `intent_id: None` produce **byte-identical** canonical JSON to ops constructed before #131. Verified two ways:

1. The pre-existing `operation::canonical_form_is_stable_for_a_known_input` golden-hash test passes unchanged — adding the field didn't shift any existing OpId.
2. A new test (`op_without_intent_keeps_pre_intent_op_id`) asserts that toggling `intent_id` to Some and back to None reproduces the original hash.

Existing stores written before this PR keep working without migration.

## Privacy boundary

Prompts may contain sensitive data. Intents live in their own addressable namespace rather than inlined on every op — makes per-intent ACLs tractable as a follow-up without touching the op log.

## Test plan

- [x] `cargo test -p lex-vcs` — 63/63 pass.
- [x] `cargo test --workspace` — 584 pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.

Tests cover:
- hash stability across `created_at` drift
- hash sensitivity to prompt / session / model / parent
- serde round-trip
- IntentLog put / get / idempotent re-put / unknown-id returns None
- golden-hash test for a known intent input
- op `intent_id` flows through the canonical hash (different intents → different OpIds; same intent → same OpId)
- backwards-compat: op without intent matches pre-#131 hash

## Out of scope (deferred)

| slice | who picks it up |
|---|---|
| `lex agent-tool` records the `--request` as an intent | producer-side change to `lex-cli` |
| `POST /v1/publish` accepts an `intent` field | producer-side change to `lex-api` |
| `lex intent show <id>`, `lex log --by-intent`, `lex blame --with-intent` | new CLI subcommands |
| `POST /v1/intent` for harnesses that register up front | new HTTP route |
| Cross-store federation, prompt encryption at rest | future work |

Each is a separate slice; none block landing the foundational data model + persistence here.

Refs #131. Foundation for #132 (attestation graph references intent_id).

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRXRypmTju3ShcQ3ERJQSu)_