### PR TITLE
feat: POST /v1/merge/start — first endpoint of #134

### DIFF
--- a/crates/lex-api/src/handlers.rs
+++ b/crates/lex-api/src/handlers.rs
@@ -11,19 +11,31 @@ use lex_bytecode::{compile_program, vm::Vm, Value};
 use lex_runtime::{check_program as check_policy, DefaultHandler, Policy};
 use lex_store::Store;
 use lex_syntax::load_program_from_str;
+use lex_vcs::{MergeSession, MergeSessionId};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
 use tiny_http::{Header, Method, Request, Response};
 
 pub struct State {
     pub store: Mutex<Store>,
+    /// In-memory merge sessions, keyed by MergeSessionId. Sessions
+    /// are ephemeral by design (#134 foundation): they live for the
+    /// lifetime of the server process and are GC'd on commit. A
+    /// future slice can persist them to disk so a session survives
+    /// process restarts. For now an agent that gets unlucky with a
+    /// restart re-runs `merge/start` and gets a fresh session.
+    pub sessions: Mutex<HashMap<MergeSessionId, MergeSession>>,
 }
 
 impl State {
     pub fn open(root: PathBuf) -> anyhow::Result<Self> {
-        Ok(Self { store: Mutex::new(Store::open(root)?) })
+        Ok(Self {
+            store: Mutex::new(Store::open(root)?),
+            sessions: Mutex::new(HashMap::new()),
+        })
     }
 }
 
@@ -98,6 +110,7 @@ fn route(
             trace_handler(state, id)
         }
         (Method::Get, "/v1/diff") => diff_handler(state, query),
+        (Method::Post, "/v1/merge/start") => merge_start_handler(state, body),
         _ => error_response(404, format!("unknown route: {method:?} {path}")),
     }
 }
@@ -462,4 +475,80 @@ fn diff_handler(state: &State, query: &str) -> Response<std::io::Cursor<Vec<u8>>
 fn json_to_value(v: &serde_json::Value) -> Value { Value::from_json(v) }
 
 fn value_to_json(v: &Value) -> serde_json::Value { v.to_json() }
+
+#[derive(Deserialize)]
+struct MergeStartReq {
+    src_branch: String,
+    dst_branch: String,
+}
+
+/// `POST /v1/merge/start` (#134) — open a stateful merge between two
+/// branch heads and return the conflicts the agent needs to
+/// resolve. Auto-resolved sigs (one-sided changes, identical
+/// changes both sides) are returned for audit but don't block
+/// commit.
+///
+/// Response: `{ merge_id, src_head, dst_head, lca, conflicts,
+/// auto_resolved_count }`. The session is held in process memory
+/// keyed by `merge_id` for subsequent `resolve` / `commit` calls
+/// (next slices).
+fn merge_start_handler(state: &State, body: &str) -> Response<std::io::Cursor<Vec<u8>>> {
+    let req: MergeStartReq = match serde_json::from_str(body) {
+        Ok(r) => r, Err(e) => return error_response(400, format!("bad request: {e}")),
+    };
+    let store = state.store.lock().unwrap();
+    let src_head = match store.get_branch(&req.src_branch) {
+        Ok(Some(b)) => b.head_op,
+        Ok(None) => return error_response(404, format!("unknown src branch `{}`", req.src_branch)),
+        Err(e) => return error_response(500, format!("src branch read: {e}")),
+    };
+    let dst_head = match store.get_branch(&req.dst_branch) {
+        Ok(Some(b)) => b.head_op,
+        Ok(None) => return error_response(404, format!("unknown dst branch `{}`", req.dst_branch)),
+        Err(e) => return error_response(500, format!("dst branch read: {e}")),
+    };
+    let log = match lex_vcs::OpLog::open(store.root()) {
+        Ok(l) => l,
+        Err(e) => return error_response(500, format!("op log: {e}")),
+    };
+    // Caller doesn't choose merge_ids — minted server-side from
+    // wall clock + a per-process counter avoids leaking session
+    // ids' shape into the public surface.
+    let merge_id = mint_merge_id();
+    let session = match MergeSession::start(
+        merge_id.clone(),
+        &log,
+        src_head.as_ref(),
+        dst_head.as_ref(),
+    ) {
+        Ok(s) => s,
+        Err(e) => return error_response(500, format!("merge start: {e}")),
+    };
+    let conflicts: Vec<&lex_vcs::ConflictRecord> = session.remaining_conflicts();
+    let auto_resolved_count = session.auto_resolved.len();
+    let body = serde_json::json!({
+        "merge_id": merge_id,
+        "src_head": session.src_head,
+        "dst_head": session.dst_head,
+        "lca":      session.lca,
+        "conflicts": conflicts,
+        "auto_resolved_count": auto_resolved_count,
+    });
+    // Drop the borrow on `conflicts` before moving session into the map.
+    drop(conflicts);
+    drop(store);
+    state.sessions.lock().unwrap().insert(merge_id, session);
+    json_response(200, &body)
+}
+
+fn mint_merge_id() -> MergeSessionId {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("merge_{nanos:x}_{n:x}")
+}
 

