### PR TITLE
feat: lex agent-tool --store emits Examples/Spec/DiffBody/SandboxRun

### DIFF
--- a/crates/lex-cli/Cargo.toml
+++ b/crates/lex-cli/Cargo.toml
@@ -13,6 +13,7 @@ serde.workspace = true
 serde_json.workspace = true
 anyhow.workspace = true
 indexmap.workspace = true
+sha2.workspace = true
 ureq = { version = "3.3", default-features = false, features = ["rustls", "platform-verifier", "json"] }
 tiny_http = "0.12"
 lex-syntax = { path = "../lex-syntax" }

--- a/crates/lex-cli/src/acli.rs
+++ b/crates/lex-cli/src/acli.rs
@@ -389,12 +389,14 @@ fn cmd_agent_tool() -> CommandInfo {
         .add_option("--examples", "string", "JSON examples for behavioral checking", None)
         .add_option("--diff-body", "string", "differential evaluation: alternate body", None)
         .add_option("--diff-body-file", "string", "differential evaluation: alternate body file", None)
+        .add_option("--store", "string", "if set, persist verification attestations against the tool stage", None)
         .add_option("--json", "bool", "machine-readable output", None)
         .with_examples(vec![
             ("Run with allow-list", "lex agent-tool --allow-effects fs_read --request \"sum lines of /tmp/log\""),
             ("Verify against spec", "lex agent-tool --spec sort.spec --body-file body.lex --json"),
+            ("Persist attestations", "lex agent-tool --examples cases.json --body-file body.lex --store ~/.lex/store"),
         ])
-        .with_see_also(vec!["check", "spec", "run"])
+        .with_see_also(vec!["check", "spec", "run", "attest", "stage"])
 }
 
 fn cmd_tool_registry() -> CommandInfo {

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -799,6 +799,53 @@ fn record_spec_attestation(
     Ok(())
 }
 
+/// Emit an attestation produced by `lex agent-tool` against the
+/// StageId of the agent-emitted `tool` fn. Centralizes the
+/// producer descriptor so every emission site (`--spec`,
+/// `--diff-body`, `--examples`, sandboxed run) tags itself
+/// consistently. The `model` field carries the Claude model name
+/// when the body came from `--request`; `None` for `--body`/
+/// `--body-file` since the model wasn't the proximate producer.
+fn emit_agent_tool_attestation(
+    log: &lex_vcs::AttestationLog,
+    stage_id: &str,
+    kind: lex_vcs::AttestationKind,
+    result: lex_vcs::AttestationResult,
+    model: Option<String>,
+) -> Result<()> {
+    let producer = lex_vcs::ProducerDescriptor {
+        tool: "lex agent-tool".into(),
+        version: env!("CARGO_PKG_VERSION").into(),
+        model,
+    };
+    let attestation = lex_vcs::Attestation::new(
+        stage_id.to_string(),
+        None,
+        None,
+        kind,
+        result,
+        producer,
+        None,
+    );
+    log.put(&attestation)?;
+    Ok(())
+}
+
+/// Lowercase-hex SHA-256 of `bytes`. Used by `lex agent-tool` to
+/// content-hash example files and diff-body sources for the
+/// `Examples`/`DiffBody` attestation kinds.
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(bytes);
+    let digest = h.finalize();
+    let mut out = String::with_capacity(64);
+    for b in digest.iter() {
+        out.push_str(&format!("{b:02x}"));
+    }
+    out
+}
+
 fn value_to_json_string(v: &Value) -> String {
     serde_json::to_string(&v.to_json()).unwrap()
 }
