### PR TITLE
feat: lex audit --effect --store emits EffectAudit attestations

### DIFF
--- a/crates/lex-cli/src/acli.rs
+++ b/crates/lex-cli/src/acli.rs
@@ -422,11 +422,18 @@ fn cmd_audit() -> CommandInfo {
         .add_option("--host", "string", "hostname filter (literal)", None)
         .add_option("--kind", "string", "AST node kind filter", None)
         .add_option("--json", "bool", "machine-readable output", None)
+        .add_option(
+            "--store",
+            "string",
+            "with --effect, persist EffectAudit attestations against each scanned stage",
+            None,
+        )
         .with_examples(vec![
             ("Find network calls", "lex audit --effect net examples"),
             ("Find a host as JSON", "lex audit --host api.example.com --json src"),
+            ("Persist effect audits", "lex audit --effect fs_write --store ~/.lex/store src"),
         ])
-        .with_see_also(vec!["ast-diff", "ast-merge"])
+        .with_see_also(vec!["ast-diff", "ast-merge", "attest", "stage"])
 }
 
 fn cmd_ast_diff() -> CommandInfo {

--- a/crates/lex-cli/src/audit.rs
+++ b/crates/lex-cli/src/audit.rs
@@ -40,6 +40,15 @@ struct AuditOpts {
     kinds: Vec<String>,
     json: bool,
     no_summary: bool,
+    /// Store root for `EffectAudit` attestation persistence (#132).
+    /// When set together with `--effect K`, every scanned FnDecl gets
+    /// an attestation against its content-hashed StageId:
+    ///
+    /// * `Passed` if it doesn't touch any of the listed effects
+    /// * `Failed` if it does (detail = which effect(s))
+    ///
+    /// Without `--store`, behavior is unchanged.
+    store_root: Option<PathBuf>,
 }
 
 #[derive(Serialize)]
@@ -66,6 +75,24 @@ pub fn cmd_audit(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     }
     let files = collect_lex_files(&opts.paths)?;
     let mut report = AuditReport { summary: BTreeMap::new(), hits: Vec::new() };
+
+    // #132: when `--store DIR` is combined with `--effect K1,K2,...`,
+    // every scanned FnDecl gets an EffectAudit attestation against
+    // its content-hashed StageId. Without `--effect`, the attestation
+    // would be a vacuous claim — refuse so callers don't accumulate
+    // noise.
+    let att_log = match (&opts.store_root, opts.effects.is_empty()) {
+        (Some(_), true) => {
+            return Err(anyhow!(
+                "`--store DIR` requires `--effect K1,K2,...` to specify the effect set the audit is checking against"));
+        }
+        (Some(root), false) => {
+            let store = lex_store::Store::open(root)
+                .with_context(|| format!("opening store at {}", root.display()))?;
+            Some(store.attestation_log()?)
+        }
+        (None, _) => None,
+    };
 
     for path in &files {
         // Parse + canonicalize. Errors are printed once, then we keep
@@ -98,6 +125,42 @@ pub fn cmd_audit(fmt: &OutputFormat, args: &[String]) -> Result<()> {
                         signature: render_signature(fd),
                         matched: if always { vec!["all".into()] } else { matched },
                     });
+                }
+
+                if let Some(log) = &att_log {
+                    if let Some(stage_id) = lex_ast::stage_id(stage) {
+                        let touched: Vec<&String> = info.effects.iter()
+                            .filter(|e| opts.effects.iter().any(|q| q == *e))
+                            .collect();
+                        let result = if touched.is_empty() {
+                            lex_vcs::AttestationResult::Passed
+                        } else {
+                            let names: Vec<&str> = touched.iter().map(|s| s.as_str()).collect();
+                            lex_vcs::AttestationResult::Failed {
+                                detail: format!("touches forbidden effect(s): {}", names.join(",")),
+                            }
+                        };
+                        let producer = lex_vcs::ProducerDescriptor {
+                            tool: "lex audit".into(),
+                            version: env!("CARGO_PKG_VERSION").into(),
+                            model: None,
+                        };
+                        let attestation = lex_vcs::Attestation::new(
+                            stage_id,
+                            None,
+                            None,
+                            lex_vcs::AttestationKind::EffectAudit,
+                            result,
+                            producer,
+                            None,
+                        );
+                        if let Err(e) = log.put(&attestation) {
+                            eprintln!(
+                                "warning: failed to persist EffectAudit attestation in {}: {e}",
+                                path.display()
+                            );
+                        }
+                    }
                 }
             }
         }
