### PR TITLE
feat: lex attest filter — cross-stage attestation queries

### DIFF
--- a/crates/lex-cli/src/acli.rs
+++ b/crates/lex-cli/src/acli.rs
@@ -116,6 +116,7 @@ fn commands() -> Vec<CommandInfo> {
         cmd_publish(),
         cmd_store(),
         cmd_stage(),
+        cmd_attest(),
         cmd_trace(),
         cmd_replay(),
         cmd_diff(),
@@ -274,6 +275,24 @@ fn cmd_stage() -> CommandInfo {
             ("Machine-readable", "lex --output json stage abc123... --attestations"),
         ])
         .with_see_also(vec!["store", "blame", "publish"])
+}
+
+fn cmd_attest() -> CommandInfo {
+    let filter = CommandInfo::new("filter", "list attestations matching kind / result / since filters")
+        .idempotent(true)
+        .add_option("--kind", "string", "attestation kind: type_check | spec | examples | diff_body | effect_audit | sandbox_run", None)
+        .add_option("--result", "string", "passed | failed | inconclusive", None)
+        .add_option("--since", "string", "epoch seconds or YYYY-MM-DD; only attestations on or after this time", None)
+        .add_option("--store", "string", "store root directory", None);
+    let mut info = CommandInfo::new("attest", "cross-stage attestation queries (CI / dashboards)")
+        .with_examples(vec![
+            ("All Spec verdicts that passed", "lex attest filter --kind spec --result passed"),
+            ("Recent type-check evidence", "lex attest filter --kind type_check --since 2026-05-01"),
+            ("Machine-readable", "lex --output json attest filter --kind spec"),
+        ])
+        .with_see_also(vec!["stage", "blame"]);
+    info.subcommands = vec![filter];
+    info
 }
 
 fn cmd_trace() -> CommandInfo {

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -77,6 +77,7 @@ fn run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         "publish" => cmd_publish(fmt, &args[1..]),
         "store" => cmd_store(fmt, &args[1..]),
         "stage" => cmd_stage(fmt, &args[1..]),
+        "attest" => cmd_attest(fmt, &args[1..]),
         "trace" => cmd_trace(fmt, &args[1..]),
         "replay" => cmd_replay(fmt, &args[1..]),
         "diff" => cmd_diff(fmt, &args[1..]),
@@ -147,6 +148,8 @@ fn print_usage() {
     println!("  store list [--store DIR]           list SigIds in the store");
     println!("  store get [--store DIR] <stage>    print metadata + canonical AST for a StageId");
     println!("  stage <stage> [--attestations]     print stage info, or list its attestations");
+    println!("  attest filter [--kind K] [--result R] [--since T] [--store DIR]");
+    println!("                                     cross-stage attestation queries");
     println!("  trace <run_id>                     print a saved trace tree as JSON");
     println!("  replay <run_id> <file> <fn> [args] [--override NODE=JSON]...");
     println!("                                     re-execute with effect overrides keyed by NodeId");
@@ -988,6 +991,147 @@ fn cmd_stage(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         println!("{}", serde_json::to_string_pretty(&v).unwrap());
     });
     Ok(())
+}
+
+/// `lex attest filter --kind K --result R --since T --store DIR`
+/// — cross-stage attestation query (#132). Walks every primary
+/// attestation file under `<store>/attestations/` and filters by
+/// the supplied criteria. Designed for CI / dashboard queries
+/// that span the whole log rather than a single stage.
+fn cmd_attest(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    let sub = args.first().ok_or_else(|| anyhow!("usage: lex attest filter [--kind K] [--result R] [--since T] [--store DIR]"))?;
+    let rest = &args[1..];
+    match sub.as_str() {
+        "filter" => {
+            let mut kind_filter: Option<String> = None;
+            let mut result_filter: Option<String> = None;
+            let mut since: Option<u64> = None;
+            let mut store_root: Option<PathBuf> = None;
+            let mut i = 0;
+            while i < rest.len() {
+                match rest[i].as_str() {
+                    "--kind" => {
+                        kind_filter = rest.get(i + 1).cloned();
+                        i += 2;
+                    }
+                    "--result" => {
+                        result_filter = rest.get(i + 1).cloned();
+                        i += 2;
+                    }
+                    "--since" => {
+                        let raw = rest.get(i + 1).ok_or_else(|| anyhow!("--since needs a value"))?;
+                        since = Some(parse_since(raw)
+                            .ok_or_else(|| anyhow!("--since must be epoch seconds or YYYY-MM-DD, got `{raw}`"))?);
+                        i += 2;
+                    }
+                    "--store" => {
+                        store_root = rest.get(i + 1).map(PathBuf::from);
+                        i += 2;
+                    }
+                    other => bail!("unexpected arg `{other}`"),
+                }
+            }
+            let root = store_root.unwrap_or_else(default_store_root);
+            let store = Store::open(&root)
+                .with_context(|| format!("opening store at {}", root.display()))?;
+            let log = store.attestation_log()?;
+            let all = log.list_all()?;
+
+            let mut filtered: Vec<lex_vcs::Attestation> = all.into_iter()
+                .filter(|a| {
+                    if let Some(k) = &kind_filter {
+                        if attestation_kind_tag(&a.kind) != *k {
+                            return false;
+                        }
+                    }
+                    if let Some(r) = &result_filter {
+                        if attestation_result_tag(&a.result) != *r {
+                            return false;
+                        }
+                    }
+                    if let Some(s) = since {
+                        if a.timestamp < s { return false; }
+                    }
+                    true
+                })
+                .collect();
+            filtered.sort_by_key(|a| std::cmp::Reverse(a.timestamp));
+
+            let data = serde_json::json!({
+                "count": filtered.len(),
+                "attestations": serde_json::to_value(&filtered)?,
+            });
+            let printable = filtered.clone();
+            acli::emit_or_text("attest", data, fmt, move || {
+                if printable.is_empty() {
+                    println!("(no attestations match)");
+                    return;
+                }
+                for a in &printable {
+                    let kind = attestation_kind_tag(&a.kind);
+                    let result = attestation_result_tag(&a.result);
+                    println!(
+                        "{}\t{}\t{}\t{:.16}…\tby={}@{}",
+                        a.timestamp, kind, result, a.stage_id,
+                        a.produced_by.tool, a.produced_by.version,
+                    );
+                }
+            });
+            Ok(())
+        }
+        other => bail!("unknown `lex attest` subcommand: {other}"),
+    }
+}
+
+fn attestation_kind_tag(k: &lex_vcs::AttestationKind) -> &'static str {
+    use lex_vcs::AttestationKind::*;
+    match k {
+        Examples { .. }   => "examples",
+        Spec { .. }       => "spec",
+        DiffBody { .. }   => "diff_body",
+        TypeCheck         => "type_check",
+        EffectAudit       => "effect_audit",
+        SandboxRun { .. } => "sandbox_run",
+    }
+}
+
+fn attestation_result_tag(r: &lex_vcs::AttestationResult) -> &'static str {
+    use lex_vcs::AttestationResult::*;
+    match r {
+        Passed              => "passed",
+        Failed { .. }       => "failed",
+        Inconclusive { .. } => "inconclusive",
+    }
+}
+
+/// Accept either Unix epoch seconds (a u64) or `YYYY-MM-DD`. The
+/// date form resolves to start-of-day UTC. Returns `None` on a
+/// shape we don't recognize so the caller can surface a friendly
+/// usage error.
+fn parse_since(s: &str) -> Option<u64> {
+    if let Ok(secs) = s.parse::<u64>() {
+        return Some(secs);
+    }
+    let parts: Vec<&str> = s.split('-').collect();
+    if parts.len() != 3 { return None; }
+    let y: i64 = parts[0].parse().ok()?;
+    let m: u32 = parts[1].parse().ok()?;
+    let d: u32 = parts[2].parse().ok()?;
+    if !(1..=12).contains(&m) || d == 0 { return None; }
+    if y < 1970 { return None; }
+
+    let mut days: i64 = 0;
+    for yr in 1970..y {
+        let yd = if (yr % 4 == 0 && yr % 100 != 0) || yr % 400 == 0 { 366 } else { 365 };
+        days += yd;
+    }
+    let leap_year = (y % 4 == 0 && y % 100 != 0) || y % 400 == 0;
+    let mdays = [31, if leap_year { 29 } else { 28 }, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    let mi = (m - 1) as usize;
+    if d > mdays[mi] as u32 { return None; }
+    days += mdays.iter().take(mi).sum::<i64>();
+    days += (d - 1) as i64;
+    Some((days as u64) * 86_400)
 }
 
 fn cmd_replay(fmt: &OutputFormat, args: &[String]) -> Result<()> {

--- a/crates/lex-cli/tests/attest_filter.rs
+++ b/crates/lex-cli/tests/attest_filter.rs
@@ -1,0 +1,126 @@
+//! `lex attest filter` — cross-stage attestation queries (#132).
+
+use std::process::Command;
+use tempfile::tempdir;
+
+fn lex_bin() -> &'static str { env!("CARGO_BIN_EXE_lex") }
+
+fn publish(store: &std::path::Path, src: &std::path::Path) {
+    let out = Command::new(lex_bin())
+        .args([
+            "--output", "json",
+            "publish",
+            "--store", store.to_str().unwrap(),
+            src.to_str().unwrap(),
+        ])
+        .output().unwrap();
+    assert!(out.status.success(), "publish failed: {}", String::from_utf8_lossy(&out.stderr));
+}
+
+fn attest_filter_json(store: &std::path::Path, extra: &[&str]) -> serde_json::Value {
+    let mut args: Vec<String> = vec![
+        "--output".into(), "json".into(),
+        "attest".into(), "filter".into(),
+        "--store".into(), store.to_str().unwrap().to_string(),
+    ];
+    for e in extra { args.push((*e).to_string()); }
+    let out = Command::new(lex_bin())
+        .args(&args)
+        .output()
+        .expect("run attest filter");
+    assert!(out.status.success(), "attest filter failed: {}", String::from_utf8_lossy(&out.stderr));
+    serde_json::from_slice(&out.stdout).unwrap()
+}
+
+#[test]
+fn filter_lists_all_attestations_when_no_filter_given() {
+    let store = tempdir().unwrap();
+    let src = store.path().join("a.lex");
+    std::fs::write(&src, "fn fac(n :: Int) -> Int { 1 }\n").unwrap();
+    publish(store.path(), &src);
+
+    let v = attest_filter_json(store.path(), &[]);
+    let count = v.pointer("/data/count").unwrap().as_u64().unwrap();
+    assert!(count >= 1, "publish should have produced ≥1 TypeCheck attestation");
+    let atts = v.pointer("/data/attestations").unwrap().as_array().unwrap();
+    assert_eq!(atts.len() as u64, count);
+}
+
+#[test]
+fn filter_by_kind_narrows_results() {
+    let store = tempdir().unwrap();
+    let src = store.path().join("a.lex");
+    std::fs::write(&src, "fn fac(n :: Int) -> Int { 1 }\n").unwrap();
+    publish(store.path(), &src);
+
+    // Only TypeCheck attestations exist; filtering by `spec` returns 0.
+    let v = attest_filter_json(store.path(), &["--kind", "spec"]);
+    assert_eq!(v.pointer("/data/count").unwrap().as_u64().unwrap(), 0);
+
+    // Filtering by `type_check` returns the publish attestation.
+    let v = attest_filter_json(store.path(), &["--kind", "type_check"]);
+    let count = v.pointer("/data/count").unwrap().as_u64().unwrap();
+    assert!(count >= 1);
+    let atts = v.pointer("/data/attestations").unwrap().as_array().unwrap();
+    for a in atts {
+        assert_eq!(a["kind"]["kind"], "type_check");
+    }
+}
+
+#[test]
+fn filter_by_result_narrows_results() {
+    let store = tempdir().unwrap();
+    let src = store.path().join("a.lex");
+    std::fs::write(&src, "fn fac(n :: Int) -> Int { 1 }\n").unwrap();
+    publish(store.path(), &src);
+
+    let v = attest_filter_json(store.path(), &["--result", "passed"]);
+    assert!(v.pointer("/data/count").unwrap().as_u64().unwrap() >= 1);
+
+    let v = attest_filter_json(store.path(), &["--result", "failed"]);
+    assert_eq!(v.pointer("/data/count").unwrap().as_u64().unwrap(), 0);
+}
+
+#[test]
+fn filter_since_in_the_future_returns_zero() {
+    let store = tempdir().unwrap();
+    let src = store.path().join("a.lex");
+    std::fs::write(&src, "fn fac(n :: Int) -> Int { 1 }\n").unwrap();
+    publish(store.path(), &src);
+
+    // Year 2999 → no attestation can possibly be ≥ this.
+    let v = attest_filter_json(store.path(), &["--since", "2999-01-01"]);
+    assert_eq!(v.pointer("/data/count").unwrap().as_u64().unwrap(), 0);
+}
+
+#[test]
+fn filter_since_at_epoch_returns_everything() {
+    let store = tempdir().unwrap();
+    let src = store.path().join("a.lex");
+    std::fs::write(&src, "fn fac(n :: Int) -> Int { 1 }\n").unwrap();
+    publish(store.path(), &src);
+
+    // 0 = epoch; every attestation has a timestamp ≥ 0.
+    let v = attest_filter_json(store.path(), &["--since", "0"]);
+    assert!(v.pointer("/data/count").unwrap().as_u64().unwrap() >= 1);
+}
+
+#[test]
+fn filter_rejects_malformed_since() {
+    let store = tempdir().unwrap();
+    let out = Command::new(lex_bin())
+        .args([
+            "attest", "filter",
+            "--store", store.path().to_str().unwrap(),
+            "--since", "yesterday",
+        ])
+        .output().unwrap();
+    assert!(!out.status.success(), "expected error on malformed --since");
+}
+
+#[test]
+fn empty_store_returns_empty_list() {
+    let store = tempdir().unwrap();
+    let v = attest_filter_json(store.path(), &[]);
+    assert_eq!(v.pointer("/data/count").unwrap().as_u64().unwrap(), 0);
+}

--- a/crates/lex-vcs/src/attestation.rs
+++ b/crates/lex-vcs/src/attestation.rs
@@ -382,6 +382,42 @@ impl AttestationLog {
         Ok(Some(attestation))
     }
 
+    /// Enumerate every attestation in the log. Walks
+    /// `<root>/attestations/*.json` directly — no per-stage index
+    /// — so cost is `O(total attestations)`. Used by `lex attest
+    /// filter` for CI / dashboard queries that span stages.
+    /// Order is not stable; callers that need stable ordering
+    /// should sort by `timestamp` or `attestation_id`.
+    pub fn list_all(&self) -> io::Result<Vec<Attestation>> {
+        let mut out = Vec::new();
+        if !self.dir.exists() {
+            return Ok(out);
+        }
+        for entry in fs::read_dir(&self.dir)? {
+            let entry = entry?;
+            let p = entry.path();
+            // Skip the by-stage/ subdir and the .tmp staging files
+            // a crashed put might have left behind.
+            if p.is_dir() {
+                continue;
+            }
+            if p.extension().is_none_or(|e| e != "json") {
+                continue;
+            }
+            let bytes = fs::read(&p)?;
+            // A corrupt primary file shouldn't take down a filter
+            // query — log to stderr and skip.
+            match serde_json::from_slice::<Attestation>(&bytes) {
+                Ok(att) => out.push(att),
+                Err(e) => eprintln!(
+                    "warning: skipping unreadable attestation {}: {e}",
+                    p.display()
+                ),
+            }
+        }
+        Ok(out)
+    }
+
     /// Enumerate attestations for a given stage. Order is not
     /// stable across calls (it follows directory iteration order).
     /// Callers that need a stable ordering should sort by
@@ -728,6 +764,43 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let log = AttestationLog::open(tmp.path()).unwrap();
         let v = log.list_for_stage(&"never-attested".to_string()).unwrap();
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn list_all_returns_every_persisted_attestation() {
+        // Cross-stage enumeration: `list_all` walks the primary
+        // directory regardless of stage, so a CI / dashboard query
+        // can filter across the whole log without iterating the
+        // by-stage index.
+        let tmp = tempfile::tempdir().unwrap();
+        let log = AttestationLog::open(tmp.path()).unwrap();
+        let on_abc = typecheck_passed();
+        let on_xyz = Attestation::with_timestamp(
+            "stage-xyz",
+            Some("op-456".into()),
+            None,
+            AttestationKind::TypeCheck,
+            AttestationResult::Passed,
+            ci_runner(),
+            None,
+            2000,
+        );
+        log.put(&on_abc).unwrap();
+        log.put(&on_xyz).unwrap();
+        let mut all = log.list_all().unwrap();
+        all.sort_by_key(|a| a.attestation_id.clone());
+        assert_eq!(all.len(), 2);
+        let ids: BTreeSet<_> = all.iter().map(|a| a.attestation_id.clone()).collect();
+        assert!(ids.contains(&on_abc.attestation_id));
+        assert!(ids.contains(&on_xyz.attestation_id));
+    }
+
+    #[test]
+    fn list_all_on_empty_log_is_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let log = AttestationLog::open(tmp.path()).unwrap();
+        let v = log.list_all().unwrap();
         assert!(v.is_empty());
     }
 


### PR DESCRIPTION
## Summary

Issue #132 — last remaining consumer slice. Adds `lex attest filter` for CI / dashboard queries that span the whole attestation log rather than a single stage.

```
lex attest filter --kind spec --result passed --since 2026-05-01
```

Flags:
- `--kind K` — `type_check` | `spec` | `examples` | `diff_body` | `effect_audit` | `sandbox_run`
- `--result R` — `passed` | `failed` | `inconclusive`
- `--since T` — epoch seconds or `YYYY-MM-DD` (start-of-day UTC)
- `--store DIR` — defaults to `~/.lex/store`

Foundation: adds `AttestationLog::list_all()` walking the primary `attestations/<id>.json` files. The `by-stage/` index remains the per-stage fast path; this is the cross-stage path.

## Test plan

- [x] `cargo test -p lex-vcs` — 2 new unit tests for `list_all` (populated and empty cases).
- [x] `cargo test -p lex-cli --test attest_filter` — 7 integration tests covering: no filter, kind narrowing, result narrowing, future `--since`, epoch `--since`, malformed `--since`, empty store.
- [x] `cargo test --workspace` — green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (Rust 1.95 lints addressed).

## Status of #132

After this PR + #150 (in flight): consumers complete (HTTP, CLI per-stage, blame, cross-stage filter). Producers: `TypeCheck` (#147) and `Spec` (#150) wired; remaining is `lex agent-tool` for `Examples` / `DiffBody` / `SandboxRun` and `lex audit --effect` (needs design — current command is discovery, not verification).

https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5

---
_Generated by [Claude Code](https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5)_