### PR TITLE
feat: lex merge {start|status|resolve|commit} — CLI mirror of #134

### DIFF
--- a/crates/lex-cli/src/acli.rs
+++ b/crates/lex-cli/src/acli.rs
@@ -130,6 +130,7 @@ fn commands() -> Vec<CommandInfo> {
         cmd_ast_merge(),
         cmd_branch(),
         cmd_store_merge(),
+        cmd_merge(),
         cmd_log(),
         cmd_repl(),
         cmd_watch(),
@@ -512,5 +513,36 @@ fn cmd_store_merge() -> CommandInfo {
             ("Preview a merge", "lex store-merge feature main"),
             ("Commit a clean merge", "lex store-merge feature main --commit"),
         ])
-        .with_see_also(vec!["branch", "ast-merge"])
+        .with_see_also(vec!["branch", "ast-merge", "merge"])
+}
+
+fn cmd_merge() -> CommandInfo {
+    let start = CommandInfo::new("start", "open a stateful merge session and surface conflicts")
+        .idempotent(false)
+        .add_option("--src", "string", "source branch (theirs)", None)
+        .add_option("--dst", "string", "destination branch (ours)", None)
+        .add_option("--store", "string", "store root directory", None);
+    let status = CommandInfo::new("status", "print remaining conflicts for a session")
+        .idempotent(true)
+        .add_argument("merge_id", "string", "session id from `lex merge start`", true)
+        .add_option("--store", "string", "store root directory", None);
+    let resolve = CommandInfo::new("resolve", "submit batched per-conflict resolutions")
+        .idempotent(false)
+        .add_argument("merge_id", "string", "session id", true)
+        .add_option("--file", "string", "JSON array of {conflict_id, resolution}", None)
+        .add_option("--store", "string", "store root directory", None);
+    let commit = CommandInfo::new("commit", "finalize the merge and advance dst's head")
+        .idempotent(false)
+        .add_argument("merge_id", "string", "session id", true)
+        .add_option("--store", "string", "store root directory", None);
+    let mut info = CommandInfo::new("merge", "stateful agent-driven merge (CLI mirror of /v1/merge/*)")
+        .with_examples(vec![
+            ("Open a merge",        "lex merge start --src feature --dst main"),
+            ("See remaining work",  "lex merge status merge_..."),
+            ("Submit resolutions",  "lex merge resolve merge_... --file resolutions.json"),
+            ("Land the merge",      "lex merge commit merge_..."),
+        ])
+        .with_see_also(vec!["store-merge", "branch", "log"]);
+    info.subcommands = vec![start, status, resolve, commit];
+    info
 }

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -15,6 +15,7 @@ mod audit;
 mod diff;
 mod ast_merge;
 mod branch;
+mod merge;
 mod acli;
 mod op;
 mod repl;
@@ -99,6 +100,7 @@ fn run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         "ast-merge" => ast_merge::cmd_ast_merge(fmt, &args[1..]),
         "branch" => branch::cmd_branch(fmt, &args[1..]),
         "store-merge" => branch::cmd_store_merge(fmt, &args[1..]),
+        "merge" => merge::cmd_merge(fmt, &args[1..]),
         "log" => branch::cmd_log(fmt, &args[1..]),
         "op" => op::cmd_op(fmt, &args[1..]),
         "repl" => repl::cmd_repl(&args[1..]),