@@ -168,6 +231,11 @@ fn parse_audit_args(args: &[String]) -> Result<AuditOpts> {
             }
             "--json"        => { o.json = true;        i += 1; }
             "--no-summary"  => { o.no_summary = true;  i += 1; }
+            "--store" => {
+                let v = args.get(i + 1).ok_or_else(|| anyhow!("--store needs a path"))?;
+                o.store_root = Some(PathBuf::from(v));
+                i += 2;
+            }
             other => { o.paths.push(PathBuf::from(other)); i += 1; }
         }
     }

--- a/crates/lex-cli/tests/audit_attestation.rs
+++ b/crates/lex-cli/tests/audit_attestation.rs
@@ -1,0 +1,141 @@
+//! `lex audit --effect K --store DIR` — EffectAudit attestation
+//! producer (#132 last producer slice).
+
+use std::process::Command;
+use tempfile::tempdir;
+
+fn lex_bin() -> &'static str { env!("CARGO_BIN_EXE_lex") }
+
+fn write_src(dir: &std::path::Path, name: &str, contents: &str) -> std::path::PathBuf {
+    let p = dir.join(name);
+    std::fs::write(&p, contents).unwrap();
+    p
+}
+
+fn list_all_attestations(store: &std::path::Path) -> serde_json::Value {
+    let out = Command::new(lex_bin())
+        .args([
+            "--output", "json",
+            "attest", "filter",
+            "--store", store.to_str().unwrap(),
+        ])
+        .output().unwrap();
+    assert!(out.status.success(), "attest filter: {}", String::from_utf8_lossy(&out.stderr));
+    serde_json::from_slice(&out.stdout).unwrap()
+}
+
+#[test]
+fn audit_with_store_emits_passed_for_pure_fns() {
+    let store = tempdir().unwrap();
+    let src = write_src(store.path(), "a.lex", "fn pure_fn(n :: Int) -> Int { n + 1 }\n");
+
+    let out = Command::new(lex_bin())
+        .args([
+            "audit", "--effect", "io",
+            "--store", store.path().to_str().unwrap(),
+            src.to_str().unwrap(),
+        ])
+        .output().unwrap();
+    assert!(out.status.success(), "audit: {}", String::from_utf8_lossy(&out.stderr));
+
+    let v = list_all_attestations(store.path());
+    let atts = v.pointer("/data/attestations").unwrap().as_array().unwrap();
+    let effect_atts: Vec<&serde_json::Value> = atts.iter()
+        .filter(|a| a["kind"]["kind"] == "effect_audit")
+        .collect();
+    assert_eq!(effect_atts.len(), 1, "expected one EffectAudit attestation");
+    assert_eq!(effect_atts[0]["result"]["result"], "passed");
+    assert_eq!(effect_atts[0]["produced_by"]["tool"], "lex audit");
+}
+
+#[test]
+fn audit_with_store_emits_failed_for_fn_touching_forbidden_effect() {
+    let store = tempdir().unwrap();
+    let src = write_src(store.path(), "b.lex",
+        "import \"std.io\" as io\nfn say(line :: Str) -> [io] Nil { io.print(line) }\n");
+
+    let out = Command::new(lex_bin())
+        .args([
+            "audit", "--effect", "io",
+            "--store", store.path().to_str().unwrap(),
+            src.to_str().unwrap(),
+        ])
+        .output().unwrap();
+    assert!(out.status.success(), "audit: {}", String::from_utf8_lossy(&out.stderr));
+
+    let v = list_all_attestations(store.path());
+    let atts = v.pointer("/data/attestations").unwrap().as_array().unwrap();
+    let effect_atts: Vec<&serde_json::Value> = atts.iter()
+        .filter(|a| a["kind"]["kind"] == "effect_audit")
+        .collect();
+    assert_eq!(effect_atts.len(), 1, "expected one EffectAudit attestation");
+    assert_eq!(effect_atts[0]["result"]["result"], "failed");
+    let detail = effect_atts[0]["result"]["detail"].as_str().unwrap_or("");
+    assert!(detail.contains("io"), "detail should mention io: {detail}");
+}
+
+#[test]
+fn audit_emits_one_attestation_per_fn_in_mixed_file() {
+    // One pure fn + one fn touching io. Each gets its own
+    // attestation: passed and failed respectively.
+    let store = tempdir().unwrap();
+    let src = write_src(store.path(), "mixed.lex",
+        "import \"std.io\" as io\n\
+         fn pure_fn(n :: Int) -> Int { n + 1 }\n\
+         fn impure_fn(line :: Str) -> [io] Nil { io.print(line) }\n");
+
+    let out = Command::new(lex_bin())
+        .args([
+            "audit", "--effect", "io",
+            "--store", store.path().to_str().unwrap(),
+            src.to_str().unwrap(),
+        ])
+        .output().unwrap();
+    assert!(out.status.success());
+
+    let v = list_all_attestations(store.path());
+    let atts = v.pointer("/data/attestations").unwrap().as_array().unwrap();
+    let effect_atts: Vec<&serde_json::Value> = atts.iter()
+        .filter(|a| a["kind"]["kind"] == "effect_audit")
+        .collect();
+    assert_eq!(effect_atts.len(), 2);
+    let passed_count = effect_atts.iter()
+        .filter(|a| a["result"]["result"] == "passed").count();
+    let failed_count = effect_atts.iter()
+        .filter(|a| a["result"]["result"] == "failed").count();
+    assert_eq!(passed_count, 1);
+    assert_eq!(failed_count, 1);
+}
+
+#[test]
+fn audit_store_without_effect_errors() {
+    // `--store` without `--effect` makes no claim — refuse to write
+    // a vacuous attestation.
+    let store = tempdir().unwrap();
+    let src = write_src(store.path(), "a.lex", "fn id(n :: Int) -> Int { n }\n");
+
+    let out = Command::new(lex_bin())
+        .args([
+            "audit",
+            "--store", store.path().to_str().unwrap(),
+            src.to_str().unwrap(),
+        ])
+        .output().unwrap();
+    assert!(!out.status.success(), "expected error when --store without --effect");
+}
+
+#[test]
+fn audit_without_store_writes_no_attestations() {
+    // Backwards-compat: existing audit invocations stay clean.
+    let store = tempdir().unwrap();
+    let src = write_src(store.path(), "a.lex", "fn id(n :: Int) -> Int { n }\n");
+
+    let out = Command::new(lex_bin())
+        .args([
+            "audit", "--effect", "io",
+            src.to_str().unwrap(),
+        ])
+        .output().unwrap();
+    assert!(out.status.success());
+    assert!(!store.path().join("attestations").exists());
+}


