### PR TITLE
feat: MCP server — `lex serve --mcp` exposes /v1/* as MCP tools (#171)

### DIFF
--- a/crates/lex-api/src/handlers.rs
+++ b/crates/lex-api/src/handlers.rs
@@ -165,7 +165,7 @@ fn parse_handler(body: &str) -> Response<std::io::Cursor<Vec<u8>>> {
     }
 }
 
-fn check_handler(body: &str) -> Response<std::io::Cursor<Vec<u8>>> {
+pub(crate) fn check_handler(body: &str) -> Response<std::io::Cursor<Vec<u8>>> {
     let req: ParseReq = match serde_json::from_str(body) {
         Ok(r) => r, Err(e) => return error_response(400, format!("bad request: {e}")),
     };
@@ -182,7 +182,7 @@ fn check_handler(body: &str) -> Response<std::io::Cursor<Vec<u8>>> {
 #[derive(Deserialize)]
 struct PublishReq { source: String, #[serde(default)] activate: bool }
 
-fn publish_handler(state: &State, body: &str) -> Response<std::io::Cursor<Vec<u8>>> {
+pub(crate) fn publish_handler(state: &State, body: &str) -> Response<std::io::Cursor<Vec<u8>>> {
     let req: PublishReq = match serde_json::from_str(body) {
         Ok(r) => r, Err(e) => return error_response(400, format!("bad request: {e}")),
     };
@@ -354,7 +354,7 @@ fn patch_handler(state: &State, body: &str) -> Response<std::io::Cursor<Vec<u8>>
     }))
 }
 
-fn stage_handler(state: &State, id: &str) -> Response<std::io::Cursor<Vec<u8>>> {
+pub(crate) fn stage_handler(state: &State, id: &str) -> Response<std::io::Cursor<Vec<u8>>> {
     let store = state.store.lock().unwrap();
     let meta = match store.get_metadata(id) {
         Ok(m) => m, Err(e) => return error_response(404, format!("{e}")),
@@ -378,7 +378,7 @@ fn stage_handler(state: &State, id: &str) -> Response<std::io::Cursor<Vec<u8>>> 
 /// caller round-tripping both endpoints sees consistent errors).
 /// Empty list (200) is *evidence of absence*: the stage exists but
 /// no producer has attested it.
-fn stage_attestations_handler(state: &State, id: &str) -> Response<std::io::Cursor<Vec<u8>>> {
+pub(crate) fn stage_attestations_handler(state: &State, id: &str) -> Response<std::io::Cursor<Vec<u8>>> {
     let store = state.store.lock().unwrap();
     if let Err(e) = store.get_metadata(id) {
         return error_response(404, format!("{e}"));
@@ -425,7 +425,7 @@ struct RunReq {
     #[serde(default)] overrides: IndexMap<String, serde_json::Value>,
 }
 
-fn run_handler(state: &State, body: &str, with_overrides: bool) -> Response<std::io::Cursor<Vec<u8>>> {
+pub(crate) fn run_handler(state: &State, body: &str, with_overrides: bool) -> Response<std::io::Cursor<Vec<u8>>> {
     let req: RunReq = match serde_json::from_str(body) {
         Ok(r) => r, Err(e) => return error_response(400, format!("bad request: {e}")),
     };

--- a/crates/lex-api/src/lib.rs
+++ b/crates/lex-api/src/lib.rs
@@ -31,6 +31,7 @@
 
 pub mod handlers;
 mod web;
+pub mod mcp;
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -40,6 +41,16 @@ pub fn serve(port: u16, store_root: PathBuf) -> anyhow::Result<()> {
         .map_err(|e| anyhow::anyhow!("bind failed: {e}"))?;
     let state = Arc::new(handlers::State::open(store_root)?);
     serve_on(server, state);
+    Ok(())
+}
+
+/// MCP server (#171). Same `State` shape as the HTTP server,
+/// stdio transport instead of TCP. Designed for hosts that
+/// spawn `lex serve --mcp` as a subprocess and pipe JSON-RPC
+/// over stdin/stdout.
+pub fn serve_mcp_stdio(store_root: PathBuf) -> anyhow::Result<()> {
+    let state = Arc::new(handlers::State::open(store_root)?);
+    mcp::serve_mcp(state)?;
     Ok(())
 }
 

--- a/crates/lex-api/src/mcp.rs
+++ b/crates/lex-api/src/mcp.rs
@@ -1,0 +1,266 @@
+//! Model Context Protocol server (#171).
+//!
+//! Wraps the JSON API at `/v1/*` as MCP tools so any MCP-speaking
+//! host (Claude Code, Cursor, Codex, etc.) can invoke Lex actions
+//! natively. Stdio transport, JSON-RPC 2.0, hand-rolled — no SDK
+//! dependency, ~250 lines.
+//!
+//! Run with `lex serve --mcp` (sticks to the same `State` shape
+//! as the HTTP server, just speaks a different protocol on
+//! stdin/stdout instead of HTTP).
+//!
+//! Tools shipped in v1:
+//!
+//! * `lex_check` — POST /v1/check
+//! * `lex_publish` — POST /v1/publish
+//! * `lex_run` — POST /v1/run (effect policy passes through)
+//! * `lex_stage_get` — GET /v1/stage/<id>
+//! * `lex_stage_attestations` — GET /v1/stage/<id>/attestations
+//!
+//! Merge endpoints + trace/diff/replay land in v2; the v1 set
+//! covers the common agent loop (check → publish → run → read
+//! attestations).
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::io::{BufRead, BufReader, Write};
+use std::sync::Arc;
+
+use crate::handlers::State;
+
+/// JSON-RPC 2.0 envelope. We deserialize into `Value` first so a
+/// missing `id` (notification) doesn't error out — notifications
+/// are valid in MCP and shouldn't crash the loop.
+#[derive(Debug, Deserialize)]
+struct RpcRequest {
+    #[serde(default)]
+    id: Option<Value>,
+    method: String,
+    #[serde(default)]
+    params: Value,
+}
+
+#[derive(Debug, Serialize)]
+struct RpcResponse {
+    jsonrpc: &'static str,
+    id: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<RpcError>,
+}
+
+#[derive(Debug, Serialize)]
+struct RpcError {
+    code: i32,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<Value>,
+}
+
+/// Run the MCP server. Reads JSON-RPC requests from stdin (one
+/// per line), writes responses to stdout. Stops cleanly on EOF.
+///
+/// `eprintln!` is fine for diagnostics — MCP hosts read stdout
+/// for the protocol and surface stderr in their UI separately.
+pub fn serve_mcp(state: Arc<State>) -> std::io::Result<()> {
+    eprintln!("lex MCP server ready (stdio); v1 tools: lex_check, lex_publish, lex_run, lex_stage_get, lex_stage_attestations");
+    let stdin = std::io::stdin();
+    let reader = BufReader::new(stdin.lock());
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+
+    for line in reader.lines() {
+        let line = line?;
+        if line.trim().is_empty() { continue; }
+        match serde_json::from_str::<RpcRequest>(&line) {
+            Ok(req) => {
+                if let Some(resp) = dispatch(&state, req) {
+                    let body = serde_json::to_string(&resp).unwrap_or_else(|_| "{}".into());
+                    writeln!(out, "{body}")?;
+                    out.flush()?;
+                }
+                // None = notification (no `id`); MCP says don't reply.
+            }
+            Err(e) => {
+                // Parse error per JSON-RPC spec: id is null.
+                let resp = RpcResponse {
+                    jsonrpc: "2.0",
+                    id: Value::Null,
+                    result: None,
+                    error: Some(RpcError {
+                        code: -32700,
+                        message: format!("parse error: {e}"),
+                        data: None,
+                    }),
+                };
+                writeln!(out, "{}", serde_json::to_string(&resp).unwrap())?;
+                out.flush()?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Returns `Some(response)` for requests that need a reply, `None`
+/// for notifications. The dispatch is small enough to be flat.
+fn dispatch(state: &State, req: RpcRequest) -> Option<RpcResponse> {
+    let id = req.id?;          // notification → drop
+    let method = req.method.as_str();
+    let result = match method {
+        "initialize" => Ok(json!({
+            "protocolVersion": "2024-11-05",
+            "capabilities": { "tools": { "listChanged": false } },
+            "serverInfo": {
+                "name": "lex",
+                "version": env!("CARGO_PKG_VERSION"),
+            }
+        })),
+        "tools/list" => Ok(json!({ "tools": tool_definitions() })),
+        "tools/call" => call_tool(state, &req.params),
+        // Hosts ping; respond with empty object.
+        "ping" => Ok(json!({})),
+        other => Err(RpcError {
+            code: -32601,
+            message: format!("method not found: {other}"),
+            data: None,
+        }),
+    };
+    Some(match result {
+        Ok(v) => RpcResponse { jsonrpc: "2.0", id, result: Some(v), error: None },
+        Err(e) => RpcResponse { jsonrpc: "2.0", id, result: None, error: Some(e) },
+    })
+}
+
+/// MCP `tools/list` response. Each entry is `{name, description,
+/// inputSchema}`. Schemas mirror the JSON request bodies the
+/// HTTP handlers already accept.
+fn tool_definitions() -> Value {
+    json!([
+        {
+            "name": "lex_check",
+            "description": "Type-check a Lex source string. Returns ok or a list of TypeErrors with structured detail.",
+            "inputSchema": {
+                "type": "object",
+                "properties": { "source": { "type": "string" } },
+                "required": ["source"]
+            }
+        },
+        {
+            "name": "lex_publish",
+            "description": "Publish a Lex source to the store. Type-check gate runs first; rejected sources don't advance the branch head. Returns the typed ops produced.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "source": { "type": "string" },
+                    "activate": { "type": "boolean", "default": false }
+                },
+                "required": ["source"]
+            }
+        },
+        {
+            "name": "lex_run",
+            "description": "Execute a Lex function under an effect policy. Pure programs run with no policy; effectful ones need allow_effects / allow_fs_read / allow_fs_write / allow_net_host grants.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "source": { "type": "string" },
+                    "fn": { "type": "string" },
+                    "args": { "type": "array", "items": {} },
+                    "policy": {
+                        "type": "object",
+                        "properties": {
+                            "allow_effects": { "type": "array", "items": { "type": "string" } },
+                            "allow_fs_read": { "type": "array", "items": { "type": "string" } },
+                            "allow_fs_write": { "type": "array", "items": { "type": "string" } },
+                            "budget": { "type": "integer" }
+                        }
+                    }
+                },
+                "required": ["source", "fn"]
+            }
+        },
+        {
+            "name": "lex_stage_get",
+            "description": "Fetch a stage's metadata + canonical AST + status by stage_id (lowercase-hex SHA-256).",
+            "inputSchema": {
+                "type": "object",
+                "properties": { "stage_id": { "type": "string" } },
+                "required": ["stage_id"]
+            }
+        },
+        {
+            "name": "lex_stage_attestations",
+            "description": "List every attestation persisted against a stage (TypeCheck / Spec / Examples / DiffBody / EffectAudit / SandboxRun). Newest-first.",
+            "inputSchema": {
+                "type": "object",
+                "properties": { "stage_id": { "type": "string" } },
+                "required": ["stage_id"]
+            }
+        }
+    ])
+}
+
+/// Dispatch a `tools/call` request. The MCP shape is `{name,
+/// arguments}`; we route on `name` and forward `arguments` as
+/// the JSON body the corresponding HTTP handler already accepts
+/// — keeps the two surfaces in lockstep without duplicating
+/// business logic.
+fn call_tool(state: &State, params: &Value) -> Result<Value, RpcError> {
+    let name = params.get("name").and_then(|v| v.as_str()).ok_or_else(|| RpcError {
+        code: -32602, message: "tools/call: missing `name`".into(), data: None,
+    })?;
+    let args = params.get("arguments").cloned().unwrap_or_else(|| json!({}));
+
+    // The HTTP handlers all take `&str` body and return a typed
+    // `Response<Cursor<Vec<u8>>>`. We extract the body bytes +
+    // status, then wrap into MCP's `content` shape: success →
+    // text content with the JSON body; error → isError + same
+    // content. Lets the host see the structured error envelope
+    // the JSON API already produces.
+    let body = serde_json::to_string(&args).unwrap_or_else(|_| "{}".into());
+    let (status, response_body): (u16, String) = match name {
+        "lex_check" => http_to_string(crate::handlers::check_handler(&body)),
+        "lex_publish" => http_to_string(crate::handlers::publish_handler(state, &body)),
+        "lex_run" => http_to_string(crate::handlers::run_handler(state, &body, false)),
+        "lex_stage_get" => {
+            let id = args.get("stage_id").and_then(|v| v.as_str()).ok_or_else(|| RpcError {
+                code: -32602, message: "lex_stage_get: missing stage_id".into(), data: None,
+            })?;
+            http_to_string(crate::handlers::stage_handler(state, id))
+        }
+        "lex_stage_attestations" => {
+            let id = args.get("stage_id").and_then(|v| v.as_str()).ok_or_else(|| RpcError {
+                code: -32602, message: "lex_stage_attestations: missing stage_id".into(), data: None,
+            })?;
+            http_to_string(crate::handlers::stage_attestations_handler(state, id))
+        }
+        other => return Err(RpcError {
+            code: -32602, message: format!("unknown tool: {other}"), data: None,
+        }),
+    };
+
+    let is_error = !(200..300).contains(&status);
+    Ok(json!({
+        "content": [{ "type": "text", "text": response_body }],
+        "isError": is_error,
+    }))
+}
+
+/// Drain an HTTP `Response` (the type all handlers return) into
+/// `(status, body_string)` so the MCP wrapper can repackage it.
+fn http_to_string(
+    resp: tiny_http::Response<std::io::Cursor<Vec<u8>>>,
+) -> (u16, String) {
+    // tiny_http's Response doesn't expose body bytes after construction
+    // without consuming the reader; we use our caller-side knowledge
+    // that handlers built the body from a Vec<u8>. The status code
+    // is on `status_code()`. For the body we re-render via the
+    // public iterator the response exposes.
+    let status = resp.status_code().0;
+    let mut buf = Vec::new();
+    let mut reader = resp.into_reader();
+    let _ = std::io::copy(&mut reader, &mut buf);
+    let body = String::from_utf8(buf).unwrap_or_default();
+    (status, body)
+}

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -1355,6 +1355,7 @@ fn cmd_replay(fmt: &OutputFormat, args: &[String]) -> Result<()> {
 fn cmd_serve(args: &[String]) -> Result<()> {
     let mut port: u16 = 4040;
     let mut store_root = default_store_root();
+    let mut mcp = false;
     let mut i = 0;
     while i < args.len() {
         match args[i].as_str() {
@@ -1368,8 +1369,16 @@ fn cmd_serve(args: &[String]) -> Result<()> {
                 store_root = std::path::PathBuf::from(v);
                 i += 2;
             }
+            "--mcp" => { mcp = true; i += 1; }
             _ => i += 1,
         }
+    }
+    if mcp {
+        // MCP transport is stdio; --port is irrelevant. The host
+        // (Claude Code, Cursor, etc.) spawns this subprocess and
+        // pipes JSON-RPC over stdin/stdout.
+        eprintln!("lex MCP server (stdio) — store: {}", store_root.display());
+        return lex_api::serve_mcp_stdio(store_root);
     }
     eprintln!("lex agent API listening on http://127.0.0.1:{port}");
     eprintln!("store: {}", store_root.display());

--- a/crates/lex-cli/tests/mcp_server.rs
+++ b/crates/lex-cli/tests/mcp_server.rs
@@ -1,0 +1,176 @@
+//! End-to-end tests for `lex serve --mcp` (#171).
+//!
+//! Spawn the binary with `--mcp`, write JSON-RPC requests to its
+//! stdin one line at a time, read responses from stdout, assert
+//! shape. Same approach a real MCP host (Claude Code, Cursor)
+//! uses, just without the host part.
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, Command, Stdio};
+use tempfile::tempdir;
+
+fn lex_bin() -> &'static str { env!("CARGO_BIN_EXE_lex") }
+
+/// Spawn the MCP server pointed at an ephemeral store. Returns
+/// the child + a stdin handle + a stdout reader. The child stays
+/// alive until dropped (Drop kills the process).
+struct McpProcess {
+    child: Child,
+    _tmp: tempfile::TempDir,
+}
+
+impl McpProcess {
+    fn start() -> Self {
+        let tmp = tempdir().unwrap();
+        let child = Command::new(lex_bin())
+            .args(["serve", "--mcp", "--store", tmp.path().to_str().unwrap()])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn lex serve --mcp");
+        Self { child, _tmp: tmp }
+    }
+
+    /// Send one JSON-RPC request, return the parsed response.
+    fn round_trip(&mut self, req: serde_json::Value) -> serde_json::Value {
+        let line = req.to_string();
+        let stdin = self.child.stdin.as_mut().expect("stdin");
+        writeln!(stdin, "{line}").expect("write stdin");
+        stdin.flush().expect("flush");
+
+        let stdout = self.child.stdout.as_mut().expect("stdout");
+        let mut reader = BufReader::new(stdout);
+        let mut buf = String::new();
+        reader.read_line(&mut buf).expect("read line");
+        serde_json::from_str(&buf).unwrap_or_else(|e| {
+            panic!("parse mcp response {buf:?}: {e}");
+        })
+    }
+}
+
+impl Drop for McpProcess {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[test]
+fn mcp_initialize_returns_server_info() {
+    let mut p = McpProcess::start();
+    let resp = p.round_trip(serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+        "params": { "protocolVersion": "2024-11-05" }
+    }));
+    assert_eq!(resp["jsonrpc"], "2.0");
+    assert_eq!(resp["id"], 1);
+    let result = &resp["result"];
+    assert_eq!(result["serverInfo"]["name"], "lex");
+    assert!(result["protocolVersion"].is_string());
+}
+
+#[test]
+fn mcp_tools_list_advertises_v1_tools() {
+    let mut p = McpProcess::start();
+    let resp = p.round_trip(serde_json::json!({
+        "jsonrpc": "2.0", "id": 2, "method": "tools/list"
+    }));
+    let tools = resp["result"]["tools"].as_array().expect("tools array");
+    let names: Vec<&str> = tools.iter()
+        .map(|t| t["name"].as_str().unwrap_or(""))
+        .collect();
+    for expected in &["lex_check", "lex_publish", "lex_run", "lex_stage_get", "lex_stage_attestations"] {
+        assert!(names.contains(expected), "missing tool {expected}; got {names:?}");
+    }
+    // Each tool must have an inputSchema; otherwise the host
+    // can't render argument forms.
+    for t in tools {
+        assert!(t["inputSchema"].is_object(), "tool missing inputSchema: {t}");
+    }
+}
+
+#[test]
+fn mcp_call_check_round_trips() {
+    let mut p = McpProcess::start();
+    let resp = p.round_trip(serde_json::json!({
+        "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+        "params": {
+            "name": "lex_check",
+            "arguments": { "source": "fn add(x :: Int, y :: Int) -> Int { x + y }" }
+        }
+    }));
+    assert_eq!(resp["result"]["isError"], false);
+    let text = resp["result"]["content"][0]["text"].as_str().expect("text content");
+    assert!(text.contains("\"ok\":true"), "expected ok envelope, got {text:?}");
+}
+
+#[test]
+fn mcp_call_check_surfaces_type_errors_as_is_error() {
+    let mut p = McpProcess::start();
+    let resp = p.round_trip(serde_json::json!({
+        "jsonrpc": "2.0", "id": 4, "method": "tools/call",
+        "params": {
+            "name": "lex_check",
+            "arguments": { "source": "fn bad(x :: Int) -> Str { x }" }
+        }
+    }));
+    // 422 → isError true; the structured TypeError JSON sits in
+    // the text content for the agent to parse.
+    assert_eq!(resp["result"]["isError"], true);
+    let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+    assert!(text.contains("type_mismatch"), "expected TypeMismatch in body: {text}");
+}
+
+#[test]
+fn mcp_publish_then_read_attestations() {
+    // The agent loop in miniature: publish, then ask for the
+    // stage's attestations. Should see the auto-emitted TypeCheck.
+    let mut p = McpProcess::start();
+    let resp = p.round_trip(serde_json::json!({
+        "jsonrpc": "2.0", "id": 5, "method": "tools/call",
+        "params": {
+            "name": "lex_publish",
+            "arguments": {
+                "source": "fn fac(n :: Int) -> Int { 1 }\n",
+                "activate": true
+            }
+        }
+    }));
+    assert_eq!(resp["result"]["isError"], false);
+    let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+    let pub_body: serde_json::Value = serde_json::from_str(text).unwrap();
+    let stage_id = pub_body["ops"][0]["kind"]["stage_id"].as_str().expect("stage_id");
+
+    let resp = p.round_trip(serde_json::json!({
+        "jsonrpc": "2.0", "id": 6, "method": "tools/call",
+        "params": {
+            "name": "lex_stage_attestations",
+            "arguments": { "stage_id": stage_id }
+        }
+    }));
+    assert_eq!(resp["result"]["isError"], false);
+    let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+    assert!(text.contains("type_check"), "expected TypeCheck attestation: {text}");
+    assert!(text.contains("passed"), "expected passed result: {text}");
+}
+
+#[test]
+fn mcp_unknown_tool_returns_error() {
+    let mut p = McpProcess::start();
+    let resp = p.round_trip(serde_json::json!({
+        "jsonrpc": "2.0", "id": 7, "method": "tools/call",
+        "params": { "name": "lex_nonexistent", "arguments": {} }
+    }));
+    assert!(resp["error"].is_object(), "expected JSON-RPC error: {resp}");
+    assert_eq!(resp["error"]["code"], -32602);
+}
+
+#[test]
+fn mcp_unknown_method_returns_error() {
+    let mut p = McpProcess::start();
+    let resp = p.round_trip(serde_json::json!({
+        "jsonrpc": "2.0", "id": 8, "method": "nonexistent/method"
+    }));
+    assert_eq!(resp["error"]["code"], -32601);
+}


### PR DESCRIPTION
## Summary

Closes #171 (v1 of MCP server). `lex serve --mcp` exposes the JSON API as Model Context Protocol tools so any MCP-speaking host (Claude Code, Cursor, Codex, …) can invoke Lex actions natively — no CLI to learn, no HTTP to wire.

Stdio transport, JSON-RPC 2.0, hand-rolled — ~250 lines, no SDK dependency. The handler functions in `lex-api` already do the work; the MCP wrapper is a thin layer over them.

## v1 tools

| MCP tool | Wraps |
|---|---|
| `lex_check` | `POST /v1/check` |
| `lex_publish` | `POST /v1/publish` |
| `lex_run` | `POST /v1/run` (effect policy passes through) |
| `lex_stage_get` | `GET /v1/stage/<id>` |
| `lex_stage_attestations` | `GET /v1/stage/<id>/attestations` |

Each tool's `inputSchema` mirrors the existing HTTP request body. JSON sent over MCP is the same JSON sent over HTTP — zero business-logic duplication. Handlers go from `fn` → `pub(crate) fn` so the new `mcp` module can call them.

The MCP `isError` flag tracks the underlying HTTP status: non-2xx → `isError: true`, body still in `content[0].text` so the host can parse the structured envelope (TypeError detail, etc.).

## Use it

```sh
# Add to Claude Code:
claude mcp add lex --command "lex serve --mcp --store ~/.lex/store"

# Or pipe directly:
echo '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
  | lex serve --mcp --store /tmp/lex
```

## Test plan

- [x] `cargo test -p lex-cli --test mcp_server` — 7 tests:
  - `initialize` returns serverInfo + protocolVersion.
  - `tools/list` advertises all 5 v1 tools with schemas.
  - `lex_check` round-trip on a clean program.
  - `lex_check` on a type-broken program → `isError: true` with `type_mismatch` in the body.
  - `lex_publish` then `lex_stage_attestations` → finds the auto-emitted TypeCheck attestation (the agent loop in miniature).
  - Unknown tool → JSON-RPC -32602 error.
  - Unknown method → JSON-RPC -32601 error.
- [x] Live smoke: `echo ... | lex serve --mcp` returns the expected JSON-RPC response.
- [x] `cargo test --workspace` — green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.

## v2 follow-ups (intentionally out of scope here)

- Merge endpoints (`/v1/merge/*`) as MCP tools.
- `trace`, `replay`, `diff`.
- HTTP/SSE transport for hosted scenarios (v1 is local-only stdio).
- Schema derivation via `schemars` instead of hand-written (so future endpoint changes don't drift from the schemas).

Each is small. Filed as comments on #171 once this lands.

https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5

---
_Generated by [Claude Code](https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5)_