### PR TITLE
feat: lex branch overlay &lt;other&gt; [--on &lt;branch&gt;]

### DIFF
--- a/crates/lex-cli/src/acli.rs
+++ b/crates/lex-cli/src/acli.rs
@@ -485,14 +485,20 @@ fn cmd_branch() -> CommandInfo {
         .add_option("--since-fork", "bool", "limit to ops since the fork from --vs (or `parent`)", None)
         .add_option("--vs", "string", "compare against this branch (default: <name>'s parent)", None)
         .add_option("--store", "string", "store root", None);
+    let overlay = CommandInfo::new("overlay", "preview a merge: project current branch as if <other> were merged in")
+        .idempotent(true)
+        .add_argument("other", "string", "branch whose ops would be merged in", true)
+        .add_option("--on", "string", "destination branch (default: current)", None)
+        .add_option("--store", "string", "store root", None);
     let mut info = CommandInfo::new("branch", "snapshot branches in lex-store (tier-1 agent-native VC)")
         .with_examples(vec![
             ("List branches", "lex branch list"),
             ("Create a feature", "lex branch create feature --from main"),
             ("Peek what feature has done since fork", "lex branch peek feature --since-fork"),
+            ("Preview merging feature into main", "lex branch overlay feature --on main"),
         ])
         .with_see_also(vec!["store-merge", "store", "log", "merge"]);
-    info.subcommands = vec![list, show, create, delete, use_b, current, log, peek];
+    info.subcommands = vec![list, show, create, delete, use_b, current, log, peek, overlay];
     info
 }
 

--- a/crates/lex-cli/src/branch.rs
+++ b/crates/lex-cli/src/branch.rs
@@ -53,6 +53,7 @@ pub fn cmd_branch(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         "current" => current(fmt, &store),
         "log"     => log(fmt, &store, &rest),
         "peek"    => peek(fmt, &store, &rest),
+        "overlay" => overlay(fmt, &store, &rest),
         other     => bail!("unknown `lex branch` subcommand `{other}`"),
     }
 }
@@ -325,6 +326,101 @@ fn peek(fmt: &OutputFormat, store: &Store, args: &[String]) -> Result<()> {
             let id = o["op_id"].as_str().unwrap_or("");
             let kind = o["kind"].as_str().unwrap_or("?");
             println!("  {id:.16}…  {kind}");
+        }
+    });
+    Ok(())
+}
+
+/// `lex branch overlay <other> [--on <branch>]` — show what the
+/// current (or `--on`) branch would look like if `<other>` were
+/// merged in (#133). Pure read: nothing is persisted, no
+/// MergeSession is created.
+///
+/// Runs the same merge engine as `store-merge` but stops after
+/// classifying outcomes, then projects the dst head map forward
+/// over the auto-resolved entries. Conflicts are returned for
+/// inspection but do *not* block the projection — overlay's job
+/// is "what would the clean parts look like, and what would
+/// remain to fight about?".
+///
+/// Output: { this_branch, other_branch, lca, projected_head,
+///           auto_resolved, conflicts }.
+fn overlay(fmt: &OutputFormat, store: &Store, args: &[String]) -> Result<()> {
+    let mut other: Option<String> = None;
+    let mut on: Option<String> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--on" => { on = args.get(i + 1).cloned(); i += 2; }
+            o if other.is_none() => { other = Some(o.to_string()); i += 1; }
+            o => bail!("unexpected arg `{o}`"),
+        }
+    }
+    let other = other.ok_or_else(|| anyhow!("usage: lex branch overlay <other> [--on <branch>]"))?;
+    let this  = on.unwrap_or_else(|| store.current_branch());
+
+    let this_head_op  = store.get_branch(&this)
+        .map_err(|e| anyhow!("read branch {this}: {e}"))?
+        .and_then(|b| b.head_op);
+    let other_head_op = store.get_branch(&other)
+        .map_err(|e| anyhow!("read branch {other}: {e}"))?
+        .ok_or_else(|| anyhow!("unknown branch `{other}`"))?
+        .head_op;
+
+    let log = lex_vcs::OpLog::open(store.root())
+        .map_err(|e| anyhow!("open op log: {e}"))?;
+    let merge_output = lex_vcs::merge(&log, other_head_op.as_ref(), this_head_op.as_ref())
+        .map_err(|e| anyhow!("merge: {e}"))?;
+
+    // Start with dst (this) branch's head map, apply Src outcomes
+    // to project what overlay would produce. Conflict sigs stay at
+    // their dst head until resolved — they're listed separately.
+    let mut projected = store.branch_head(&this)
+        .map_err(|e| anyhow!("branch_head {this}: {e}"))?;
+
+    let mut auto_resolved: Vec<&lex_vcs::MergeOutcome> = Vec::new();
+    let mut conflicts: Vec<&lex_vcs::MergeOutcome> = Vec::new();
+    for o in &merge_output.outcomes {
+        match o {
+            lex_vcs::MergeOutcome::Src { sig_id, stage_id } => {
+                match stage_id {
+                    Some(s) => { projected.insert(sig_id.clone(), s.clone()); }
+                    None    => { projected.remove(sig_id); }
+                }
+                auto_resolved.push(o);
+            }
+            lex_vcs::MergeOutcome::Both { .. } | lex_vcs::MergeOutcome::Dst { .. } => {
+                auto_resolved.push(o);
+            }
+            lex_vcs::MergeOutcome::Conflict { .. } => {
+                conflicts.push(o);
+            }
+        }
+    }
+
+    let data = serde_json::json!({
+        "this_branch":     &this,
+        "other_branch":    &other,
+        "lca":             merge_output.lca,
+        "projected_head":  serde_json::to_value(&projected)?,
+        "auto_resolved":   serde_json::to_value(&auto_resolved)?,
+        "conflicts":       serde_json::to_value(&conflicts)?,
+    });
+    let projected_for_text = projected.clone();
+    let conflicts_count    = conflicts.len();
+    let auto_count         = auto_resolved.len();
+    let this_for_text      = this.clone();
+    let other_for_text     = other.clone();
+    acli_mod::emit_or_text("branch", data, fmt, move || {
+        println!("overlay {other_for_text} on {this_for_text}: {} auto-resolved, {} conflict(s)",
+            auto_count, conflicts_count);
+        if conflicts_count == 0 {
+            println!("  projection ({} sigs):", projected_for_text.len());
+        } else {
+            println!("  projection (conflicting sigs unchanged from {this_for_text}):");
+        }
+        for (sig, stage) in &projected_for_text {
+            println!("    {sig:.16}…  →  {stage:.16}…");
         }
     });
     Ok(())

