### PR TITLE
feat: POST /v1/merge/&lt;id&gt;/resolve — second endpoint of #134

### DIFF
--- a/crates/lex-api/src/handlers.rs
+++ b/crates/lex-api/src/handlers.rs
@@ -111,6 +111,10 @@ fn route(
         }
         (Method::Get, "/v1/diff") => diff_handler(state, query),
         (Method::Post, "/v1/merge/start") => merge_start_handler(state, body),
+        (Method::Post, p) if p.starts_with("/v1/merge/") && p.ends_with("/resolve") => {
+            let id = &p["/v1/merge/".len()..p.len() - "/resolve".len()];
+            merge_resolve_handler(state, id, body)
+        }
         _ => error_response(404, format!("unknown route: {method:?} {path}")),
     }
 }
@@ -538,6 +542,55 @@ fn merge_start_handler(state: &State, body: &str) -> Response<std::io::Cursor<Ve
     drop(conflicts);
     drop(store);
     state.sessions.lock().unwrap().insert(merge_id, session);
+    json_response(200, &body)
+}
+
+#[derive(Deserialize)]
+struct MergeResolveReq {
+    /// Each entry is `(conflict_id, resolution)`. The resolution is
+    /// the same shape as `lex_vcs::Resolution`'s tagged JSON form
+    /// — `{"kind":"take_ours"}`, `{"kind":"take_theirs"}`,
+    /// `{"kind":"defer"}`, or `{"kind":"custom","op":{...}}`.
+    resolutions: Vec<MergeResolveEntry>,
+}
+
+#[derive(Deserialize)]
+struct MergeResolveEntry {
+    conflict_id: String,
+    resolution: lex_vcs::Resolution,
+}
+
+/// `POST /v1/merge/<id>/resolve` (#134) — submit batched
+/// resolutions against the conflicts surfaced by `merge/start`.
+/// Returns one verdict per input: accepted (recorded against the
+/// session) or rejected (with structured reason). The session
+/// stays alive across calls so an agent can iterate.
+///
+/// Errors:
+/// - 404 if `merge_id` doesn't refer to a live session (a typo
+///   or a session GC'd by a server restart).
+/// - 400 on malformed body.
+fn merge_resolve_handler(
+    state: &State,
+    merge_id: &str,
+    body: &str,
+) -> Response<std::io::Cursor<Vec<u8>>> {
+    let req: MergeResolveReq = match serde_json::from_str(body) {
+        Ok(r) => r, Err(e) => return error_response(400, format!("bad request: {e}")),
+    };
+    let mut sessions = state.sessions.lock().unwrap();
+    let Some(session) = sessions.get_mut(merge_id) else {
+        return error_response(404, format!("unknown merge_id `{merge_id}`"));
+    };
+    let pairs: Vec<(String, lex_vcs::Resolution)> = req.resolutions.into_iter()
+        .map(|e| (e.conflict_id, e.resolution))
+        .collect();
+    let verdicts = session.resolve(pairs);
+    let remaining: Vec<&lex_vcs::ConflictRecord> = session.remaining_conflicts();
+    let body = serde_json::json!({
+        "verdicts": verdicts,
+        "remaining_conflicts": remaining,
+    });
     json_response(200, &body)
 }
 

--- a/crates/lex-api/src/lib.rs
+++ b/crates/lex-api/src/lib.rs
@@ -14,7 +14,8 @@
 //!   GET  /v1/trace/<run_id>  → TraceTree
 //!   POST /v1/replay          { source, fn, args, policy, overrides } → { run_id, output | error }
 //!   GET  /v1/diff?a=&b=      → Divergence | { divergence: null }
-//!   POST /v1/merge/start     { src_branch, dst_branch } → { merge_id, conflicts, ... }
+//!   POST /v1/merge/start              { src_branch, dst_branch } → { merge_id, conflicts, ... }
+//!   POST /v1/merge/<id>/resolve       { resolutions: [...] } → { verdicts, remaining_conflicts }
 //!   GET  /v1/health          → { ok: true }
 
 pub mod handlers;

--- a/crates/lex-api/tests/m8.rs
+++ b/crates/lex-api/tests/m8.rs
@@ -246,6 +246,102 @@ fn merge_start_returns_session_id_and_no_conflicts_for_disjoint_branches() {
     assert!(v["auto_resolved_count"].as_u64().unwrap() >= 1, "at least one sig auto-resolved");
 }
 
