### PR TITLE
feat: stdlib std.yaml / std.dotenv / std.csv

### DIFF
--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -26,6 +26,8 @@ tiny_http = { version = "0.12", features = ["ssl-rustls"] }
 tungstenite = "0.29"
 ureq = { version = "3.3", default-features = false, features = ["rustls", "platform-verifier"] }
 toml = "0.9"
+serde_yaml = "0.9"
+csv = "1"
 rusqlite = { version = "0.36", features = ["bundled"] }
 lex-bytecode = { path = "../lex-bytecode" }
 

--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -31,7 +31,7 @@ pub fn is_pure_module(kind: &str) -> bool {
     matches!(kind, "str" | "int" | "float" | "bool" | "list"
         | "option" | "result" | "tuple" | "json" | "bytes" | "flow" | "math"
         | "map" | "set" | "crypto" | "regex" | "deque" | "datetime" | "http"
-        | "toml")
+        | "toml" | "yaml" | "dotenv" | "csv")
 }
 
 fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
@@ -258,6 +258,113 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             match toml::to_string(&json) {
                 Ok(s)  => Ok(ok_v(Value::Str(s))),
                 Err(e) => Ok(err_v(Value::Str(format!("toml.stringify: {e}")))),
+            }
+        }
+
+        // -- yaml -- mirrors std.toml. Wraps serde_yaml so values
+        // map to the same Lex shape as JSON. YAML's Tag/Anchor
+        // features are folded out by serde_yaml's deserialize-to-
+        // Value path; non-representable shapes (e.g. non-string
+        // map keys when stringifying) surface as Result::Err.
+        ("yaml", "parse") => {
+            let s = expect_str(args.first())?;
+            match serde_yaml::from_str::<serde_json::Value>(&s) {
+                Ok(v)  => Ok(ok_v(json_to_value(&v))),
+                Err(e) => Ok(err_v(Value::Str(format!("{e}")))),
+            }
+        }
+        ("yaml", "stringify") => {
+            let v = first_arg(args)?;
+            let json = value_to_json(v);
+            match serde_yaml::to_string(&json) {
+                Ok(s)  => Ok(ok_v(Value::Str(s))),
+                Err(e) => Ok(err_v(Value::Str(format!("yaml.stringify: {e}")))),
+            }
+        }
+
+        // -- dotenv -- KEY=VALUE pair files. Hand-rolled parser
+        // because the dotenvy crate's API is geared at loading
+        // into the process env, not parsing-to-data. The grammar
+        // we accept: blank lines, `# comment` lines, and
+        // `KEY=VALUE` (optional surrounding `"..."` or `'...'`,
+        // unescaped). Simple but covers the .env files in the
+        // wild that aren't trying to be shell.
+        ("dotenv", "parse") => {
+            use std::collections::BTreeMap;
+            use lex_bytecode::MapKey;
+            let s = expect_str(args.first())?;
+            match parse_dotenv(&s) {
+                Ok(map) => {
+                    let mut bt: BTreeMap<MapKey, Value> = BTreeMap::new();
+                    for (k, v) in map {
+                        bt.insert(MapKey::Str(k), Value::Str(v));
+                    }
+                    Ok(ok_v(Value::Map(bt)))
+                }
+                Err(e) => Ok(err_v(Value::Str(e))),
+            }
+        }
+
+        // -- csv -- rows-as-lists; first row is whatever the file
+        // has. The caller decides whether row 0 is a header. We
+        // could ship a `parse_with_headers` later that returns a
+        // List[Map[Str, Str]]; v1 keeps the surface tight.
+        ("csv", "parse") => {
+            let s = expect_str(args.first())?;
+            let mut rdr = csv::ReaderBuilder::new()
+                .has_headers(false)
+                .flexible(true)
+                .from_reader(s.as_bytes());
+            let mut rows: Vec<Value> = Vec::new();
+            for r in rdr.records() {
+                match r {
+                    Ok(rec) => {
+                        let row: Vec<Value> = rec.iter()
+                            .map(|f| Value::Str(f.to_string()))
+                            .collect();
+                        rows.push(Value::List(row));
+                    }
+                    Err(e) => return Ok(err_v(Value::Str(format!("csv.parse: {e}")))),
+                }
+            }
+            Ok(ok_v(Value::List(rows)))
+        }
+        ("csv", "stringify") => {
+            // List[List[Str]] → CSV string. Mixed-type rows are
+            // not allowed (CSV is text-only); non-Str cells get
+            // stringified via to_json since that's already the
+            // convention for `json.stringify` etc.
+            let v = first_arg(args)?;
+            let rows = match v {
+                Value::List(rs) => rs,
+                _ => return Ok(err_v(Value::Str("csv.stringify expects List[List[Str]]".into()))),
+            };
+            let mut out = Vec::new();
+            {
+                let mut wtr = csv::WriterBuilder::new()
+                    .has_headers(false)
+                    .from_writer(&mut out);
+                for row in rows {
+                    let cells = match row {
+                        Value::List(cs) => cs,
+                        _ => return Ok(err_v(Value::Str("csv.stringify row must be List[Str]".into()))),
+                    };
+                    let strs: Vec<String> = cells.iter().map(|c| match c {
+                        Value::Str(s) => s.clone(),
+                        other => serde_json::to_string(&other.to_json())
+                            .unwrap_or_else(|_| String::new()),
+                    }).collect();
+                    if let Err(e) = wtr.write_record(&strs) {
+                        return Ok(err_v(Value::Str(format!("csv.stringify: {e}"))));
+                    }
+                }
+                if let Err(e) = wtr.flush() {
+                    return Ok(err_v(Value::Str(format!("csv.stringify flush: {e}"))));
+                }
+            }
+            match String::from_utf8(out) {
+                Ok(s) => Ok(ok_v(Value::Str(s))),
+                Err(e) => Ok(err_v(Value::Str(format!("csv.stringify utf8: {e}")))),
             }
         }
 
