### PR TITLE
fix: lex-api POST /v1/publish returns 422 on StoreError::TypeError

### DIFF
--- a/crates/lex-api/src/handlers.rs
+++ b/crates/lex-api/src/handlers.rs
@@ -180,6 +180,16 @@ fn publish_handler(state: &State, body: &str) -> Response<std::io::Cursor<Vec<u8
             "ops": outcome.ops,
             "head_op": outcome.head_op,
         })),
+        // The store-write gate (#130) also type-checks at the top
+        // of `publish_program`. The handler above already pre-checks,
+        // so this branch is reached only on a race or a state we
+        // didn't see at handler time. Surface the structured
+        // envelope (422) instead of a generic 500 — same shape the
+        // initial pre-check uses, so a client only has one error
+        // contract to handle.
+        Err(lex_store::StoreError::TypeError(errs)) => {
+            error_with_detail(422, "type errors", serde_json::to_value(&errs).unwrap())
+        }
         Err(e) => error_response(500, format!("publish_program: {e}")),
     }
 }


### PR DESCRIPTION
## Summary

Small follow-up to #141. The `POST /v1/publish` handler already pre-checks the program with `lex_types::check_program` and returns `422` with the structured `TypeError` envelope:

```rust
if let Err(errs) = lex_types::check_program(&stages) {
    return error_with_detail(422, "type errors", serde_json::to_value(&errs).unwrap());
}
```

After #141 wired the gate into `Store::publish_program`, the store-side check can also fire — in a race where the handler's pre-check passed but state advanced. Today that surfaces as a generic `500 publish_program: TypeError(...)` which breaks the 422 contract the pre-check sets.

This PR pattern-matches the new `StoreError::TypeError(errs)` variant and reuses the same `error_with_detail(422, "type errors", ...)` helper. One error contract for clients to handle.

The 500 fallthrough still catches genuine I/O / consistency failures.

## Why this matters

#142's PR description called out this exact gap as a deferred follow-up:

> `POST /v1/publish` → 422 with the structured `TypeError` envelope (currently a 500 since `lex-api` doesn't yet know about the new `StoreError` variant). Separate slice.

This is that slice.

## Test plan

- [x] `cargo build -p lex-api` clean.
- [x] `cargo test --workspace` — 615 pass, no regressions.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.

No new tests: the path is reachable only on a race between handler-side and store-side checks; both checks use the same `lex_types::check_program` so triggering the divergence requires concurrent state changes that aren't easy to script. The change is a 10-line pattern-match arm that mirrors the existing 422 path verbatim.

Refs #130. Closes the HTTP envelope follow-up from #141 / #142.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRXRypmTju3ShcQ3ERJQSu)_