### PR TITLE
feat: std.{toml,yaml,json}.parse_strict — required-field validation (#168)

### DIFF
--- a/crates/lex-api/src/web.rs
+++ b/crates/lex-api/src/web.rs
@@ -259,7 +259,7 @@ pub(crate) fn trust_handler(state: &State) -> Response<Cursor<Vec<u8>>> {
         });
         for ((tool, model), s) in &entries {
             let total = s.passed + s.failed + s.inconclusive;
-            let pct = if total > 0 { (s.passed * 100) / total } else { 0 };
+            let pct = (s.passed * 100).checked_div(total).unwrap_or(0);
             let recent_fail = match (&s.latest_failure_ts, &s.latest_failure_stage) {
                 (Some(ts), Some(stage)) => format!(
                     r#"<a href="/web/stage/{stage}" class="mono">{stage:.16}…</a> <span class="muted">@{ts}</span>"#,

--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -1453,7 +1453,7 @@ fn check_required_fields(
     };
     let missing: Vec<&str> = required.iter()
         .filter(|n| !obj.contains_key(n.as_str()))
-        .map(|s| s.as_str())
+        .map(String::as_str)
         .collect();
     if missing.is_empty() {
         Ok(())

--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -232,6 +232,20 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
                 Err(e) => Ok(err_v(Value::Str(format!("{e}")))),
             }
         }
+        // Tactical fix for #168: validate required fields before
+        // returning Ok. The full type-driven fix (derive `required`
+        // from `T` at type-check time) tracked in #168.
+        ("json", "parse_strict") => {
+            let s = expect_str(args.first())?;
+            let required = required_field_names(args.get(1))?;
+            match serde_json::from_str::<serde_json::Value>(&s) {
+                Ok(v) => match check_required_fields(&v, &required) {
+                    Ok(()) => Ok(ok_v(json_to_value(&v))),
+                    Err(e) => Ok(err_v(Value::Str(e))),
+                },
+                Err(e) => Ok(err_v(Value::Str(format!("{e}")))),
+            }
+        }
 
         // -- toml (config parser; routes through serde_json::Value
         // so the parsed shape composes with the existing json
@@ -243,6 +257,24 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
                 Ok(mut v) => {
                     unwrap_toml_datetime_markers(&mut v);
                     Ok(ok_v(json_to_value(&v)))
+                }
+                Err(e) => Ok(err_v(Value::Str(format!("{e}")))),
+            }
+        }
+        // Tactical fix for #168: validate required fields before
+        // returning Ok. Caller passes the field names explicitly
+        // so the runtime doesn't need T's shape (which lex-bytecode
+        // doesn't carry today). Full type-driven fix tracked in #168.
+        ("toml", "parse_strict") => {
+            let s = expect_str(args.first())?;
+            let required = required_field_names(args.get(1))?;
+            match toml::from_str::<serde_json::Value>(&s) {
+                Ok(mut v) => {
+                    unwrap_toml_datetime_markers(&mut v);
+                    match check_required_fields(&v, &required) {
+                        Ok(()) => Ok(ok_v(json_to_value(&v))),
+                        Err(e) => Ok(err_v(Value::Str(e))),
+                    }
                 }
                 Err(e) => Ok(err_v(Value::Str(format!("{e}")))),
             }
@@ -270,6 +302,18 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             let s = expect_str(args.first())?;
             match serde_yaml::from_str::<serde_json::Value>(&s) {
                 Ok(v)  => Ok(ok_v(json_to_value(&v))),
+                Err(e) => Ok(err_v(Value::Str(format!("{e}")))),
+            }
+        }
+        // Tactical fix for #168 — same shape as toml.parse_strict.
+        ("yaml", "parse_strict") => {
+            let s = expect_str(args.first())?;
+            let required = required_field_names(args.get(1))?;
+            match serde_yaml::from_str::<serde_json::Value>(&s) {
+                Ok(v) => match check_required_fields(&v, &required) {
+                    Ok(()) => Ok(ok_v(json_to_value(&v))),
+                    Err(e) => Ok(err_v(Value::Str(e))),
+                },
                 Err(e) => Ok(err_v(Value::Str(format!("{e}")))),
             }
         }
@@ -1364,6 +1408,59 @@ fn unwrap_toml_datetime_markers(v: &mut serde_json::Value) {
 }
 
 fn json_to_value(v: &serde_json::Value) -> Value { Value::from_json(v) }