--- a/crates/lex-cli/tests/branch_overlay.rs
+++ b/crates/lex-cli/tests/branch_overlay.rs
@@ -1,0 +1,131 @@
+//! `lex branch overlay <other> [--on <branch>]` — preview merge
+//! result without committing (#133).
+
+use std::process::Command;
+use tempfile::tempdir;
+
+fn lex_bin() -> &'static str { env!("CARGO_BIN_EXE_lex") }
+
+fn publish(store: &std::path::Path, src: &std::path::Path) {
+    let out = Command::new(lex_bin())
+        .args([
+            "--output", "json",
+            "publish",
+            "--store", store.to_str().unwrap(),
+            src.to_str().unwrap(),
+        ])
+        .output().unwrap();
+    assert!(out.status.success(), "publish: {}", String::from_utf8_lossy(&out.stderr));
+}
+
+fn overlay_json(store: &std::path::Path, other: &str, extra: &[&str]) -> serde_json::Value {
+    let mut args: Vec<String> = vec![
+        "--output".into(), "json".into(),
+        "branch".into(), "overlay".into(),
+        "--store".into(), store.to_str().unwrap().to_string(),
+        other.into(),
+    ];
+    for e in extra { args.push((*e).to_string()); }
+    let out = Command::new(lex_bin())
+        .args(&args)
+        .output()
+        .expect("overlay");
+    assert!(out.status.success(), "overlay: {}", String::from_utf8_lossy(&out.stderr));
+    serde_json::from_slice(&out.stdout).unwrap()
+}
+
+#[test]
+fn overlay_clean_merge_projects_added_sigs_into_dst() {
+    // main has fn foo. feature adds fn bar (disjoint). Overlay
+    // feature on main should auto-resolve and project bar in.
+    let store = tempdir().unwrap();
+    let src = store.path().join("a.lex");
+    std::fs::write(&src, "fn foo(n :: Int) -> Int { n }\n").unwrap();
+    publish(store.path(), &src);
+
+    let s = lex_store::Store::open(store.path()).unwrap();
+    s.create_branch("feature", lex_store::DEFAULT_BRANCH).unwrap();
+    s.set_current_branch("feature").unwrap();
+    drop(s);
+    std::fs::write(&src, "fn foo(n :: Int) -> Int { n }\nfn bar(n :: Int) -> Int { n + 1 }\n").unwrap();
+    publish(store.path(), &src);
+
+    // Switch back to main so it's the dst (current).
+    let s = lex_store::Store::open(store.path()).unwrap();
+    s.set_current_branch(lex_store::DEFAULT_BRANCH).unwrap();
+    drop(s);
+
+    let v = overlay_json(store.path(), "feature", &[]);
+    assert_eq!(v.pointer("/data/this_branch").unwrap(), lex_store::DEFAULT_BRANCH);
+    assert_eq!(v.pointer("/data/other_branch").unwrap(), "feature");
+    let conflicts = v.pointer("/data/conflicts").unwrap().as_array().unwrap();
+    assert_eq!(conflicts.len(), 0, "disjoint adds should auto-resolve");
+    let projected = v.pointer("/data/projected_head").unwrap().as_object().unwrap();
+    assert_eq!(projected.len(), 2, "projection should contain both foo and bar");
+}
+
+#[test]
+fn overlay_with_conflict_lists_it_but_keeps_projection_at_dst() {
+    // main and feature both modify foo differently. Overlay should
+    // surface a conflict and keep dst's stage in the projection
+    // (the conflict is noted, not auto-merged).
+    let store = tempdir().unwrap();
+    let src = store.path().join("a.lex");
+    std::fs::write(&src, "fn foo(n :: Int) -> Int { n }\n").unwrap();
+    publish(store.path(), &src);
+
+    let s = lex_store::Store::open(store.path()).unwrap();
+    s.create_branch("feature", lex_store::DEFAULT_BRANCH).unwrap();
+    s.set_current_branch("feature").unwrap();
+    drop(s);
+    std::fs::write(&src, "fn foo(n :: Int) -> Int { n + 1 }\n").unwrap();
+    publish(store.path(), &src);
+
+    let s = lex_store::Store::open(store.path()).unwrap();
+    s.set_current_branch(lex_store::DEFAULT_BRANCH).unwrap();
+    drop(s);
+    std::fs::write(&src, "fn foo(n :: Int) -> Int { n + 2 }\n").unwrap();
+    publish(store.path(), &src);
+
+    let v = overlay_json(store.path(), "feature", &[]);
+    let conflicts = v.pointer("/data/conflicts").unwrap().as_array().unwrap();
+    assert_eq!(conflicts.len(), 1, "expected one ModifyModify conflict");
+    // Projection still has foo at dst's (main's) stage.
+    let projected = v.pointer("/data/projected_head").unwrap().as_object().unwrap();
+    assert_eq!(projected.len(), 1);
+}
+
+#[test]
+fn overlay_on_explicit_dst_works() {
+    // --on <branch> overrides the current-branch default.
+    let store = tempdir().unwrap();
+    let src = store.path().join("a.lex");
+    std::fs::write(&src, "fn foo(n :: Int) -> Int { n }\n").unwrap();
+    publish(store.path(), &src);
+
+    let s = lex_store::Store::open(store.path()).unwrap();
+    s.create_branch("feature", lex_store::DEFAULT_BRANCH).unwrap();
+    drop(s);
+
+    // Stay on main; overlay feature explicitly on main.
+    let v = overlay_json(store.path(), "feature", &["--on", lex_store::DEFAULT_BRANCH]);
+    assert_eq!(v.pointer("/data/this_branch").unwrap(), lex_store::DEFAULT_BRANCH);
+    assert_eq!(v.pointer("/data/other_branch").unwrap(), "feature");
+}
+
+#[test]
+fn overlay_unknown_other_errors() {
+    let store = tempdir().unwrap();
+    let src = store.path().join("a.lex");
+    std::fs::write(&src, "fn foo(n :: Int) -> Int { n }\n").unwrap();
+    publish(store.path(), &src);
+
+    let out = Command::new(lex_bin())
+        .args([
+            "branch", "overlay",
+            "--store", store.path().to_str().unwrap(),
+            "no_such_branch",
+        ])
+        .output().unwrap();
+    assert!(!out.status.success());
+}