+/// Set up two branches that *both* modify the same fn (`foo`).
+/// Returns the running server, the temp store dir, and the session
+/// `merge_id` produced by `/v1/merge/start`. Used by the resolve
+/// tests to avoid duplicating the divergence setup.
+fn with_modify_modify_session() -> (Server, TempDir, String) {
+    let (srv, tmp) = start_server();
+
+    // 1) Publish initial fn on main.
+    let v0 = "fn foo(n :: Int) -> Int { n }\n";
+    let (s, b) = http(&srv.addr, "POST", "/v1/publish", &json!({"source": v0, "activate": true}).to_string());
+    assert_eq!(s, 200, "publish v0: {b}");
+
+    // 2) Create + switch to feature, modify foo.
+    {
+        let store = lex_store::Store::open(tmp.path()).unwrap();
+        store.create_branch("feature", lex_store::DEFAULT_BRANCH).unwrap();
+        store.set_current_branch("feature").unwrap();
+    }
+    let v_feat = "fn foo(n :: Int) -> Int { n + 1 }\n";
+    let (s, b) = http(&srv.addr, "POST", "/v1/publish", &json!({"source": v_feat, "activate": true}).to_string());
+    assert_eq!(s, 200, "publish feature: {b}");
+
+    // 3) Switch back to main, modify foo differently.
+    {
+        let store = lex_store::Store::open(tmp.path()).unwrap();
+        store.set_current_branch(lex_store::DEFAULT_BRANCH).unwrap();
+    }
+    let v_main = "fn foo(n :: Int) -> Int { n + 2 }\n";
+    let (s, b) = http(&srv.addr, "POST", "/v1/publish", &json!({"source": v_main, "activate": true}).to_string());
+    assert_eq!(s, 200, "publish main: {b}");
+
+    // 4) Start the merge — should produce a ModifyModify conflict on `foo`.
+    let body = json!({"src_branch": "feature", "dst_branch": lex_store::DEFAULT_BRANCH}).to_string();
+    let (s, b) = http(&srv.addr, "POST", "/v1/merge/start", &body);
+    assert_eq!(s, 200, "merge/start: {b}");
+    let v: serde_json::Value = serde_json::from_str(&b).unwrap();
+    let merge_id = v["merge_id"].as_str().unwrap().to_string();
+    let conflicts = v["conflicts"].as_array().unwrap();
+    assert_eq!(conflicts.len(), 1, "expected exactly one conflict, got: {conflicts:?}");
+    (srv, tmp, merge_id)
+}
+
+#[test]
+fn merge_resolve_take_ours_clears_the_conflict() {
+    let (srv, _tmp, merge_id) = with_modify_modify_session();
+    let path = format!("/v1/merge/{merge_id}/resolve");
+    // Find the conflict id (same as sig_id of `foo`).
+    let (_, start_body) = http(&srv.addr, "POST", "/v1/merge/start", &json!({
+        "src_branch": "feature", "dst_branch": lex_store::DEFAULT_BRANCH,
+    }).to_string());
+    // Re-run start to pull a fresh conflict list keyed to a *new* merge_id —
+    // but the resolution we're testing is against `merge_id` from the
+    // helper, so the conflict_id is the same (sig).
+    let v: serde_json::Value = serde_json::from_str(&start_body).unwrap();
+    let conflict_id = v["conflicts"][0]["conflict_id"].as_str().unwrap().to_string();
+
+    let body = json!({
+        "resolutions": [
+            {"conflict_id": conflict_id, "resolution": {"kind": "take_ours"}}
+        ]
+    }).to_string();
+    let (s, b) = http(&srv.addr, "POST", &path, &body);
+    assert_eq!(s, 200, "resolve: {b}");
+    let v: serde_json::Value = serde_json::from_str(&b).unwrap();
+    let verdicts = v["verdicts"].as_array().unwrap();
+    assert_eq!(verdicts.len(), 1);
+    assert_eq!(verdicts[0]["accepted"], true);
+    let remaining = v["remaining_conflicts"].as_array().unwrap();
+    assert_eq!(remaining.len(), 0, "the take_ours resolution should clear the conflict");
+}
+
+#[test]
+fn merge_resolve_unknown_conflict_is_rejected_per_entry() {
+    let (srv, _tmp, merge_id) = with_modify_modify_session();
+    let path = format!("/v1/merge/{merge_id}/resolve");
+    let body = json!({
+        "resolutions": [
+            {"conflict_id": "definitely-not-a-real-sig", "resolution": {"kind": "take_ours"}}
+        ]
+    }).to_string();
+    let (s, b) = http(&srv.addr, "POST", &path, &body);
+    assert_eq!(s, 200, "resolve should still 200 with per-entry verdicts");
+    let v: serde_json::Value = serde_json::from_str(&b).unwrap();
+    let verdicts = v["verdicts"].as_array().unwrap();
+    assert_eq!(verdicts[0]["accepted"], false);
+    assert_eq!(verdicts[0]["rejection"]["kind"], "unknown_conflict");
+}
+
+#[test]
+fn merge_resolve_unknown_session_returns_404() {
+    let (srv, _tmp) = start_server();
+    let body = json!({"resolutions": []}).to_string();
+    let (s, _) = http(&srv.addr, "POST", "/v1/merge/no_such_session/resolve", &body);
+    assert_eq!(s, 404, "unknown merge_id should 404");
+}
+
 #[test]
 fn replay_with_overrides() {
     let (srv, _tmp) = start_server();

--- a/crates/lex-vcs/src/merge_session.rs
+++ b/crates/lex-vcs/src/merge_session.rs
@@ -102,7 +102,7 @@ pub enum ResolutionRejection {
     /// The conflict_id doesn't refer to any pending conflict in
     /// the session. Either the agent invented one, or it was
     /// already resolved and the session pruned it.
-    UnknownConflict(ConflictId),
+    UnknownConflict { conflict_id: ConflictId },
     /// The custom op's parents don't include both `ours` and
     /// `theirs`. A custom resolution that doesn't acknowledge
     /// both sides isn't a merge — it's a fork.
@@ -260,7 +260,7 @@ impl MergeSession {
         resolution: &Resolution,
     ) -> Result<(), ResolutionRejection> {
         if !self.conflicts.contains_key(conflict_id) {
-            return Err(ResolutionRejection::UnknownConflict(conflict_id.clone()));
+            return Err(ResolutionRejection::UnknownConflict { conflict_id: conflict_id.clone() });
         }
         if let Resolution::Custom { op } = resolution {
             // Validate that the custom op's parent set acknowledges
@@ -476,7 +476,7 @@ mod tests {
         assert!(!verdicts[0].accepted);
         assert!(matches!(
             verdicts[0].rejection,
-            Some(ResolutionRejection::UnknownConflict(_)),
+            Some(ResolutionRejection::UnknownConflict { .. }),
         ));
     }
 


### PR DESCRIPTION
## Summary

Second HTTP endpoint of #134. Submits batched per-conflict resolutions against a session opened by `/v1/merge/start`.

```
POST /v1/merge/<id>/resolve
  Body:     { resolutions: [{conflict_id, resolution: {kind, ...}}, ...] }
  Response: { verdicts: [...], remaining_conflicts: [...] }
```

- **404** on unknown `merge_id` (typo or session GC'd by server restart).
- **400** on malformed body.
- **Per-conflict** rejections (unknown `conflict_id`, custom op missing parents) come back as 200 + `verdict.rejection`. Partial submissions don't fail the call, matching the issue's "submit 50 resolutions, see which were accepted, fix the broken ones, retry" flow.

The session stays alive across calls so the next slice (`/v1/merge/<id>/commit`) finalizes against the same accumulated state.

### Side change

`ResolutionRejection::UnknownConflict(ConflictId)` → `UnknownConflict { conflict_id: ConflictId }`. The newtype-variant form was incompatible with `#[serde(tag = "kind")]` (serde-json refuses tagged newtype variants containing primitives). The struct-variant shape serializes cleanly and is the form external callers will see.

## Test plan

- [x] `cargo test -p lex-api --test m8 merge` — 3 new tests:
  - `merge_resolve_take_ours_clears_the_conflict` — happy path: ModifyModify on `foo`, `take_ours` resolution → `accepted`, `remaining_conflicts` empty.
  - `merge_resolve_unknown_conflict_is_rejected_per_entry` — 200 with rejection verdict carrying `kind: "unknown_conflict"`.
  - `merge_resolve_unknown_session_returns_404` — 404 on bogus `merge_id`.
- [x] `cargo test --workspace` — green (existing `MergeSession` tests still pass with the struct-variant shape).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.

## Remaining for #134

- `POST /v1/merge/<id>/commit` — finalize, advance dst head, return new head op id (or 422 with remaining conflicts).
- CLI mirrors: `lex merge start | resolve | commit | status`.

https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5

---
_Generated by [Claude Code](https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5)_