### PR TITLE
feat: expose stage attestations via HTTP and CLI

### DIFF
--- a/crates/lex-api/src/handlers.rs
+++ b/crates/lex-api/src/handlers.rs
@@ -82,8 +82,14 @@ fn route(
         (Method::Post, "/v1/publish") => publish_handler(state, body),
         (Method::Post, "/v1/patch") => patch_handler(state, body),
         (Method::Get, p) if p.starts_with("/v1/stage/") => {
-            let id = &p["/v1/stage/".len()..];
-            stage_handler(state, id)
+            let suffix = &p["/v1/stage/".len()..];
+            // Match `/v1/stage/<id>/attestations` first so a literal
+            // stage_id of "attestations" can't be misrouted.
+            if let Some(id) = suffix.strip_suffix("/attestations") {
+                stage_attestations_handler(state, id)
+            } else {
+                stage_handler(state, suffix)
+            }
         }
         (Method::Post, "/v1/run") => run_handler(state, body, false),
         (Method::Post, "/v1/replay") => run_handler(state, body, true),
@@ -315,6 +321,31 @@ fn stage_handler(state: &State, id: &str) -> Response<std::io::Cursor<Vec<u8>>> 
         "ast": ast,
         "status": status,
     }))
+}
+
+/// `GET /v1/stage/<id>/attestations` — every persisted attestation
+/// for this stage, newest-first by timestamp. Issue #132's
+/// queryable-evidence consumer surface.
+///
+/// 404s on unknown stage_id (matches `/v1/stage/<id>`'s shape so a
+/// caller round-tripping both endpoints sees consistent errors).
+/// Empty list (200) is *evidence of absence*: the stage exists but
+/// no producer has attested it.
+fn stage_attestations_handler(state: &State, id: &str) -> Response<std::io::Cursor<Vec<u8>>> {
+    let store = state.store.lock().unwrap();
+    if let Err(e) = store.get_metadata(id) {
+        return error_response(404, format!("{e}"));
+    }
+    let log = match store.attestation_log() {
+        Ok(l) => l,
+        Err(e) => return error_response(500, format!("attestation log: {e}")),
+    };
+    let mut listing = match log.list_for_stage(&id.to_string()) {
+        Ok(v) => v,
+        Err(e) => return error_response(500, format!("list_for_stage: {e}")),
+    };
+    listing.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    json_response(200, &serde_json::json!({"attestations": listing}))
 }
 
 #[derive(Deserialize, Default)]

--- a/crates/lex-api/src/handlers.rs
+++ b/crates/lex-api/src/handlers.rs
@@ -344,7 +344,7 @@ fn stage_attestations_handler(state: &State, id: &str) -> Response<std::io::Curs
         Ok(v) => v,
         Err(e) => return error_response(500, format!("list_for_stage: {e}")),
     };
-    listing.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    listing.sort_by_key(|a| std::cmp::Reverse(a.timestamp));
     json_response(200, &serde_json::json!({"attestations": listing}))
 }
 

--- a/crates/lex-api/src/lib.rs
+++ b/crates/lex-api/src/lib.rs
@@ -9,6 +9,7 @@
 //!   POST /v1/check           { source } → { ok: true } | [TypeError]
 //!   POST /v1/publish         { source, activate? } → [{ stage_id, sig_id, status }]
 //!   GET  /v1/stage/<id>      → { metadata, ast, status }
+//!   GET  /v1/stage/<id>/attestations → { attestations: [Attestation] }
 //!   POST /v1/run             { source, fn, args, policy } → { run_id, output | error }
 //!   GET  /v1/trace/<run_id>  → TraceTree
 //!   POST /v1/replay          { source, fn, args, policy, overrides } → { run_id, output | error }