@@ -1216,6 +1323,47 @@ fn unwrap_toml_datetime_markers(v: &mut serde_json::Value) {
 }
 
 fn json_to_value(v: &serde_json::Value) -> Value { Value::from_json(v) }
+
+/// Parse a `.env`-style file into key→value pairs. Accepts:
+///
+/// * Blank lines and `# comment` lines (ignored).
+/// * `KEY=VALUE` with no spaces around `=`. Optional surrounding
+///   `"..."` or `'...'` quotes on the value. No escape sequences,
+///   no shell expansion — by design; we want this to be a *data*
+///   parser, not a shell snippet evaluator.
+///
+/// Errors carry the offending line number (1-indexed) so the
+/// agent's verifier can point a human at the right place.
+fn parse_dotenv(src: &str) -> Result<indexmap::IndexMap<String, String>, String> {
+    let mut out = indexmap::IndexMap::new();
+    for (idx, raw) in src.lines().enumerate() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        // Optional `export KEY=VALUE` shell form — accepted for
+        // compat with files that grew out of `set -a` workflows.
+        let after_export = line.strip_prefix("export ").unwrap_or(line);
+        let (k, v) = match after_export.split_once('=') {
+            Some(kv) => kv,
+            None => return Err(format!("dotenv.parse line {}: missing `=`", idx + 1)),
+        };
+        let key = k.trim();
+        if key.is_empty() {
+            return Err(format!("dotenv.parse line {}: empty key", idx + 1));
+        }
+        let v_trim = v.trim();
+        let value = if let Some(q) = v_trim.strip_prefix('"').and_then(|s| s.strip_suffix('"')) {
+            q.to_string()
+        } else if let Some(q) = v_trim.strip_prefix('\'').and_then(|s| s.strip_suffix('\'')) {
+            q.to_string()
+        } else {
+            v_trim.to_string()
+        };
+        out.insert(key.to_string(), value);
+    }
+    Ok(out)
+}
 
 // -- datetime helpers (Instant ↔ chrono::DateTime<Utc>) --
 