@@ -178,6 +180,9 @@ fn print_usage() {
     println!("  store-merge <src> <dst> [--commit] [--json]  three-way merge between two branches in");
     println!("                                     the store; conflicts as JSON. --commit applies a");
     println!("                                     clean merge; refuses if any conflicts remain.");
+    println!("  merge {{start|status|resolve|commit}}");
+    println!("                                     stateful merge for agent loops (#134); persists");
+    println!("                                     a session under <store>/merges/<merge_id>.json");
     println!();
     println!("policy flags (run, replay):");
     println!("  --allow-effects k1,k2,...   permit these effect kinds");
@@ -860,6 +865,13 @@ fn default_store_root() -> PathBuf {
         return PathBuf::from(home).join(".lex").join("store");
     }
     PathBuf::from(".lex-store")
+}
+
+/// Public re-export for sibling CLI modules. `default_store_root`
+/// itself stays private to keep the binary's surface tight; modules
+/// that need it call this trampoline.
+pub(crate) fn default_store_root_pub() -> PathBuf {
+    default_store_root()
 }
 
 fn parse_store_flag(args: &[String]) -> (PathBuf, Vec<String>, bool, bool) {

--- a/crates/lex-cli/src/merge.rs
+++ b/crates/lex-cli/src/merge.rs
@@ -1,0 +1,357 @@
+//! `lex merge` — CLI mirror of `POST /v1/merge/{start,<id>/resolve,
+//! <id>/commit}` (#134). Runs the same MergeSession engine
+//! directly (no HTTP server needed) and persists in-flight
+//! sessions to `<store>/merges/<merge_id>.json` so each
+//! invocation is its own process.
+//!
+//! Subcommands:
+//!
+//!   lex merge start  --src <B1> --dst <B2> [--store DIR]
+//!   lex merge status <merge_id>            [--store DIR]
+//!   lex merge resolve <merge_id> --file <resolutions.json> [--store DIR]
+//!   lex merge commit <merge_id>            [--store DIR]
+//!
+//! The resolutions file is a JSON array of
+//! `{"conflict_id": "...", "resolution": {"kind": "take_ours" | ... }}`.
+//! Same shape as the HTTP /resolve body's `resolutions` field.
+
+use crate::acli as acli_mod;
+use ::acli::OutputFormat;
+use anyhow::{anyhow, bail, Context, Result};
+use lex_store::Store;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// On-disk envelope for an in-flight merge. Wraps the lex-vcs
+/// `MergeSession` with the branch labels the start command captured
+/// (the engine session itself only carries OpId heads, not branch
+/// names; commit needs the dst branch to advance the right head).
+#[derive(Debug, Serialize, Deserialize)]
+struct MergeFile {
+    src_branch: String,
+    dst_branch: String,
+    session: lex_vcs::MergeSession,
+}
+
+fn merges_dir(root: &Path) -> PathBuf {
+    root.join("merges")
+}
+
+fn merge_path(root: &Path, merge_id: &str) -> PathBuf {
+    merges_dir(root).join(format!("{merge_id}.json"))
+}
+
+fn load_merge(root: &Path, merge_id: &str) -> Result<MergeFile> {
+    let p = merge_path(root, merge_id);
+    let bytes = std::fs::read(&p)
+        .with_context(|| format!("read merge session {}", p.display()))?;
+    serde_json::from_slice(&bytes)
+        .with_context(|| format!("parse merge session {}", p.display()))
+}
+
+fn save_merge(root: &Path, file: &MergeFile) -> Result<()> {
+    std::fs::create_dir_all(merges_dir(root))?;
+    let p = merge_path(root, &file.session.merge_id);
+    let bytes = serde_json::to_vec_pretty(file)?;
+    std::fs::write(&p, bytes)
+        .with_context(|| format!("write merge session {}", p.display()))
+}
+
+fn delete_merge(root: &Path, merge_id: &str) -> Result<()> {
+    let p = merge_path(root, merge_id);
+    if p.exists() {
+        std::fs::remove_file(&p)
+            .with_context(|| format!("remove merge session {}", p.display()))?;
+    }
+    Ok(())
+}
+
+fn parse_store_arg(args: &[String]) -> (PathBuf, Vec<String>) {
+    let mut root: Option<PathBuf> = None;
+    let mut rest = Vec::new();
+    let mut i = 0;
+    while i < args.len() {
+        if args[i] == "--store" {
+            if let Some(v) = args.get(i + 1) {
+                root = Some(PathBuf::from(v));
+                i += 2;
+                continue;
+            }
+        }
+        rest.push(args[i].clone());
+        i += 1;
+    }
+    (root.unwrap_or_else(crate::default_store_root_pub), rest)
+}
+
+pub fn cmd_merge(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    let sub = args.first().ok_or_else(||
+        anyhow!("usage: lex merge {{start|status|resolve|commit}} ..."))?;
+    let rest = &args[1..];
+    match sub.as_str() {
+        "start"   => cmd_start(fmt, rest),
+        "status"  => cmd_status(fmt, rest),
+        "resolve" => cmd_resolve(fmt, rest),
+        "commit"  => cmd_commit(fmt, rest),
+        other => bail!("unknown `lex merge` subcommand: {other}"),
+    }
+}
+
+fn cmd_start(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    let (root, rest) = parse_store_arg(args);
+    let mut src: Option<String> = None;
+    let mut dst: Option<String> = None;
+    let mut i = 0;
+    while i < rest.len() {
+        match rest[i].as_str() {
+            "--src" => { src = rest.get(i + 1).cloned(); i += 2; }
+            "--dst" => { dst = rest.get(i + 1).cloned(); i += 2; }
+            other => bail!("unexpected arg `{other}`"),
+        }
+    }
+    let src_branch = src.ok_or_else(|| anyhow!("--src <branch> required"))?;
+    let dst_branch = dst.ok_or_else(|| anyhow!("--dst <branch> required"))?;
+    let store = Store::open(&root)
+        .with_context(|| format!("opening store at {}", root.display()))?;
+
+    let src_head = store.get_branch(&src_branch)?
+        .ok_or_else(|| anyhow!("unknown src branch `{src_branch}`"))?
+        .head_op;
+    let dst_head = store.get_branch(&dst_branch)?
+        .ok_or_else(|| anyhow!("unknown dst branch `{dst_branch}`"))?
+        .head_op;
+    let log = lex_vcs::OpLog::open(store.root())?;
+    let merge_id = mint_merge_id();
+    let session = lex_vcs::MergeSession::start(
+        merge_id.clone(),
+        &log,
+        src_head.as_ref(),
+        dst_head.as_ref(),
+    )?;
+    let conflicts: Vec<lex_vcs::ConflictRecord> = session
+        .remaining_conflicts()
+        .into_iter()
+        .cloned()
+        .collect();
+    let auto_resolved_count = session.auto_resolved.len();
+
+    let file = MergeFile { src_branch, dst_branch, session };
+    save_merge(&root, &file)?;
+
+    let data = serde_json::json!({
+        "merge_id":            file.session.merge_id,
+        "src_head":            file.session.src_head,
+        "dst_head":            file.session.dst_head,
+        "lca":                 file.session.lca,
+        "conflicts":           conflicts,
+        "auto_resolved_count": auto_resolved_count,
+    });
+    let conflicts_for_text = conflicts.clone();
+    let merge_id_for_text = file.session.merge_id.clone();
+    acli_mod::emit_or_text("merge", data, fmt, move || {
+        println!("merge_id: {merge_id_for_text}");
+        println!("conflicts: {} (auto_resolved: {auto_resolved_count})", conflicts_for_text.len());
+        for c in &conflicts_for_text {
+            println!("  {} ({:?})", c.conflict_id, c.kind);
+        }
+    });
+    Ok(())
+}
+
+fn cmd_status(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    let (root, rest) = parse_store_arg(args);
+    let merge_id = rest.first().ok_or_else(|| anyhow!("usage: lex merge status <merge_id>"))?;
+    let file = load_merge(&root, merge_id)?;
+    let remaining: Vec<lex_vcs::ConflictRecord> = file.session
+        .remaining_conflicts()
+        .into_iter()
+        .cloned()
+        .collect();
+    let data = serde_json::json!({
+        "merge_id":            file.session.merge_id,
+        "src_branch":          file.src_branch,
+        "dst_branch":          file.dst_branch,
+        "remaining_conflicts": remaining,
+    });
+    let remaining_for_text = remaining.clone();
+    let merge_id_for_text  = file.session.merge_id.clone();
+    let src_for_text       = file.src_branch.clone();
+    let dst_for_text       = file.dst_branch.clone();
+    acli_mod::emit_or_text("merge", data, fmt, move || {
+        println!("merge_id: {merge_id_for_text}");
+        println!("merging:  {src_for_text} → {dst_for_text}");
+        println!("remaining: {}", remaining_for_text.len());
+        for c in &remaining_for_text {
+            println!("  {} ({:?})", c.conflict_id, c.kind);
+        }
+    });
+    Ok(())
+}
+
+#[derive(Deserialize)]
+struct ResolutionEntry {
+    conflict_id: String,
+    resolution: lex_vcs::Resolution,
+}
+
+fn cmd_resolve(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    let (root, rest) = parse_store_arg(args);
+    let mut merge_id: Option<String> = None;
+    let mut file_arg: Option<String> = None;
+    let mut i = 0;
+    while i < rest.len() {
+        match rest[i].as_str() {
+            "--file" => { file_arg = rest.get(i + 1).cloned(); i += 2; }
+            other if merge_id.is_none() => { merge_id = Some(other.to_string()); i += 1; }
+            other => bail!("unexpected arg `{other}`"),
+        }
+    }
+    let merge_id  = merge_id.ok_or_else(|| anyhow!("usage: lex merge resolve <merge_id> --file <resolutions.json>"))?;
+    let file_path = file_arg.ok_or_else(|| anyhow!("--file <resolutions.json> required"))?;
+    let raw = std::fs::read(&file_path)
+        .with_context(|| format!("read resolutions file {file_path}"))?;
+    let entries: Vec<ResolutionEntry> = serde_json::from_slice(&raw)
+        .with_context(|| format!("parse resolutions file {file_path}"))?;
+
+    let mut file = load_merge(&root, &merge_id)?;
+    let pairs: Vec<(String, lex_vcs::Resolution)> = entries.into_iter()
+        .map(|e| (e.conflict_id, e.resolution))
+        .collect();
+    let verdicts = file.session.resolve(pairs);
+    let remaining: Vec<lex_vcs::ConflictRecord> = file.session
+        .remaining_conflicts()
+        .into_iter()
+        .cloned()
+        .collect();
+    save_merge(&root, &file)?;
+
+    let data = serde_json::json!({
+        "verdicts":            verdicts,
+        "remaining_conflicts": remaining,
+    });
+    let verdicts_for_text = verdicts.clone();
+    let remaining_for_text = remaining.clone();
+    acli_mod::emit_or_text("merge", data, fmt, move || {
+        for v in &verdicts_for_text {
+            let mark = if v.accepted { "✓" } else { "✗" };
+            println!("  {mark} {}", v.conflict_id);
+        }
+        println!("remaining: {}", remaining_for_text.len());
+    });
+    Ok(())
+}
+
+fn cmd_commit(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    let (root, rest) = parse_store_arg(args);
+    let merge_id = rest.first().ok_or_else(|| anyhow!("usage: lex merge commit <merge_id>"))?;
+    let file = load_merge(&root, merge_id)?;
+    let store = Store::open(&root)
+        .with_context(|| format!("opening store at {}", root.display()))?;
+
+    let dst_branch = file.dst_branch.clone();
+    let src_head   = file.session.src_head.clone();
+    let dst_head   = file.session.dst_head.clone();
+    let auto_resolved = file.session.auto_resolved.clone();
+
+    // Translate auto-resolved + resolutions into the
+    // StageTransition::Merge entries map. Mirrors the HTTP
+    // /v1/merge/<id>/commit handler.
+    let mut entries: BTreeMap<lex_vcs::SigId, Option<lex_vcs::StageId>> = BTreeMap::new();
+    for outcome in &auto_resolved {
+        if let lex_vcs::MergeOutcome::Src { sig_id, stage_id } = outcome {
+            entries.insert(sig_id.clone(), stage_id.clone());
+        }
+    }
+
+    let resolved = match file.session.commit() {
+        Ok(r) => r,
+        Err(lex_vcs::CommitError::ConflictsRemaining(ids)) => {
+            bail!("conflicts remaining: {}", ids.join(", "));
+        }
+    };
+
+    for (conflict_id, resolution) in resolved {
+        match resolution {
+            lex_vcs::Resolution::TakeOurs => {}
+            lex_vcs::Resolution::TakeTheirs => {
+                let stage_id = walk_src_for_sig(&store, &src_head, &conflict_id)?;
+                entries.insert(conflict_id, stage_id);
+            }
+            lex_vcs::Resolution::Custom { .. } => {
+                bail!("custom resolutions not yet supported by `lex merge commit`");
+            }
+            lex_vcs::Resolution::Defer => {
+                bail!("internal: Defer resolution slipped past commit gate");
+            }
+        }
+    }
+
+    let resolved_count = entries.len();
+    let mut parents: Vec<lex_vcs::OpId> = Vec::new();
+    if let Some(d) = dst_head { parents.push(d); }
+    if let Some(s) = src_head { parents.push(s); }
+    let op = lex_vcs::Operation::new(
+        lex_vcs::OperationKind::Merge { resolved: resolved_count },
+        parents,
+    );
+    let transition = lex_vcs::StageTransition::Merge { entries };
+    let new_head_op = store.apply_operation(&dst_branch, op, transition)?;
+
+    delete_merge(&root, merge_id)?;
+
+    let data = serde_json::json!({
+        "new_head_op": new_head_op,
+        "dst_branch":  dst_branch,
+    });
+    let new_head_for_text = new_head_op.clone();
+    let dst_for_text = dst_branch.clone();
+    acli_mod::emit_or_text("merge", data, fmt, move || {
+        println!("merged {dst_for_text}: head_op = {new_head_for_text}");
+    });
+    Ok(())
+}
+
+fn walk_src_for_sig(
+    store: &Store,
+    src_head: &Option<lex_vcs::OpId>,
+    sig: &lex_vcs::SigId,
+) -> Result<Option<lex_vcs::StageId>> {
+    let log = lex_vcs::OpLog::open(store.root())?;
+    let Some(head) = src_head.as_ref() else { return Ok(None); };
+    let mut current: Option<lex_vcs::StageId> = None;
+    for record in log.walk_forward(head, None)? {
+        match &record.produces {
+            lex_vcs::StageTransition::Create { sig_id, stage_id }
+                if sig_id == sig => { current = Some(stage_id.clone()); }
+            lex_vcs::StageTransition::Replace { sig_id, to, .. }
+                if sig_id == sig => { current = Some(to.clone()); }
+            lex_vcs::StageTransition::Remove { sig_id, .. }
+                if sig_id == sig => { current = None; }
+            lex_vcs::StageTransition::Rename { from, to, body_stage_id }
+                if from == sig || to == sig => {
+                if from == sig { current = None; }
+                if to == sig   { current = Some(body_stage_id.clone()); }
+            }
+            lex_vcs::StageTransition::Merge { entries } => {
+                if let Some(opt) = entries.get(sig) {
+                    current = opt.clone();
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(current)
+}
+
+fn mint_merge_id() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("merge_{nanos:x}_{n:x}")
+}

--- a/crates/lex-cli/tests/merge_cli.rs
+++ b/crates/lex-cli/tests/merge_cli.rs
@@ -1,0 +1,176 @@
+//! `lex merge {start|status|resolve|commit}` — CLI mirror of the
+//! /v1/merge/* HTTP API (#134). Same engine, persisted to disk so
+//! each CLI invocation is its own process.
+
+use std::process::Command;
+use tempfile::tempdir;
+
+fn lex_bin() -> &'static str { env!("CARGO_BIN_EXE_lex") }
+
+fn publish(store: &std::path::Path, src: &std::path::Path) {
+    let out = Command::new(lex_bin())
+        .args([
+            "--output", "json",
+            "publish",
+            "--store", store.to_str().unwrap(),
+            src.to_str().unwrap(),
+        ])
+        .output().unwrap();
+    assert!(out.status.success(), "publish failed: {}", String::from_utf8_lossy(&out.stderr));
+}
+
+/// Set up a ModifyModify conflict on `foo` between `feature` and
+/// the default branch, mirroring `with_modify_modify_session` in
+/// the API tests.
+fn modify_modify_setup(store: &std::path::Path) {
+    let src = store.join("a.lex");
+    std::fs::write(&src, "fn foo(n :: Int) -> Int { n }\n").unwrap();
+    publish(store, &src);
+
+    let s = lex_store::Store::open(store).unwrap();
+    s.create_branch("feature", lex_store::DEFAULT_BRANCH).unwrap();
+    s.set_current_branch("feature").unwrap();
+    drop(s);
+    std::fs::write(&src, "fn foo(n :: Int) -> Int { n + 1 }\n").unwrap();
+    publish(store, &src);
+
+    let s = lex_store::Store::open(store).unwrap();
+    s.set_current_branch(lex_store::DEFAULT_BRANCH).unwrap();
+    drop(s);
+    std::fs::write(&src, "fn foo(n :: Int) -> Int { n + 2 }\n").unwrap();
+    publish(store, &src);
+}
+
+fn merge_start(store: &std::path::Path, src: &str, dst: &str) -> serde_json::Value {
+    let out = Command::new(lex_bin())
+        .args([
+            "--output", "json",
+            "merge", "start",
+            "--store", store.to_str().unwrap(),
+            "--src", src,
+            "--dst", dst,
+        ])
+        .output().unwrap();
+    assert!(out.status.success(), "merge start failed: {}", String::from_utf8_lossy(&out.stderr));
+    serde_json::from_slice(&out.stdout).unwrap()
+}
+
+#[test]
+fn merge_start_persists_session_to_disk() {
+    let store = tempdir().unwrap();
+    modify_modify_setup(store.path());
+
+    let v = merge_start(store.path(), "feature", lex_store::DEFAULT_BRANCH);
+    let merge_id = v.pointer("/data/merge_id").unwrap().as_str().unwrap();
+    let conflicts = v.pointer("/data/conflicts").unwrap().as_array().unwrap();
+    assert_eq!(conflicts.len(), 1, "expected one ModifyModify conflict");
+
+    // The session file lives under <store>/merges/<merge_id>.json.
+    let session_path = store.path().join("merges").join(format!("{merge_id}.json"));
+    assert!(session_path.exists(), "session should be persisted at {session_path:?}");
+}
+
+#[test]
+fn merge_status_shows_remaining_conflicts() {
+    let store = tempdir().unwrap();
+    modify_modify_setup(store.path());
+    let v = merge_start(store.path(), "feature", lex_store::DEFAULT_BRANCH);
+    let merge_id = v.pointer("/data/merge_id").unwrap().as_str().unwrap();
+
+    let out = Command::new(lex_bin())
+        .args([
+            "--output", "json",
+            "merge", "status",
+            "--store", store.path().to_str().unwrap(),
+            merge_id,
+        ])
+        .output().unwrap();
+    assert!(out.status.success(), "status failed: {}", String::from_utf8_lossy(&out.stderr));
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v.pointer("/data/src_branch").unwrap(), "feature");
+    assert_eq!(v.pointer("/data/dst_branch").unwrap(), lex_store::DEFAULT_BRANCH);
+    let remaining = v.pointer("/data/remaining_conflicts").unwrap().as_array().unwrap();
+    assert_eq!(remaining.len(), 1);
+}
+
+#[test]
+fn merge_full_cycle_resolve_then_commit() {
+    let store = tempdir().unwrap();
+    modify_modify_setup(store.path());
+    let v = merge_start(store.path(), "feature", lex_store::DEFAULT_BRANCH);
+    let merge_id = v.pointer("/data/merge_id").unwrap().as_str().unwrap().to_string();
+    let conflict_id = v.pointer("/data/conflicts/0/conflict_id").unwrap().as_str().unwrap().to_string();
+
+    // Write a resolutions file.
+    let resolutions_path = store.path().join("res.json");
+    let body = serde_json::json!([
+        {"conflict_id": conflict_id, "resolution": {"kind": "take_theirs"}}
+    ]);
+    std::fs::write(&resolutions_path, serde_json::to_vec(&body).unwrap()).unwrap();
+
+    // Resolve.
+    let out = Command::new(lex_bin())
+        .args([
+            "--output", "json",
+            "merge", "resolve",
+            "--store", store.path().to_str().unwrap(),
+            &merge_id,
+            "--file", resolutions_path.to_str().unwrap(),
+        ])
+        .output().unwrap();
+    assert!(out.status.success(), "resolve failed: {}", String::from_utf8_lossy(&out.stderr));
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let verdicts = v.pointer("/data/verdicts").unwrap().as_array().unwrap();
+    assert_eq!(verdicts.len(), 1);
+    assert_eq!(verdicts[0]["accepted"], true);
+
+    // Commit.
+    let out = Command::new(lex_bin())
+        .args([
+            "--output", "json",
+            "merge", "commit",
+            "--store", store.path().to_str().unwrap(),
+            &merge_id,
+        ])
+        .output().unwrap();
+    assert!(out.status.success(), "commit failed: {}", String::from_utf8_lossy(&out.stderr));
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert!(!v.pointer("/data/new_head_op").unwrap().as_str().unwrap().is_empty());
+    assert_eq!(v.pointer("/data/dst_branch").unwrap(), lex_store::DEFAULT_BRANCH);
+
+    // Session file should be gone after commit.
+    let session_path = store.path().join("merges").join(format!("{merge_id}.json"));
+    assert!(!session_path.exists(), "session file should be deleted after commit");
+}
+
+#[test]
+fn merge_commit_with_unresolved_conflicts_errors() {
+    let store = tempdir().unwrap();
+    modify_modify_setup(store.path());
+    let v = merge_start(store.path(), "feature", lex_store::DEFAULT_BRANCH);
+    let merge_id = v.pointer("/data/merge_id").unwrap().as_str().unwrap().to_string();
+
+    let out = Command::new(lex_bin())
+        .args([
+            "merge", "commit",
+            "--store", store.path().to_str().unwrap(),
+            &merge_id,
+        ])
+        .output().unwrap();
+    assert!(!out.status.success(), "commit should fail when conflicts remain");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("conflicts remaining"), "stderr should mention conflicts: {stderr}");
+}
+
+#[test]
+fn merge_status_unknown_id_errors() {
+    let store = tempdir().unwrap();
+    let out = Command::new(lex_bin())
+        .args([
+            "merge", "status",
+            "--store", store.path().to_str().unwrap(),
+            "no_such_merge",
+        ])
+        .output().unwrap();
+    assert!(!out.status.success());
+}

--- a/crates/lex-vcs/src/merge.rs
+++ b/crates/lex-vcs/src/merge.rs
@@ -9,7 +9,8 @@ use crate::operation::{OpId, OperationKind, OperationRecord, SigId, StageId};
 use std::collections::{BTreeMap, BTreeSet};
 use std::io;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
 pub enum MergeOutcome {
     /// Both sides converged on the same op_id for this sig.
     Both { sig_id: SigId, stage_id: Option<StageId> },

--- a/crates/lex-vcs/src/merge_session.rs
+++ b/crates/lex-vcs/src/merge_session.rs
@@ -136,7 +136,7 @@ pub enum CommitError {
 /// `start` and `commit`. Sessions are not thread-safe; the HTTP
 /// wrapper is expected to wrap them in a `Mutex` keyed by
 /// [`MergeSessionId`].
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct MergeSession {
     pub merge_id: MergeSessionId,
     pub src_head: Option<OpId>,


### PR DESCRIPTION
## Summary

CLI mirrors of the merge HTTP API for #134. Wraps the same `MergeSession` engine but talks to the store directly (no server needed). Sessions persist to `<store>/merges/<merge_id>.json` so each invocation is its own process — matches the iterative agent flow without requiring `lex serve`.

```
lex merge start  --src B1 --dst B2 [--store DIR]
lex merge status <merge_id>        [--store DIR]
lex merge resolve <merge_id> --file <resolutions.json> [--store DIR]
lex merge commit <merge_id>        [--store DIR]
```

The resolutions file is a JSON array of `{"conflict_id": "...", "resolution": {"kind": "take_ours" | ... }}` — same shape as the HTTP `/resolve` body's `resolutions` field, so the same JSON works for both surfaces.

### Side changes

- `MergeSession` and `MergeOutcome` get `Serialize` / `Deserialize` derives so a session can round-trip through disk between CLI invocations. Struct-variant compatibility was already addressed by #154's `ResolutionRejection` fix.
- `Custom` resolutions are rejected at commit (matching the HTTP endpoint's 422). Landing them needs an extra apply pass for the supplied op — deferred.

## Test plan

- [x] `cargo test -p lex-cli --test merge_cli` — 5 new tests:
  - `merge_start_persists_session_to_disk` — file created at expected path.
  - `merge_status_shows_remaining_conflicts` — branches + remaining list visible.
  - `merge_full_cycle_resolve_then_commit` — end-to-end happy path; session file deleted after commit.
  - `merge_commit_with_unresolved_conflicts_errors` — non-zero exit + clear stderr message.
  - `merge_status_unknown_id_errors`.
- [x] `cargo test --workspace` — green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.

## Status of #134

HTTP API and CLI mirrors complete. Only `Custom`-resolution support inside commit remains (currently 422'd in both surfaces).

https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5

---
_Generated by [Claude Code](https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5)_