### PR TITLE
feat: support Resolution::Custom in merge commit (HTTP + CLI)

### DIFF
--- a/crates/lex-api/src/handlers.rs
+++ b/crates/lex-api/src/handlers.rs
@@ -694,12 +694,40 @@ fn merge_commit_handler(
                     Err(e) => return error_response(500, format!("resolve take_theirs: {e}")),
                 }
             }
-            lex_vcs::Resolution::Custom { .. } => {
-                return error_with_detail(
-                    422,
-                    "custom resolutions not yet supported by /v1/merge/<id>/commit",
-                    serde_json::json!({"conflict_id": conflict_id}),
-                );
+            lex_vcs::Resolution::Custom { op } => {
+                // The agent's brand-new op carries the merge target
+                // in its kind (e.g. ModifyBody.to_stage_id). The op
+                // itself isn't separately recorded in the log here
+                // — its head-map effect is folded into the merge
+                // op's entries map. Callers that want the op as a
+                // first-class history entry should publish it via
+                // /v1/publish first and submit a TakeTheirs/TakeOurs
+                // resolution against the resulting head.
+                match op.kind.merge_target() {
+                    Some((sig, stage)) => {
+                        if sig != conflict_id {
+                            return error_with_detail(
+                                422,
+                                "custom op targets a different sig than the conflict",
+                                serde_json::json!({
+                                    "conflict_id": conflict_id,
+                                    "op_targets": sig,
+                                }),
+                            );
+                        }
+                        entries.insert(conflict_id, stage);
+                    }
+                    None => {
+                        return error_with_detail(
+                            422,
+                            "custom op kind doesn't yield a single sig→stage delta",
+                            serde_json::json!({
+                                "conflict_id": conflict_id,
+                                "kind": serde_json::to_value(&op.kind).unwrap_or(serde_json::Value::Null),
+                            }),
+                        );
+                    }
+                }
             }
             lex_vcs::Resolution::Defer => {
                 // Unreachable: commit() rejects Defer above.

--- a/crates/lex-api/tests/m8.rs
+++ b/crates/lex-api/tests/m8.rs
@@ -394,6 +394,104 @@ fn merge_commit_unknown_session_returns_404() {
 }
 
 #[test]
+fn merge_commit_with_custom_resolution_lands_agent_supplied_stage() {
+    // Same ModifyModify setup as the take_theirs test, but the
+    // agent submits a `Custom { op }` whose ModifyBody.to_stage_id
+    // names a brand-new stage. commit folds the op's target into
+    // the merge entries.
+    let (srv, _tmp, merge_id) = with_modify_modify_session();
+    let path_resolve = format!("/v1/merge/{merge_id}/resolve");
+    let path_commit  = format!("/v1/merge/{merge_id}/commit");
+
+    // Pull conflict + ours/theirs stage ids from the fresh session
+    // start (same merge_id; conflict_id == sig).
+    let (_, b) = http(&srv.addr, "POST", "/v1/merge/start", &json!({
+        "src_branch": "feature", "dst_branch": lex_store::DEFAULT_BRANCH,
+    }).to_string());
+    let v: serde_json::Value = serde_json::from_str(&b).unwrap();
+    let conflict = &v["conflicts"][0];
+    let conflict_id = conflict["conflict_id"].as_str().unwrap().to_string();
+    let ours_stage = conflict["ours"].as_str().unwrap().to_string();
+    let theirs_stage = conflict["theirs"].as_str().unwrap().to_string();
+    let custom_stage = "stage-agent-resolved-001".to_string();
+
+    let resolve_body = json!({
+        "resolutions": [
+            {
+                "conflict_id": conflict_id,
+                "resolution": {
+                    "kind": "custom",
+                    "op": {
+                        // Operation's `kind` is #[serde(flatten)],
+                        // so OperationKind's tag + fields appear at
+                        // the top level alongside `parents`.
+                        "op": "modify_body",
+                        "sig_id": conflict_id,
+                        "from_stage_id": ours_stage,
+                        "to_stage_id":   custom_stage,
+                        "parents": [
+                            // Conflict resolution must list both
+                            // sides; MergeSession enforces parents.len() ≥ 2.
+                            ours_stage.clone(),
+                            theirs_stage,
+                        ],
+                    }
+                }
+            }
+        ]
+    }).to_string();
+    let (s, b) = http(&srv.addr, "POST", &path_resolve, &resolve_body);
+    assert_eq!(s, 200, "resolve: {b}");
+    let rv: serde_json::Value = serde_json::from_str(&b).unwrap();
+    assert_eq!(rv["verdicts"][0]["accepted"], true);
+
+    let (s, b) = http(&srv.addr, "POST", &path_commit, "");
+    assert_eq!(s, 200, "commit: {b}");
+    // After commit, dst's branch_head for `foo` should be the
+    // agent-supplied custom stage. We can verify via the public
+    // /v1/stage/<id> endpoint isn't present (it's not a real
+    // stage), but the merge op recorded the head delta — read the
+    // op log via /v1/diff is overkill; instead just check the
+    // response's new_head_op is set.
+    let cv: serde_json::Value = serde_json::from_str(&b).unwrap();
+    assert!(cv["new_head_op"].as_str().is_some());
+}
+
+#[test]
+fn merge_commit_rejects_custom_op_targeting_wrong_sig() {
+    let (srv, _tmp, merge_id) = with_modify_modify_session();
+    let path_resolve = format!("/v1/merge/{merge_id}/resolve");
+    let path_commit  = format!("/v1/merge/{merge_id}/commit");
+
+    let (_, b) = http(&srv.addr, "POST", "/v1/merge/start", &json!({
+        "src_branch": "feature", "dst_branch": lex_store::DEFAULT_BRANCH,
+    }).to_string());
+    let v: serde_json::Value = serde_json::from_str(&b).unwrap();
+    let conflict_id = v["conflicts"][0]["conflict_id"].as_str().unwrap().to_string();
+
+    let resolve_body = json!({
+        "resolutions": [{
+            "conflict_id": conflict_id,
+            "resolution": {
+                "kind": "custom",
+                "op": {
+                    "op": "modify_body",
+                    "sig_id": "fn::not_the_conflict_sig",
+                    "from_stage_id": "x",
+                    "to_stage_id":   "y",
+                    "parents": ["a", "b"],
+                }
+            }
+        }]
+    }).to_string();
+    let (s, _) = http(&srv.addr, "POST", &path_resolve, &resolve_body);
+    assert_eq!(s, 200, "resolve accepts; mismatch caught at commit");
+    let (s, b) = http(&srv.addr, "POST", &path_commit, "");
+    assert_eq!(s, 422, "commit should 422 on mismatched-sig custom op: {b}");
+    assert!(b.contains("targets a different sig"));
+}
+
+#[test]
 fn replay_with_overrides() {
     let (srv, _tmp) = start_server();
     let src = "import \"std.io\" as io\nfn read_one(p :: Str) -> [io] Result[Str, Str] { io.read(p) }\n";

--- a/crates/lex-cli/src/merge.rs
+++ b/crates/lex-cli/src/merge.rs
@@ -278,8 +278,14 @@ fn cmd_commit(fmt: &OutputFormat, args: &[String]) -> Result<()> {
                 let stage_id = walk_src_for_sig(&store, &src_head, &conflict_id)?;
                 entries.insert(conflict_id, stage_id);
             }
-            lex_vcs::Resolution::Custom { .. } => {
-                bail!("custom resolutions not yet supported by `lex merge commit`");
+            lex_vcs::Resolution::Custom { op } => {
+                let (sig, stage) = op.kind.merge_target()
+                    .ok_or_else(|| anyhow!(
+                        "custom op kind doesn't yield a single sig→stage delta: {:?}", op.kind))?;
+                if sig != conflict_id {
+                    bail!("custom op targets sig `{sig}` but the conflict is on `{conflict_id}`");
+                }
+                entries.insert(conflict_id, stage);
             }
             lex_vcs::Resolution::Defer => {
                 bail!("internal: Defer resolution slipped past commit gate");

--- a/crates/lex-cli/tests/merge_cli.rs
+++ b/crates/lex-cli/tests/merge_cli.rs
@@ -163,6 +163,59 @@ fn merge_commit_with_unresolved_conflicts_errors() {
 }
 
 #[test]
+fn merge_full_cycle_with_custom_resolution_lands_agent_stage() {
+    let store = tempdir().unwrap();
+    modify_modify_setup(store.path());
+    let v = merge_start(store.path(), "feature", lex_store::DEFAULT_BRANCH);
+    let merge_id = v.pointer("/data/merge_id").unwrap().as_str().unwrap().to_string();
+    let conflict = v.pointer("/data/conflicts/0").unwrap();
+    let conflict_id = conflict["conflict_id"].as_str().unwrap().to_string();
+    let ours = conflict["ours"].as_str().unwrap().to_string();
+    let theirs = conflict["theirs"].as_str().unwrap().to_string();
+
+    let resolutions_path = store.path().join("res.json");
+    // Same shape as the HTTP /resolve body. Operation's `kind` is
+    // serde-flattened so the OperationKind tag lives at the top.
+    let body = serde_json::json!([{
+        "conflict_id": conflict_id,
+        "resolution": {
+            "kind": "custom",
+            "op": {
+                "op": "modify_body",
+                "sig_id": conflict_id,
+                "from_stage_id": ours,
+                "to_stage_id":   "stage-agent-resolved-cli-001",
+                "parents": [ours, theirs],
+            }
+        }
+    }]);
+    std::fs::write(&resolutions_path, serde_json::to_vec(&body).unwrap()).unwrap();
+
+    let out = Command::new(lex_bin())
+        .args([
+            "--output", "json",
+            "merge", "resolve",
+            "--store", store.path().to_str().unwrap(),
+            &merge_id,
+            "--file", resolutions_path.to_str().unwrap(),
+        ])
+        .output().unwrap();
+    assert!(out.status.success(), "resolve: {}", String::from_utf8_lossy(&out.stderr));
+
+    let out = Command::new(lex_bin())
+        .args([
+            "--output", "json",
+            "merge", "commit",
+            "--store", store.path().to_str().unwrap(),
+            &merge_id,
+        ])
+        .output().unwrap();
+    assert!(out.status.success(), "commit: {}", String::from_utf8_lossy(&out.stderr));
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert!(!v.pointer("/data/new_head_op").unwrap().as_str().unwrap().is_empty());
+}
+
+#[test]
 fn merge_status_unknown_id_errors() {
     let store = tempdir().unwrap();
     let out = Command::new(lex_bin())

--- a/crates/lex-vcs/src/operation.rs
+++ b/crates/lex-vcs/src/operation.rs
@@ -143,6 +143,38 @@ pub enum OperationKind {
     },
 }
 
+impl OperationKind {
+    /// The `(SigId, Option<StageId>)` an op kind targets, as used by
+    /// `StageTransition::Merge::entries`. Used by the merge-commit
+    /// path (#134) to translate a `Resolution::Custom { op }` into
+    /// the head-map delta the merge op records:
+    ///
+    /// * Adds → `(sig, Some(stage_id))`
+    /// * Modifies → `(sig, Some(to_stage_id))`
+    /// * Removes → `(sig, None)`
+    /// * Renames → `(to_sig, Some(body_stage_id))`
+    /// * `AddImport` / `RemoveImport` / nested `Merge` → `None`
+    ///   (no single sig→stage delta)
+    pub fn merge_target(&self) -> Option<(SigId, Option<StageId>)> {
+        use OperationKind::*;
+        match self {
+            AddFunction { sig_id, stage_id, .. }
+            | AddType { sig_id, stage_id }
+                => Some((sig_id.clone(), Some(stage_id.clone()))),
+            ModifyBody { sig_id, to_stage_id, .. }
+            | ChangeEffectSig { sig_id, to_stage_id, .. }
+            | ModifyType { sig_id, to_stage_id, .. }
+                => Some((sig_id.clone(), Some(to_stage_id.clone()))),
+            RemoveFunction { sig_id, .. }
+            | RemoveType { sig_id, .. }
+                => Some((sig_id.clone(), None)),
+            RenameSymbol { to, body_stage_id, .. }
+                => Some((to.clone(), Some(body_stage_id.clone()))),
+            AddImport { .. } | RemoveImport { .. } | Merge { .. } => None,
+        }
+    }
+}
+
 /// The operation as a whole — its kind and the causal predecessors
 /// it assumes. The `OpId` is computed from this plus a sorted view
 /// of `parents`.


### PR DESCRIPTION
## Summary

Closes the last gap in #134's commit logic. A `Custom { op }` resolution carries the agent's brand-new op; commit had been 422'ing it pending design.

Now: commit extracts `(sig, stage)` from the op's kind via a new `OperationKind::merge_target` helper and folds it into the merge op's `StageTransition` entries map. Both surfaces share the same logic: `POST /v1/merge/<id>/commit` and `lex merge commit`.

### Translation rules (`OperationKind::merge_target`)

| OperationKind | Merge target |
|---|---|
| `AddFunction` / `AddType` | `(sig, Some(stage_id))` |
| `ModifyBody` / `ChangeEffectSig` / `ModifyType` | `(sig, Some(to_stage_id))` |
| `RemoveFunction` / `RemoveType` | `(sig, None)` |
| `RenameSymbol` | `(to_sig, Some(body_stage_id))` |
| `AddImport` / `RemoveImport` / nested `Merge` | `None` — rejected at commit |

A Custom op whose target sig disagrees with the conflict's sig is rejected at commit (422 / non-zero exit) — keeps the agent honest about what they're resolving.

### Caveat documented in commits

The custom op itself is **not** separately persisted in the op log — its head-map effect is folded into the merge op's `entries`. An agent that wants the custom op as a first-class history entry should publish it via `/v1/publish` first and submit a `TakeTheirs` resolution against the resulting head.

## Test plan

- [x] `cargo test -p lex-api --test m8 merge` — 2 new tests on top of the existing 8:
  - `merge_commit_with_custom_resolution_lands_agent_supplied_stage` — happy path.
  - `merge_commit_rejects_custom_op_targeting_wrong_sig` — 422 on sig mismatch.
- [x] `cargo test -p lex-cli --test merge_cli` — 1 new test (`merge_full_cycle_with_custom_resolution_lands_agent_stage`) for the CLI mirror.
- [x] `cargo test --workspace` — green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.

## Status of #134

HTTP API + CLI mirrors complete; **all four `Resolution` variants** now land via commit. Issue can be closed.

https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5

---
_Generated by [Claude Code](https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5)_