--- a/crates/lex-runtime/tests/std_config.rs
+++ b/crates/lex-runtime/tests/std_config.rs
@@ -1,0 +1,198 @@
+//! Integration tests for `std.yaml` / `std.dotenv` / `std.csv`.
+//!
+//! These are pure parsers; no effects required. They mirror
+//! `std.toml`'s shape — `parse :: Str -> Result[T, Str]` with
+//! the type checker inferring `T` from the call site.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::sync::Arc;
+
+fn run(src: &str, fn_name: &str, args: Vec<Value>) -> Value {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors:\n{errs:#?}");
+    }
+    let bc = Arc::new(compile_program(&stages));
+    let handler = DefaultHandler::new(Policy::pure()).with_program(Arc::clone(&bc));
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(fn_name, args).unwrap_or_else(|e| panic!("call {fn_name}: {e}"))
+}
+
+// ---- yaml ----
+
+const YAML_SRC: &str = r#"
+import "std.yaml" as yaml
+
+type Cargo = { name :: Str, version :: Str }
+
+fn parse_cargo(s :: Str) -> Result[Cargo, Str] { yaml.parse(s) }
+
+fn round_trip(s :: Str) -> Result[Str, Str] {
+  let parsed :: Result[Cargo, Str] := yaml.parse(s)
+  match parsed {
+    Ok(v)  => yaml.stringify(v),
+    Err(e) => Err(e),
+  }
+}
+"#;
+
+#[test]
+fn yaml_parse_typed_record() {
+    let v = run(YAML_SRC, "parse_cargo", vec![Value::Str(
+        "name: lex\nversion: 0.1.0\n".into()
+    )]);
+    match v {
+        Value::Variant { name, args } if name == "Ok" => {
+            match &args[0] {
+                Value::Record(fields) => {
+                    let mut m: std::collections::BTreeMap<&str, &Value> = fields.iter()
+                        .map(|(k, v)| (k.as_str(), v)).collect();
+                    assert_eq!(m.remove("name"), Some(&Value::Str("lex".into())));
+                    assert_eq!(m.remove("version"), Some(&Value::Str("0.1.0".into())));
+                }
+                other => panic!("expected Record, got {other:?}"),
+            }
+        }
+        other => panic!("expected Ok, got {other:?}"),
+    }
+}
+
+#[test]
+fn yaml_parse_returns_err_on_garbage() {
+    let v = run(YAML_SRC, "parse_cargo", vec![Value::Str("[: this is not yaml".into())]);
+    match v {
+        Value::Variant { name, .. } if name == "Err" => {}
+        other => panic!("expected Err, got {other:?}"),
+    }
+}
+
+#[test]
+fn yaml_round_trip() {
+    let v = run(YAML_SRC, "round_trip", vec![Value::Str("name: lex\nversion: 0.1.0\n".into())]);
+    match v {
+        Value::Variant { name, args } if name == "Ok" => match &args[0] {
+            Value::Str(s) => {
+                assert!(s.contains("name") && s.contains("lex"), "round-trip lost data: {s}");
+            }
+            other => panic!("expected Str, got {other:?}"),
+        },
+        other => panic!("expected Ok, got {other:?}"),
+    }
+}
+
+// ---- dotenv ----
+
+const DOTENV_SRC: &str = r#"
+import "std.dotenv" as dotenv
+import "std.map"    as map
+
+fn parse_count(s :: Str) -> Result[Int, Str] {
+  match dotenv.parse(s) {
+    Ok(m)  => Ok(map.size(m)),
+    Err(e) => Err(e),
+  }
+}
+
+fn parse_get(s :: Str, k :: Str) -> Result[Option[Str], Str] {
+  match dotenv.parse(s) {
+    Ok(m)  => Ok(map.get(m, k)),
+    Err(e) => Err(e),
+  }
+}
+"#;
+
+#[test]
+fn dotenv_parses_simple_pairs() {
+    let body = "DB_URL=postgres://localhost/lex\nLOG_LEVEL=info\n";
+    let v = run(DOTENV_SRC, "parse_count", vec![Value::Str(body.into())]);
+    match v {
+        Value::Variant { name, args } if name == "Ok" => assert_eq!(args[0], Value::Int(2)),
+        other => panic!("expected Ok, got {other:?}"),
+    }
+}
+
+#[test]
+fn dotenv_skips_blank_and_comment_lines() {
+    let body = "# header\n\nKEY=value\n# trailing comment\n";
+    let v = run(DOTENV_SRC, "parse_count", vec![Value::Str(body.into())]);
+    match v {
+        Value::Variant { name, args } if name == "Ok" => assert_eq!(args[0], Value::Int(1)),
+        other => panic!("expected Ok, got {other:?}"),
+    }
+}
+
+#[test]
+fn dotenv_handles_quoted_values_and_export_prefix() {
+    let body = "export A=\"hello world\"\nB='single'\nC=plain\n";
+    let v = run(DOTENV_SRC, "parse_get", vec![
+        Value::Str(body.into()), Value::Str("A".into()),
+    ]);
+    match v {
+        Value::Variant { name, args } if name == "Ok" => match &args[0] {
+            Value::Variant { name, args } if name == "Some" => {
+                assert_eq!(&args[0], &Value::Str("hello world".into()));
+            }
+            other => panic!("expected Some, got {other:?}"),
+        }
+        other => panic!("expected Ok, got {other:?}"),
+    }
+}
+
+#[test]
+fn dotenv_returns_err_on_missing_equals() {
+    let body = "KEY_WITHOUT_EQUALS\n";
+    let v = run(DOTENV_SRC, "parse_count", vec![Value::Str(body.into())]);
+    match v {
+        Value::Variant { name, .. } if name == "Err" => {}
+        other => panic!("expected Err, got {other:?}"),
+    }
+}
+
+// ---- csv ----
+
+const CSV_SRC: &str = r#"
+import "std.csv"  as csv
+import "std.list" as list
+
+fn row_count(s :: Str) -> Result[Int, Str] {
+  match csv.parse(s) {
+    Ok(rows) => Ok(list.len(rows)),
+    Err(e)   => Err(e),
+  }
+}
+
+fn round_trip(rows :: List[List[Str]]) -> Result[Str, Str] { csv.stringify(rows) }
+"#;
+
+#[test]
+fn csv_parse_counts_rows() {
+    let body = "name,version\nlex,0.1.0\nrust,1.94\n";
+    let v = run(CSV_SRC, "row_count", vec![Value::Str(body.into())]);
+    match v {
+        Value::Variant { name, args } if name == "Ok" => assert_eq!(args[0], Value::Int(3)),
+        other => panic!("expected Ok, got {other:?}"),
+    }
+}
+
+#[test]
+fn csv_stringify_round_trips() {
+    let rows = Value::List(vec![
+        Value::List(vec![Value::Str("a".into()), Value::Str("b".into())]),
+        Value::List(vec![Value::Str("1".into()), Value::Str("2".into())]),
+    ]);
+    let v = run(CSV_SRC, "round_trip", vec![rows]);
+    match v {
+        Value::Variant { name, args } if name == "Ok" => match &args[0] {
+            Value::Str(s) => {
+                assert!(s.contains("a,b"), "got: {s:?}");
+                assert!(s.contains("1,2"), "got: {s:?}");
+            }
+            other => panic!("expected Str, got {other:?}"),
+        }
+        other => panic!("expected Ok, got {other:?}"),
+    }
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -1138,6 +1138,55 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
             ));
             Some(Ty::Record(fields))
         }
