### PR TITLE
feat: stdlib std.test — assertion helpers

### DIFF
--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -31,7 +31,7 @@ pub fn is_pure_module(kind: &str) -> bool {
     matches!(kind, "str" | "int" | "float" | "bool" | "list"
         | "option" | "result" | "tuple" | "json" | "bytes" | "flow" | "math"
         | "map" | "set" | "crypto" | "regex" | "deque" | "datetime" | "http"
-        | "toml" | "yaml" | "dotenv" | "csv")
+        | "toml" | "yaml" | "dotenv" | "csv" | "test")
 }
 
 fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
@@ -365,6 +365,47 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             match String::from_utf8(out) {
                 Ok(s) => Ok(ok_v(Value::Str(s))),
                 Err(e) => Ok(err_v(Value::Str(format!("csv.stringify utf8: {e}")))),
+            }
+        }
+
+        // -- test -- tiny assertion library. Each helper is pure
+        // and returns `Result[Unit, Str]` so tests are themselves
+        // functions returning a Result. A suite is a List the user
+        // iterates with `list.fold`; no Rust-side Suite/Runner
+        // types in v1, so the whole thing is 4 builtins + a few
+        // Lex-source helpers callers can copy into their tests/.
+        ("test", "assert_eq") => {
+            let a = first_arg(args)?;
+            let b = args.get(1).ok_or("test.assert_eq: missing second arg")?;
+            if a == b {
+                Ok(ok_v(Value::Unit))
+            } else {
+                Ok(err_v(Value::Str(format!("assert_eq: lhs {} != rhs {}",
+                    value_to_json(a), value_to_json(b)))))
+            }
+        }
+        ("test", "assert_ne") => {
+            let a = first_arg(args)?;
+            let b = args.get(1).ok_or("test.assert_ne: missing second arg")?;
+            if a != b {
+                Ok(ok_v(Value::Unit))
+            } else {
+                Ok(err_v(Value::Str(format!("assert_ne: both sides are {}",
+                    value_to_json(a)))))
+            }
+        }
+        ("test", "assert_true") => {
+            match first_arg(args)? {
+                Value::Bool(true) => Ok(ok_v(Value::Unit)),
+                Value::Bool(false) => Ok(err_v(Value::Str("assert_true: was false".into()))),
+                other => Err(format!("test.assert_true expects Bool, got {other:?}")),
+            }
+        }
+        ("test", "assert_false") => {
+            match first_arg(args)? {
+                Value::Bool(false) => Ok(ok_v(Value::Unit)),
+                Value::Bool(true)  => Ok(err_v(Value::Str("assert_false: was true".into()))),
+                other => Err(format!("test.assert_false expects Bool, got {other:?}")),
             }
         }
 

--- a/crates/lex-runtime/tests/std_test.rs
+++ b/crates/lex-runtime/tests/std_test.rs
@@ -1,0 +1,113 @@
+//! Integration tests for `std.test`. The module is itself an
+//! assertion library, so the tests below verify that the four
+//! helpers return the expected `Result[Unit, Str]` shape on both
+//! the pass and fail paths.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::sync::Arc;
+
+fn run(src: &str, fn_name: &str, args: Vec<Value>) -> Value {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors:\n{errs:#?}");
+    }
+    let bc = Arc::new(compile_program(&stages));
+    let handler = DefaultHandler::new(Policy::pure()).with_program(Arc::clone(&bc));
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(fn_name, args).unwrap_or_else(|e| panic!("call {fn_name}: {e}"))
+}
+
+const SRC: &str = r#"
+import "std.test" as test
+import "std.list" as list
+
+fn eq_pass(a :: Int, b :: Int) -> Result[Unit, Str] { test.assert_eq(a, b) }
+fn ne_pass(a :: Int, b :: Int) -> Result[Unit, Str] { test.assert_ne(a, b) }
+fn t_pass(b :: Bool) -> Result[Unit, Str] { test.assert_true(b) }
+fn f_pass(b :: Bool) -> Result[Unit, Str] { test.assert_false(b) }
+
+# A tiny suite runner — exactly the shape the user's tests/
+# directory would carry. Each test is `() -> Result[Unit, Str]`
+# but Lex doesn't have closures-as-values in records, so the
+# suite here is a list of pre-computed verdicts.
+fn run_suite(verdicts :: List[Result[Unit, Str]]) -> Int {
+  list.fold(verdicts, 0, fn (acc :: Int, v :: Result[Unit, Str]) -> Int {
+    match v {
+      Ok(_)  => acc,
+      Err(_) => acc + 1,
+    }
+  })
+}
+"#;
+
+fn assert_ok(v: &Value) {
+    match v {
+        Value::Variant { name, .. } if name == "Ok" => {}
+        other => panic!("expected Ok, got {other:?}"),
+    }
+}
+
+fn assert_err_contains(v: &Value, needle: &str) {
+    match v {
+        Value::Variant { name, args } if name == "Err" => match &args[0] {
+            Value::Str(s) => assert!(s.contains(needle), "Err {s:?} missing {needle:?}"),
+            other => panic!("expected Err(Str), got {other:?}"),
+        },
+        other => panic!("expected Err, got {other:?}"),
+    }
+}
+
+#[test]
+fn assert_eq_passes_and_fails() {
+    assert_ok(&run(SRC, "eq_pass", vec![Value::Int(1), Value::Int(1)]));
+    assert_err_contains(
+        &run(SRC, "eq_pass", vec![Value::Int(1), Value::Int(2)]),
+        "assert_eq",
+    );
+}
+
+#[test]
+fn assert_ne_passes_and_fails() {
+    assert_ok(&run(SRC, "ne_pass", vec![Value::Int(1), Value::Int(2)]));
+    assert_err_contains(
+        &run(SRC, "ne_pass", vec![Value::Int(7), Value::Int(7)]),
+        "assert_ne",
+    );
+}
+
+#[test]
+fn assert_true_passes_and_fails() {
+    assert_ok(&run(SRC, "t_pass", vec![Value::Bool(true)]));
+    assert_err_contains(&run(SRC, "t_pass", vec![Value::Bool(false)]), "assert_true");
+}
+
+#[test]
+fn assert_false_passes_and_fails() {
+    assert_ok(&run(SRC, "f_pass", vec![Value::Bool(false)]));
+    assert_err_contains(&run(SRC, "f_pass", vec![Value::Bool(true)]), "assert_false");
+}
+
+#[test]
+fn suite_runner_counts_failures() {
+    // Composing three Results into a list and reducing with foldl
+    // is exactly how a user-side test suite would tally verdicts.
+    let suite = Value::List(vec![
+        ok_unit(),                              // pass
+        err_msg("first failure"),               // fail
+        ok_unit(),                              // pass
+        err_msg("second failure"),              // fail
+    ]);
+    let v = run(SRC, "run_suite", vec![suite]);
+    assert_eq!(v, Value::Int(2));
+}
+
+fn ok_unit() -> Value {
+    Value::Variant { name: "Ok".into(), args: vec![Value::Unit] }
+}
+fn err_msg(s: &str) -> Value {
+    Value::Variant { name: "Err".into(), args: vec![Value::Str(s.into())] }
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -1187,6 +1187,31 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
             ));
             Some(Ty::Record(fields))
         }