--- a/crates/lex-api/tests/m8.rs
+++ b/crates/lex-api/tests/m8.rs
@@ -119,6 +119,21 @@ fn agent_loop_publish_run_trace_diff() {
     assert_eq!(s, 200, "stage GET: {b}");
     assert!(b.contains("FnDecl"));
 
+    // 2b) #132: TypeCheck attestation written by the store-write
+    // gate is queryable via /v1/stage/<id>/attestations.
+    let (s, b) = http(&srv.addr, "GET", &format!("/v1/stage/{stage_id}/attestations"), "");
+    assert_eq!(s, 200, "attestations GET: {b}");
+    let v: serde_json::Value = serde_json::from_str(&b).unwrap();
+    let atts = v["attestations"].as_array().expect("attestations array");
+    assert!(!atts.is_empty(), "publish should have produced a TypeCheck attestation");
+    assert_eq!(atts[0]["kind"]["kind"], "type_check");
+    assert_eq!(atts[0]["result"]["result"], "passed");
+    assert_eq!(atts[0]["produced_by"]["tool"], "lex-store");
+
+    // 2c) Unknown stage_id → 404 (matches /v1/stage/<id>'s shape).
+    let (s, _) = http(&srv.addr, "GET", "/v1/stage/nonexistent/attestations", "");
+    assert_eq!(s, 404, "unknown stage_id should 404");
+
     // 3) run the function
     let run_body = json!({"source": src, "fn": "factorial", "args": [5]}).to_string();
     let (s, b) = http(&srv.addr, "POST", "/v1/run", &run_body);

--- a/crates/lex-cli/src/acli.rs
+++ b/crates/lex-cli/src/acli.rs
@@ -115,6 +115,7 @@ fn commands() -> Vec<CommandInfo> {
         cmd_blame(),
         cmd_publish(),
         cmd_store(),
+        cmd_stage(),
         cmd_trace(),
         cmd_replay(),
         cmd_diff(),
@@ -252,6 +253,20 @@ fn cmd_store() -> CommandInfo {
         .with_see_also(vec!["publish", "branch", "store-merge"]);
     info.subcommands = vec![list, get];
     info
+}
+
+fn cmd_stage() -> CommandInfo {
+    CommandInfo::new("stage", "print stage info, or list attestations for a stage")
+        .idempotent(true)
+        .add_argument("stage_id", "string", "StageId hex", true)
+        .add_option("--store", "string", "store root directory", None)
+        .add_option("--attestations", "bool", "list attestations instead of stage info", None)
+        .with_examples(vec![
+            ("Print stage info", "lex stage abc123..."),
+            ("List attestations", "lex stage abc123... --attestations"),
+            ("Machine-readable", "lex --output json stage abc123... --attestations"),
+        ])
+        .with_see_also(vec!["store", "blame", "publish"])
 }
 
 fn cmd_trace() -> CommandInfo {

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -76,6 +76,7 @@ fn run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         "blame" => cmd_blame(fmt, &args[1..]),
         "publish" => cmd_publish(fmt, &args[1..]),
         "store" => cmd_store(fmt, &args[1..]),
+        "stage" => cmd_stage(fmt, &args[1..]),
         "trace" => cmd_trace(fmt, &args[1..]),
         "replay" => cmd_replay(fmt, &args[1..]),
         "diff" => cmd_diff(fmt, &args[1..]),
@@ -145,6 +146,7 @@ fn print_usage() {
     println!("                                     publish each stage to the store as Draft");
     println!("  store list [--store DIR]           list SigIds in the store");
     println!("  store get [--store DIR] <stage>    print metadata + canonical AST for a StageId");
+    println!("  stage <stage> [--attestations]     print stage info, or list its attestations");
     println!("  trace <run_id>                     print a saved trace tree as JSON");
     println!("  replay <run_id> <file> <fn> [args] [--override NODE=JSON]...");
     println!("                                     re-execute with effect overrides keyed by NodeId");
@@ -871,6 +873,84 @@ fn cmd_store(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         }
         other => bail!("unknown `lex store` subcommand: {other}"),
     }
+}
+
+/// `lex stage <stage_id>` — print metadata + canonical AST + status.
+/// `lex stage <stage_id> --attestations` — list every attestation
+/// for the stage, newest-first by timestamp. CLI mirror of
+/// `GET /v1/stage/<id>` and `GET /v1/stage/<id>/attestations`.
+fn cmd_stage(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    let (root, rest, _, _) = parse_store_flag(args);
+    let attestations_mode = rest.iter().any(|a| a == "--attestations");
+    let positional: Vec<&String> = rest.iter().filter(|a| !a.starts_with("--")).collect();
+    let id = positional
+        .first()
+        .ok_or_else(|| anyhow!("usage: lex stage <stage_id> [--attestations]"))?;
+    let store = Store::open(&root).with_context(|| format!("opening store at {}", root.display()))?;
+
+    if attestations_mode {
+        // 404-equivalent: refuse to list against an unknown stage so
+        // callers can't silently get an empty list for a typo.
+        store
+            .get_metadata(id)
+            .with_context(|| format!("unknown stage `{id}`"))?;
+        let log = store.attestation_log()?;
+        let mut listing = log.list_for_stage(&(*id).clone())?;
+        listing.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        let data = serde_json::json!({
+            "stage_id": id,
+            "attestations": serde_json::to_value(&listing)?,
+        });
+        let listing_for_text = listing.clone();
+        acli::emit_or_text("stage", data, fmt, move || {
+            if listing_for_text.is_empty() {
+                println!("(no attestations)");
+                return;
+            }
+            for a in &listing_for_text {
+                let kind = match &a.kind {
+                    lex_vcs::AttestationKind::TypeCheck => "TypeCheck".to_string(),
+                    lex_vcs::AttestationKind::EffectAudit => "EffectAudit".to_string(),
+                    lex_vcs::AttestationKind::Examples { count, .. } => {
+                        format!("Examples({count})")
+                    }
+                    lex_vcs::AttestationKind::Spec { spec_id, .. } => {
+                        format!("Spec({spec_id})")
+                    }
+                    lex_vcs::AttestationKind::DiffBody { input_count, .. } => {
+                        format!("DiffBody({input_count})")
+                    }
+                    lex_vcs::AttestationKind::SandboxRun { effects } => {
+                        format!("SandboxRun([{}])", effects.iter().cloned().collect::<Vec<_>>().join(","))
+                    }
+                };
+                let result = match &a.result {
+                    lex_vcs::AttestationResult::Passed => "passed".to_string(),
+                    lex_vcs::AttestationResult::Failed { detail } => format!("failed: {detail}"),
+                    lex_vcs::AttestationResult::Inconclusive { detail } => format!("inconclusive: {detail}"),
+                };
+                println!(
+                    "{}\t{}\t{}\tby={}@{}",
+                    a.timestamp, kind, result, a.produced_by.tool, a.produced_by.version,
+                );
+            }
+        });
+        return Ok(());
+    }
+
+    // Default: stage info, mirroring `GET /v1/stage/<id>`.
+    let meta = store.get_metadata(id)?;
+    let ast = store.get_ast(id)?;
+    let status = format!("{:?}", store.get_status(id)?).to_lowercase();
+    let v = serde_json::json!({
+        "metadata": serde_json::to_value(&meta)?,
+        "ast": serde_json::to_value(&ast)?,
+        "status": status,
+    });
+    acli::emit_or_text("stage", v.clone(), fmt, || {
+        println!("{}", serde_json::to_string_pretty(&v).unwrap());
+    });
+    Ok(())
 }
 
 fn cmd_replay(fmt: &OutputFormat, args: &[String]) -> Result<()> {

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -896,7 +896,7 @@ fn cmd_stage(fmt: &OutputFormat, args: &[String]) -> Result<()> {
             .with_context(|| format!("unknown stage `{id}`"))?;
         let log = store.attestation_log()?;
         let mut listing = log.list_for_stage(id)?;
-        listing.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        listing.sort_by_key(|a| std::cmp::Reverse(a.timestamp));
         let data = serde_json::json!({
             "stage_id": id,
             "attestations": serde_json::to_value(&listing)?,

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -882,9 +882,9 @@ fn cmd_store(fmt: &OutputFormat, args: &[String]) -> Result<()> {
 fn cmd_stage(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let (root, rest, _, _) = parse_store_flag(args);
     let attestations_mode = rest.iter().any(|a| a == "--attestations");
-    let positional: Vec<&String> = rest.iter().filter(|a| !a.starts_with("--")).collect();
-    let id = positional
-        .first()
+    let id = rest
+        .iter()
+        .find(|a| !a.starts_with("--"))
         .ok_or_else(|| anyhow!("usage: lex stage <stage_id> [--attestations]"))?;
     let store = Store::open(&root).with_context(|| format!("opening store at {}", root.display()))?;
 
@@ -895,19 +895,18 @@ fn cmd_stage(fmt: &OutputFormat, args: &[String]) -> Result<()> {
             .get_metadata(id)
             .with_context(|| format!("unknown stage `{id}`"))?;
         let log = store.attestation_log()?;
-        let mut listing = log.list_for_stage(&(*id).clone())?;
+        let mut listing = log.list_for_stage(id)?;
         listing.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
         let data = serde_json::json!({
             "stage_id": id,
             "attestations": serde_json::to_value(&listing)?,
         });
-        let listing_for_text = listing.clone();
         acli::emit_or_text("stage", data, fmt, move || {
-            if listing_for_text.is_empty() {
+            if listing.is_empty() {
                 println!("(no attestations)");
                 return;
             }
-            for a in &listing_for_text {
+            for a in &listing {
                 let kind = match &a.kind {
                     lex_vcs::AttestationKind::TypeCheck => "TypeCheck".to_string(),
                     lex_vcs::AttestationKind::EffectAudit => "EffectAudit".to_string(),
@@ -921,7 +920,8 @@ fn cmd_stage(fmt: &OutputFormat, args: &[String]) -> Result<()> {
                         format!("DiffBody({input_count})")
                     }
                     lex_vcs::AttestationKind::SandboxRun { effects } => {
-                        format!("SandboxRun([{}])", effects.iter().cloned().collect::<Vec<_>>().join(","))
+                        let joined: Vec<&str> = effects.iter().map(String::as_str).collect();
+                        format!("SandboxRun([{}])", joined.join(","))
                     }
                 };
                 let result = match &a.result {

--- a/crates/lex-cli/tests/stage.rs
+++ b/crates/lex-cli/tests/stage.rs
@@ -1,0 +1,93 @@
+//! `lex stage <stage_id>` and `lex stage <stage_id> --attestations`.
+
+use std::process::Command;
+use tempfile::tempdir;
+
+fn lex_bin() -> &'static str { env!("CARGO_BIN_EXE_lex") }
+
+fn publish(store: &std::path::Path, src: &std::path::Path) -> serde_json::Value {
+    let out = Command::new(lex_bin())
+        .args([
+            "--output", "json",
+            "publish",
+            "--store", store.to_str().unwrap(),
+            src.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run publish");
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    serde_json::from_slice(&out.stdout).unwrap()
+}
+
+#[test]
+fn lex_stage_prints_metadata_and_ast() {
+    let store = tempdir().unwrap();
+    let src = store.path().join("a.lex");
+    std::fs::write(&src, "fn fac(n :: Int) -> Int { 1 }\n").unwrap();
+    let v = publish(store.path(), &src);
+    let ops = v.pointer("/data/ops").unwrap().as_array().unwrap();
+    let stage_id = ops[0]["kind"]["stage_id"].as_str().unwrap();
+
+    let out = Command::new(lex_bin())
+        .args([
+            "--output", "json",
+            "stage",
+            "--store", store.path().to_str().unwrap(),
+            stage_id,
+        ])
+        .output()
+        .expect("run stage");
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let data = v.pointer("/data").unwrap();
+    assert!(data["metadata"]["stage_id"].as_str().is_some());
+    assert!(data["ast"].is_object());
+    assert!(data["status"].is_string());
+}
+
+#[test]
+fn lex_stage_attestations_lists_typecheck_evidence() {
+    // After a `lex publish` against a fresh store, the store-write
+    // gate (#130) emits a TypeCheck::Passed attestation. The CLI
+    // must surface it via `lex stage <id> --attestations`.
+    let store = tempdir().unwrap();
+    let src = store.path().join("a.lex");
+    std::fs::write(&src, "fn fac(n :: Int) -> Int { 1 }\n").unwrap();
+    let v = publish(store.path(), &src);
+    let ops = v.pointer("/data/ops").unwrap().as_array().unwrap();
+    let stage_id = ops[0]["kind"]["stage_id"].as_str().unwrap();
+
+    let out = Command::new(lex_bin())
+        .args([
+            "--output", "json",
+            "stage",
+            "--store", store.path().to_str().unwrap(),
+            stage_id,
+            "--attestations",
+        ])
+        .output()
+        .expect("run stage --attestations");
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let atts = v.pointer("/data/attestations").unwrap().as_array().unwrap();
+    assert!(!atts.is_empty(), "expected a TypeCheck attestation; got: {v}");
+    assert_eq!(atts[0]["kind"]["kind"], "type_check");
+    assert_eq!(atts[0]["result"]["result"], "passed");
+    assert_eq!(atts[0]["produced_by"]["tool"], "lex-store");
+    assert_eq!(atts[0]["stage_id"], stage_id);
+}
+
+#[test]
+fn lex_stage_unknown_id_errors() {
+    let store = tempdir().unwrap();
+    let out = Command::new(lex_bin())
+        .args([
+            "stage",
+            "--store", store.path().to_str().unwrap(),
+            "nonexistent_stage_id",
+            "--attestations",
+        ])
+        .output()
+        .expect("run stage");
+    assert!(!out.status.success(), "expected nonzero exit on unknown stage");
+}


### PR DESCRIPTION
## Summary

First consumer slice of #132. The producer side landed in #147 (TypeCheck attestations from the store-write gate); this PR makes that evidence readable.

- **HTTP**: `GET /v1/stage/<id>/attestations` — every attestation for the stage, newest-first by timestamp. 404 on unknown stage_id; empty list (200) is evidence of absence.
- **CLI**: `lex stage <id>` (mirrors `GET /v1/stage/<id>`) and `lex stage <id> --attestations` (mirrors the new endpoint). The base subcommand stands on its own so `--attestations` is an alternate output mode, not a required arg.
- Both surfaces refuse to list against an unknown stage_id so a typo can't silently look like "no evidence yet."

## Test plan

- [x] `cargo test -p lex-api` — `agent_loop_publish_run_trace_diff` extended to verify the attestation written by `publish` is queryable via the new endpoint, and that unknown stage_ids 404.
- [x] `cargo test -p lex-cli --test stage` — 3 new tests covering: stage info default mode, `--attestations` listing the TypeCheck evidence, and unknown-stage error path.
- [x] `cargo test --workspace` — all green, no regressions.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.

## Remaining for #132

After this slice, three producers (`lex agent-tool --examples`/`--spec`/`--diff-body`, `lex spec check`, `lex audit --effect`) and two consumers (`lex blame --with-evidence`, `lex attest filter`) remain. Each is its own small PR.

https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5

---
_Generated by [Claude Code](https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5)_