+
+/// Extract the `List[Str]` of required field names from the second
+/// argument of `*.parse_strict`. The list is allowed to be empty
+/// (the parse degenerates to plain `parse`); other shapes are a
+/// caller bug rather than a parse error.
+fn required_field_names(arg: Option<&Value>) -> Result<Vec<String>, String> {
+    let list = expect_list(arg)?;
+    let mut out = Vec::with_capacity(list.len());
+    for v in list {
+        match v {
+            Value::Str(s) => out.push(s.clone()),
+            other => return Err(format!(
+                "parse_strict: required-fields list must contain Str, got {other:?}"
+            )),
+        }
+    }
+    Ok(out)
+}
+
+/// Verify that `value`'s top level is an object containing every
+/// name in `required`. Returns a stable, human-readable error
+/// listing the missing field(s) so the agent's verifier can
+/// surface it directly.
+///
+/// Tactical fix for #168 — gives users a way to make
+/// `parse[T]` errors propagate as `Result::Err` instead of as
+/// runtime `GetField` errors at access time. The full
+/// type-driven fix (deriving `required` from `T` at type-check
+/// time so plain `parse[T]` works) tracked in #168.
+fn check_required_fields(
+    value: &serde_json::Value,
+    required: &[String],
+) -> Result<(), String> {
+    if required.is_empty() {
+        return Ok(());
+    }
+    let obj = match value {
+        serde_json::Value::Object(o) => o,
+        _ => return Err(format!(
+            "parse_strict: expected top-level object with fields {:?}, got {value}",
+            required
+        )),
+    };
+    let missing: Vec<&str> = required.iter()
+        .filter(|n| !obj.contains_key(n.as_str()))
+        .map(|s| s.as_str())
+        .collect();
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(format!("missing required field(s): {}", missing.join(", ")))
+    }
+}
 
 /// Parse a `.env`-style file into key→value pairs. Accepts:
 ///

