### PR TITLE
feat: lex blame --with-evidence shows attestation trail

### DIFF
--- a/crates/lex-cli/src/acli.rs
+++ b/crates/lex-cli/src/acli.rs
@@ -216,11 +216,18 @@ fn cmd_blame() -> CommandInfo {
         .idempotent(true)
         .add_argument("file", "string", "path to a .lex file", true)
         .add_option("--store", "string", "store root directory", None)
+        .add_option(
+            "--with-evidence",
+            "bool",
+            "attach attestations to each history entry",
+            None,
+        )
         .with_examples(vec![
             ("Blame a file", "lex blame app.lex"),
+            ("With evidence trail", "lex blame --with-evidence app.lex"),
             ("Machine-readable", "lex --output json blame app.lex"),
         ])
-        .with_see_also(vec!["hash", "publish", "store", "log"])
+        .with_see_also(vec!["hash", "publish", "store", "stage", "log"])
 }
 
 fn cmd_publish() -> CommandInfo {

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -530,12 +530,19 @@ fn cmd_hash(fmt: &OutputFormat, args: &[String]) -> Result<()> {
 }
 
 fn cmd_blame(fmt: &OutputFormat, args: &[String]) -> Result<()> {
-    // usage: lex blame [--store DIR] <file>
-    let (root, rest, _, _) = parse_store_flag(args);
-    let path = rest.first().ok_or_else(|| anyhow!("usage: lex blame [--store DIR] <file>"))?;
+    // usage: lex blame [--store DIR] [--with-evidence] <file>
+    let (root, mut rest, _, _) = parse_store_flag(args);
+    let with_evidence = rest.iter().any(|a| a == "--with-evidence");
+    rest.retain(|a| a != "--with-evidence");
+    let path = rest.first().ok_or_else(|| anyhow!("usage: lex blame [--store DIR] [--with-evidence] <file>"))?;
     let prog = read_program(path)?;
     let stages = canonicalize_program(&prog);
     let store = Store::open(&root).with_context(|| format!("opening store at {}", root.display()))?;
+    // Attestation log is opened once per blame run (not per stage)
+    // so a 1000-entry blame doesn't pay 1000 fs::create_dir_all
+    // calls. The log itself is just a path holder; reads are
+    // per-stage directory listings.
+    let att_log = if with_evidence { Some(store.attestation_log()?) } else { None };
 
     let mut entries = Vec::new();
     for s in &stages {
@@ -551,18 +558,32 @@ fn cmd_blame(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         let here_status = history.iter().find(|h| h.stage_id == here_stage)
             .map(|h| format!("{:?}", h.status).to_lowercase());
 
+        let history_json: Vec<serde_json::Value> = history.iter().map(|h| {
+            let mut entry = serde_json::json!({
+                "stage_id": h.stage_id,
+                "status": format!("{:?}", h.status).to_lowercase(),
+                "last_at": h.last_at,
+                "published_at": h.published_at,
+            });
+            if let Some(log) = &att_log {
+                let mut atts = log.list_for_stage(&h.stage_id).unwrap_or_default();
+                atts.sort_by_key(|a| std::cmp::Reverse(a.timestamp));
+                if let Some(obj) = entry.as_object_mut() {
+                    obj.insert(
+                        "attestations".into(),
+                        serde_json::to_value(&atts).unwrap_or(serde_json::Value::Null),
+                    );
+                }
+            }
+            entry
+        }).collect();
         entries.push(serde_json::json!({
             "name": name,
             "sig_id": sig,
             "here_stage_id": here_stage,
             "here_status": here_status,    // None => unpublished
             "active_stage_id": active_stage,
-            "history": history.iter().map(|h| serde_json::json!({
-                "stage_id": h.stage_id,
-                "status": format!("{:?}", h.status).to_lowercase(),
-                "last_at": h.last_at,
-                "published_at": h.published_at,
-            })).collect::<Vec<_>>(),
+            "history": history_json,
         }));
 
         // New: causal history from the op log.
@@ -646,6 +667,22 @@ fn print_blame_entry(e: &serde_json::Value) {
             let at  = h["last_at"].as_u64().unwrap_or(0);
             let marker = if sid == here { " ←" } else { "" };
             println!("    {sid:.16}…  {st:<10} {}{marker}", format_blame_ts(at));
+            // `--with-evidence` attaches attestations to each history
+            // entry. Render compactly: one line per attestation,
+            // showing kind, result, and producer.
+            if let Some(atts) = h["attestations"].as_array() {
+                if atts.is_empty() {
+                    println!("      evidence: (none)");
+                } else {
+                    for a in atts {
+                        let kind = a["kind"]["kind"].as_str().unwrap_or("?");
+                        let result = a["result"]["result"].as_str().unwrap_or("?");
+                        let tool = a["produced_by"]["tool"].as_str().unwrap_or("?");
+                        let ver = a["produced_by"]["version"].as_str().unwrap_or("?");
+                        println!("      {kind:<14} {result:<8} by {tool}@{ver}");
+                    }
+                }
+            }
         }
     }
     println!();

--- a/crates/lex-cli/tests/publish.rs
+++ b/crates/lex-cli/tests/publish.rs
@@ -46,6 +46,85 @@ fn republish_unchanged_source_emits_zero_ops() {
 }
 
 #[test]
+fn blame_with_evidence_attaches_typecheck_attestation() {
+    // After `lex publish`, every accepted op carries a TypeCheck::Passed
+    // attestation (#132 + #147). `lex blame --with-evidence` must
+    // surface that evidence under the corresponding history entry.
+    let store = tempdir().unwrap();
+    let src = store.path().join("a.lex");
+    std::fs::write(&src, "fn fac(n :: Int) -> Int { 1 }\n").unwrap();
+    let _ = Command::new(lex_bin())
+        .args([
+            "--output", "json",
+            "publish",
+            "--store", store.path().to_str().unwrap(),
+            src.to_str().unwrap(),
+        ])
+        .output().unwrap();
+
+    let out = Command::new(lex_bin())
+        .args([
+            "--output", "json",
+            "blame",
+            "--store", store.path().to_str().unwrap(),
+            "--with-evidence",
+            src.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run blame");
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let blame = v.pointer("/data/blame").unwrap().as_array().unwrap();
+    let entry = blame.iter().find(|e| e["name"] == "fac").expect("fac in blame");
+    let history = entry["history"].as_array().expect("history array");
+    assert!(!history.is_empty(), "expected non-empty history");
+    let stage_entry = &history[0];
+    let atts = stage_entry["attestations"].as_array()
+        .expect("attestations field present under --with-evidence");
+    assert!(!atts.is_empty(), "expected at least one TypeCheck attestation");
+    assert_eq!(atts[0]["kind"]["kind"], "type_check");
+    assert_eq!(atts[0]["result"]["result"], "passed");
+    assert_eq!(atts[0]["produced_by"]["tool"], "lex-store");
+}
+
+#[test]
+fn blame_without_evidence_does_not_attach_attestations() {
+    // Without --with-evidence the JSON shape stays unchanged
+    // (no `attestations` field). Important for backward
+    // compatibility with consumers that didn't ask for evidence.
+    let store = tempdir().unwrap();
+    let src = store.path().join("a.lex");
+    std::fs::write(&src, "fn fac(n :: Int) -> Int { 1 }\n").unwrap();
+    let _ = Command::new(lex_bin())
+        .args([
+            "--output", "json",
+            "publish",
+            "--store", store.path().to_str().unwrap(),
+            src.to_str().unwrap(),
+        ])
+        .output().unwrap();
+
+    let out = Command::new(lex_bin())
+        .args([
+            "--output", "json",
+            "blame",
+            "--store", store.path().to_str().unwrap(),
+            src.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run blame");
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let blame = v.pointer("/data/blame").unwrap().as_array().unwrap();
+    let entry = blame.iter().find(|e| e["name"] == "fac").unwrap();
+    let history = entry["history"].as_array().unwrap();
+    assert!(
+        history[0].get("attestations").is_none(),
+        "attestations field must not appear without --with-evidence",
+    );
+}
+
+#[test]
 fn blame_after_rename_shows_one_causal_event() {
     let store = tempdir().unwrap();
     let src1 = store.path().join("a.lex");


### PR DESCRIPTION
## Summary

Second consumer slice of #132. Adds `--with-evidence` to `lex blame`: each stage in the history now carries an `attestations` array under the flag, sourced from `Store::attestation_log()`. Currently surfaces the `TypeCheck::Passed` attestations from #147; subsequent producer slices (`lex spec check`, `lex agent-tool`) will populate further kinds without further blame changes.

- **Without the flag**, JSON shape is unchanged — important for harnesses that didn't ask for evidence.
- **Text mode** renders one compact line per attestation: `<kind> <result> by <tool>@<version>`.
- The attestation log is opened **once per blame run**, not per stage.

## Test plan

- [x] `cargo test -p lex-cli --test publish` — 2 new tests:
  - `blame_with_evidence_attaches_typecheck_attestation` — flag attaches the TypeCheck attestation written by publish.
  - `blame_without_evidence_does_not_attach_attestations` — backward-compat: no `attestations` field without the flag.
- [x] `cargo test --workspace` — green, no regressions in existing blame test.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.

## Remaining for #132

After this slice, the consumer side has: HTTP `GET /v1/stage/<id>/attestations` (#148, in flight), `lex stage <id> --attestations` (#148), `lex blame --with-evidence` (this PR). Still missing: `lex attest filter`. Producer side still needs `lex spec check`, `lex audit --effect` (needs design — current command is discovery, not verification), and `lex agent-tool` (`--examples`, `--spec`, `--diff-body`).

https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5

---
_Generated by [Claude Code](https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5)_