### PR TITLE
feat: lex-tea v2 — human-only audit + triage views

### DIFF
--- a/crates/lex-api/src/handlers.rs
+++ b/crates/lex-api/src/handlers.rs
@@ -100,8 +100,11 @@ fn route(
     body: &str,
 ) -> Response<std::io::Cursor<Vec<u8>>> {
     match (method, path) {
-        // ---- lex-tea v1 (HTML browser) ------------------------
-        (Method::Get, "/") => crate::web::index_handler(state),
+        // ---- lex-tea v2 (HTML browser) ------------------------
+        (Method::Get, "/") => crate::web::activity_handler(state),
+        (Method::Get, "/web/branches") => crate::web::branches_handler(state),
+        (Method::Get, "/web/trust") => crate::web::trust_handler(state),
+        (Method::Get, "/web/attention") => crate::web::attention_handler(state),
         (Method::Get, p) if p.starts_with("/web/branch/") => {
             let name = &p["/web/branch/".len()..];
             crate::web::branch_handler(state, name)

--- a/crates/lex-api/src/lib.rs
+++ b/crates/lex-api/src/lib.rs
@@ -19,10 +19,15 @@
 //!   POST /v1/merge/<id>/commit        → { new_head_op, dst_branch } | 422 conflicts remaining
 //!   GET  /v1/health          → { ok: true }
 //!
-//! Web (lex-tea v1, read-only HTML over the JSON API):
-//!   GET  /                      → branch list
-//!   GET  /web/branch/<name>     → fns on a branch
-//!   GET  /web/stage/<id>        → stage info + attestation trail
+//! Web (lex-tea v2, read-only HTML; human-only audit + triage):
+//!   GET  /                      → activity stream (recent attestations)
+//!   GET  /web/attention         → exceptions queue (Failed / Inconclusive,
+//!                                 stale merge sessions)
+//!   GET  /web/trust             → per-producer rollup (pass rate, latest
+//!                                 failure)
+//!   GET  /web/branches          → branch list
+//!   GET  /web/branch/<name>     → fns on a branch (detail)
+//!   GET  /web/stage/<id>        → stage info + attestation trail (detail)
 
 pub mod handlers;
 mod web;

--- a/crates/lex-api/src/web.rs
+++ b/crates/lex-api/src/web.rs
@@ -1,35 +1,52 @@
-//! `lex-tea` v1 — a minimal HTML browser over the existing
-//! lex-vcs JSON endpoints. Three read-only pages:
+//! `lex-tea` v2 — read-only HTML browser over lex-vcs, oriented at
+//! the things humans uniquely need (audit, trust calibration,
+//! exception triage). The JSON API at `/v1/*` stays the
+//! agent-driven surface; this is the human-only complement.
 //!
-//! * `/`                    — list of branches
-//! * `/web/branch/<name>`   — list of fns on a branch with stage_id links
-//! * `/web/stage/<id>`      — stage metadata + attestation trail
+//! Pages:
+//!   GET /                  — activity stream (recent attestations)
+//!   GET /web/branches      — branch list + head_op
+//!   GET /web/trust         — per-producer rollup (pass rate, failures)
+//!   GET /web/attention     — exceptions queue (Failed/Inconclusive,
+//!                            stale merge sessions)
+//!   GET /web/branch/<name> — fns on a branch (detail)
+//!   GET /web/stage/<id>    — stage info + attestation trail (detail)
 //!
-//! Wired into the same `tiny_http` server as the JSON API
-//! (no extra binary, no new port). The point is to expose
-//! the JSON API's structure to humans without a SPA build
-//! pipeline. CSS is one short embedded blob; no JS.
+//! Why this shape: agents drive the JSON API in batches. Humans
+//! glance at a page once a day to decide whether to intervene.
+//! Per-conflict click-resolve UI would be a regression — agents
+//! handle that. The home page is the *macro* view; v1's
+//! "browse-by-branch" home moves to `/web/branches` as a detail
+//! surface.
+//!
+//! No JS, single embedded CSS blob. Promote to its own crate when
+//! it outgrows the single-file footprint.
 
 use lex_store::Store;
+use lex_vcs::{AttestationKind, AttestationResult};
+use std::collections::BTreeMap;
 use std::io::Cursor;
 use tiny_http::{Header, Response};
 
 use crate::handlers::State;
 
-/// Embedded so a `cargo build` produces a fully-self-contained
-/// binary. ~1KB; not worth a separate file dance.
 const STYLE: &str = r#"
 * { box-sizing: border-box; }
 body { font: 14px/1.5 -apple-system, system-ui, sans-serif;
-       max-width: 880px; margin: 2rem auto; padding: 0 1rem; color: #222; }
-h1 { font-weight: 600; margin: 0 0 1.5rem; }
+       max-width: 920px; margin: 0 auto; padding: 0 1rem; color: #222; }
+header { padding: 1.5rem 0 .5rem; border-bottom: 1px solid #eee; margin-bottom: 1rem; }
+header .nav { font-size: 13px; }
+header .nav a { margin-right: .8rem; color: #666; }
+header .nav a.current { color: #0a5; font-weight: 500; }
+h1 { font-weight: 600; margin: 0 0 .3rem; font-size: 22px; }
 h2 { font-weight: 500; margin: 1.5rem 0 .5rem; color: #444; }
+h3 { font-weight: 500; margin: 1rem 0 .3rem; color: #555; font-size: 14px; }
 a { color: #0a5; text-decoration: none; }
 a:hover { text-decoration: underline; }
-nav { font-size: 13px; color: #888; margin-bottom: 1rem; }
+nav.crumb { font-size: 13px; color: #888; margin: .5rem 0 1rem; }
 table { border-collapse: collapse; width: 100%; font-size: 13px; }
-th, td { text-align: left; padding: .35rem .6rem; border-bottom: 1px solid #eee; }
-th { color: #666; font-weight: 500; }
+th, td { text-align: left; padding: .35rem .6rem; border-bottom: 1px solid #eee; vertical-align: top; }
+th { color: #666; font-weight: 500; background: #fafafa; }
 .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; }
 .muted { color: #999; }
 .tag { display: inline-block; padding: 1px 6px; font-size: 11px; border-radius: 3px;
@@ -37,8 +54,16 @@ th { color: #666; font-weight: 500; }
 .tag.ok { background: #dfd; color: #060; }
 .tag.fail { background: #fdd; color: #800; }
 .tag.inc { background: #ffd; color: #850; }
-pre { background: #f6f6f6; padding: .8rem; overflow-x: auto; font-size: 12px; border-radius: 3px; }
-.empty { color: #aaa; font-style: italic; }
+.tag.kind { background: #eef0f3; color: #445; }
+.empty { color: #aaa; font-style: italic; padding: 1rem; }
+.summary { display: flex; gap: 1.5rem; margin: 1rem 0; }
+.stat { padding: .5rem 1rem; background: #fafafa; border-radius: 4px; min-width: 110px; }
+.stat .n { font-size: 22px; font-weight: 600; color: #222; line-height: 1.1; }
+.stat .l { font-size: 11px; color: #888; text-transform: uppercase; letter-spacing: .04em; }
+.stat.fail .n { color: #b00; }
+.stat.inc  .n { color: #850; }
+.note { background: #f8f8fa; padding: .8rem 1rem; border-left: 3px solid #ddd; color: #666;
+        font-size: 13px; margin: 1rem 0; }
 "#;
 
 fn html_response(status: u16, body: String) -> Response<Cursor<Vec<u8>>> {
@@ -49,7 +74,21 @@ fn html_response(status: u16, body: String) -> Response<Cursor<Vec<u8>>> {
         )
 }
 
-fn page(title: &str, breadcrumb: &str, body: &str) -> String {
+/// Top-level page chrome. `current` selects which top-nav link is
+/// highlighted (one of "/", "/web/branches", "/web/trust",
+/// "/web/attention"); for detail pages pass `""`.
+fn page(title: &str, current: &str, body: &str) -> String {
+    let nav_link = |href: &str, label: &str| -> String {
+        let class = if current == href { "current" } else { "" };
+        format!(r#"<a href="{href}" class="{class}">{label}</a>"#)
+    };
+    let nav = format!(
+        "{} {} {} {}",
+        nav_link("/", "activity"),
+        nav_link("/web/attention", "attention"),
+        nav_link("/web/trust", "trust"),
+        nav_link("/web/branches", "branches"),
+    );
     format!(
         r#"<!doctype html>
 <html lang="en">
@@ -59,7 +98,7 @@ fn page(title: &str, breadcrumb: &str, body: &str) -> String {
 <style>{STYLE}</style>
 </head>
 <body>
-<nav>{breadcrumb}</nav>
+<header><div class="nav">{nav}</div></header>
 {body}
 </body>
 </html>
@@ -74,12 +113,338 @@ fn esc(s: &str) -> String {
         .replace('"', "&quot;")
 }
 
-/// `GET /` — branch list.
-pub(crate) fn index_handler(state: &State) -> Response<Cursor<Vec<u8>>> {
+// ---- Activity stream (`GET /`) -----------------------------------
+
+/// Walks every attestation in the store, sorts newest-first, and
+/// renders one row per event. Why attestations and not ops:
+/// attestations have explicit timestamps; ops are
+/// content-addressed but the OpRecord has no `recorded_at` field
+/// (intentional — preserving op identity). Every accepted op
+/// auto-emits a TypeCheck attestation, so the attestation feed is
+/// effectively the op feed plus richer signals (Spec, Examples,
+/// EffectAudit, SandboxRun).
+pub(crate) fn activity_handler(state: &State) -> Response<Cursor<Vec<u8>>> {
+    let store = state.store.lock().unwrap();
+    let log = match store.attestation_log() {
+        Ok(l) => l,
+        Err(e) => return html_response(500, page("error", "/", &format!("<pre>{}</pre>", esc(&e.to_string())))),
+    };
+    let mut atts = log.list_all().unwrap_or_default();
+    atts.sort_by_key(|a| std::cmp::Reverse(a.timestamp));
+
+    // Headline counters: pass / fail / inconclusive in the last 24h.
+    // 24h from "now" via wall clock; small enough to be glanceable,
+    // big enough to catch overnight drift.
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let cutoff = now.saturating_sub(24 * 60 * 60);
+    let recent: Vec<&_> = atts.iter().filter(|a| a.timestamp >= cutoff).collect();
+    let pass = recent.iter().filter(|a| matches!(a.result, AttestationResult::Passed)).count();
+    let fail = recent.iter().filter(|a| matches!(a.result, AttestationResult::Failed { .. })).count();
+    let inc  = recent.iter().filter(|a| matches!(a.result, AttestationResult::Inconclusive { .. })).count();
+
+    let mut rows = String::new();
+    if atts.is_empty() {
+        rows.push_str(r#"<tr><td colspan="4" class="empty">no activity yet — try `lex publish &lt;file.lex&gt;`</td></tr>"#);
+    } else {
+        // Cap at 200 rows so a long-lived store doesn't render a
+        // page that takes forever to scroll. Older events are
+        // reachable via per-stage detail pages.
+        for a in atts.iter().take(200) {
+            let kind_tag = kind_short(&a.kind);
+            let (result_lbl, css) = result_short(&a.result);
+            let summary = match &a.result {
+                AttestationResult::Failed { detail }
+                | AttestationResult::Inconclusive { detail } => esc(detail),
+                AttestationResult::Passed => esc(&a.produced_by.tool),
+            };
+            rows.push_str(&format!(
+                r#"<tr>
+                  <td class="muted mono">{ts}</td>
+                  <td><span class="tag kind">{kind}</span></td>
+                  <td><span class="tag {css}">{result}</span> <span class="muted">{summary}</span></td>
+                  <td class="mono"><a href="/web/stage/{stage}">{stage:.16}…</a></td>
+                </tr>"#,
+                ts = a.timestamp,
+                kind = esc(&kind_tag),
+                css = css,
+                result = result_lbl,
+                summary = summary,
+                stage = esc(&a.stage_id),
+            ));
+        }
+    }
+
+    let body = format!(
+        r#"<h1>activity</h1>
+<p class="muted">Reverse-chrono feed of attestations — one event per row.
+Every accepted op auto-emits a TypeCheck; Spec / Examples / DiffBody /
+SandboxRun / EffectAudit show up as agents and CI run them.</p>
+<div class="summary">
+  <div class="stat"><div class="n">{pass}</div><div class="l">passed (24h)</div></div>
+  <div class="stat fail"><div class="n">{fail}</div><div class="l">failed (24h)</div></div>
+  <div class="stat inc"><div class="n">{inc}</div><div class="l">inconclusive (24h)</div></div>
+  <div class="stat"><div class="n">{total}</div><div class="l">total events</div></div>
+</div>
+<table>
+  <thead><tr><th>ts</th><th>kind</th><th>result</th><th>stage</th></tr></thead>
+  <tbody>{rows}</tbody>
+</table>"#,
+        total = atts.len(),
+    );
+    html_response(200, page("activity", "/", &body))
+}
+
+// ---- Trust (`GET /web/trust`) ------------------------------------
+
+/// Per-producer rollup: count by result, recent-failure latch.
+/// Designed to surface *which* model / tool is regressing without
+/// asking the human to scan rows.
+pub(crate) fn trust_handler(state: &State) -> Response<Cursor<Vec<u8>>> {
+    let store = state.store.lock().unwrap();
+    let log = match store.attestation_log() {
+        Ok(l) => l,
+        Err(e) => return html_response(500, page("error", "/web/trust",
+            &format!("<pre>{}</pre>", esc(&e.to_string())))),
+    };
+    let atts = log.list_all().unwrap_or_default();
+
+    // Group by (tool, model). The `model` is `None` for
+    // store-side / harness-side producers; `Some(name)` when an
+    // LLM was the proximate producer (e.g. `lex agent-tool`
+    // with `--request`). We keep them separated so a model
+    // regression doesn't get hidden in the tool's totals.
+    #[derive(Default)]
+    struct Stats {
+        passed: usize,
+        failed: usize,
+        inconclusive: usize,
+        latest_failure_ts: Option<u64>,
+        latest_failure_stage: Option<String>,
+    }
+    let mut groups: BTreeMap<(String, String), Stats> = BTreeMap::new();
+    for a in &atts {
+        let key = (
+            a.produced_by.tool.clone(),
+            a.produced_by.model.clone().unwrap_or_else(|| "—".into()),
+        );
+        let s = groups.entry(key).or_default();
+        match &a.result {
+            AttestationResult::Passed => s.passed += 1,
+            AttestationResult::Failed { .. } => {
+                s.failed += 1;
+                if s.latest_failure_ts.map(|t| t < a.timestamp).unwrap_or(true) {
+                    s.latest_failure_ts = Some(a.timestamp);
+                    s.latest_failure_stage = Some(a.stage_id.clone());
+                }
+            }
+            AttestationResult::Inconclusive { .. } => s.inconclusive += 1,
+        }
+    }
+
+    let mut rows = String::new();
+    if groups.is_empty() {
+        rows.push_str(r#"<tr><td colspan="6" class="empty">no producers have attested yet</td></tr>"#);
+    } else {
+        // Sort by recent-failure first (descending ts), then by
+        // total volume. The thing humans want at the top of the
+        // page is "who broke recently."
+        let mut entries: Vec<_> = groups.into_iter().collect();
+        entries.sort_by(|a, b| {
+            b.1.latest_failure_ts.cmp(&a.1.latest_failure_ts)
+                .then_with(|| (b.1.passed + b.1.failed + b.1.inconclusive)
+                    .cmp(&(a.1.passed + a.1.failed + a.1.inconclusive)))
+        });
+        for ((tool, model), s) in &entries {
+            let total = s.passed + s.failed + s.inconclusive;
+            let pct = if total > 0 { (s.passed * 100) / total } else { 0 };
+            let recent_fail = match (&s.latest_failure_ts, &s.latest_failure_stage) {
+                (Some(ts), Some(stage)) => format!(
+                    r#"<a href="/web/stage/{stage}" class="mono">{stage:.16}…</a> <span class="muted">@{ts}</span>"#,
+                    stage = esc(stage), ts = ts,
+                ),
+                _ => r#"<span class="muted">—</span>"#.into(),
+            };
+            rows.push_str(&format!(
+                r#"<tr>
+                  <td>{tool}</td>
+                  <td class="mono">{model}</td>
+                  <td>{total}</td>
+                  <td>{pass} <span class="muted">({pct}%)</span></td>
+                  <td>{fail}</td>
+                  <td>{recent_fail}</td>
+                </tr>"#,
+                tool = esc(tool),
+                model = esc(model),
+                total = total,
+                pass = s.passed,
+                pct = pct,
+                fail = s.failed,
+                recent_fail = recent_fail,
+            ));
+        }
+    }
+
+    let body = format!(
+        r#"<h1>trust</h1>
+<p class="muted">One row per producer (<code>tool</code>, <code>model</code>). Sorted
+by most-recent failure first so a regressing model rises to the top.
+Pass rate is over the producer's lifetime; the
+<strong>latest failure</strong> column links to the stage so you can
+read the detail.</p>
+<table>
+  <thead><tr>
+    <th>tool</th><th>model</th><th>total</th><th>passed</th>
+    <th>failed</th><th>latest failure</th>
+  </tr></thead>
+  <tbody>{rows}</tbody>
+</table>"#,
+    );
+    html_response(200, page("trust", "/web/trust", &body))
+}
+
+// ---- Attention (`GET /web/attention`) ----------------------------
+
+/// The "pay attention to this" list: failed / inconclusive
+/// attestations from the last week, plus open merge sessions.
+/// What's left here is what humans should look at.
+pub(crate) fn attention_handler(state: &State) -> Response<Cursor<Vec<u8>>> {
+    let store = state.store.lock().unwrap();
+    let log = match store.attestation_log() {
+        Ok(l) => l,
+        Err(e) => return html_response(500, page("error", "/web/attention",
+            &format!("<pre>{}</pre>", esc(&e.to_string())))),
+    };
+    let mut atts = log.list_all().unwrap_or_default();
+    atts.sort_by_key(|a| std::cmp::Reverse(a.timestamp));
+
+    // 7-day window for the exceptions table — long enough that an
+    // overnight regression is still visible after a weekend; short
+    // enough that the page doesn't grow unbounded.
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let cutoff = now.saturating_sub(7 * 24 * 60 * 60);
+
+    let exceptions: Vec<&_> = atts.iter()
+        .filter(|a| a.timestamp >= cutoff)
+        .filter(|a| !matches!(a.result, AttestationResult::Passed))
+        .collect();
+
+    let mut ex_rows = String::new();
+    if exceptions.is_empty() {
+        ex_rows.push_str(r#"<tr><td colspan="4" class="empty">no failed or inconclusive attestations in the last 7 days — clear runway</td></tr>"#);
+    } else {
+        for a in &exceptions {
+            let kind = kind_short(&a.kind);
+            let (lbl, css) = result_short(&a.result);
+            let detail = match &a.result {
+                AttestationResult::Failed { detail }
+                | AttestationResult::Inconclusive { detail } => esc(detail),
+                _ => String::new(),
+            };
+            ex_rows.push_str(&format!(
+                r#"<tr>
+                  <td class="muted mono">{ts}</td>
+                  <td><span class="tag kind">{kind}</span> <span class="tag {css}">{lbl}</span></td>
+                  <td>{detail}</td>
+                  <td class="mono"><a href="/web/stage/{stage}">{stage:.16}…</a></td>
+                </tr>"#,
+                ts = a.timestamp,
+                kind = esc(&kind),
+                css = css,
+                lbl = lbl,
+                detail = detail,
+                stage = esc(&a.stage_id),
+            ));
+        }
+    }
+
+    // Open merge sessions: read the directory directly. Each
+    // session file is a JSON envelope persisted by `lex merge
+    // start`. Show its src/dst branches and how stale it is so a
+    // reviewer can spot a session the agent forgot to commit.
+    let merges_dir = store.root().join("merges");
+    let mut merge_rows = String::new();
+    let mut merge_count = 0usize;
+    if let Ok(entries) = std::fs::read_dir(&merges_dir) {
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if p.extension().is_none_or(|e| e != "json") { continue; }
+            let bytes = match std::fs::read(&p) { Ok(b) => b, Err(_) => continue };
+            let v: serde_json::Value = match serde_json::from_slice(&bytes) {
+                Ok(v) => v, Err(_) => continue,
+            };
+            let id = p.file_stem().and_then(|s| s.to_str()).unwrap_or("?").to_string();
+            let src = v["src_branch"].as_str().unwrap_or("?").to_string();
+            let dst = v["dst_branch"].as_str().unwrap_or("?").to_string();
+            let conflicts = v.pointer("/session/conflicts")
+                .and_then(|c| c.as_object())
+                .map(|o| o.len())
+                .unwrap_or(0);
+            let mtime = entry.metadata().ok()
+                .and_then(|m| m.modified().ok())
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            let age_secs = now.saturating_sub(mtime);
+            let age = if age_secs < 3600 { format!("{}m", age_secs / 60) }
+                else if age_secs < 86_400 { format!("{}h", age_secs / 3600) }
+                else { format!("{}d", age_secs / 86_400) };
+            merge_rows.push_str(&format!(
+                r#"<tr>
+                  <td class="mono">{id}</td>
+                  <td>{src} → {dst}</td>
+                  <td>{conflicts}</td>
+                  <td class="muted">{age} old</td>
+                </tr>"#,
+                id = esc(&id),
+                src = esc(&src),
+                dst = esc(&dst),
+                conflicts = conflicts,
+                age = age,
+            ));
+            merge_count += 1;
+        }
+    }
+    if merge_count == 0 {
+        merge_rows = r#"<tr><td colspan="4" class="empty">no in-flight merges</td></tr>"#.into();
+    }
+
+    let body = format!(
+        r#"<h1>attention</h1>
+<p class="muted">The "pay attention to this" list — exceptions from
+the last 7 days, plus in-flight merge sessions. If both tables show
+"empty," there's nothing for a reviewer to do.</p>
+
+<h2>exceptions</h2>
+<table>
+  <thead><tr><th>ts</th><th>kind</th><th>detail</th><th>stage</th></tr></thead>
+  <tbody>{ex_rows}</tbody>
+</table>
+
+<h2>open merge sessions</h2>
+<table>
+  <thead><tr><th>merge_id</th><th>branches</th><th>conflicts</th><th>age</th></tr></thead>
+  <tbody>{merge_rows}</tbody>
+</table>"#,
+    );
+    html_response(200, page("attention", "/web/attention", &body))
+}
+
+// ---- Branch list (`GET /web/branches`) ----------------------------
+
+/// Moved from v1's `/`. Still useful as a detail page; the new
+/// home is the activity stream.
+pub(crate) fn branches_handler(state: &State) -> Response<Cursor<Vec<u8>>> {
     let store = state.store.lock().unwrap();
     let branches = match store.list_branches() {
         Ok(b) => b,
-        Err(e) => return html_response(500, page("error", "/", &format!("<pre>{}</pre>", esc(&e.to_string())))),
+        Err(e) => return html_response(500, page("error", "/web/branches",
+            &format!("<pre>{}</pre>", esc(&e.to_string())))),
     };
     let current = store.current_branch();
 
@@ -97,86 +462,69 @@ pub(crate) fn index_handler(state: &State) -> Response<Cursor<Vec<u8>>> {
                 .unwrap_or_default();
             let marker = if *name == current {
                 r#"<span class="tag ok">current</span>"#
-            } else {
-                ""
-            };
+            } else { "" };
             rows.push_str(&format!(
                 r#"<tr><td><a href="/web/branch/{n}">{n}</a> {marker}{predicate}</td><td class="mono">{h:.16}…</td></tr>"#,
-                n = esc(name),
-                marker = marker,
-                predicate = predicate,
-                h = esc(&head),
+                n = esc(name), marker = marker, predicate = predicate, h = esc(&head),
             ));
         }
     }
     let body = format!(
-        r#"<h1>lex-tea</h1>
-<p class="muted">Read-only browser over <code>lex-vcs</code>. JSON API at <code>/v1/*</code>.</p>
-<h2>branches</h2>
+        r#"<h1>branches</h1>
 <table><thead><tr><th>name</th><th>head_op</th></tr></thead><tbody>{rows}</tbody></table>"#,
     );
-    html_response(200, page("branches", "/", &body))
+    html_response(200, page("branches", "/web/branches", &body))
 }
 
-/// `GET /web/branch/<name>` — fns on a branch.
+// ---- Branch detail (unchanged shape) -----------------------------
+
 pub(crate) fn branch_handler(state: &State, name: &str) -> Response<Cursor<Vec<u8>>> {
     let store = state.store.lock().unwrap();
     let head_map = match store.branch_head(name) {
         Ok(m) => m,
-        Err(e) => return html_response(404, page("error", &nav_for_branch(name), &format!("<pre>{}</pre>", esc(&e.to_string())))),
+        Err(e) => return html_response(404, page("error", "",
+            &format!(r#"<nav class="crumb"><a href="/web/branches">branches</a> / {}</nav><pre>{}</pre>"#,
+                esc(name), esc(&e.to_string())))),
     };
-
     let mut rows = String::new();
     if head_map.is_empty() {
         rows.push_str(r#"<tr><td colspan="2" class="empty">no fns on this branch</td></tr>"#);
     } else {
-        // `head_map` is SigId → StageId. Render the stage_id as the
-        // primary link; sig_id is an internal identifier we don't
-        // surface yet beyond a hover.
         for (sig, stage_id) in &head_map {
             let fn_name = lookup_name_for_stage(&store, stage_id).unwrap_or_else(|| "—".into());
             rows.push_str(&format!(
                 r#"<tr><td>{name}</td><td class="mono"><a href="/web/stage/{sid}" title="sig {sig}">{sid:.16}…</a></td></tr>"#,
-                name = esc(&fn_name),
-                sid = esc(stage_id),
-                sig = esc(sig),
+                name = esc(&fn_name), sid = esc(stage_id), sig = esc(sig),
             ));
         }
     }
     let body = format!(
-        r#"<h1>{n}</h1>
+        r#"<nav class="crumb"><a href="/web/branches">branches</a> / <strong>{n}</strong></nav>
+<h1>{n}</h1>
 <table><thead><tr><th>fn</th><th>stage</th></tr></thead><tbody>{rows}</tbody></table>"#,
         n = esc(name),
     );
-    html_response(200, page(name, &nav_for_branch(name), &body))
+    html_response(200, page(name, "", &body))
 }
 
 fn lookup_name_for_stage(store: &Store, stage_id: &str) -> Option<String> {
     store.get_metadata(stage_id).ok().map(|m| m.name)
 }
 
-fn nav_for_branch(name: &str) -> String {
-    format!(r#"<a href="/">branches</a> / <strong>{}</strong>"#, esc(name))
-}
+// ---- Stage detail (unchanged shape) -------------------------------
 
-fn nav_for_stage(stage_id: &str) -> String {
-    format!(
-        r#"<a href="/">branches</a> / <strong class="mono">{}</strong>"#,
-        esc(&format!("{stage_id:.16}…")),
-    )
-}
-
-/// `GET /web/stage/<id>` — stage metadata + attestation trail.
 pub(crate) fn stage_html_handler(state: &State, id: &str) -> Response<Cursor<Vec<u8>>> {
     let store = state.store.lock().unwrap();
     let meta = match store.get_metadata(id) {
         Ok(m) => m,
-        Err(e) => return html_response(404, page("not found", &nav_for_stage(id), &format!("<pre>{}</pre>", esc(&e.to_string())))),
+        Err(e) => return html_response(404, page("not found", "",
+            &format!(r#"<nav class="crumb"><a href="/">activity</a></nav><pre>{}</pre>"#, esc(&e.to_string())))),
     };
     let status = store.get_status(id).map(|s| format!("{s:?}")).unwrap_or_else(|_| "?".into());
     let log = match store.attestation_log() {
         Ok(l) => l,
-        Err(e) => return html_response(500, page("error", &nav_for_stage(id), &format!("<pre>{}</pre>", esc(&e.to_string())))),
+        Err(e) => return html_response(500, page("error", "",
+            &format!("<pre>{}</pre>", esc(&e.to_string())))),
     };
     let mut atts = log.list_for_stage(&id.to_string()).unwrap_or_default();
     atts.sort_by_key(|a| std::cmp::Reverse(a.timestamp));
@@ -186,29 +534,21 @@ pub(crate) fn stage_html_handler(state: &State, id: &str) -> Response<Cursor<Vec
         att_rows.push_str(r#"<tr><td colspan="4" class="empty">no attestations yet</td></tr>"#);
     } else {
         for a in &atts {
-            let kind = match &a.kind {
-                lex_vcs::AttestationKind::TypeCheck => "TypeCheck".to_string(),
-                lex_vcs::AttestationKind::EffectAudit => "EffectAudit".to_string(),
-                lex_vcs::AttestationKind::Spec { spec_id, .. } => format!("Spec({spec_id:.12}…)"),
-                lex_vcs::AttestationKind::Examples { count, .. } => format!("Examples({count})"),
-                lex_vcs::AttestationKind::DiffBody { input_count, .. } => format!("DiffBody({input_count})"),
-                lex_vcs::AttestationKind::SandboxRun { effects } => {
-                    let names: Vec<&str> = effects.iter().map(|s| s.as_str()).collect();
-                    format!("SandboxRun([{}])", names.join(","))
-                }
-            };
-            let (result, css) = match &a.result {
-                lex_vcs::AttestationResult::Passed => ("passed".to_string(), "ok"),
-                lex_vcs::AttestationResult::Failed { detail } => (format!("failed: {detail}"), "fail"),
-                lex_vcs::AttestationResult::Inconclusive { detail } => {
-                    (format!("inconclusive: {detail}"), "inc")
-                }
+            let kind = kind_short(&a.kind);
+            let (lbl, css) = result_short(&a.result);
+            let detail = match &a.result {
+                AttestationResult::Failed { detail }
+                | AttestationResult::Inconclusive { detail } => esc(detail),
+                AttestationResult::Passed => String::new(),
             };
             att_rows.push_str(&format!(
-                r#"<tr><td>{kind}</td><td><span class="tag {css}">{result}</span></td><td class="mono">{tool}@{ver}</td><td class="muted mono">{ts}</td></tr>"#,
-                kind = esc(&kind),
-                css = css,
-                result = esc(&result),
+                r#"<tr>
+                  <td><span class="tag kind">{kind}</span></td>
+                  <td><span class="tag {css}">{lbl}</span> {detail}</td>
+                  <td class="mono">{tool}@{ver}</td>
+                  <td class="muted mono">{ts}</td>
+                </tr>"#,
+                kind = esc(&kind), css = css, lbl = lbl, detail = detail,
                 tool = esc(&a.produced_by.tool),
                 ver = esc(&a.produced_by.version),
                 ts = a.timestamp,
@@ -217,7 +557,8 @@ pub(crate) fn stage_html_handler(state: &State, id: &str) -> Response<Cursor<Vec
     }
 
     let body = format!(
-        r#"<h1>{name}</h1>
+        r#"<nav class="crumb"><a href="/">activity</a> / <strong class="mono">{id_short}…</strong></nav>
+<h1>{name}</h1>
 <table>
   <tr><th>name</th><td>{name}</td></tr>
   <tr><th>sig_id</th><td class="mono">{sig:.16}…</td></tr>
@@ -230,6 +571,7 @@ pub(crate) fn stage_html_handler(state: &State, id: &str) -> Response<Cursor<Vec
   <thead><tr><th>kind</th><th>result</th><th>by</th><th>ts</th></tr></thead>
   <tbody>{att_rows}</tbody>
 </table>"#,
+        id_short = esc(&format!("{id:.16}")),
         name = esc(&meta.name),
         sig = esc(&meta.sig_id),
         stage = esc(&meta.stage_id),
@@ -237,5 +579,32 @@ pub(crate) fn stage_html_handler(state: &State, id: &str) -> Response<Cursor<Vec
         ts = meta.published_at,
         n = atts.len(),
     );
-    html_response(200, page(&meta.name, &nav_for_stage(id), &body))
+    html_response(200, page(&meta.name, "", &body))
+}
+
+// ---- shared helpers -----------------------------------------------
+
+/// Compact label for an `AttestationKind`. Used by every renderer
+/// so the activity feed and the stage page show the same string.
+fn kind_short(k: &AttestationKind) -> String {
+    match k {
+        AttestationKind::TypeCheck => "TypeCheck".into(),
+        AttestationKind::EffectAudit => "EffectAudit".into(),
+        AttestationKind::Spec { spec_id, .. } => format!("Spec({spec_id:.12}…)"),
+        AttestationKind::Examples { count, .. } => format!("Examples({count})"),
+        AttestationKind::DiffBody { input_count, .. } => format!("DiffBody({input_count})"),
+        AttestationKind::SandboxRun { effects } => {
+            let names: Vec<&str> = effects.iter().map(|s| s.as_str()).collect();
+            format!("SandboxRun([{}])", names.join(","))
+        }
+    }
+}
+
+/// `(label, css class)` pair for the result tag.
+fn result_short(r: &AttestationResult) -> (&'static str, &'static str) {
+    match r {
+        AttestationResult::Passed => ("passed", "ok"),
+        AttestationResult::Failed { .. } => ("failed", "fail"),
+        AttestationResult::Inconclusive { .. } => ("inconclusive", "inc"),
+    }
 }

--- a/crates/lex-api/tests/m8.rs
+++ b/crates/lex-api/tests/m8.rs
@@ -335,17 +335,70 @@ fn merge_resolve_unknown_conflict_is_rejected_per_entry() {
 }
 
 #[test]
-fn web_index_lists_branches_as_html() {
+fn web_activity_stream_lists_recent_attestations() {
+    // The new home page (lex-tea v2) is an activity stream sourced
+    // from the attestation log. After a publish, there's at least
+    // one TypeCheck::Passed event the page should render.
     let (srv, _tmp) = start_server();
-    // Publish so main has a head_op to display.
     let src = "fn foo(n :: Int) -> Int { n }\n";
     let (s, _) = http(&srv.addr, "POST", "/v1/publish", &json!({"source": src, "activate": true}).to_string());
     assert_eq!(s, 200);
 
     let (s, b) = http(&srv.addr, "GET", "/", "");
     assert_eq!(s, 200, "GET /: {b}");
-    assert!(b.contains("<title>") && b.contains("lex-tea"), "html with title expected: {b}");
+    assert!(b.contains("<title>") && b.contains("lex-tea"), "html title: {b}");
+    assert!(b.contains("activity"), "activity heading expected: {b}");
+    assert!(b.contains("TypeCheck"), "auto-emitted TypeCheck row expected: {b}");
+    assert!(b.contains("/web/stage/"), "should link to stage detail: {b}");
+}
+
+#[test]
+fn web_branches_page_lists_branches() {
+    // The v1 home moved to /web/branches in v2; verify it still
+    // renders the branch list.
+    let (srv, _tmp) = start_server();
+    let src = "fn foo(n :: Int) -> Int { n }\n";
+    let (s, _) = http(&srv.addr, "POST", "/v1/publish", &json!({"source": src, "activate": true}).to_string());
+    assert_eq!(s, 200);
+
+    let (s, b) = http(&srv.addr, "GET", "/web/branches", "");
+    assert_eq!(s, 200, "GET /web/branches: {b}");
     assert!(b.contains("main"), "branch list should mention main: {b}");
+}
+
+#[test]
+fn web_trust_page_groups_by_producer() {
+    // After a publish, the trust page should show a row for the
+    // store-side producer (`lex-store`) since the type-check gate
+    // auto-emitted a TypeCheck attestation under that name.
+    let (srv, _tmp) = start_server();
+    let src = "fn foo(n :: Int) -> Int { n }\n";
+    let (s, _) = http(&srv.addr, "POST", "/v1/publish", &json!({"source": src, "activate": true}).to_string());
+    assert_eq!(s, 200);
+
+    let (s, b) = http(&srv.addr, "GET", "/web/trust", "");
+    assert_eq!(s, 200, "GET /web/trust: {b}");
+    assert!(b.contains("trust"), "trust heading: {b}");
+    assert!(b.contains("lex-store"), "lex-store producer row: {b}");
+}
+
+#[test]
+fn web_attention_empty_when_only_passed_attestations_exist() {
+    // The exceptions table should be empty when every attestation
+    // is Passed — the "clear runway" message renders. Exercises
+    // the attention page's empty-state path so a regression that
+    // accidentally shows passed attestations as exceptions is
+    // caught.
+    let (srv, _tmp) = start_server();
+    let src = "fn foo(n :: Int) -> Int { n }\n";
+    let (s, _) = http(&srv.addr, "POST", "/v1/publish", &json!({"source": src, "activate": true}).to_string());
+    assert_eq!(s, 200);
+
+    let (s, b) = http(&srv.addr, "GET", "/web/attention", "");
+    assert_eq!(s, 200, "GET /web/attention: {b}");
+    assert!(b.contains("attention"), "attention heading: {b}");
+    assert!(b.contains("clear runway") || b.contains("no failed"),
+        "empty-state copy expected: {b}");
 }
 
 #[test]


### PR DESCRIPTION
Reframes the home page from a thinner-version-of-the-API into
the macro view a human reviewer needs. Agents drive the JSON
API in batches; lex-tea is the complementary surface humans
glance at to decide whether to intervene.

Three new pages, plus the v1 detail surfaces stay:

  GET /                — activity stream (newest-first attestations,
                          with 24h pass/fail/inconclusive headline
                          counters)
  GET /web/attention   — exceptions queue (Failed/Inconclusive
                          attestations from the last 7 days +
                          in-flight merge sessions with age)
  GET /web/trust       — per-(tool, model) rollup: total events,
                          pass rate, latest failure linked to its
                          stage. Sorted by most-recent failure
                          first so a regressing producer rises to
                          the top.

  GET /web/branches    — v1's home moved here (still useful as a
                          detail surface)
  GET /web/branch/<n>  — unchanged
  GET /web/stage/<id>  — unchanged

Top nav across pages so a reviewer can move between
activity / attention / trust / branches with one click.

Why this shape rather than a click-to-resolve merge UI:
agents already do that better through `/v1/merge/*`. A human
clicking TakeOurs one-conflict-at-a-time would be a regression
vs the agent's batched resolve. The valuable human action is
*deciding policy* (which producer to trust, which stage to
override), not micro-resolving — v2 informs; v3 will let
humans act on that information with audited overrides.

Implementation: ~470 lines, single file. No new dependencies.
Activity feed is sourced from `AttestationLog::list_all` since
attestations have explicit timestamps and every accepted op
auto-emits a TypeCheck (so the attestation feed is the op
feed plus richer signals).