--- a/crates/lex-runtime/tests/std_parse_strict.rs
+++ b/crates/lex-runtime/tests/std_parse_strict.rs
@@ -1,0 +1,191 @@
+//! `*.parse_strict` — required-field validation at parse time
+//! (tactical fix for #168). The full type-driven fix — deriving
+//! the required-field list from the target `T` at type-check
+//! time, so plain `parse[T]` validates without the user passing
+//! field names — is still tracked in #168 itself.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::sync::Arc;
+
+fn run(src: &str, fn_name: &str, args: Vec<Value>) -> Value {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors:\n{errs:#?}");
+    }
+    let bc = Arc::new(compile_program(&stages));
+    let handler = DefaultHandler::new(Policy::pure()).with_program(Arc::clone(&bc));
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(fn_name, args).unwrap_or_else(|e| panic!("call {fn_name}: {e}"))
+}
+
+fn ok(v: &Value) -> &Value {
+    match v {
+        Value::Variant { name, args } if name == "Ok" => &args[0],
+        other => panic!("expected Ok, got {other:?}"),
+    }
+}
+
+fn err_msg(v: &Value) -> &str {
+    match v {
+        Value::Variant { name, args } if name == "Err" => match &args[0] {
+            Value::Str(s) => s.as_str(),
+            other => panic!("expected Err(Str), got {other:?}"),
+        },
+        other => panic!("expected Err, got {other:?}"),
+    }
+}
+
+// ---- toml ---------------------------------------------------------
+
+const TOML_SRC: &str = r#"
+import "std.toml" as toml
+
+type Manifest = { license :: Str, version :: Str }
+
+# Plain parse — pre-#168 behavior, returns Ok with whatever's there.
+fn plain(s :: Str) -> Result[Manifest, Str] { toml.parse(s) }
+
+# Strict parse — caller declares the fields T requires; runtime
+# checks the parsed table for them.
+fn strict(s :: Str, required :: List[Str]) -> Result[Manifest, Str] {
+  toml.parse_strict(s, required)
+}
+"#;
+
+#[test]
+fn toml_parse_strict_passes_when_all_fields_present() {
+    let src = "license = \"EUPL-1.2\"\nversion = \"0.1.0\"\n";
+    let v = run(TOML_SRC, "strict", vec![
+        Value::Str(src.into()),
+        Value::List(vec![Value::Str("license".into()), Value::Str("version".into())]),
+    ]);
+    let m = ok(&v);
+    // Should be a Record with both fields.
+    match m {
+        Value::Record(fields) => {
+            assert!(fields.contains_key("license"));
+            assert!(fields.contains_key("version"));
+        }
+        other => panic!("expected Record, got {other:?}"),
+    }
+}
+
+#[test]
+fn toml_parse_strict_fails_when_required_field_missing() {
+    // Reproduces the rubric scenario: TOML has `version` but no
+    // `license`. Plain `parse` returns Ok(incomplete record);
+    // `parse_strict` returns Err naming the missing field.
+    let src = "version = \"0.1.0\"\n";
+    let v = run(TOML_SRC, "strict", vec![
+        Value::Str(src.into()),
+        Value::List(vec![Value::Str("license".into()), Value::Str("version".into())]),
+    ]);
+    let detail = err_msg(&v);
+    assert!(detail.contains("missing required field"), "got: {detail}");
+    assert!(detail.contains("license"), "should name the missing field: {detail}");
+}
+
+#[test]
+fn toml_parse_with_empty_required_degenerates_to_plain_parse() {
+    let src = "version = \"0.1.0\"\n";
+    let v = run(TOML_SRC, "strict", vec![
+        Value::Str(src.into()),
+        Value::List(vec![]),
+    ]);
+    // Empty required-list ⇒ no validation ⇒ behaves like plain parse.
+    let _ = ok(&v);
+}
+
+#[test]
+fn toml_plain_parse_still_returns_ok_on_incomplete_record() {
+    // Documents the original #168 behavior: plain `parse` doesn't
+    // validate. This test pins the existing semantics so the
+    // tactical fix doesn't change them silently — when the full
+    // type-driven fix lands in #168 it will modify this test.
+    let src = "version = \"0.1.0\"\n";
+    let v = run(TOML_SRC, "plain", vec![Value::Str(src.into())]);
+    // Plain parse returns Ok even though `license` is missing.
+    let _ = ok(&v);
+}
+
+// ---- yaml ---------------------------------------------------------
+
+const YAML_SRC: &str = r#"
+import "std.yaml" as yaml
+
+type Cargo = { name :: Str, version :: Str }
+
+fn strict(s :: Str, required :: List[Str]) -> Result[Cargo, Str] {
+  yaml.parse_strict(s, required)
+}
+"#;
+
+#[test]
+fn yaml_parse_strict_fails_on_missing_field() {
+    let src = "name: lex\n";
+    let v = run(YAML_SRC, "strict", vec![
+        Value::Str(src.into()),
+        Value::List(vec![Value::Str("name".into()), Value::Str("version".into())]),
+    ]);
+    let detail = err_msg(&v);
+    assert!(detail.contains("version"), "should name missing field: {detail}");
+}
+
+#[test]
+fn yaml_parse_strict_passes_when_all_present() {
+    let src = "name: lex\nversion: 0.1.0\n";
+    let v = run(YAML_SRC, "strict", vec![
+        Value::Str(src.into()),
+        Value::List(vec![Value::Str("name".into()), Value::Str("version".into())]),
+    ]);
+    let _ = ok(&v);
+}
+
+// ---- json ---------------------------------------------------------
+
+const JSON_SRC: &str = r#"
+import "std.json" as json
+
+type Repo = { url :: Str, branch :: Str }
+
+fn strict(s :: Str, required :: List[Str]) -> Result[Repo, Str] {
+  json.parse_strict(s, required)
+}
+"#;
+
+#[test]
+fn json_parse_strict_fails_on_missing_field() {
+    let src = r#"{"url": "https://example.com"}"#;
+    let v = run(JSON_SRC, "strict", vec![
+        Value::Str(src.into()),
+        Value::List(vec![Value::Str("url".into()), Value::Str("branch".into())]),
+    ]);
+    let detail = err_msg(&v);
+    assert!(detail.contains("branch"), "should name missing field: {detail}");
+}
+
+#[test]
+fn json_parse_strict_passes_when_all_present() {
+    let src = r#"{"url": "https://example.com", "branch": "main"}"#;
+    let v = run(JSON_SRC, "strict", vec![
+        Value::Str(src.into()),
+        Value::List(vec![Value::Str("url".into()), Value::Str("branch".into())]),
+    ]);
+    let _ = ok(&v);
+}
+
+#[test]
+fn json_parse_strict_fails_when_top_level_is_not_an_object() {
+    // A bare JSON array can't have named fields. parse_strict
+    // surfaces this as Err rather than crashing.
+    let src = "[1, 2, 3]";
+    let v = run(JSON_SRC, "strict", vec![
+        Value::Str(src.into()),
+        Value::List(vec![Value::Str("url".into())]),
+    ]);
+    let _ = err_msg(&v);
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -362,6 +362,15 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 vec![Ty::str()], EffectSet::empty(),
                 Ty::Con("Result".into(), vec![Ty::Var(0), Ty::str()]),
             ));