--- a/crates/lex-api/src/lib.rs
+++ b/crates/lex-api/src/lib.rs
@@ -14,6 +14,7 @@
 //!   GET  /v1/trace/<run_id>  → TraceTree
 //!   POST /v1/replay          { source, fn, args, policy, overrides } → { run_id, output | error }
 //!   GET  /v1/diff?a=&b=      → Divergence | { divergence: null }
+//!   POST /v1/merge/start     { src_branch, dst_branch } → { merge_id, conflicts, ... }
 //!   GET  /v1/health          → { ok: true }
 
 pub mod handlers;

--- a/crates/lex-api/tests/m8.rs
+++ b/crates/lex-api/tests/m8.rs
@@ -195,6 +195,58 @@ fn run_with_policy_succeeds() {
 }
 
 #[test]
+fn merge_start_unknown_branch_returns_404() {
+    let (srv, _tmp) = start_server();
+    let body = json!({"src_branch": "nonexistent_a", "dst_branch": "nonexistent_b"}).to_string();
+    let (s, b) = http(&srv.addr, "POST", "/v1/merge/start", &body);
+    assert_eq!(s, 404, "unknown branch should 404, got {s}: {b}");
+}
+
+#[test]
+fn merge_start_returns_session_id_and_no_conflicts_for_disjoint_branches() {
+    // Two branches that touch *different* sigs auto-resolve into a
+    // clean merge — no conflicts. The endpoint should still mint a
+    // session, return the conflict list (empty), and report the
+    // count of auto-resolved sigs so the agent can audit what the
+    // engine took unilaterally.
+    let (srv, tmp) = start_server();
+
+    // 1) Publish fn foo on main.
+    let src_main = "fn foo(n :: Int) -> Int { n + 1 }\n";
+    let pub_main = json!({"source": src_main, "activate": true}).to_string();
+    let (s, b) = http(&srv.addr, "POST", "/v1/publish", &pub_main);
+    assert_eq!(s, 200, "publish main: {b}");
+
+    // 2) Create + switch to feature, publish fn bar.
+    {
+        let store = lex_store::Store::open(tmp.path()).unwrap();
+        store.create_branch("feature", lex_store::DEFAULT_BRANCH)
+            .expect("create feature");
+        store.set_current_branch("feature").expect("switch to feature");
+    }
+    let src_feature = "fn foo(n :: Int) -> Int { n + 1 }\nfn bar(n :: Int) -> Int { n - 1 }\n";
+    let pub_feat = json!({"source": src_feature, "activate": true}).to_string();
+    let (s, b) = http(&srv.addr, "POST", "/v1/publish", &pub_feat);
+    assert_eq!(s, 200, "publish feature: {b}");
+
+    // 3) Switch back to main so it remains the dst.
+    {
+        let store = lex_store::Store::open(tmp.path()).unwrap();
+        store.set_current_branch(lex_store::DEFAULT_BRANCH).expect("switch back");
+    }
+
+    // 4) Start the merge.
+    let body = json!({"src_branch": "feature", "dst_branch": lex_store::DEFAULT_BRANCH}).to_string();
+    let (s, b) = http(&srv.addr, "POST", "/v1/merge/start", &body);
+    assert_eq!(s, 200, "merge/start: {b}");
+    let v: serde_json::Value = serde_json::from_str(&b).unwrap();
+    assert!(v["merge_id"].as_str().is_some(), "merge_id should be set");
+    let conflicts = v["conflicts"].as_array().unwrap();
+    assert_eq!(conflicts.len(), 0, "disjoint adds shouldn't conflict, got {conflicts:?}");
+    assert!(v["auto_resolved_count"].as_u64().unwrap() >= 1, "at least one sig auto-resolved");
+}
+
+#[test]
 fn replay_with_overrides() {
     let (srv, _tmp) = start_server();
     let src = "import \"std.io\" as io\nfn read_one(p :: Str) -> [io] Result[Str, Str] { io.read(p) }\n";

--- a/crates/lex-vcs/src/merge.rs
+++ b/crates/lex-vcs/src/merge.rs
@@ -27,7 +27,8 @@ pub enum MergeOutcome {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ConflictKind {
     ModifyModify,
     ModifyDelete,

--- a/crates/lex-vcs/src/merge_session.rs
+++ b/crates/lex-vcs/src/merge_session.rs
@@ -41,6 +41,8 @@
 
 use std::collections::BTreeMap;
 
+use serde::{Deserialize, Serialize};
+
 use crate::merge::{ConflictKind, MergeOutcome, MergeOutput};
 use crate::op_log::OpLog;
 use crate::operation::{OpId, Operation, SigId, StageId};
@@ -58,7 +60,7 @@ pub type MergeSessionId = String;
 pub type ConflictId = SigId;
 
 /// Snapshot of one conflict the agent needs to resolve.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ConflictRecord {
     pub conflict_id: ConflictId,
     pub sig_id: SigId,
@@ -75,7 +77,8 @@ pub struct ConflictRecord {
 }
 
 /// Choice for a single conflict.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
 pub enum Resolution {
     /// Keep dst's stage; discard src's.
     TakeOurs,
@@ -93,7 +96,8 @@ pub enum Resolution {
 /// Why a resolution was rejected. Distinct from [`CommitError`]
 /// because a resolve call returns *per-conflict* verdicts; commit
 /// returns a single overall verdict.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ResolutionRejection {
     /// The conflict_id doesn't refer to any pending conflict in
     /// the session. Either the agent invented one, or it was
@@ -110,7 +114,7 @@ pub enum ResolutionRejection {
 }
 
 /// Per-conflict outcome of a resolve call.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ResolveVerdict {
     pub conflict_id: ConflictId,
     pub accepted: bool,


### PR DESCRIPTION
## Summary

First HTTP endpoint of #134 (programmatic merge API). Wires `lex-vcs::MergeSession` into the agent API so harnesses can open a stateful merge over HTTP without going through the CLI.

```
POST /v1/merge/start
  Body:     { src_branch, dst_branch }
  Response: { merge_id, src_head, dst_head, lca, conflicts, auto_resolved_count }
```

Sessions are held in process memory keyed by `MergeSessionId` (minted server-side from wall-clock-nanos + a per-process counter). They live for the lifetime of the server process; the next slices add `POST /v1/merge/<id>/resolve` and `POST /v1/merge/<id>/commit` against the same session pool.

Adds `Serialize` / `Deserialize` derives to `ConflictKind`, `ConflictRecord`, `Resolution`, `ResolutionRejection`, and `ResolveVerdict` so the engine types serialize across HTTP without an intermediate DTO layer.

## Test plan

- [x] `cargo test -p lex-api --test m8 merge` — 2 new tests:
  - `merge_start_unknown_branch_returns_404` — 404 when either branch is missing.
  - `merge_start_returns_session_id_and_no_conflicts_for_disjoint_branches` — non-overlapping changes auto-resolve, response carries `merge_id` + empty `conflicts` + non-zero `auto_resolved_count`.
- [x] `cargo test --workspace` — green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.

## Remaining for #134

- `POST /v1/merge/<id>/resolve` — batched per-conflict resolutions with verdicts.
- `POST /v1/merge/<id>/commit` — finalize, advance dst head, return new head op id (or 422 with remaining conflicts).
- CLI mirrors: `lex merge start | resolve | commit | status`.

Each is its own small PR.

https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5

---
_Generated by [Claude Code](https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5)_