### PR TITLE
fix(ci): drop --locked from `cargo install cargo-fuzz`

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -30,7 +30,15 @@ jobs:
         with:
           workspaces: "fuzz -> target"
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz --locked
+        # `--locked` was pinning a stale `rustix 0.36.5` in
+        # cargo-fuzz's lockfile; that version uses
+        # `#[cfg_attr(rustc_attrs, ...)]`, which newer rustc
+        # rejects with "attributes starting with `rustc` are
+        # reserved." Drop `--locked` so cargo resolves a newer
+        # rustix transitively. cargo-fuzz isn't a runtime
+        # dependency of ours — the install is for the binary
+        # only — so a floating resolve is fine here.
+        run: cargo install cargo-fuzz
       # Smoke run: 60 seconds per target on PRs, 300 on the cron.
       # libFuzzer exits non-zero on any crash / timeout / OOM, which
       # surfaces as a CI failure with the offending input attached


### PR DESCRIPTION
The fuzz workflow's locked install pulls cargo-fuzz 0.13.1's lockfile, which pins `rustix 0.36.5`. That rustix version uses `#[cfg_attr(rustc_attrs, rustc_layout_scalar_valid_range_*)]` attributes; newer rustc (1.94+) rejects them with:

  error: attributes starting with `rustc` are reserved for
         use by the `rustc` compiler

So every PR touching `lex-syntax` / `lex-ast` / `lex-types` / `fuzz/**` (the fuzz workflow's path filter) fails on the `Install cargo-fuzz` step before any fuzzing runs.

Without `--locked`, cargo resolves a newer rustix transitively and the install succeeds. cargo-fuzz isn't an ABI dependency of ours — it's just a build tool installed for the workflow run — so a floating resolve is appropriate here.

<!--
Thanks for contributing! See CONTRIBUTING.md for the conventions
this project follows. CI runs `cargo build`, `cargo test`, and
`cargo clippy --workspace --all-targets -- -D warnings`; please
make sure all three are green locally before pushing.
-->

## Summary

What does this PR change? One paragraph.

## Why

What's the user-facing problem this solves, or the gap this
closes? If it's tied to a tracked issue, link it (`closes #N`).

## Test plan

- [ ] `cargo test --workspace` passes locally
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] New behavior has a regression test
- [ ] If this changes a public CLI flag or JSON shape, README /
      Toolchain reference / langspec is updated

## Risk / scope

- Touches: `<crate-list-or-CLI-or-docs>`
- Breaking change to wire format / SigId / StageId / canonical AST? **yes / no**
- Adds a new effect kind or runtime variant? **yes / no**