### PR DESCRIPTION
## Summary

Pure-read preview of a merge for #133. Projects the dst branch's head map forward over what the merge engine would auto-resolve, lists any remaining conflicts. No `MergeSession`, no commit, no side effects.

```
lex branch overlay <other> [--on <branch>]
```

Use case: *"what would my branch look like with `feature` merged in?"* — without paying the cost of starting a real merge and without locking dst against further changes.

Output: `{ this_branch, other_branch, lca, projected_head, auto_resolved, conflicts }`.

Conflicts don't block the projection: `projected_head` holds dst's stages for any conflicting sigs (until resolved), and the `conflicts` array enumerates them for inspection. Pairs naturally with `lex branch peek` from #157 — peek tells you what the other branch has done, overlay tells you how the merge would shake out.

## Test plan

- [x] `cargo test -p lex-cli --test branch_overlay` — 4 tests:
  - Clean merge projects added sigs from feature into main's head map.
  - ModifyModify conflict is listed; projection keeps dst's stage.
  - `--on <branch>` overrides the current-branch default.
  - Unknown `<other>` errors.
- [x] `cargo test --workspace` — green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.

## Status of #133

After this PR + #157 (peek): `peek` and `overlay` both ship. The remaining acceptance item is migration of existing `branches/<name>.json` files to predicate-defined branches — mostly already true since the predicate engine (#144) preserves the snapshot format as a materialization cache.

https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5

---
_Generated by [Claude Code](https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5)_