### PR TITLE
docs: agent_merge example — end-to-end lex-vcs walkthrough

### DIFF
--- a/examples/agent_merge/README.md
+++ b/examples/agent_merge/README.md
@@ -1,0 +1,105 @@
+# `agent_merge` — agent-native VCS, end-to-end
+
+A scripted walkthrough of `lex-vcs`'s tier-2 features (#128). Two
+"agents" work in parallel on the same function, produce a
+ModifyModify conflict, and a third agent (this script) resolves
+it programmatically — no text editing, no merge markers, no
+re-running `lex check` to make sure the result still typechecks
+because the store-write gate (#130) does that on every accepted
+op automatically.
+
+What this example demonstrates, mapped to the issues:
+
+| Concept | Issue | Surface used |
+|---|---|---|
+| Operation as the unit of change | #129 | every `publish` produces a typed op |
+| Write-time type-check gate | #130 | `publish_program` rejects bad source pre-commit |
+| TypeCheck attestation auto-emitted | #132 | `lex stage <id> --attestations` |
+| Stateful merge session | #134 | `lex merge start \| resolve \| commit` |
+| Spec attestation as evidence | #132 | `lex spec check --store DIR` |
+| Evidence trail per stage | #132 | `lex blame --with-evidence`, `lex attest filter` |
+
+## The scenario
+
+Two agents working in parallel modify `clamp(x, lo, hi) -> Int`:
+
+- `feature` (one agent): refactors to `min2(max2(x, lo), hi)`.
+- `main` (a different agent, or the human): adds an early-return
+  guard for the degenerate `lo > hi` case.
+
+Both bodies typecheck. Both pass the same spec
+(`r >= lo and r <= hi` when `lo <= hi`). But the AST diverged on
+both sides, so a merge sees a `ModifyModify` conflict on the
+`clamp` sig.
+
+In a Git world the agent would now be reading text merge
+markers and guessing whether a hunk is right. Here, the agent
+gets the structured conflict over JSON and submits a typed
+resolution.
+
+## Run it
+
+The whole flow is one script. It uses an ephemeral store under
+`$STORE` (default: a fresh `mktemp` dir) so it can't disturb a
+real `~/.lex/store`.
+
+```sh
+cd <repo-root>
+bash examples/agent_merge/run.sh
+```
+
+You should see eight stages of output (numbered 1–8) walking
+the merge from publish through to the evidence trail. The most
+interesting are:
+
+- **Step 1b** — the `TypeCheck::Passed` attestation that
+  `Store::publish_program` wrote *automatically* when the v0
+  body landed. No `lex check` was run; the gate ran inside the
+  store-write path.
+- **Step 4** — the merge surfaces the conflict as JSON, with
+  `ours` / `theirs` / `base` stage_ids the agent can compare
+  programmatically. Compare to `git diff --merge` and the line
+  noise around `<<<<<<<` markers.
+- **Step 6** — the merge op lands as a single typed operation
+  with the right parents in the DAG. `lex log main` shows it
+  alongside the original publishes.
+- **Step 8** — `lex blame --with-evidence` and `lex attest
+  filter` read back the cumulative evidence: every TypeCheck
+  the gate emitted plus the Spec we just persisted.
+
+## Adapt this for an agent harness
+
+The shell script substitutes a hard-coded `take_theirs` for the
+agent's decision in step 5. A real harness would:
+
+1. Read `merge start`'s JSON conflict list.
+2. For each conflict, fetch the `ours` / `theirs` stages via
+   `GET /v1/stage/<id>` (or `lex stage <id>`).
+3. Pick a resolution per conflict (`take_ours` / `take_theirs` /
+   `custom` with a brand-new op / `defer` to a human).
+4. POST the batch to `/v1/merge/<merge_id>/resolve` (or `lex
+   merge resolve`).
+5. POST `/v1/merge/<merge_id>/commit`.
+
+The HTTP and CLI surfaces are 1:1 — same JSON shape, same
+verdicts. Pick whichever fits the harness; `lex serve` keeps
+the store hot if the agent runs many merges per session.
+
+## Predicate branches (#133)
+
+This example uses snapshot branches (`lex branch create
+feature`). The same VCS supports predicate-defined branches —
+saved queries over the op log:
+
+```sh
+# "All ops produced under intent ses_3781fc"
+lex branch create my-view --predicate \
+  '{"predicate":"intent","intent_id":"ses_3781fc"}'
+
+# "Everything in main since the fork from feature"
+lex branch peek feature --since-fork --vs main
+```
+
+That model is what makes 20 parallel exploration branches per
+agent-task cheap (each is a small JSON predicate file, not a
+copy of the world). See #133 for the full design.

--- a/examples/agent_merge/clamp.spec
+++ b/examples/agent_merge/clamp.spec
@@ -1,0 +1,5 @@
+spec clamp {
+  forall x :: Int, lo :: Int, hi :: Int where lo <= hi:
+    let r := clamp(x, lo, hi)
+    (r >= lo) and (r <= hi)
+}

--- a/examples/agent_merge/run.sh
+++ b/examples/agent_merge/run.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# End-to-end demo: agent-native VCS workflow against a fresh store.
+#
+# What this script shows:
+#   1. Publish v0 → main. The store's write-time gate (#130) emits
+#      a TypeCheck attestation automatically (#132).
+#   2. Branch into `feature`, publish a divergent body there.
+#   3. Diverge `main` again — now both branches have modified
+#      `clamp` differently, producing a ModifyModify conflict.
+#   4. Open a stateful merge session (#134), inspect the conflict.
+#   5. Resolve it (this demo: TakeTheirs; an agent harness would
+#      decide programmatically).
+#   6. Commit. The merge op lands as a real op in the log.
+#   7. Verify the spec against the merged body and persist a Spec
+#      attestation (#132).
+#   8. Read the evidence trail back via blame/stage/attest filter.
+#
+# Run from the repo root with `lex` already built (or on $PATH):
+#   bash examples/agent_merge/run.sh
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STORE="${STORE:-$(mktemp -d)/lex-store}"
+mkdir -p "$STORE"
+
+LEX="${LEX:-lex}"
+say() { printf '\n\x1b[1;36m▶ %s\x1b[0m\n' "$*"; }
+
+# ----------------------------------------------------------------
+say "1. publish v0 to main; TypeCheck attestation lands automatically"
+"$LEX" --output json publish --store "$STORE" --activate "$HERE/v0_initial.lex" \
+  | jq '{ops: .data.ops | map({kind: .kind.op}), head_op: .data.head_op}'
+
+stage_id=$("$LEX" --output json blame --store "$STORE" "$HERE/v0_initial.lex" \
+  | jq -r '.data.blame[] | select(.name=="clamp") | .here_stage_id')
+echo "stage_id of clamp on main: $stage_id"
+
+say "1b. read the evidence already on disk (TypeCheck::Passed from #147)"
+"$LEX" --output json stage --store "$STORE" --attestations "$stage_id" \
+  | jq '.data.attestations | map({kind: .kind.kind, result: .result.result, by: .produced_by.tool})'
+
+# ----------------------------------------------------------------
+say "2. fork: create 'feature' from main, switch, publish v1_feature"
+"$LEX" branch create --store "$STORE" feature
+"$LEX" branch use    --store "$STORE" feature
+"$LEX" --output json publish --store "$STORE" --activate "$HERE/v1_feature.lex" \
+  | jq '.data.ops | map({kind: .kind.op})'
+
+# ----------------------------------------------------------------
+say "3. switch back to main, publish v1_main — both sides have now modified clamp"
+"$LEX" branch use    --store "$STORE" main
+"$LEX" --output json publish --store "$STORE" --activate "$HERE/v1_main.lex" \
+  | jq '.data.ops | map({kind: .kind.op})'
+
+# ----------------------------------------------------------------
+say "4. open the merge session — stateful, agent-driven (#134)"
+start_out=$("$LEX" --output json merge start --store "$STORE" --src feature --dst main)
+echo "$start_out" | jq '{merge_id: .data.merge_id, conflicts: .data.conflicts | map({sig: .conflict_id, kind: .kind})}'
+merge_id=$(echo "$start_out" | jq -r '.data.merge_id')
+conflict_id=$(echo "$start_out" | jq -r '.data.conflicts[0].conflict_id')
+
+say "5. agent decides: take the feature branch's resolution (TakeTheirs)"
+cat > "$STORE/resolutions.json" <<EOF
+[{"conflict_id": "$conflict_id", "resolution": {"kind": "take_theirs"}}]
+EOF
+"$LEX" --output json merge resolve --store "$STORE" "$merge_id" --file "$STORE/resolutions.json" \
+  | jq '{verdicts: .data.verdicts | map({sig: .conflict_id, accepted: .accepted}),
+         remaining: .data.remaining_conflicts | length}'
+
+# ----------------------------------------------------------------
+say "6. commit — Merge op lands; a new TypeCheck attestation lands too"
+commit_out=$("$LEX" --output json merge commit --store "$STORE" "$merge_id")
+echo "$commit_out" | jq '{new_head: .data.new_head_op, dst: .data.dst_branch}'
+
+# ----------------------------------------------------------------
+say "7. verify the spec against the merged body and persist evidence (#132)"
+# After the merge the active stage on main is feature's body
+# (`min2`/`max2` form). The spec checker proves the contract
+# against that body and writes a Spec attestation.
+"$LEX" spec check "$HERE/clamp.spec" \
+  --source "$HERE/v1_feature.lex" \
+  --store  "$STORE" \
+  --trials 200 \
+  | jq '{status: .status, method: .evidence.method, trials: .evidence.trials}' \
+  || echo "(spec check exits non-zero on counterexample/inconclusive — that's a verdict, not a bug)"
+
+# ----------------------------------------------------------------
+say "8. read the full evidence trail across the store"
+echo "→ blame --with-evidence (per-stage history + every attestation):"
+"$LEX" --output json blame --with-evidence --store "$STORE" "$HERE/v1_feature.lex" \
+  | jq '.data.blame[] | {name, attestations_per_stage: .history | map(.attestations | length)}'
+
+echo
+echo "→ attest filter (cross-stage; passed Spec attestations only):"
+"$LEX" --output json attest filter --store "$STORE" --kind spec --result passed \
+  | jq '.data | {count, attestations: .attestations | map({kind: .kind.kind, by: .produced_by.tool, stage: .stage_id})}'
+
+echo
+say "done. store at: $STORE"

