### PR TITLE
feat: lex-tea v1 — read-only HTML browser over lex-vcs

### DIFF
--- a/crates/lex-api/src/handlers.rs
+++ b/crates/lex-api/src/handlers.rs
@@ -100,6 +100,17 @@ fn route(
     body: &str,
 ) -> Response<std::io::Cursor<Vec<u8>>> {
     match (method, path) {
+        // ---- lex-tea v1 (HTML browser) ------------------------
+        (Method::Get, "/") => crate::web::index_handler(state),
+        (Method::Get, p) if p.starts_with("/web/branch/") => {
+            let name = &p["/web/branch/".len()..];
+            crate::web::branch_handler(state, name)
+        }
+        (Method::Get, p) if p.starts_with("/web/stage/") => {
+            let id = &p["/web/stage/".len()..];
+            crate::web::stage_html_handler(state, id)
+        }
+        // ---- JSON API -----------------------------------------
         (Method::Get, "/v1/health") => json_response(200, &serde_json::json!({"ok": true})),
         (Method::Post, "/v1/parse") => parse_handler(body),
         (Method::Post, "/v1/check") => check_handler(body),

--- a/crates/lex-api/src/lib.rs
+++ b/crates/lex-api/src/lib.rs
@@ -18,8 +18,14 @@
 //!   POST /v1/merge/<id>/resolve       { resolutions: [...] } → { verdicts, remaining_conflicts }
 //!   POST /v1/merge/<id>/commit        → { new_head_op, dst_branch } | 422 conflicts remaining
 //!   GET  /v1/health          → { ok: true }
+//!
+//! Web (lex-tea v1, read-only HTML over the JSON API):
+//!   GET  /                      → branch list
+//!   GET  /web/branch/<name>     → fns on a branch
+//!   GET  /web/stage/<id>        → stage info + attestation trail
 
 pub mod handlers;
+mod web;
 
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/crates/lex-api/src/web.rs
+++ b/crates/lex-api/src/web.rs
@@ -1,0 +1,241 @@
+//! `lex-tea` v1 — a minimal HTML browser over the existing
+//! lex-vcs JSON endpoints. Three read-only pages:
+//!
+//! * `/`                    — list of branches
+//! * `/web/branch/<name>`   — list of fns on a branch with stage_id links
+//! * `/web/stage/<id>`      — stage metadata + attestation trail
+//!
+//! Wired into the same `tiny_http` server as the JSON API
+//! (no extra binary, no new port). The point is to expose
+//! the JSON API's structure to humans without a SPA build
+//! pipeline. CSS is one short embedded blob; no JS.
+
+use lex_store::Store;
+use std::io::Cursor;
+use tiny_http::{Header, Response};
+
+use crate::handlers::State;
+
+/// Embedded so a `cargo build` produces a fully-self-contained
+/// binary. ~1KB; not worth a separate file dance.
+const STYLE: &str = r#"
+* { box-sizing: border-box; }
+body { font: 14px/1.5 -apple-system, system-ui, sans-serif;
+       max-width: 880px; margin: 2rem auto; padding: 0 1rem; color: #222; }
+h1 { font-weight: 600; margin: 0 0 1.5rem; }
+h2 { font-weight: 500; margin: 1.5rem 0 .5rem; color: #444; }
+a { color: #0a5; text-decoration: none; }
+a:hover { text-decoration: underline; }
+nav { font-size: 13px; color: #888; margin-bottom: 1rem; }
+table { border-collapse: collapse; width: 100%; font-size: 13px; }
+th, td { text-align: left; padding: .35rem .6rem; border-bottom: 1px solid #eee; }
+th { color: #666; font-weight: 500; }
+.mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; }
+.muted { color: #999; }
+.tag { display: inline-block; padding: 1px 6px; font-size: 11px; border-radius: 3px;
+       background: #eef; color: #335; margin-right: 4px; }
+.tag.ok { background: #dfd; color: #060; }
+.tag.fail { background: #fdd; color: #800; }
+.tag.inc { background: #ffd; color: #850; }
+pre { background: #f6f6f6; padding: .8rem; overflow-x: auto; font-size: 12px; border-radius: 3px; }
+.empty { color: #aaa; font-style: italic; }
+"#;
+
+fn html_response(status: u16, body: String) -> Response<Cursor<Vec<u8>>> {
+    Response::from_data(body.into_bytes())
+        .with_status_code(status)
+        .with_header(
+            Header::from_bytes(&b"Content-Type"[..], &b"text/html; charset=utf-8"[..]).unwrap(),
+        )
+}
+
+fn page(title: &str, breadcrumb: &str, body: &str) -> String {
+    format!(
+        r#"<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>{title} — lex-tea</title>
+<style>{STYLE}</style>
+</head>
+<body>
+<nav>{breadcrumb}</nav>
+{body}
+</body>
+</html>
+"#,
+    )
+}
+
+fn esc(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+/// `GET /` — branch list.
+pub(crate) fn index_handler(state: &State) -> Response<Cursor<Vec<u8>>> {
+    let store = state.store.lock().unwrap();
+    let branches = match store.list_branches() {
+        Ok(b) => b,
+        Err(e) => return html_response(500, page("error", "/", &format!("<pre>{}</pre>", esc(&e.to_string())))),
+    };
+    let current = store.current_branch();
+
+    let mut rows = String::new();
+    if branches.is_empty() {
+        rows.push_str(r#"<tr><td colspan="3" class="empty">no branches yet — try `lex publish &lt;file.lex&gt;`</td></tr>"#);
+    } else {
+        for name in &branches {
+            let head = store.get_branch(name).ok().flatten()
+                .and_then(|b| b.head_op)
+                .unwrap_or_else(|| "—".into());
+            let predicate = store.get_branch(name).ok().flatten()
+                .and_then(|b| b.predicate)
+                .map(|_| r#"<span class="tag">predicate</span>"#)
+                .unwrap_or_default();
+            let marker = if *name == current {
+                r#"<span class="tag ok">current</span>"#
+            } else {
+                ""
+            };
+            rows.push_str(&format!(
+                r#"<tr><td><a href="/web/branch/{n}">{n}</a> {marker}{predicate}</td><td class="mono">{h:.16}…</td></tr>"#,
+                n = esc(name),
+                marker = marker,
+                predicate = predicate,
+                h = esc(&head),
+            ));
+        }
+    }
+    let body = format!(
+        r#"<h1>lex-tea</h1>
+<p class="muted">Read-only browser over <code>lex-vcs</code>. JSON API at <code>/v1/*</code>.</p>
+<h2>branches</h2>
+<table><thead><tr><th>name</th><th>head_op</th></tr></thead><tbody>{rows}</tbody></table>"#,
+    );
+    html_response(200, page("branches", "/", &body))
+}
+
+/// `GET /web/branch/<name>` — fns on a branch.
+pub(crate) fn branch_handler(state: &State, name: &str) -> Response<Cursor<Vec<u8>>> {
+    let store = state.store.lock().unwrap();
+    let head_map = match store.branch_head(name) {
+        Ok(m) => m,
+        Err(e) => return html_response(404, page("error", &nav_for_branch(name), &format!("<pre>{}</pre>", esc(&e.to_string())))),
+    };
+
+    let mut rows = String::new();
+    if head_map.is_empty() {
+        rows.push_str(r#"<tr><td colspan="2" class="empty">no fns on this branch</td></tr>"#);
+    } else {
+        // `head_map` is SigId → StageId. Render the stage_id as the
+        // primary link; sig_id is an internal identifier we don't
+        // surface yet beyond a hover.
+        for (sig, stage_id) in &head_map {
+            let fn_name = lookup_name_for_stage(&store, stage_id).unwrap_or_else(|| "—".into());
+            rows.push_str(&format!(
+                r#"<tr><td>{name}</td><td class="mono"><a href="/web/stage/{sid}" title="sig {sig}">{sid:.16}…</a></td></tr>"#,
+                name = esc(&fn_name),
+                sid = esc(stage_id),
+                sig = esc(sig),
+            ));
+        }
+    }
+    let body = format!(
+        r#"<h1>{n}</h1>
+<table><thead><tr><th>fn</th><th>stage</th></tr></thead><tbody>{rows}</tbody></table>"#,
+        n = esc(name),
+    );
+    html_response(200, page(name, &nav_for_branch(name), &body))
+}
+
+fn lookup_name_for_stage(store: &Store, stage_id: &str) -> Option<String> {
+    store.get_metadata(stage_id).ok().map(|m| m.name)
+}
+
+fn nav_for_branch(name: &str) -> String {
+    format!(r#"<a href="/">branches</a> / <strong>{}</strong>"#, esc(name))
+}
+
+fn nav_for_stage(stage_id: &str) -> String {
+    format!(
+        r#"<a href="/">branches</a> / <strong class="mono">{}</strong>"#,
+        esc(&format!("{stage_id:.16}…")),
+    )
+}
+
+/// `GET /web/stage/<id>` — stage metadata + attestation trail.
+pub(crate) fn stage_html_handler(state: &State, id: &str) -> Response<Cursor<Vec<u8>>> {
+    let store = state.store.lock().unwrap();
+    let meta = match store.get_metadata(id) {
+        Ok(m) => m,
+        Err(e) => return html_response(404, page("not found", &nav_for_stage(id), &format!("<pre>{}</pre>", esc(&e.to_string())))),
+    };
+    let status = store.get_status(id).map(|s| format!("{s:?}")).unwrap_or_else(|_| "?".into());
+    let log = match store.attestation_log() {
+        Ok(l) => l,
+        Err(e) => return html_response(500, page("error", &nav_for_stage(id), &format!("<pre>{}</pre>", esc(&e.to_string())))),
+    };
+    let mut atts = log.list_for_stage(&id.to_string()).unwrap_or_default();
+    atts.sort_by_key(|a| std::cmp::Reverse(a.timestamp));
+
+    let mut att_rows = String::new();
+    if atts.is_empty() {
+        att_rows.push_str(r#"<tr><td colspan="4" class="empty">no attestations yet</td></tr>"#);
+    } else {
+        for a in &atts {
+            let kind = match &a.kind {
+                lex_vcs::AttestationKind::TypeCheck => "TypeCheck".to_string(),
+                lex_vcs::AttestationKind::EffectAudit => "EffectAudit".to_string(),
+                lex_vcs::AttestationKind::Spec { spec_id, .. } => format!("Spec({spec_id:.12}…)"),
+                lex_vcs::AttestationKind::Examples { count, .. } => format!("Examples({count})"),
+                lex_vcs::AttestationKind::DiffBody { input_count, .. } => format!("DiffBody({input_count})"),
+                lex_vcs::AttestationKind::SandboxRun { effects } => {
+                    let names: Vec<&str> = effects.iter().map(|s| s.as_str()).collect();
+                    format!("SandboxRun([{}])", names.join(","))
+                }
+            };
+            let (result, css) = match &a.result {
+                lex_vcs::AttestationResult::Passed => ("passed".to_string(), "ok"),
+                lex_vcs::AttestationResult::Failed { detail } => (format!("failed: {detail}"), "fail"),
+                lex_vcs::AttestationResult::Inconclusive { detail } => {
+                    (format!("inconclusive: {detail}"), "inc")
+                }
+            };
+            att_rows.push_str(&format!(
+                r#"<tr><td>{kind}</td><td><span class="tag {css}">{result}</span></td><td class="mono">{tool}@{ver}</td><td class="muted mono">{ts}</td></tr>"#,
+                kind = esc(&kind),
+                css = css,
+                result = esc(&result),
+                tool = esc(&a.produced_by.tool),
+                ver = esc(&a.produced_by.version),
+                ts = a.timestamp,
+            ));
+        }
+    }
+
+    let body = format!(
+        r#"<h1>{name}</h1>
+<table>
+  <tr><th>name</th><td>{name}</td></tr>
+  <tr><th>sig_id</th><td class="mono">{sig:.16}…</td></tr>
+  <tr><th>stage_id</th><td class="mono">{stage:.16}…</td></tr>
+  <tr><th>status</th><td>{status}</td></tr>
+  <tr><th>published</th><td class="muted">{ts}</td></tr>
+</table>
+<h2>attestations ({n})</h2>
+<table>
+  <thead><tr><th>kind</th><th>result</th><th>by</th><th>ts</th></tr></thead>
+  <tbody>{att_rows}</tbody>
+</table>"#,
+        name = esc(&meta.name),
+        sig = esc(&meta.sig_id),
+        stage = esc(&meta.stage_id),
+        status = esc(&status),
+        ts = meta.published_at,
+        n = atts.len(),
+    );
+    html_response(200, page(&meta.name, &nav_for_stage(id), &body))
+}

--- a/crates/lex-api/tests/m8.rs
+++ b/crates/lex-api/tests/m8.rs
@@ -335,6 +335,58 @@ fn merge_resolve_unknown_conflict_is_rejected_per_entry() {
 }
 
 #[test]
+fn web_index_lists_branches_as_html() {
+    let (srv, _tmp) = start_server();
+    // Publish so main has a head_op to display.
+    let src = "fn foo(n :: Int) -> Int { n }\n";
+    let (s, _) = http(&srv.addr, "POST", "/v1/publish", &json!({"source": src, "activate": true}).to_string());
+    assert_eq!(s, 200);
+
+    let (s, b) = http(&srv.addr, "GET", "/", "");
+    assert_eq!(s, 200, "GET /: {b}");
+    assert!(b.contains("<title>") && b.contains("lex-tea"), "html with title expected: {b}");
+    assert!(b.contains("main"), "branch list should mention main: {b}");
+}
+
+#[test]
+fn web_branch_page_lists_fn_with_stage_link() {
+    let (srv, _tmp) = start_server();
+    let src = "fn foo(n :: Int) -> Int { n }\n";
+    let (s, _) = http(&srv.addr, "POST", "/v1/publish", &json!({"source": src, "activate": true}).to_string());
+    assert_eq!(s, 200);
+
+    let (s, b) = http(&srv.addr, "GET", "/web/branch/main", "");
+    assert_eq!(s, 200, "GET /web/branch/main: {b}");
+    assert!(b.contains("foo"), "fn name should appear: {b}");
+    assert!(b.contains("/web/stage/"), "should link to stage page: {b}");
+}
+
+#[test]
+fn web_stage_page_shows_attestations() {
+    let (srv, _tmp) = start_server();
+    let src = "fn foo(n :: Int) -> Int { n }\n";
+    let (s, b) = http(&srv.addr, "POST", "/v1/publish", &json!({"source": src, "activate": true}).to_string());
+    assert_eq!(s, 200);
+    let v: serde_json::Value = serde_json::from_str(&b).unwrap();
+    let stage_id = v["ops"][0]["kind"]["stage_id"].as_str().unwrap();
+
+    let (s, b) = http(&srv.addr, "GET", &format!("/web/stage/{stage_id}"), "");
+    assert_eq!(s, 200, "GET /web/stage/<id>: {b}");
+    // The TypeCheck attestation auto-emitted by publish_program
+    // should show up on the page.
+    assert!(b.contains("TypeCheck"), "TypeCheck attestation row expected: {b}");
+    assert!(b.contains("passed"), "passed result expected: {b}");
+    assert!(b.contains("foo"), "fn name in heading expected: {b}");
+}
+
+#[test]
+fn web_unknown_stage_returns_404_html() {
+    let (srv, _tmp) = start_server();
+    let (s, _) = http(&srv.addr, "GET", "/web/stage/no_such_stage", "");
+    assert_eq!(s, 404);
+}
+
+#[test]
 fn merge_resolve_unknown_session_returns_404() {
     let (srv, _tmp) = start_server();
     let body = json!({"resolutions": []}).to_string();


### PR DESCRIPTION
## Summary

v1 of lex-tea — a read-only HTML browser over lex-vcs, served from the same `lex serve` process. No extra binary, no extra port, no frontend build pipeline.

```
GET /                    branch list
GET /web/branch/<name>   fns on a branch
GET /web/stage/<id>      stage info + full attestation trail
```

The point of v1 is to expose what makes lex-vcs different — typed ops, attestations, evidence trails — to humans without building a SPA. CSS is one short embedded blob; zero JS. JSON API at `/v1/*` is unchanged.

## Implementation

Single file: `crates/lex-api/src/web.rs` (~280 lines including inline CSS). Reads straight off `Store` and `AttestationLog`; no new dependencies. Promote to its own crate when (and if) it outgrows the single-file footprint.

## Test plan

- [x] `cargo test -p lex-api --test m8 web` — 4 new tests:
  - Index lists branches with HTML title.
  - Branch page lists fn names + links to stage page.
  - Stage page shows the auto-emitted `TypeCheck::Passed` attestation.
  - Unknown stage_id returns 404.
- [x] **Live smoke**: `lex publish ...` then `lex serve --port 7777` and `curl /` / `/web/branch/main` returns rendered HTML with the published fn.
- [x] `cargo test --workspace` — green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.

## Try it

```sh
STORE=$(mktemp -d)
lex publish --store "$STORE" --activate examples/a_factorial.lex
lex serve --store "$STORE" --port 7777
# Open http://127.0.0.1:7777/
```

## Roadmap (per the design discussion)

- v2: merge UI — visualize `/web/merge/<id>` with TakeOurs/TakeTheirs buttons.
- v3: comments via Intent.
- v4: basic auth + multi-tenancy.
- v5: webhooks for harness integration.

Each is a separate, small PR. v1 is the walking skeleton; we evolve based on actual usage.

https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5

---
_Generated by [Claude Code](https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5)_