+        "yaml" => {
+            // YAML config parser. Same shape as `std.toml`: parse
+            // is polymorphic, output Value layout matches std.json
+            // (Str/Int/Float/Bool/List/Record). Anchors and tags
+            // are flattened by serde_yaml's deserializer.
+            let mut fields = IndexMap::new();
+            fields.insert("parse".into(), Ty::function(
+                vec![Ty::str()], EffectSet::empty(),
+                Ty::Con("Result".into(), vec![Ty::Var(0), Ty::str()]),
+            ));
+            fields.insert("stringify".into(), Ty::function(
+                vec![Ty::Var(0)], EffectSet::empty(),
+                Ty::Con("Result".into(), vec![Ty::str(), Ty::str()]),
+            ));
+            Some(Ty::Record(fields))
+        }
+        "dotenv" => {
+            // .env-style files. parse :: Str -> Result[Map[Str,Str], Str].
+            // Returns a map (not a polymorphic record) because
+            // dotenv files don't carry shape — every value is a
+            // string and keys aren't statically known.
+            let mut fields = IndexMap::new();
+            fields.insert("parse".into(), Ty::function(
+                vec![Ty::str()], EffectSet::empty(),
+                Ty::Con("Result".into(), vec![
+                    Ty::Con("Map".into(), vec![Ty::str(), Ty::str()]),
+                    Ty::str(),
+                ]),
+            ));
+            Some(Ty::Record(fields))
+        }
+        "csv" => {
+            // CSV rows-as-lists. parse :: Str -> Result[List[List[Str]], Str].
+            // Header awareness is left to the caller — row 0 is
+            // whatever the file has. A `parse_with_headers` that
+            // returns List[Map[Str,Str]] is a natural follow-up.
+            let row_ty = Ty::List(Box::new(Ty::str()));
+            let rows_ty = Ty::List(Box::new(row_ty.clone()));
+            let mut fields = IndexMap::new();
+            fields.insert("parse".into(), Ty::function(
+                vec![Ty::str()], EffectSet::empty(),
+                Ty::Con("Result".into(), vec![rows_ty.clone(), Ty::str()]),
+            ));
+            fields.insert("stringify".into(), Ty::function(
+                vec![rows_ty], EffectSet::empty(),
+                Ty::Con("Result".into(), vec![Ty::str(), Ty::str()]),
+            ));
+            Some(Ty::Record(fields))
+        }
         "toml" => {
             // TOML config parser. Mirrors `std.json`'s shape: parse
             // is polymorphic so callers annotate the expected
@@ -1211,6 +1260,9 @@ pub fn module_for_import(reference: &str) -> Option<&'static str> {
         "log" => "log",
         "http" => "http",
         "toml" => "toml",
+        "yaml" => "yaml",
+        "dotenv" => "dotenv",
+        "csv" => "csv",
         _ => return None,
     })
 }