@@ -1472,6 +1519,12 @@ struct AgentToolOpts {
     /// Catches model-version regressions when v1's emission and v2's
     /// emission disagree on at least one case the host cares about.
     diff_body_source: Option<BodySource>,
+    /// Store root for attestation persistence (#132). When set,
+    /// every verification step (`--examples`, `--spec`, `--diff-body`,
+    /// and the final sandboxed run) emits an attestation against
+    /// the StageId of the agent-emitted `tool` fn. None ⇒ verifications
+    /// run as before with no persistence.
+    store_root: Option<PathBuf>,
 }
 
 enum BodySource {
@@ -1516,6 +1569,31 @@ fn cmd_agent_tool(args: &[String]) -> Result<()> {
     // effect on `fn tool` and the checker rejects it.
     let prog = load_program_from_str(&src).context("parse agent-generated source")?;
     let stages = canonicalize_program(&prog);
+
+    // #132: every verification step below is an attestation producer
+    // when `--store DIR` is set. Compute the StageId of the agent-
+    // emitted `tool` fn once; open the log once. Subsequent emit
+    // sites are content-addressed against this StageId so a later
+    // `lex stage <id> --attestations` can answer "what evidence
+    // exists for this exact body?".
+    let tool_stage_id: Option<String> = stages.iter()
+        .find_map(|s| match s {
+            Stage::FnDecl(fd) if fd.name == "tool" => stage_id(s),
+            _ => None,
+        });
+    let att_log: Option<lex_vcs::AttestationLog> = match &opts.store_root {
+        Some(root) => {
+            let store = Store::open(root)
+                .with_context(|| format!("opening store at {}", root.display()))?;
+            Some(store.attestation_log()?)
+        }
+        None => None,
+    };
+    let model_for_attestation: Option<String> = match &opts.body_source {
+        BodySource::Request(_) => Some(opts.model.clone()),
+        _ => None,
+    };
+
     if let Err(errs) = lex_types::check_program(&stages) {
         eprintln!("→ TYPE-CHECK REJECTED — tool not run.");
         for e in &errs {
@@ -1557,6 +1635,33 @@ fn cmd_agent_tool(args: &[String]) -> Result<()> {
             eprintln!("→ checking spec `{}`…", spec.name);
         }
         let report = spec_checker::check_spec(&spec, &src, opts.spec_trials);
+
+        // Emit the Spec attestation *before* the match below acts on
+        // the verdict — Counterexample / strict Inconclusive both
+        // exit, so we'd lose evidence on the failure path otherwise.
+        // Failures are evidence too (#132 trust model).
+        if let (Some(log), Some(sid)) = (&att_log, &tool_stage_id) {
+            let result = match &report.status {
+                spec_checker::ProofStatus::Proved => lex_vcs::AttestationResult::Passed,
+                spec_checker::ProofStatus::Counterexample => {
+                    let detail = report.evidence.counterexample.as_ref()
+                        .and_then(|c| serde_json::to_string(c).ok())
+                        .map(|s| format!("counterexample: {s}"))
+                        .unwrap_or_else(|| "counterexample".into());
+                    lex_vcs::AttestationResult::Failed { detail }
+                }
+                spec_checker::ProofStatus::Inconclusive => lex_vcs::AttestationResult::Inconclusive {
+                    detail: report.evidence.note.clone().unwrap_or_else(|| "inconclusive".into()),
+                },
+            };
+            let kind = lex_vcs::AttestationKind::Spec {
+                spec_id: report.spec_id.clone(),
+                method: lex_vcs::SpecMethod::Random,
+                trials: Some(opts.spec_trials as usize),
+            };
+            emit_agent_tool_attestation(log, sid, kind, result, model_for_attestation.clone())?;
+        }
+
         match report.status {
             spec_checker::ProofStatus::Proved => {
                 if opts.show_source {
@@ -1643,6 +1748,27 @@ fn cmd_agent_tool(args: &[String]) -> Result<()> {
                 diverged.push((input.clone(), out_a, out_b));
             }
         }
+        // Emit a DiffBody attestation against the original tool's
+        // StageId. `other_body_hash` is the SHA-256 of the second
+        // body's source so re-running with the same pair dedups.
+        // Failed attestation carries a summary of how many inputs
+        // diverged.
+        if let (Some(log), Some(sid)) = (&att_log, &tool_stage_id) {
+            let other_body_hash = sha256_hex(diff_body_text.as_bytes());
+            let result = if diverged.is_empty() {
+                lex_vcs::AttestationResult::Passed
+            } else {
+                lex_vcs::AttestationResult::Failed {
+                    detail: format!("{}/{} inputs diverged", diverged.len(), inputs.len()),
+                }
+            };
+            let kind = lex_vcs::AttestationKind::DiffBody {
+                other_body_hash,
+                input_count: inputs.len(),
+            };
+            emit_agent_tool_attestation(log, sid, kind, result, model_for_attestation.clone())?;
+        }
+
         if !diverged.is_empty() {
             eprintln!("→ DIFFERENTIAL DIVERGENCE — {} of {} inputs differ.",
                 diverged.len(), inputs.len());
@@ -1659,6 +1785,18 @@ fn cmd_agent_tool(args: &[String]) -> Result<()> {
         // Print body A's output on the first input — single-shot mode.
         let chosen = inputs.first().cloned().unwrap_or_default();
         let out = run_tool_once(&bc, &policy, opts.max_steps, &chosen)?;
+        if let (Some(log), Some(sid)) = (&att_log, &tool_stage_id) {
+            let kind = lex_vcs::AttestationKind::SandboxRun {
+                effects: opts.allowed_effects.iter().cloned().collect(),
+            };
+            emit_agent_tool_attestation(
+                log,
+                sid,
+                kind,
+                lex_vcs::AttestationResult::Passed,
+                model_for_attestation.clone(),
+            )?;
+        }
         println!("{out}");
         return Ok(());
     }
@@ -1668,7 +1806,11 @@ fn cmd_agent_tool(args: &[String]) -> Result<()> {
     // the type system says what code touches; the examples say what it
     // should return. On any mismatch, exit 5 (distinct from 2/3/4).
     if let Some(path) = opts.examples_file.as_ref() {
-        let examples = load_examples(path)?;
+        let raw_examples = fs::read(path)
+            .with_context(|| format!("read examples file {}", path.display()))?;
+        let examples_file_hash = sha256_hex(&raw_examples);
+        let examples: Vec<Example> = serde_json::from_slice(&raw_examples)
+            .with_context(|| format!("parse examples file {}; expected JSON array of {{input, expected}}", path.display()))?;
         if opts.show_source {
             eprintln!("→ checking {} example(s)…", examples.len());
         }
@@ -1679,6 +1821,24 @@ fn cmd_agent_tool(args: &[String]) -> Result<()> {
                 failures.push((idx, ex, out));
             }
         }
+
+        // Emit Examples attestation regardless of pass/fail. Same
+        // "failures are evidence too" rule as Spec.
+        if let (Some(log), Some(sid)) = (&att_log, &tool_stage_id) {
+            let result = if failures.is_empty() {
+                lex_vcs::AttestationResult::Passed
+            } else {
+                lex_vcs::AttestationResult::Failed {
+                    detail: format!("{}/{} examples mismatched", failures.len(), examples.len()),
+                }
+            };
+            let kind = lex_vcs::AttestationKind::Examples {
+                file_hash: examples_file_hash,
+                count: examples.len(),
+            };
+            emit_agent_tool_attestation(log, sid, kind, result, model_for_attestation.clone())?;
+        }
+
         if !failures.is_empty() {
             eprintln!("→ EXAMPLES FAILED — tool not trusted ({} of {} mismatched).",
                 failures.len(), examples.len());
@@ -1697,6 +1857,23 @@ fn cmd_agent_tool(args: &[String]) -> Result<()> {
     // 5b) Single-shot run with the user_input. With --examples this
     // doubles as a sanity invocation; without examples it's the only run.
     let result = run_tool_once(&bc, &policy, opts.max_steps, &opts.user_input)?;
+
+    // Emit a SandboxRun attestation tagging the effects the policy
+    // actually allowed. `Passed` only — a runtime-error path
+    // returns Err above and never reaches this point.
+    if let (Some(log), Some(sid)) = (&att_log, &tool_stage_id) {
+        let kind = lex_vcs::AttestationKind::SandboxRun {
+            effects: opts.allowed_effects.iter().cloned().collect(),
+        };
+        emit_agent_tool_attestation(
+            log,
+            sid,
+            kind,
+            lex_vcs::AttestationResult::Passed,
+            model_for_attestation.clone(),
+        )?;
+    }
+
     println!("{result}");
     Ok(())
 }
@@ -1772,6 +1949,7 @@ fn parse_agent_tool_args(args: &[String]) -> Result<AgentToolOpts> {
     let mut spec_allow_inconclusive = false;
     let mut spec_trials: u32 = 1000;
     let mut diff_body: Option<BodySource> = None;
+    let mut store_root: Option<PathBuf> = None;
     let mut i = 0;
     while i < args.len() {
         match args[i].as_str() {
@@ -1848,6 +2026,11 @@ fn parse_agent_tool_args(args: &[String]) -> Result<AgentToolOpts> {
                     .ok_or_else(|| anyhow!("--diff-body-file needs a path"))?)));
                 i += 2;
             }
+            "--store" => {
+                store_root = Some(PathBuf::from(args.get(i + 1)
+                    .ok_or_else(|| anyhow!("--store needs a path"))?));
+                i += 2;
+            }
             "--quiet" => { show_source = false; i += 1; }
             other => bail!("unknown agent-tool flag: {other}"),
         }
@@ -1868,6 +2051,7 @@ fn parse_agent_tool_args(args: &[String]) -> Result<AgentToolOpts> {
         spec_allow_inconclusive,
         spec_trials,
         diff_body_source: diff_body,
+        store_root,
     })
 }
 

--- a/crates/lex-cli/tests/agent_tool_attestation.rs
+++ b/crates/lex-cli/tests/agent_tool_attestation.rs
@@ -1,0 +1,177 @@
+//! `lex agent-tool --store` — Examples / Spec / DiffBody / SandboxRun
+//! attestation producer (#132 final producer slice).
+
+use std::process::Command;
+use tempfile::tempdir;
+
+fn lex_bin() -> &'static str { env!("CARGO_BIN_EXE_lex") }
+
+const ID_BODY: &str = "input";
+
+const ID_EXAMPLES: &str = r#"[
+    {"input": "a", "expected": "a"},
+    {"input": "b", "expected": "b"}
+]"#;
+
+const ID_BAD_EXAMPLES: &str = r#"[
+    {"input": "a", "expected": "z"}
+]"#;
+
+fn list_attestations(store: &std::path::Path) -> serde_json::Value {
+    let out = Command::new(lex_bin())
+        .args([
+            "--output", "json",
+            "attest", "filter",
+            "--store", store.to_str().unwrap(),
+        ])
+        .output().unwrap();
+    assert!(out.status.success(), "attest filter failed: {}", String::from_utf8_lossy(&out.stderr));
+    serde_json::from_slice(&out.stdout).unwrap()
+}
+
+fn run_agent_tool(store: &std::path::Path, extra: &[&str]) -> std::process::Output {
+    let mut args: Vec<String> = vec![
+        "agent-tool".into(),
+        "--allow-effects".into(), "".into(),
+        "--quiet".into(),
+        "--body".into(), ID_BODY.into(),
+        "--input".into(), "hello".into(),
+        "--store".into(), store.to_str().unwrap().to_string(),
+    ];
+    for e in extra { args.push((*e).to_string()); }
+    Command::new(lex_bin())
+        .args(&args)
+        .output()
+        .expect("run agent-tool")
+}
+
+#[test]
+fn passing_examples_writes_examples_attestation() {
+    let store = tempdir().unwrap();
+    let ex = store.path().join("ex.json");
+    std::fs::write(&ex, ID_EXAMPLES).unwrap();
+
+    let out = run_agent_tool(store.path(), &[
+        "--examples", ex.to_str().unwrap(),
+    ]);
+    assert!(out.status.success(), "agent-tool failed: {}", String::from_utf8_lossy(&out.stderr));
+
+    let v = list_attestations(store.path());
+    let atts = v.pointer("/data/attestations").unwrap().as_array().unwrap();
+    let examples_att = atts.iter().find(|a| a["kind"]["kind"] == "examples")
+        .expect("expected an Examples attestation");
+    assert_eq!(examples_att["result"]["result"], "passed");
+    assert_eq!(examples_att["kind"]["count"], 2);
+    assert_eq!(examples_att["produced_by"]["tool"], "lex agent-tool");
+    let file_hash = examples_att["kind"]["file_hash"].as_str().unwrap();
+    assert_eq!(file_hash.len(), 64, "file_hash should be SHA-256 hex");
+
+    // The successful single-shot run also produces a SandboxRun.
+    let sandbox_att = atts.iter().find(|a| a["kind"]["kind"] == "sandbox_run")
+        .expect("expected a SandboxRun attestation");
+    assert_eq!(sandbox_att["result"]["result"], "passed");
+}
+
+#[test]
+fn failing_examples_writes_failed_attestation() {
+    let store = tempdir().unwrap();
+    let ex = store.path().join("bad.json");
+    std::fs::write(&ex, ID_BAD_EXAMPLES).unwrap();
+
+    let out = run_agent_tool(store.path(), &[
+        "--examples", ex.to_str().unwrap(),
+    ]);
+    assert_eq!(out.status.code(), Some(5), "expected exit 5 on examples mismatch");
+
+    let v = list_attestations(store.path());
+    let atts = v.pointer("/data/attestations").unwrap().as_array().unwrap();
+    let examples_att = atts.iter().find(|a| a["kind"]["kind"] == "examples")
+        .expect("Failed Examples attestation should still persist");
+    assert_eq!(examples_att["result"]["result"], "failed");
+    let detail = examples_att["result"]["detail"].as_str().unwrap_or("");
+    assert!(detail.contains("mismatched"), "detail: {detail}");
+
+    // No SandboxRun on failure: examples block exits before the
+    // single-shot run.
+    assert!(
+        atts.iter().all(|a| a["kind"]["kind"] != "sandbox_run"),
+        "no SandboxRun expected when examples failed",
+    );
+}
+
+#[test]
+fn diff_body_passes_writes_diff_body_attestation() {
+    // Same body twice → no divergence → Passed.
+    let store = tempdir().unwrap();
+    let out = run_agent_tool(store.path(), &[
+        "--diff-body", ID_BODY,
+    ]);
+    assert!(out.status.success(), "agent-tool failed: {}", String::from_utf8_lossy(&out.stderr));
+
+    let v = list_attestations(store.path());
+    let atts = v.pointer("/data/attestations").unwrap().as_array().unwrap();
+    let diff_att = atts.iter().find(|a| a["kind"]["kind"] == "diff_body")
+        .expect("expected a DiffBody attestation");
+    assert_eq!(diff_att["result"]["result"], "passed");
+    let other_hash = diff_att["kind"]["other_body_hash"].as_str().unwrap();
+    assert_eq!(other_hash.len(), 64);
+    assert_eq!(diff_att["kind"]["input_count"], 1);
+}
+
+#[test]
+fn diff_body_diverges_writes_failed_attestation() {
+    // Different body that returns "constant" instead of input.
+    let store = tempdir().unwrap();
+    let out = run_agent_tool(store.path(), &[
+        "--diff-body", "\"constant\"",
+    ]);
+    assert_eq!(out.status.code(), Some(7), "expected exit 7 on divergence");
+
+    let v = list_attestations(store.path());
+    let atts = v.pointer("/data/attestations").unwrap().as_array().unwrap();
+    let diff_att = atts.iter().find(|a| a["kind"]["kind"] == "diff_body")
+        .expect("expected a DiffBody attestation on divergence too");
+    assert_eq!(diff_att["result"]["result"], "failed");
+    let detail = diff_att["result"]["detail"].as_str().unwrap_or("");
+    assert!(detail.contains("diverged"), "detail: {detail}");
+}
+
+#[test]
+fn no_store_means_no_attestation() {
+    // Without --store, agent-tool runs as before — no attestation
+    // directory created.
+    let store = tempdir().unwrap();
+    let ex = store.path().join("ex.json");
+    std::fs::write(&ex, ID_EXAMPLES).unwrap();
+    let out = Command::new(lex_bin())
+        .args([
+            "agent-tool",
+            "--allow-effects", "",
+            "--quiet",
+            "--body", ID_BODY,
+            "--input", "hello",
+            "--examples", ex.to_str().unwrap(),
+        ])
+        .output().unwrap();
+    assert!(out.status.success(), "agent-tool failed: {}", String::from_utf8_lossy(&out.stderr));
+    assert!(!store.path().join("attestations").exists());
+}
+
+#[test]
+fn sandbox_run_records_allowed_effects() {
+    // No examples, no spec — just a single-shot run. Should still
+    // produce a SandboxRun attestation tagged with the effect set
+    // the policy allowed.
+    let store = tempdir().unwrap();
+    let out = run_agent_tool(store.path(), &[]);
+    assert!(out.status.success());
+
+    let v = list_attestations(store.path());
+    let atts = v.pointer("/data/attestations").unwrap().as_array().unwrap();
+    let sandbox_att = atts.iter().find(|a| a["kind"]["kind"] == "sandbox_run")
+        .expect("expected a SandboxRun attestation");
+    assert_eq!(sandbox_att["result"]["result"], "passed");
+    let effects = sandbox_att["kind"]["effects"].as_array().unwrap();
+    // Empty allow-effects means no effects in the attestation.
+    assert_eq!(effects.len(), 0);
+}


### PR DESCRIPTION
## Summary

Issue #132 final producer slice. Adds `--store DIR` to `lex agent-tool`; every verification step now persists an attestation against the StageId of the agent-emitted `tool` fn.

| Step | Kind | Pass / fail conditions |
|---|---|---|
| `--examples FILE` | `Examples { file_hash, count }` | Passed if every case matches; Failed with `<n>/<total> mismatched` detail |
| `--spec FILE` | `Spec { spec_id, method, trials }` | Passed / Failed (counterexample bindings) / Inconclusive (note) |
| `--diff-body 'src'` | `DiffBody { other_body_hash, input_count }` | Passed if both bodies agree on every input; Failed with `<n>/<total> diverged` |
| Sandboxed run | `SandboxRun { effects }` | Passed, in both differential and single-shot paths |

`produced_by.model` carries the Claude model name only when the body came from `--request`; `--body` / `--body-file` runs don't tag the default model spuriously.

Failures persist alongside successes — a flaky producer must not be able to overwrite negative evidence by re-running (#132 trust model).

## Test plan

- [x] `cargo test -p lex-cli --test agent_tool_attestation` — 6 new tests:
  - Passing examples → `Examples::Passed` + `SandboxRun::Passed`.
  - Failing examples → `Examples::Failed` (and no `SandboxRun`, since exit happens first).
  - DiffBody passes (same body twice) → `DiffBody::Passed`.
  - DiffBody diverges → `DiffBody::Failed` with `diverged` detail.
  - No `--store` → no `attestations/` dir created (backward compat).
  - Single-shot run → `SandboxRun::Passed` with the allowed effects.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (Rust 1.95).
- [x] `cargo test --workspace` — green.

## Status of #132 after this PR

Producers complete: `TypeCheck` (#147), `Spec` (#150), `Examples` / `DiffBody` / `SandboxRun` (this PR). Consumers complete: HTTP `GET /v1/stage/<id>/attestations` (#148), `lex stage --attestations` (#148), `lex blame --with-evidence` (#149), `lex attest filter` (#151).

**Only `lex audit --effect K` → `EffectAudit` remains, and it needs design** — current `audit` is a discovery tool, not a verification tool, so emitting an attestation requires defining new semantics (e.g. an `--audit-policy FILE` mode that asserts no fn declares the disallowed effect).

https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5

---
_Generated by [Claude Code](https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5)_