### PR DESCRIPTION
## Summary

Closes the last producer slice in #132. When `--store DIR` is combined with `--effect K1,K2,...`, every scanned FnDecl gets an `EffectAudit` attestation against its content-hashed StageId:

- **`Passed`** if the fn doesn't touch any of the listed effects
- **`Failed { detail: "touches forbidden effect(s): ..." }`** if it does

```
lex audit --effect fs_write --store ~/.lex/store src/
```

Without `--store`, behavior is unchanged. Without `--effect` (but with `--store`), the call errors — no claim is being made, so writing a vacuous attestation would just accumulate noise.

The attestation lets a downstream `lex stage <id> --attestations` or `GET /v1/stage/<id>/attestations` answer *"has this stage been checked against effect-policy K?"* without re-running the audit. Producer is `lex audit` pinned to crate version.

## Test plan

- [x] `cargo test -p lex-cli --test audit_attestation` — 5 tests:
  - Pure fn → `Passed` attestation.
  - Fn touching forbidden effect → `Failed` with detail naming the effect.
  - Mixed file (1 pure, 1 impure) → exactly 1 passed + 1 failed.
  - `--store` without `--effect` errors.
  - Without `--store` no `attestations/` dir is created (backward compat).
- [x] `cargo test --workspace` — green, existing audit tests still pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (Rust 1.95).

## Status of #132

**All producers and consumers shipped.** Producers: TypeCheck (#147), Spec (#150 + #152), Examples / DiffBody / SandboxRun (#152), EffectAudit (this PR). Consumers: HTTP `GET /v1/stage/<id>/attestations` (#148), `lex stage --attestations` (#148), `lex blame --with-evidence` (#149), `lex attest filter` (#151).

#132 can be closed.

## Tier-2 (#128) status

- **#129** Operation as first-class unit ✅
- **#130** Write-time type-check gate ✅
- **#131** Intent ✅
- **#132** Attestation graph ✅ (this PR closes the last gap)
- **#133** Predicate branches ✅ engine + `peek` (#157) + `overlay` (#158)
- **#134** Programmatic merge API ✅ HTTP (#153/154/155) + CLI (#156) + Custom (#159)

https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5

---
_Generated by [Claude Code](https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5)_