### PR TITLE
feat: lex-store emits TypeCheck attestations on accepted ops

### DIFF
--- a/crates/lex-store/src/store.rs
+++ b/crates/lex-store/src/store.rs
@@ -519,12 +519,14 @@ impl Store {
                 }
             }
             let transition = transition_for_kind(&kind);
+            let attestable = attestable_stage_ids(&transition);
             let head_now = self.get_branch(branch)?.and_then(|b| b.head_op);
             let op = lex_vcs::Operation::new(
                 kind.clone(),
                 head_now.into_iter().collect::<Vec<_>>(),
             );
             let op_id = self.apply_operation(branch, op, transition)?;
+            self.record_typecheck_passed(&attestable, &op_id)?;
             ops_out.push(PublishOp {
                 op_id: op_id.clone(),
                 kind: serde_json::to_value(&kind)
@@ -632,7 +634,56 @@ impl Store {
         if let Err(errors) = lex_types::check_program(candidate) {
             return Err(StoreError::TypeError(errors));
         }
-        self.apply_operation(branch, op, transition)
+        let attestable = attestable_stage_ids(&transition);
+        let op_id = self.apply_operation(branch, op, transition)?;
+        self.record_typecheck_passed(&attestable, &op_id)?;
+        Ok(op_id)
+    }
+
+    /// Open the attestation log rooted at this store. The log lives
+    /// under `<root>/attestations/`; opening is idempotent and cheap
+    /// (`fs::create_dir_all`). Exposed publicly so consumers — `lex
+    /// blame --with-evidence`, `GET /v1/stage/<id>/attestations` —
+    /// can read what the store gate emitted without round-tripping
+    /// through this crate's API surface.
+    pub fn attestation_log(&self) -> Result<lex_vcs::AttestationLog, StoreError> {
+        Ok(lex_vcs::AttestationLog::open(self.root())?)
+    }
+
+    /// Emit one `TypeCheck::Passed` attestation per stage produced by
+    /// a successful gated apply. Idempotent on `attestation_id` —
+    /// re-running the same gate run dedups via content addressing.
+    ///
+    /// Failure modes: `io::Error` from the attestation log (disk
+    /// full, perms). The op has already landed by the time this
+    /// runs; an error here means the op is durable but the evidence
+    /// is missing. We propagate so the caller sees the partial
+    /// state rather than silently swallowing — re-attesting the
+    /// same op against the same op_id is idempotent (content
+    /// addressing) so a retry is safe once the underlying issue is
+    /// fixed.
+    fn record_typecheck_passed(
+        &self,
+        stage_ids: &[String],
+        op_id: &lex_vcs::OpId,
+    ) -> Result<(), StoreError> {
+        if stage_ids.is_empty() {
+            return Ok(());
+        }
+        let log = self.attestation_log()?;
+        for stage_id in stage_ids {
+            let attestation = lex_vcs::Attestation::new(
+                stage_id.clone(),
+                Some(op_id.clone()),
+                None,
+                lex_vcs::AttestationKind::TypeCheck,
+                lex_vcs::AttestationResult::Passed,
+                typecheck_producer(),
+                None,
+            );
+            log.put(&attestation)?;
+        }
+        Ok(())
     }
 
     /// `set_branch_head_op` for the durability story on the branch
@@ -713,6 +764,38 @@ fn transition_for_kind(kind: &lex_vcs::OperationKind) -> lex_vcs::StageTransitio
         },
         AddImport { .. } | RemoveImport { .. } => StageTransition::ImportOnly,
         Merge { .. } => StageTransition::Merge { entries: Default::default() },
+    }
+}
+
+/// Producer identity for TypeCheck attestations emitted by the
+/// store-write gate. Pinned to this crate's name + version so an
+/// attestation produced by a different `lex-store` revision is
+/// distinguishable (content-hashed `produced_by`).
+fn typecheck_producer() -> lex_vcs::ProducerDescriptor {
+    lex_vcs::ProducerDescriptor {
+        tool: "lex-store".into(),
+        version: env!("CARGO_PKG_VERSION").into(),
+        model: None,
+    }
+}
+
+/// The set of stage_ids a transition introduces. These are the
+/// stages a successful TypeCheck pass attests *about* — the new
+/// head produced by Create/Replace, the renamed body, or the per-
+/// sig resolution of a Merge. Removes and ImportOnly produce no
+/// attestable stage; the program typechecks but no specific stage
+/// is the subject of the claim.
+fn attestable_stage_ids(transition: &lex_vcs::StageTransition) -> Vec<String> {
+    use lex_vcs::StageTransition::*;
+    match transition {
+        Create { stage_id, .. } => vec![stage_id.clone()],
+        Replace { to, .. } => vec![to.clone()],
+        Rename { body_stage_id, .. } => vec![body_stage_id.clone()],
+        Merge { entries } => entries
+            .values()
+            .filter_map(|opt| opt.clone())
+            .collect(),
+        Remove { .. } | ImportOnly => Vec::new(),
     }
 }
 