+        "test" => {
+            // Tiny assertion library (#proposed-stdlib). Each helper
+            // returns Result[Unit, Str] so a test is itself a fn
+            // returning Result. Callers compose suites in user code
+            // (a List of (name, () -> Result[Unit, Str]) pairs +
+            // list.fold to accumulate verdicts). Property generators
+            // and a Rust-side Suite type are deferred to v2.
+            let mut fields = IndexMap::new();
+            // assert_eq[a, b] :: T -> T -> Result[Unit, Str]
+            // (T constrained equal by unification on the two args)
+            let unit_result = || Ty::Con("Result".into(), vec![Ty::Unit, Ty::str()]);
+            fields.insert("assert_eq".into(), Ty::function(
+                vec![Ty::Var(0), Ty::Var(0)], EffectSet::empty(), unit_result(),
+            ));
+            fields.insert("assert_ne".into(), Ty::function(
+                vec![Ty::Var(0), Ty::Var(0)], EffectSet::empty(), unit_result(),
+            ));
+            fields.insert("assert_true".into(), Ty::function(
+                vec![Ty::bool()], EffectSet::empty(), unit_result(),
+            ));
+            fields.insert("assert_false".into(), Ty::function(
+                vec![Ty::bool()], EffectSet::empty(), unit_result(),
+            ));
+            Some(Ty::Record(fields))
+        }
         "toml" => {
             // TOML config parser. Mirrors `std.json`'s shape: parse
             // is polymorphic so callers annotate the expected
@@ -1263,6 +1288,7 @@ pub fn module_for_import(reference: &str) -> Option<&'static str> {
         "yaml" => "yaml",
         "dotenv" => "dotenv",
         "csv" => "csv",
+        "test" => "test",
         _ => return None,
     })
 }


### PR DESCRIPTION
Tiny v1: four pure assertion builtins that return
`Result[Unit, Str]`, no Rust-side Suite type. A test is itself a fn returning Result; suites are user-side lists composed with list.fold. Property generators and a richer runner are deferred to v2 once we have feedback on what users actually write.

Surface:

  test.assert_eq[T](a :: T, b :: T) -> Result[Unit, Str]
  test.assert_ne[T](a :: T, b :: T) -> Result[Unit, Str]
  test.assert_true(b :: Bool) -> Result[Unit, Str]
  test.assert_false(b :: Bool) -> Result[Unit, Str]

assert_eq/ne are polymorphic via Ty::Var(0); the type checker unifies the two args. Failure messages render the offending values as JSON for diff-friendly output.

Tests: pass and fail paths for each helper, plus a tiny list.fold-based suite runner that demonstrates how a userland tests/ directory composes verdicts.

<!--
Thanks for contributing! See CONTRIBUTING.md for the conventions
this project follows. CI runs `cargo build`, `cargo test`, and
`cargo clippy --workspace --all-targets -- -D warnings`; please
make sure all three are green locally before pushing.
-->

## Summary

What does this PR change? One paragraph.

## Why

What's the user-facing problem this solves, or the gap this
closes? If it's tied to a tracked issue, link it (`closes #N`).

## Test plan

- [ ] `cargo test --workspace` passes locally
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] New behavior has a regression test
- [ ] If this changes a public CLI flag or JSON shape, README /
      Toolchain reference / langspec is updated

## Risk / scope

- Touches: `<crate-list-or-CLI-or-docs>`
- Breaking change to wire format / SigId / StageId / canonical AST? **yes / no**
- Adds a new effect kind or runtime variant? **yes / no**
