### PR TITLE
feat: lex spec check --store emits Spec attestations

### DIFF
--- a/crates/lex-cli/src/acli.rs
+++ b/crates/lex-cli/src/acli.rs
@@ -338,7 +338,14 @@ fn cmd_spec() -> CommandInfo {
     let check = CommandInfo::new("check", "check a Spec against a Lex source")
         .idempotent(true)
         .add_argument("spec", "string", "spec file", true)
-        .add_option("--source", "string", "source file to verify against", None);
+        .add_option("--source", "string", "source file to verify against", None)
+        .add_option("--trials", "string", "randomized trial count (default 1000)", None)
+        .add_option(
+            "--store",
+            "string",
+            "if set, persist a Spec attestation against the target stage",
+            None,
+        );
     let smt = CommandInfo::new("smt", "emit SMT-LIB for external Z3")
         .idempotent(true)
         .add_argument("spec", "string", "spec file", true);

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -153,7 +153,9 @@ fn print_usage() {
     println!("  diff <run_a> <run_b>               first NodeId where two traces diverge");
     println!("  serve [--port N] [--store DIR]     start the agent API HTTP server");
     println!("  conformance <dir>                  run all JSON test descriptors in <dir>");
-    println!("  spec check <spec> --source <file>  check a Spec against a Lex source");
+    println!("  spec check <spec> --source <file> [--store DIR] [--trials N]");
+    println!("                                     check a Spec against a Lex source");
+    println!("                                     (--store: persist a Spec attestation)");
     println!("  spec smt <spec>                    emit SMT-LIB for external Z3");
     println!("  agent-tool [--allow-effects ks] (--request 'q' | --body-file F | --body 'B')");
     println!("                                     have an LLM emit a Lex tool body, run it");
@@ -726,6 +728,74 @@ fn json_to_value(v: &serde_json::Value) -> Value {
     Value::from_json(v)
 }
 
+/// Find the StageId of a function declared in `lex_src` whose name
+/// matches `fn_name`. Returns `None` if the source doesn't parse,
+/// the fn isn't there, or it's a non-FnDecl stage. Used by `lex
+/// spec check` to tie its Spec attestation to the exact stage the
+/// spec was verified against.
+fn find_stage_id_for_fn(lex_src: &str, fn_name: &str) -> Option<String> {
+    let prog = load_program_from_str(lex_src).ok()?;
+    let stages = canonicalize_program(&prog);
+    let stage = stages.iter().find(|s| matches!(s, Stage::FnDecl(fd) if fd.name == fn_name))?;
+    stage_id(stage)
+}
+
+/// Persist a `Spec` attestation against `stage_id` capturing the
+/// outcome of a `lex spec check` run. Emits passed / failed (with
+/// counterexample summary) / inconclusive (with note) so the
+/// evidence trail covers all three verdicts — failures are
+/// evidence too (#132 trust model).
+fn record_spec_attestation(
+    store_root: &std::path::Path,
+    stage_id: &str,
+    spec_name: &str,
+    r: &spec_checker::CheckResult,
+    trials: u32,
+) -> Result<()> {
+    use lex_vcs::{
+        Attestation, AttestationKind, AttestationResult, ProducerDescriptor, SpecMethod,
+    };
+    let store = Store::open(store_root)
+        .with_context(|| format!("opening store at {}", store_root.display()))?;
+    let log = store.attestation_log()?;
+
+    let result = match r.status {
+        spec_checker::ProofStatus::Proved => AttestationResult::Passed,
+        spec_checker::ProofStatus::Counterexample => {
+            let detail = r.evidence.counterexample.as_ref()
+                .and_then(|c| serde_json::to_string(c).ok())
+                .map(|s| format!("counterexample: {s}"))
+                .unwrap_or_else(|| "counterexample".into());
+            AttestationResult::Failed { detail }
+        }
+        spec_checker::ProofStatus::Inconclusive => AttestationResult::Inconclusive {
+            detail: r.evidence.note.clone().unwrap_or_else(|| "inconclusive".into()),
+        },
+    };
+    let kind = AttestationKind::Spec {
+        spec_id: r.spec_id.clone(),
+        method: SpecMethod::Random,
+        trials: Some(trials as usize),
+    };
+    let producer = ProducerDescriptor {
+        tool: "lex spec check".into(),
+        version: env!("CARGO_PKG_VERSION").into(),
+        model: None,
+    };
+    let _ = spec_name; // Reserved for future provenance fields.
+    let attestation = Attestation::new(
+        stage_id.to_string(),
+        None,
+        None,
+        kind,
+        result,
+        producer,
+        None,
+    );
+    log.put(&attestation)?;
+    Ok(())
+}
+
 fn value_to_json_string(v: &Value) -> String {
     serde_json::to_string(&v.to_json()).unwrap()
 }
@@ -1134,6 +1204,7 @@ fn cmd_spec(fmt: &OutputFormat, args: &[String]) -> Result<()> {
             let mut spec_path: Option<&String> = None;
             let mut src_path: Option<&String> = None;
             let mut trials: u32 = 1000;
+            let mut store_root: Option<PathBuf> = None;
             let mut i = 0;
             while i < rest.len() {
                 match rest[i].as_str() {
@@ -1141,6 +1212,10 @@ fn cmd_spec(fmt: &OutputFormat, args: &[String]) -> Result<()> {
                     "--trials" => {
                         trials = rest.get(i + 1).and_then(|s| s.parse().ok())
                             .ok_or_else(|| anyhow!("--trials needs a u32"))?;
+                        i += 2;
+                    }
+                    "--store" => {
+                        store_root = rest.get(i + 1).map(PathBuf::from);
                         i += 2;
                     }
                     _ if spec_path.is_none() => { spec_path = Some(&rest[i]); i += 1; }
@@ -1154,6 +1229,24 @@ fn cmd_spec(fmt: &OutputFormat, args: &[String]) -> Result<()> {
             let spec = spec_checker::parse_spec(&spec_src)
                 .map_err(|e| anyhow!("spec parse: {e}"))?;
             let r = spec_checker::check_spec(&spec, &lex_src, trials);
+
+            // #132: when --store is provided, emit a Spec attestation
+            // tied to the StageId of the function the spec targets.
+            // The attestation captures the verification result
+            // (passed / failed-with-counterexample / inconclusive)
+            // so a downstream `lex blame --with-evidence` or
+            // `GET /v1/stage/<id>/attestations` answers "has this
+            // stage ever been spec-checked?" without re-running.
+            //
+            // No-ops if `--store` is absent or the source doesn't
+            // contain a fn matching `spec.name` (the typical case
+            // is a spec referring to a fn that *is* in the source).
+            if let Some(root) = &store_root {
+                if let Some(target_stage_id) = find_stage_id_for_fn(&lex_src, &spec.name) {
+                    record_spec_attestation(root, &target_stage_id, &spec.name, &r, trials)?;
+                }
+            }
+
             let data = serde_json::to_value(&r)?;
             acli::emit_or_text("spec", data.clone(), fmt, || {
                 println!("{}", serde_json::to_string_pretty(&data).unwrap());

--- a/crates/lex-cli/tests/spec_attestation.rs
+++ b/crates/lex-cli/tests/spec_attestation.rs
@@ -1,0 +1,141 @@
+//! `lex spec check --store DIR` — Spec attestation producer (#132).
+
+use std::process::Command;
+use tempfile::tempdir;
+
+fn lex_bin() -> &'static str { env!("CARGO_BIN_EXE_lex") }
+
+const CLAMP_GOOD: &str = "fn clamp(x :: Int, lo :: Int, hi :: Int) -> Int {\n  match x < lo {\n    true => lo,\n    false => match x > hi {\n      true => hi,\n      false => x,\n    },\n  }\n}\n";
+
+const CLAMP_BAD: &str = "fn clamp(x :: Int, lo :: Int, hi :: Int) -> Int {\n  match x < lo {\n    true => x,\n    false => match x > hi {\n      true => x,\n      false => x,\n    },\n  }\n}\n";
+
+const CLAMP_SPEC: &str = "spec clamp {\n  forall x :: Int, lo :: Int, hi :: Int where lo <= hi:\n    let r := clamp(x, lo, hi)\n    (r >= lo) and (r <= hi)\n}\n";
+
+fn write_files(store: &std::path::Path, lex_src: &str) -> (std::path::PathBuf, std::path::PathBuf) {
+    let lex = store.join("clamp.lex");
+    let spec = store.join("clamp.spec");
+    std::fs::write(&lex, lex_src).unwrap();
+    std::fs::write(&spec, CLAMP_SPEC).unwrap();
+    (lex, spec)
+}
+
+fn publish(store: &std::path::Path, lex: &std::path::Path) {
+    let out = Command::new(lex_bin())
+        .args([
+            "--output", "json",
+            "publish",
+            "--store", store.to_str().unwrap(),
+            lex.to_str().unwrap(),
+        ])
+        .output().unwrap();
+    assert!(out.status.success(), "publish failed: {}", String::from_utf8_lossy(&out.stderr));
+}
+
+#[test]
+fn passing_spec_writes_passed_attestation() {
+    let store = tempdir().unwrap();
+    let (lex, spec) = write_files(store.path(), CLAMP_GOOD);
+    publish(store.path(), &lex);
+
+    let out = Command::new(lex_bin())
+        .args([
+            "spec", "check",
+            spec.to_str().unwrap(),
+            "--source", lex.to_str().unwrap(),
+            "--store", store.path().to_str().unwrap(),
+            "--trials", "200",
+        ])
+        .output()
+        .expect("run spec check");
+    assert!(out.status.success(), "spec check failed: {}", String::from_utf8_lossy(&out.stderr));
+
+    // The clamp fn should now have a Spec attestation recorded.
+    let stage_out = Command::new(lex_bin())
+        .args([
+            "--output", "json",
+            "blame",
+            "--store", store.path().to_str().unwrap(),
+            "--with-evidence",
+            lex.to_str().unwrap(),
+        ])
+        .output().unwrap();
+    assert!(stage_out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&stage_out.stdout).unwrap();
+    let blame = v.pointer("/data/blame").unwrap().as_array().unwrap();
+    let entry = blame.iter().find(|e| e["name"] == "clamp").expect("clamp entry");
+    let history = entry["history"].as_array().unwrap();
+    let atts = history[0]["attestations"].as_array().unwrap();
+
+    let spec_att = atts.iter().find(|a| a["kind"]["kind"] == "spec")
+        .expect("expected a Spec attestation alongside the TypeCheck one");
+    assert_eq!(spec_att["result"]["result"], "passed");
+    assert_eq!(spec_att["produced_by"]["tool"], "lex spec check");
+    // spec_id is a content hash from the spec_checker, not the spec
+    // name — non-empty and stable across runs.
+    let spec_id = spec_att["kind"]["spec_id"].as_str().expect("spec_id string");
+    assert!(!spec_id.is_empty(), "spec_id should be non-empty");
+    assert_eq!(spec_att["kind"]["method"], "random");
+    assert_eq!(spec_att["kind"]["trials"], 200);
+}
+
+#[test]
+fn counterexample_writes_failed_attestation() {
+    let store = tempdir().unwrap();
+    let (lex, spec) = write_files(store.path(), CLAMP_BAD);
+    publish(store.path(), &lex);
+
+    // CLAMP_BAD violates the spec; exit code 5 expected.
+    let out = Command::new(lex_bin())
+        .args([
+            "spec", "check",
+            spec.to_str().unwrap(),
+            "--source", lex.to_str().unwrap(),
+            "--store", store.path().to_str().unwrap(),
+            "--trials", "200",
+        ])
+        .output()
+        .expect("run spec check");
+    assert_eq!(out.status.code(), Some(5), "expected exit 5 for counterexample");
+
+    // Even on failure, the attestation must be persisted — failures
+    // are evidence too (#132 trust model).
+    let stage_out = Command::new(lex_bin())
+        .args([
+            "--output", "json",
+            "blame",
+            "--store", store.path().to_str().unwrap(),
+            "--with-evidence",
+            lex.to_str().unwrap(),
+        ])
+        .output().unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&stage_out.stdout).unwrap();
+    let blame = v.pointer("/data/blame").unwrap().as_array().unwrap();
+    let entry = blame.iter().find(|e| e["name"] == "clamp").unwrap();
+    let history = entry["history"].as_array().unwrap();
+    let atts = history[0]["attestations"].as_array().unwrap();
+    let spec_att = atts.iter().find(|a| a["kind"]["kind"] == "spec")
+        .expect("expected a Failed Spec attestation");
+    assert_eq!(spec_att["result"]["result"], "failed");
+    let detail = spec_att["result"]["detail"].as_str().unwrap_or("");
+    assert!(detail.starts_with("counterexample"), "detail should describe the counterexample, got: {detail}");
+}
+
+#[test]
+fn no_store_means_no_attestation() {
+    // Without --store, the spec checker still runs and reports the
+    // verdict, but writes nothing. Backwards-compat for the prior
+    // CLI surface.
+    let store = tempdir().unwrap();
+    let (lex, spec) = write_files(store.path(), CLAMP_GOOD);
+    let out = Command::new(lex_bin())
+        .args([
+            "spec", "check",
+            spec.to_str().unwrap(),
+            "--source", lex.to_str().unwrap(),
+            "--trials", "100",
+        ])
+        .output().unwrap();
+    assert!(out.status.success());
+    // No attestation directory should have been created.
+    assert!(!store.path().join("attestations").exists());
+}


### PR DESCRIPTION
## Summary

Issue #132 producer slice — `lex spec check --store DIR` now persists a `Spec` attestation against the StageId of the function the spec targets. Verdict mapping:

- `Proved` → `Passed`
- `Counterexample` → `Failed { detail: "counterexample: <bindings>" }`
- `Inconclusive` → `Inconclusive { detail: <note> }`

Per #132's trust model, **failures are evidence too** — a flaky producer must not be able to overwrite negative evidence by re-running.

The attestation kind is `Spec { spec_id, method: Random, trials }`. `spec_id` is the spec checker's existing content-addressed identifier (stable across runs of the same spec). Producer is `lex spec check` pinned to crate version so a regression in the checker is distinguishable from a regression in the verified code.

Without `--store`, behavior is unchanged.

## Test plan

- [x] `cargo test -p lex-cli --test spec_attestation` — 3 new tests:
  - `passing_spec_writes_passed_attestation` — clamp.spec passes against good clamp; `Spec::Passed` lands and is visible via `lex blame --with-evidence` (#149).
  - `counterexample_writes_failed_attestation` — bad clamp returns counterexample, exits 5, persists `Spec::Failed` with the counterexample bindings in `detail`.
  - `no_store_means_no_attestation` — without `--store`, no `attestations/` dir is created.
- [x] `cargo test --workspace` — green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (1.95-tested locally now).

## Remaining for #132

After this PR: `TypeCheck` (#147), `Spec` (this PR) wired. Still left on the producer side: `lex agent-tool` for `Examples`/`DiffBody`/`SandboxRun` and `lex audit --effect` (needs design — current command is discovery, not verification). On the consumer side: `lex attest filter` is the only remaining surface.

https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5

---
_Generated by [Claude Code](https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5)_