--- a/crates/lex-store/tests/apply_operation_checked.rs
+++ b/crates/lex-store/tests/apply_operation_checked.rs
@@ -7,6 +7,7 @@
 use lex_ast::canonicalize_program;
 use lex_store::{Operation, OperationKind, StageTransition, Store, StoreError, DEFAULT_BRANCH};
 use lex_syntax::parse_source;
+use lex_vcs::{AttestationKind, AttestationResult};
 use std::collections::BTreeSet;
 
 fn fresh() -> (Store, tempfile::TempDir) {
@@ -124,6 +125,103 @@ fn apply_operation_checked_does_not_advance_head_after_rejection() {
         Some(head1.as_str()),
         "branch head should still point at head1 after rejected op",
     );
+}
+
+#[test]
+fn apply_operation_checked_emits_typecheck_attestation_for_created_stage() {
+    // After a clean checked apply, the store-write gate persists a
+    // TypeCheck::Passed attestation against the produced stage.
+    // Issue #132: "Emitted by the store-write gate (#130) on every
+    // accepted op."
+    let (s, _tmp) = fresh();
+    let candidate = parse(
+        "fn factorial(n :: Int) -> Int { match n { 0 => 1, _ => n * factorial(n - 1) } }\n",
+    );
+    let (op, t) = add_fac_op();
+    let op_id = s
+        .apply_operation_checked(DEFAULT_BRANCH, op, t, &candidate)
+        .expect("clean candidate should pass the gate");
+
+    let log = s.attestation_log().unwrap();
+    let listing = log.list_for_stage(&"stg-1".to_string()).unwrap();
+    assert_eq!(listing.len(), 1, "exactly one attestation for the created stage");
+    let att = &listing[0];
+    assert!(matches!(att.kind, AttestationKind::TypeCheck));
+    assert!(matches!(att.result, AttestationResult::Passed));
+    assert_eq!(att.op_id.as_deref(), Some(op_id.as_str()));
+    assert_eq!(att.stage_id, "stg-1");
+    assert_eq!(att.produced_by.tool, "lex-store");
+}
+
+#[test]
+fn apply_operation_checked_emits_no_attestation_on_rejection() {
+    // Type-broken candidate: no op landed, no attestation written.
+    // The TypeCheck attestation is *evidence the gate passed*, so
+    // it must not appear when the gate rejected.
+    let (s, _tmp) = fresh();
+    let candidate = parse("fn broken(x :: Int) -> Int { not_defined(x) }\n");
+    let (op, t) = add_fac_op();
+    let _ = s
+        .apply_operation_checked(DEFAULT_BRANCH, op, t, &candidate)
+        .expect_err("expected TypeError");
+
+    let attestations_dir = s.root().join("attestations");
+    if attestations_dir.exists() {
+        // The dir may exist from a prior log open elsewhere; what
+        // matters is that no primary attestation file was written.
+        let primary_count = std::fs::read_dir(&attestations_dir)
+            .unwrap()
+            .filter(|e| {
+                e.as_ref()
+                    .map(|e| e.path().extension().is_some_and(|x| x == "json"))
+                    .unwrap_or(false)
+            })
+            .count();
+        assert_eq!(primary_count, 0, "no attestation should be written on rejection");
+    }
+}
+
+#[test]
+fn apply_operation_checked_attestation_dedups_across_runs() {
+    // Re-applying the same logical op against the same parent state
+    // should produce the same attestation_id (content addressing),
+    // so the put is idempotent and the per-stage listing stays at 1.
+    // We can't directly retry `apply_operation_checked` (the second
+    // call will hit StaleParent), so we exercise dedup at the log
+    // level instead: the same attestation written twice should not
+    // produce two index entries.
+    let (s, _tmp) = fresh();
+    let candidate = parse(
+        "fn factorial(n :: Int) -> Int { match n { 0 => 1, _ => n * factorial(n - 1) } }\n",
+    );
+    let (op, t) = add_fac_op();
+    let op_id = s
+        .apply_operation_checked(DEFAULT_BRANCH, op, t, &candidate)
+        .unwrap();
+
+    let log = s.attestation_log().unwrap();
+    let listing_a = log.list_for_stage(&"stg-1".to_string()).unwrap();
+    assert_eq!(listing_a.len(), 1);
+
+    // Re-put the same attestation; idempotent on attestation_id.
+    let same = lex_vcs::Attestation::with_timestamp(
+        "stg-1".to_string(),
+        Some(op_id.clone()),
+        None,
+        AttestationKind::TypeCheck,
+        AttestationResult::Passed,
+        lex_vcs::ProducerDescriptor {
+            tool: "lex-store".into(),
+            version: env!("CARGO_PKG_VERSION").into(),
+            model: None,
+        },
+        None,
+        listing_a[0].timestamp + 100,
+    );
+    log.put(&same).unwrap();
+
+    let listing_b = log.list_for_stage(&"stg-1".to_string()).unwrap();
+    assert_eq!(listing_b.len(), 1, "content addressing dedups across re-puts");
 }
 
 #[test]