--- a/examples/agent_merge/v0_initial.lex
+++ b/examples/agent_merge/v0_initial.lex
@@ -1,0 +1,15 @@
+# Initial implementation of `clamp` — the version on `main`
+# before the agent's branch diverges. Both the "feature"
+# branch and `main` will modify this body in incompatible
+# ways, producing a ModifyModify conflict the agent has to
+# resolve.
+
+fn clamp(x :: Int, lo :: Int, hi :: Int) -> Int {
+  match x < lo {
+    true => lo,
+    false => match x > hi {
+      true => hi,
+      false => x,
+    },
+  }
+}

--- a/examples/agent_merge/v1_feature.lex
+++ b/examples/agent_merge/v1_feature.lex
@@ -1,0 +1,11 @@
+# "feature" branch: an agent rewrote `clamp` to use min/max-style
+# arithmetic instead of nested matches. Same behavior, different
+# AST — the merge engine sees a ModifyModify because the body
+# changed.
+
+fn min2(a :: Int, b :: Int) -> Int { match a < b { true => a, false => b } }
+fn max2(a :: Int, b :: Int) -> Int { match a > b { true => a, false => b } }
+
+fn clamp(x :: Int, lo :: Int, hi :: Int) -> Int {
+  min2(max2(x, lo), hi)
+}

