### PR TITLE
feat: per-op type-check gate via `Store::apply_operation_checked` (#130 cont'd)

### DIFF
--- a/crates/lex-store/Cargo.toml
+++ b/crates/lex-store/Cargo.toml
@@ -12,6 +12,7 @@ thiserror.workspace = true
 indexmap.workspace = true
 lex-ast = { path = "../lex-ast" }
 lex-trace = { path = "../lex-trace" }
+lex-types = { path = "../lex-types" }
 lex-vcs = { path = "../lex-vcs" }
 
 [dev-dependencies]

--- a/crates/lex-store/src/store.rs
+++ b/crates/lex-store/src/store.rs
@@ -33,6 +33,13 @@ pub enum StoreError {
     UnknownBranch(String),
     #[error(transparent)]
     Apply(#[from] lex_vcs::ApplyError),
+    /// The candidate program — i.e. the source the caller is
+    /// publishing — doesn't typecheck. The branch head is unchanged
+    /// and no op records are persisted. Issue #130's "always-valid
+    /// HEAD" invariant: the gate runs before any side effect, so a
+    /// type-broken publish leaves no footprint.
+    #[error("type errors in published program: {} error(s)", .0.len())]
+    TypeError(Vec<lex_types::TypeError>),
 }
 
 /// The outcome returned by [`Store::publish_program`].
@@ -451,6 +458,18 @@ impl Store {
         activate: bool,
     ) -> Result<PublishOutcome, StoreError> {
         use std::collections::{BTreeMap, BTreeSet};
+
+        // #130's write-time gate: verify the candidate program
+        // typechecks (and effects are correctly declared) before
+        // any disk side-effect. If anything fails, return the
+        // structured envelope and leave the branch head unchanged
+        // — the store's "always-valid HEAD" invariant only holds
+        // because this is the only batch-publish path that
+        // advances heads. Single-op writes via the lower-level
+        // `apply_operation` are not gated yet (#130 follow-up).
+        if let Err(errors) = lex_types::check_program(stages) {
+            return Err(StoreError::TypeError(errors));
+        }
 
         // Build old-side views from the current branch.
         let old_head = self.branch_head(branch)?;

--- a/crates/lex-store/src/store.rs
+++ b/crates/lex-store/src/store.rs
@@ -590,6 +590,51 @@ impl Store {
     /// can leave an orphan op record in the log with no branch
     /// pointing at it. The op is content-addressed and cheap to
     /// re-derive from the same source. See
+    /// Apply a single op against `branch`, gated on the candidate
+    /// program typechecking. The per-op variant of #130's
+    /// write-time gate — counterpart to [`Self::publish_program`]'s
+    /// batch-mode check.
+    ///
+    /// `candidate` is the sequence of `Stage`s that *would* exist
+    /// on this branch after the op is applied. Caller's
+    /// responsibility: today neither `lex-store` nor `lex-vcs`
+    /// reconstruct the candidate from the op + branch state on
+    /// behalf of the caller. The natural callers (HTTP `POST
+    /// /v1/publish` for a single op; agent harnesses driving
+    /// merges via the future #134 API) already have the candidate
+    /// in memory.
+    ///
+    /// On rejection: branch head unchanged, no op record persisted.
+    /// Same atomicity guarantee as the publish path.
+    ///
+    /// # Why a separate method, not a flag on `apply_operation`
+    ///
+    /// The merge engine in `lex-vcs::merge` calls
+    /// `Store::apply_operation` directly to land merge ops, and at
+    /// merge time the resolved program isn't a single `Vec<Stage>`
+    /// the way it is on the publish path — it's a per-sig
+    /// resolution map. Forcing a candidate through `apply_operation`
+    /// would either require the merge engine to assemble one (slow,
+    /// every active stage off disk) or accept `Option<&[Stage]>`
+    /// and silently skip the gate — the second is exactly the kind
+    /// of "secretly opt-out" path #130 is trying to remove. The
+    /// honest split is two methods: `apply_operation` for callers
+    /// that already typecheck their inputs (or don't need to —
+    /// rare, but the merge-resolve case), `apply_operation_checked`
+    /// for everyone else.
+    pub fn apply_operation_checked(
+        &self,
+        branch: &str,
+        op: lex_vcs::Operation,
+        transition: lex_vcs::StageTransition,
+        candidate: &[lex_ast::Stage],
+    ) -> Result<lex_vcs::OpId, StoreError> {
+        if let Err(errors) = lex_types::check_program(candidate) {
+            return Err(StoreError::TypeError(errors));
+        }
+        self.apply_operation(branch, op, transition)
+    }
+
     /// `set_branch_head_op` for the durability story on the branch
     /// file itself.
     pub fn apply_operation(

--- a/crates/lex-store/tests/apply_operation_checked.rs
+++ b/crates/lex-store/tests/apply_operation_checked.rs
@@ -1,0 +1,166 @@
+//! Per-op write-time gate (#130 cont'd).
+//! `Store::apply_operation_checked` is the single-op variant of
+//! the publish-program gate: caller passes the candidate program;
+//! gate runs `lex_types::check_program` first; on rejection the
+//! branch head is unchanged and no op record is persisted.
+
+use lex_ast::canonicalize_program;
+use lex_store::{Operation, OperationKind, StageTransition, Store, StoreError, DEFAULT_BRANCH};
+use lex_syntax::parse_source;
+use std::collections::BTreeSet;
+
+fn fresh() -> (Store, tempfile::TempDir) {
+    let tmp = tempfile::tempdir().unwrap();
+    let s = Store::open(tmp.path()).unwrap();
+    (s, tmp)
+}
+
+fn parse(src: &str) -> Vec<lex_ast::Stage> {
+    let prog = parse_source(src).expect("parse");
+    canonicalize_program(&prog)
+}
+
+fn add_fac_op() -> (Operation, StageTransition) {
+    let op = Operation::new(
+        OperationKind::AddFunction {
+            sig_id: "fac".into(),
+            stage_id: "stg-1".into(),
+            effects: BTreeSet::new(),
+        },
+        [],
+    );
+    let t = StageTransition::Create {
+        sig_id: "fac".into(),
+        stage_id: "stg-1".into(),
+    };
+    (op, t)
+}
+
+#[test]
+fn apply_operation_checked_advances_head_on_clean_candidate() {
+    let (s, _tmp) = fresh();
+    let candidate = parse(
+        "fn factorial(n :: Int) -> Int { match n { 0 => 1, _ => n * factorial(n - 1) } }\n",
+    );
+    let (op, t) = add_fac_op();
+    let op_id = s
+        .apply_operation_checked(DEFAULT_BRANCH, op, t, &candidate)
+        .expect("clean candidate should pass the gate");
+    let head = s.branch_head(DEFAULT_BRANCH).unwrap();
+    assert_eq!(head.get("fac"), Some(&"stg-1".to_string()));
+    let b = s.get_branch(DEFAULT_BRANCH).unwrap().unwrap();
+    assert_eq!(b.head_op.as_deref(), Some(op_id.as_str()));
+}
+
+#[test]
+fn apply_operation_checked_rejects_type_broken_candidate() {
+    let (s, _tmp) = fresh();
+    // The candidate references `not_defined` — type checker emits
+    // an `UnknownIdentifier`. Gate runs before any side effect.
+    let candidate = parse("fn broken(x :: Int) -> Int { not_defined(x) }\n");
+    let (op, t) = add_fac_op();
+
+    let err = s
+        .apply_operation_checked(DEFAULT_BRANCH, op, t, &candidate)
+        .expect_err("expected TypeError");
+    assert!(matches!(err, StoreError::TypeError(_)));
+
+    // Branch head unchanged.
+    assert!(
+        s.get_branch(DEFAULT_BRANCH).unwrap().is_none(),
+        "branch should not have been created on the rejection path",
+    );
+
+    // No op records persisted on the failure path.
+    let ops_dir = s.root().join("ops");
+    if ops_dir.exists() {
+        let count = std::fs::read_dir(&ops_dir).unwrap().count();
+        assert_eq!(count, 0, "no op records should be persisted on TypeError");
+    }
+}
+
+#[test]
+fn apply_operation_checked_does_not_advance_head_after_rejection() {
+    // The earlier test confirms the branch isn't created on rejection
+    // against a fresh store. This one confirms the same behavior
+    // against an existing branch with prior history — the gate
+    // must not advance the head even when the branch already
+    // exists.
+    let (s, _tmp) = fresh();
+
+    // First op lands cleanly to give the branch a head_op.
+    let initial_candidate = parse(
+        "fn factorial(n :: Int) -> Int { match n { 0 => 1, _ => n * factorial(n - 1) } }\n",
+    );
+    let (op1, t1) = add_fac_op();
+    let head1 = s
+        .apply_operation_checked(DEFAULT_BRANCH, op1, t1, &initial_candidate)
+        .expect("first op should land");
+
+    // Second op submitted with a type-broken candidate. Should
+    // be rejected; branch head must still point at head1.
+    let bad_candidate = parse("fn broken(x :: Int) -> Int { not_defined(x) }\n");
+    let op2 = Operation::new(
+        OperationKind::ModifyBody {
+            sig_id: "fac".into(),
+            from_stage_id: "stg-1".into(),
+            to_stage_id: "stg-2".into(),
+        },
+        [head1.clone()],
+    );
+    let t2 = StageTransition::Replace {
+        sig_id: "fac".into(),
+        from: "stg-1".into(),
+        to: "stg-2".into(),
+    };
+    let err = s
+        .apply_operation_checked(DEFAULT_BRANCH, op2, t2, &bad_candidate)
+        .expect_err("expected TypeError");
+    assert!(matches!(err, StoreError::TypeError(_)));
+
+    let b_after = s.get_branch(DEFAULT_BRANCH).unwrap().unwrap();
+    assert_eq!(
+        b_after.head_op.as_deref(),
+        Some(head1.as_str()),
+        "branch head should still point at head1 after rejected op",
+    );
+}
+
+#[test]
+fn apply_operation_checked_propagates_apply_errors() {
+    // Type-clean candidate but stale parent — gate accepts the
+    // typecheck, then the underlying `apply_operation` rejects on
+    // structure. The error should pass through as
+    // `StoreError::Apply(StaleParent)`, not `TypeError`.
+    let (s, _tmp) = fresh();
+    let candidate = parse(
+        "fn factorial(n :: Int) -> Int { match n { 0 => 1, _ => n * factorial(n - 1) } }\n",
+    );
+    // First op lands.
+    let (op1, t1) = add_fac_op();
+    let _ = s
+        .apply_operation_checked(DEFAULT_BRANCH, op1, t1, &candidate)
+        .unwrap();
+
+    // Second op declares the wrong parent.
+    let bogus = Operation::new(
+        OperationKind::ModifyBody {
+            sig_id: "fac".into(),
+            from_stage_id: "stg-1".into(),
+            to_stage_id: "stg-2".into(),
+        },
+        ["someone-else".into()],
+    );
+    let t = StageTransition::Replace {
+        sig_id: "fac".into(),
+        from: "stg-1".into(),
+        to: "stg-2".into(),
+    };
+    let err = s
+        .apply_operation_checked(DEFAULT_BRANCH, bogus, t, &candidate)
+        .expect_err("expected Apply(StaleParent)");
+    match err {
+        StoreError::Apply(_) => {}
+        other => panic!("expected StoreError::Apply, got {other:?}"),
+    }
+}

--- a/crates/lex-store/tests/publish_program_gate.rs
+++ b/crates/lex-store/tests/publish_program_gate.rs
@@ -1,0 +1,110 @@
+//! Write-time type-check gate (#130) wired into
+//! `Store::publish_program`. Verifies that a publish whose source
+//! doesn't typecheck returns `StoreError::TypeError` with the
+//! structured envelope and leaves the branch head unchanged.
+
+use lex_ast::canonicalize_program;
+use lex_store::{Store, StoreError, DEFAULT_BRANCH};
+use lex_syntax::parse_source;
+use lex_vcs::{DiffReport, ImportMap};
+
+fn fresh() -> (Store, tempfile::TempDir) {
+    let tmp = tempfile::tempdir().unwrap();
+    let s = Store::open(tmp.path()).unwrap();
+    (s, tmp)
+}
+
+fn parse(src: &str) -> Vec<lex_ast::Stage> {
+    let prog = parse_source(src).expect("parse");
+    canonicalize_program(&prog)
+}
+
+#[test]
+fn publish_program_rejects_program_with_unknown_identifier() {
+    let (store, _tmp) = fresh();
+
+    // `not_defined` is referenced but never declared — type checker
+    // emits an `UnknownIdentifier`. publish_program runs the gate
+    // before any side-effect, so the rejection must leave the branch
+    // head unchanged and persist no ops.
+    let stages = parse("fn broken(x :: Int) -> Int { not_defined(x) }\n");
+    let diff = DiffReport::default();
+    let imports = ImportMap::default();
+
+    let err = store
+        .publish_program(DEFAULT_BRANCH, &stages, &diff, &imports, /*activate=*/ true)
+        .expect_err("expected TypeError");
+
+    match err {
+        StoreError::TypeError(errs) => {
+            assert!(!errs.is_empty(), "expected at least one TypeError");
+        }
+        other => panic!("expected StoreError::TypeError, got {other:?}"),
+    }
+
+    // Branch head unchanged — store's "always-valid HEAD" invariant.
+    assert!(
+        store.get_branch(DEFAULT_BRANCH).unwrap().is_none(),
+        "branch should not have been created on the rejection path",
+    );
+
+    // No op records persisted.
+    let ops_dir = store.root().join("ops");
+    if ops_dir.exists() {
+        let count = std::fs::read_dir(&ops_dir).unwrap().count();
+        assert_eq!(count, 0, "no op records should be persisted on TypeError");
+    }
+}
+
+#[test]
+fn publish_program_rejects_program_with_arity_mismatch() {
+    // Verifies that multiple `TypeError` variants flow through the
+    // gate (not just `UnknownIdentifier`). Calling `add` with one
+    // arg when it takes two emits an `ArityMismatch`.
+    let (store, _tmp) = fresh();
+    let stages = parse(
+        "fn add(x :: Int, y :: Int) -> Int { x + y }\nfn caller() -> Int { add(1) }\n",
+    );
+    let err = store
+        .publish_program(
+            DEFAULT_BRANCH,
+            &stages,
+            &DiffReport::default(),
+            &ImportMap::default(),
+            true,
+        )
+        .expect_err("expected TypeError");
+    assert!(matches!(err, StoreError::TypeError(_)));
+}
+
+#[test]
+fn publish_program_accepts_clean_program() {
+    // Sanity check that the gate doesn't false-positive: a
+    // syntactically and type-correct program publishes through.
+    // We don't assert on the diff machinery here (that's covered
+    // by the parallel #129 work); just that the gate doesn't
+    // refuse a typing-clean program.
+    let (store, _tmp) = fresh();
+    let stages = parse(
+        "fn factorial(n :: Int) -> Int { match n { 0 => 1, _ => n * factorial(n - 1) } }\n",
+    );
+
+    // For an empty diff/imports, publish_program produces zero
+    // ops (nothing to apply against the empty old-side view). The
+    // gate runs first regardless, so the test demonstrates that
+    // "clean program → no error" — which is the property we care
+    // about for the gate's correctness, decoupled from whatever
+    // diff_to_ops happens to do with an empty diff.
+    let outcome = store
+        .publish_program(
+            DEFAULT_BRANCH,
+            &stages,
+            &DiffReport::default(),
+            &ImportMap::default(),
+            true,
+        )
+        .expect("clean program should pass the gate");
+    // `outcome.ops` may be empty (no diff entries to convert); the
+    // load-bearing assertion is that we didn't error out.
+    assert!(outcome.ops.is_empty() || !outcome.ops.is_empty());
+}

--- a/crates/lex-vcs/Cargo.toml
+++ b/crates/lex-vcs/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 
 [dependencies]
 lex-ast = { path = "../lex-ast" }
+lex-types = { path = "../lex-types" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/lex-vcs/src/gate.rs
+++ b/crates/lex-vcs/src/gate.rs
@@ -1,0 +1,206 @@
+//! Write-time type-check gate (#130).
+//!
+//! Wraps [`apply`](crate::apply::apply) with a type-checker pass.
+//! When this gate is the only path that advances a branch head,
+//! the store's invariant becomes "every accepted operation
+//! produces a program that typechecks." The cascading-breakage
+//! failure mode that breaks agentic workflows — agent A commits a
+//! typing-broken stage, agent B reads it and builds work
+//! assuming the broken stage, hours pass, CI catches the bug —
+//! becomes impossible by construction.
+//!
+//! Effect violations surface here too: `lex-types::check_program`
+//! reports an undeclared-effect call as a `TypeError` variant, so
+//! a single rejection envelope covers both type and effect bugs.
+//!
+//! ## Performance
+//!
+//! The gate runs `lex_types::check_program` against the *candidate*
+//! program — the sequence of `Stage`s that would exist after the
+//! op is applied. Computing that sequence is the caller's job
+//! (typically `Store::publish_program`, which already has it in
+//! memory). The gate itself does not load anything from disk; it
+//! just runs the type checker.
+//!
+//! Performance budget from #130: <50 ms p99 for a single-function
+//! op on a 1000-stage store. This module doesn't validate that —
+//! the budget belongs to the caller's candidate-assembly path
+//! plus `lex_types::check_program`. We'll measure once the gate
+//! is wired into a real `Store::publish_program` flow.
+
+use lex_ast::Stage;
+use lex_types::{check_program, TypeError};
+
+use crate::apply::{apply, ApplyError, NewHead};
+use crate::op_log::OpLog;
+use crate::operation::{OpId, Operation, StageTransition};
+
+#[derive(Debug, thiserror::Error)]
+pub enum GateError {
+    /// The operation's parent or merge structure is wrong.
+    /// Pass-through from [`ApplyError`]; same shape so callers
+    /// already handling stale-parent / unknown-merge-parent on the
+    /// raw apply path can keep their existing match arms.
+    #[error(transparent)]
+    Apply(#[from] ApplyError),
+    /// The candidate program — i.e. the state that would exist
+    /// after applying the op — doesn't typecheck. The op is *not*
+    /// persisted; the branch head is unchanged.
+    ///
+    /// `op_id` is the would-be op_id (computed before the apply
+    /// path persisted anything). Lets callers correlate the
+    /// rejection with the op they submitted, even though no
+    /// `<root>/ops/<op_id>.json` file exists.
+    ///
+    /// `errors` is the structured envelope `lex check` already
+    /// emits. Effect violations show up here as a `TypeError`
+    /// variant; the gate doesn't model them as a separate kind
+    /// because the type checker doesn't either.
+    #[error("type errors after applying op {op_id}: {} error(s)", errors.len())]
+    TypeError {
+        op_id: OpId,
+        errors: Vec<TypeError>,
+    },
+}
+
+/// Apply an operation only if the resulting candidate program
+/// typechecks. Otherwise return [`GateError::TypeError`] with the
+/// structured error envelope; nothing is persisted.
+///
+/// `candidate` is the sequence of `Stage`s that would exist after
+/// the op is applied. The caller computes it — typically by
+/// applying the op's [`StageTransition`] to the program it just
+/// loaded from source. The gate does not assemble it from the
+/// store; the cost of "load every stage" is on the caller, where
+/// it can be amortized across the full publish flow.
+pub fn check_and_apply(
+    op_log: &OpLog,
+    head_op: Option<&OpId>,
+    op: Operation,
+    transition: StageTransition,
+    candidate: &[Stage],
+) -> Result<NewHead, GateError> {
+    if let Err(errors) = check_program(candidate) {
+        return Err(GateError::TypeError {
+            op_id: op.op_id(),
+            errors,
+        });
+    }
+    Ok(apply(op_log, head_op, op, transition)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::operation::OperationKind;
+    use std::collections::BTreeSet;
+
+    fn fac_op_and_transition() -> (Operation, StageTransition) {
+        let op = Operation::new(
+            OperationKind::AddFunction {
+                sig_id: "fac".into(),
+                stage_id: "s1".into(),
+                effects: BTreeSet::new(),
+            },
+            [],
+        );
+        let t = StageTransition::Create {
+            sig_id: "fac".into(),
+            stage_id: "s1".into(),
+        };
+        (op, t)
+    }
+
+    fn parse(src: &str) -> Vec<Stage> {
+        let prog = lex_syntax::parse_source(src).expect("parse");
+        lex_ast::canonicalize_program(&prog)
+    }
+
+    #[test]
+    fn clean_program_is_accepted_and_persisted() {
+        let tmp = tempfile::tempdir().unwrap();
+        let log = OpLog::open(tmp.path()).unwrap();
+        let candidate = parse(
+            "fn factorial(n :: Int) -> Int { match n { 0 => 1, _ => n * factorial(n - 1) } }\n",
+        );
+        let (op, t) = fac_op_and_transition();
+        let head = check_and_apply(&log, None, op, t, &candidate).unwrap();
+        assert!(log.get(&head.op_id).unwrap().is_some());
+    }
+
+    #[test]
+    fn type_error_is_rejected_and_nothing_persisted() {
+        let tmp = tempfile::tempdir().unwrap();
+        let log = OpLog::open(tmp.path()).unwrap();
+        // `not_defined` is referenced but never declared — the type
+        // checker emits an `UnknownIdentifier` error.
+        let candidate =
+            parse("fn broken(x :: Int) -> Int { not_defined(x) }\n");
+        let (op, t) = fac_op_and_transition();
+        let expected_op_id = op.op_id();
+        let err = check_and_apply(&log, None, op, t, &candidate)
+            .expect_err("expected TypeError");
+        match err {
+            GateError::TypeError { op_id, errors } => {
+                assert_eq!(op_id, expected_op_id);
+                assert!(!errors.is_empty(), "expected at least one TypeError");
+            }
+            other => panic!("expected TypeError, got {other:?}"),
+        }
+        // The op record was NOT persisted on the rejection path —
+        // the store's "always-valid HEAD" invariant holds.
+        assert!(log.get(&expected_op_id).unwrap().is_none());
+    }
+
+    #[test]
+    fn arity_mismatch_is_rejected() {
+        // Calling `add` with one arg when it takes two should
+        // produce an `ArityMismatch`. Verifies that several
+        // `TypeError` variants flow through the gate, not just
+        // unknown-identifier.
+        let tmp = tempfile::tempdir().unwrap();
+        let log = OpLog::open(tmp.path()).unwrap();
+        let candidate = parse(
+            "fn add(x :: Int, y :: Int) -> Int { x + y }\nfn caller() -> Int { add(1) }\n",
+        );
+        let (op, t) = fac_op_and_transition();
+        let err = check_and_apply(&log, None, op, t, &candidate)
+            .expect_err("expected TypeError");
+        assert!(matches!(err, GateError::TypeError { .. }));
+    }
+
+    #[test]
+    fn parent_check_still_runs_when_program_is_clean() {
+        // Pass a clean candidate but a stale-parent op. The gate
+        // shouldn't accept it just because typechecking passed —
+        // structural rejection still wins.
+        let tmp = tempfile::tempdir().unwrap();
+        let log = OpLog::open(tmp.path()).unwrap();
+        let candidate = parse(
+            "fn factorial(n :: Int) -> Int { match n { 0 => 1, _ => n * factorial(n - 1) } }\n",
+        );
+        // First op lands cleanly so head_op is set.
+        let (op1, t1) = fac_op_and_transition();
+        let head1 = check_and_apply(&log, None, op1, t1, &candidate).unwrap();
+        // Second op declares a wrong parent.
+        let bogus = Operation::new(
+            OperationKind::ModifyBody {
+                sig_id: "fac".into(),
+                from_stage_id: "s1".into(),
+                to_stage_id: "s2".into(),
+            },
+            ["someone-else".into()],
+        );
+        let t = StageTransition::Replace {
+            sig_id: "fac".into(),
+            from: "s1".into(),
+            to: "s2".into(),
+        };
+        let err = check_and_apply(&log, Some(&head1.op_id), bogus, t, &candidate)
+            .expect_err("expected Apply(StaleParent)");
+        match err {
+            GateError::Apply(ApplyError::StaleParent { .. }) => {}
+            other => panic!("expected Apply(StaleParent), got {other:?}"),
+        }
+    }
+}

--- a/crates/lex-vcs/src/lib.rs
+++ b/crates/lex-vcs/src/lib.rs
@@ -33,6 +33,7 @@ mod canonical;
 mod compute_diff;
 pub mod diff_report;
 mod diff_to_ops;
+mod gate;
 mod merge;
 mod op_log;
 mod operation;
@@ -41,6 +42,7 @@ pub use apply::{apply, ApplyError, NewHead};
 pub use compute_diff::{compute_diff, effect_label, render_signature};
 pub use diff_report::DiffReport;
 pub use diff_to_ops::{diff_to_ops, DiffInputs, DiffMappingError, ImportMap};
+pub use gate::{check_and_apply, GateError};
 pub use merge::{merge, ConflictKind, MergeOutcome, MergeOutput};
 pub use op_log::OpLog;
 pub use operation::{


### PR DESCRIPTION
## Summary

Stacks on **#141** (the publish-program gate). Adds the per-op counterpart so callers that go through `Store::apply_operation` directly — single-op HTTP writes, the future #134 merge resolution API, tooling that lands ops one at a time — can get the same type-check guarantee.

```rust
pub fn apply_operation_checked(
    &self,
    branch: &str,
    op: Operation,
    transition: StageTransition,
    candidate: &[Stage],
) -> Result<OpId, StoreError>;
```

Caller passes the candidate program (the post-apply `Vec<Stage>`). Neither `lex-store` nor `lex-vcs` reconstruct it on behalf of the caller; the natural callers already have it in memory.

## Why a separate method, not a flag on `apply_operation`

The merge engine in `lex-vcs::merge` calls `Store::apply_operation` directly to land merge ops. At merge time the resolved program isn't a single `Vec<Stage>` the way it is on the publish path — it's a per-sig resolution map. Forcing a candidate through `apply_operation` would either require the merge engine to assemble one (slow — every active stage off disk) or accept `Option<&[Stage]>` and silently skip the gate when `None` — that "secretly opt-out" path is exactly what #130 is trying to remove.

Honest split: `apply_operation` for callers that already typecheck their inputs (or are the merge-resolve case), `apply_operation_checked` for everyone else.

## Test plan

- [x] `cargo test -p lex-store --test apply_operation_checked` — 4/4 pass:
  - clean candidate → branch head advances
  - type-broken candidate → `TypeError`; branch not created; no op records persisted
  - type-broken candidate against an *existing* branch → head unchanged (gate didn't advance even partially)
  - type-clean candidate but stale parent → `Apply(StaleParent)` passes through, not silently masked as `TypeError`
- [x] `cargo test --workspace` — 571/571 pass (567 → 571).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Out of scope (deferred)

- `apply_operation` itself reconstructing the candidate from store state. Trade-off: simpler caller, slower path (load-every-stage). Worth measuring on a real ~1000-stage store before committing.
- HTTP `POST /v1/publish` → 422 with the structured `TypeError` envelope (currently a 500 since `lex-api` doesn't yet know about the new `StoreError` variant). Separate slice.
- Migration of existing internal `apply_operation` callers to the checked variant. Merge engine stays unchecked for now; the per-sig resolution shape is genuinely different from a `Vec<Stage>` and wants its own discussion.

Refs #130. Stacks on #141.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRXRypmTju3ShcQ3ERJQSu)_