--- a/crates/lex-store/tests/publish_program_gate.rs
+++ b/crates/lex-store/tests/publish_program_gate.rs
@@ -6,7 +6,7 @@
 use lex_ast::canonicalize_program;
 use lex_store::{Store, StoreError, DEFAULT_BRANCH};
 use lex_syntax::parse_source;
-use lex_vcs::{DiffReport, ImportMap};
+use lex_vcs::{AttestationKind, AttestationResult, DiffReport, ImportMap};
 
 fn fresh() -> (Store, tempfile::TempDir) {
     let tmp = tempfile::tempdir().unwrap();
@@ -107,4 +107,43 @@ fn publish_program_accepts_clean_program() {
     // `outcome.ops` may be empty (no diff entries to convert); the
     // load-bearing assertion is that we didn't error out.
     assert!(outcome.ops.is_empty() || !outcome.ops.is_empty());
+}
+
+#[test]
+fn publish_program_emits_typecheck_attestation_per_added_op() {
+    // A real diff that produces an `AddFunction` op should leave
+    // behind a TypeCheck::Passed attestation against the produced
+    // stage. Issue #132 specifies "every accepted op" — wired
+    // through `Store::publish_program`'s per-op apply loop.
+    let (store, _tmp) = fresh();
+    let stages = parse(
+        "fn factorial(n :: Int) -> Int { match n { 0 => 1, _ => n * factorial(n - 1) } }\n",
+    );
+
+    // Hand-construct a minimal diff that adds `factorial`. We don't
+    // exercise the diff machinery here — the `lex-vcs::compute_diff`
+    // tests cover that — we just need a non-empty diff so the
+    // publish loop produces an op.
+    let diff = lex_vcs::DiffReport {
+        added: vec![lex_vcs::diff_report::AddRemove {
+            name: "factorial".into(),
+            signature: "fn factorial(Int) -> Int".into(),
+        }],
+        ..Default::default()
+    };
+
+    let outcome = store
+        .publish_program(DEFAULT_BRANCH, &stages, &diff, &ImportMap::default(), true)
+        .expect("clean program should pass the gate");
+    assert_eq!(outcome.ops.len(), 1, "exactly one AddFunction op expected");
+
+    let log = store.attestation_log().unwrap();
+    let stage_id = lex_ast::stage_id(&stages[0]).unwrap();
+    let listing = log.list_for_stage(&stage_id).unwrap();
+    assert_eq!(listing.len(), 1, "one TypeCheck attestation per produced stage");
+    let att = &listing[0];
+    assert!(matches!(att.kind, AttestationKind::TypeCheck));
+    assert!(matches!(att.result, AttestationResult::Passed));
+    assert_eq!(att.op_id.as_ref(), Some(&outcome.ops[0].op_id));
+    assert_eq!(att.produced_by.tool, "lex-store");
 }


### PR DESCRIPTION
## Summary

- Wires #132's `TypeCheck` producer into the write-time gate in `lex-store`. Every op that lands via `Store::apply_operation_checked` or per-op via `Store::publish_program` now persists a `TypeCheck::Passed` attestation against the produced stage.
- Removes and `ImportOnly` transitions emit nothing — the program typechecks but no specific stage is the subject of the claim.
- Adds `Store::attestation_log()` so consumers (`lex blame --with-evidence`, `GET /v1/stage/<id>/attestations`) can read what the gate emitted.
- Producer is pinned to `lex-store` + crate version so a regression in this gate is distinguishable from a regression in the verified code via content-hashed `produced_by`.

## Test plan

- [x] `cargo test -p lex-store` — 33 passed, including 4 new tests covering: attestation emission on Create, no emission on rejection, dedup across re-puts, and per-op emission inside `publish_program`.
- [x] `cargo test --workspace` — all green; no regressions in callers of `apply_operation_checked` / `publish_program`.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.

https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5

---
_Generated by [Claude Code](https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5)_