--- a/examples/agent_merge/v1_main.lex
+++ b/examples/agent_merge/v1_main.lex
@@ -1,0 +1,17 @@
+# Meanwhile on `main`: a different agent (or the human
+# maintainer) rewrote `clamp` to add an early-return guard for
+# the degenerate `lo > hi` case. Different body again — the
+# merge will see this as ours-side of the same ModifyModify.
+
+fn clamp(x :: Int, lo :: Int, hi :: Int) -> Int {
+  match lo > hi {
+    true => x,
+    false => match x < lo {
+      true => lo,
+      false => match x > hi {
+        true => hi,
+        false => x,
+      },
+    },
+  }
+}


### PR DESCRIPTION
## Summary

End-to-end example demonstrating the tier-2 lex-vcs workflow: two agents diverge on the same fn, produce a `ModifyModify` conflict, and a third agent resolves it programmatically. No text editing, no merge markers.

```sh
bash examples/agent_merge/run.sh
```

## What it covers

The `run.sh` walks eight stages, each mapped to the relevant tier-2 issue:

| Stage | Concept | Issue |
|---|---|---|
| 1, 1b | Publish + auto-emitted `TypeCheck` attestation | #129 + #130 + #132 |
| 2, 3 | Branch fork + divergent publishes | #129 |
| 4 | `lex merge start` — typed conflict over JSON | #134 |
| 5 | Agent submits a `take_theirs` resolution | #134 |
| 6 | `lex merge commit` — typed Merge op lands | #134 |
| 7 | `lex spec check --store` — Spec attestation persisted | #132 |
| 8 | `blame --with-evidence` + `attest filter` — full evidence trail | #132 |

The clamp scenario was chosen because **both rewrites are behaviorally equivalent** (they pass the same spec) but diverge structurally — the hard case for line-based merge tools and the easy case for op-based merge.

## Files

- `README.md` — narrative walkthrough, mapping to issues, how to adapt for HTTP-driven harnesses, predicate branches teaser.
- `run.sh` — runnable demo (uses an ephemeral `mktemp` store by default; override with `STORE=...`).
- `v0_initial.lex` — base implementation of `clamp`.
- `v1_feature.lex` — agent-A's rewrite (min2/max2 form).
- `v1_main.lex` — agent-B's rewrite (early-return guard for `lo > hi`).
- `clamp.spec` — `r >= lo and r <= hi` when `lo <= hi`.

## Verified locally

`bash examples/agent_merge/run.sh` runs to completion against a fresh store, exits 0, and the final `attest filter` shows the persisted Spec attestation alongside the auto-emitted TypeCheck attestations from each accepted op.

https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5

---
_Generated by [Claude Code](https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5)_