+            // parse_strict :: (Str, List[Str]) -> Result[T, Str]
+            // Tactical fix for #168 — caller passes the field names
+            // T requires; runtime returns Err if any are missing
+            // from the parsed object instead of letting field
+            // access panic later.
+            fields.insert("parse_strict".into(), Ty::function(
+                vec![Ty::str(), Ty::List(Box::new(Ty::str()))], EffectSet::empty(),
+                Ty::Con("Result".into(), vec![Ty::Var(0), Ty::str()]),
+            ));
             Some(Ty::Record(fields))
         }
         "result" => {
@@ -1148,6 +1157,12 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 vec![Ty::str()], EffectSet::empty(),
                 Ty::Con("Result".into(), vec![Ty::Var(0), Ty::str()]),
             ));
+            // Tactical fix for #168 — caller-supplied required-field
+            // list. See std.json's parse_strict for context.
+            fields.insert("parse_strict".into(), Ty::function(
+                vec![Ty::str(), Ty::List(Box::new(Ty::str()))], EffectSet::empty(),
+                Ty::Con("Result".into(), vec![Ty::Var(0), Ty::str()]),
+            ));
             fields.insert("stringify".into(), Ty::function(
                 vec![Ty::Var(0)], EffectSet::empty(),
                 Ty::Con("Result".into(), vec![Ty::str(), Ty::str()]),
@@ -1234,6 +1249,17 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
             // parse :: Str -> Result[T, Str]
             fields.insert("parse".into(), Ty::function(
                 vec![Ty::str()], EffectSet::empty(),
+                Ty::Con("Result".into(), vec![Ty::Var(0), Ty::str()]),
+            ));
+            // parse_strict :: (Str, List[Str]) -> Result[T, Str]
+            // Tactical fix for #168 — caller passes the field
+            // names T requires; runtime returns Err if any are
+            // missing from the parsed table instead of letting
+            // field access panic later. The full type-driven fix
+            // (deriving `required` from T at type-check time so
+            // plain `parse[T]` validates) is tracked in #168.
+            fields.insert("parse_strict".into(), Ty::function(
+                vec![Ty::str(), Ty::List(Box::new(Ty::str()))], EffectSet::empty(),
                 Ty::Con("Result".into(), vec![Ty::Var(0), Ty::str()]),
             ));
             // stringify :: T -> Result[Str, Str]


### PR DESCRIPTION
## Summary

Tactical fix for #168 (rubric team's manifest-license bug). Adds:

```
toml.parse_strict[T](s :: Str, required :: List[Str]) -> Result[T, Str]
yaml.parse_strict[T](s :: Str, required :: List[Str]) -> Result[T, Str]
json.parse_strict[T](s :: Str, required :: List[Str]) -> Result[T, Str]
```

Caller passes the field names `T` requires; the runtime checks the parsed object before returning `Ok`. Missing fields surface as `Err("missing required field(s): ...")` so `match parse_strict(...) { Err(e) => ... }` actually catches the case the user already expected. Plain `parse[T]` keeps its original semantics so existing callers don't break — they get an explicit upgrade path via the `_strict` variant.

## Why this is **half** the fix (and #168 stays open)

The full fix is "derive `required` from `T` at type-check time so plain `parse[T]` validates without the explicit list." That requires threading T's shape through type-check → bytecode → runtime — significant scope, and the runtime today erases types.

This PR ships the immediate workaround that unblocks rubric (their `[project].license` / `[package].license` cross-check pilot) without touching the type-checker pipeline. #168 stays open tracking the architectural fix; the same gap on `Option[F]` auto-wrap (absent fields not auto-`None`-wrapped) is the other half of that work.

## Test plan

- [x] `cargo test -p lex-runtime --test std_parse_strict` — 9 tests:
  - **toml**: passes when all required fields present; fails (with field name in detail) when missing; empty `required` list degenerates to plain parse; plain `parse` still returns `Ok` on incomplete records (pinning the pre-fix behavior so a future change is intentional).
  - **yaml**: pass + missing-field tests.
  - **json**: pass + missing-field + bare-array (top-level not an object) tests.
- [x] `cargo test --workspace` — green (one parallelism flake on tiny_http port binding, retries clean).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.

## Followups already filed

- #168 — full type-driven fix (this PR's parent issue stays open).
- #169 — closures-as-values in record fields (separate enhancement from rubric).
- #171, #172, #173 — MCP server, lex-tea v3 overrides, tier-3 distributed sync (independent tracks).

https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5

---
_Generated by [Claude Code](https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5)_