### PR DESCRIPTION
Closes the std.config gaps from the OSS Auditor stdlib roadmap. std.toml + std.sql were already shipped; this PR fills in the remaining three formats so manifests like Cargo.toml, pyproject.toml, .github/workflows/*.yml, .env files, and analytics/cost CSVs can be read without bespoke regex.

* `std.yaml.parse(s) -> Result[T, Str]` — polymorphic, mirrors std.toml.parse. Wraps serde_yaml; YAML's tags/anchors are flattened by the deserializer. Plus `stringify`.

* `std.dotenv.parse(s) -> Result[Map[Str,Str], Str]` — KEY=VALUE pairs. Hand-rolled parser (~30 lines) instead of pulling dotenvy because the crate is geared at loading-into-process- env, not parse-to-data. Accepts blank lines, # comments, optional `export ` prefix, and quoted values (`"..."` / `'...'`). No shell expansion — by design; dotenv is data, not a script.

* `std.csv.parse(s) -> Result[List[List[Str]], Str]` — rows-as-lists, header awareness left to the caller. Plus `stringify`. Wraps the `csv` crate.

All three slot into the same shape as std.toml: pure parse fns, no effects, output in the same Lex Value shape as std.json produces, errors as `Result::Err(Str)`.

Tests in crates/lex-runtime/tests/std_config.rs cover round- trip, error paths (unparseable input, missing `=`, etc.), and quoted/comment/export-prefix variations for dotenv.

<!--
Thanks for contributing! See CONTRIBUTING.md for the conventions
this project follows. CI runs `cargo build`, `cargo test`, and
`cargo clippy --workspace --all-targets -- -D warnings`; please
make sure all three are green locally before pushing.
-->

## Summary

What does this PR change? One paragraph.

## Why

What's the user-facing problem this solves, or the gap this
closes? If it's tied to a tracked issue, link it (`closes #N`).

## Test plan

- [ ] `cargo test --workspace` passes locally
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] New behavior has a regression test
- [ ] If this changes a public CLI flag or JSON shape, README /
      Toolchain reference / langspec is updated

## Risk / scope

- Touches: `<crate-list-or-CLI-or-docs>`
- Breaking change to wire format / SigId / StageId / canonical AST? **yes / no**
- Adds a new effect kind or runtime variant? **yes / no**
