### PR TITLE
feat: lex stage pin — record human override attestation (lex-tea v3a, #172)

### DIFF
--- a/crates/lex-api/src/handlers.rs
+++ b/crates/lex-api/src/handlers.rs
@@ -113,6 +113,12 @@ fn route(
             let id = &p["/web/stage/".len()..];
             crate::web::stage_html_handler(state, id)
         }
+        // lex-tea v3a: human override pin (#172). HTML form
+        // posts to /web/stage/<id>/pin with `reason` body.
+        (Method::Post, p) if p.starts_with("/web/stage/") && p.ends_with("/pin") => {
+            let id = &p["/web/stage/".len()..p.len() - "/pin".len()];
+            crate::web::stage_pin_handler(state, id, body)
+        }
         // ---- JSON API -----------------------------------------
         (Method::Get, "/v1/health") => json_response(200, &serde_json::json!({"ok": true})),
         (Method::Post, "/v1/parse") => parse_handler(body),

--- a/crates/lex-api/src/web.rs
+++ b/crates/lex-api/src/web.rs
@@ -556,6 +556,37 @@ pub(crate) fn stage_html_handler(state: &State, id: &str) -> Response<Cursor<Vec
         }
     }
 
+    // Override form (lex-tea v3a, #172). Renders only when a
+    // user identifier is set via `LEX_TEA_USER`; without one the
+    // pin handler refuses the action anyway, so showing a button
+    // would be misleading. Single-user-mode for v3a; v3b adds
+    // sessions + `<store>/users.json`.
+    let actor = std::env::var("LEX_TEA_USER").ok();
+    let pin_form = match &actor {
+        Some(name) => format!(
+            r#"<h2>override</h2>
+<p class="muted">Pin this stage to Active and record an Override
+attestation under your name. Auditable: shows up under
+<code>kind=override</code> in <code>lex attest filter</code>.</p>
+<form method="post" action="/web/stage/{id}/pin">
+  <p><strong>actor:</strong> <span class="mono">{actor}</span></p>
+  <p><label for="reason">reason:</label><br>
+     <input type="text" id="reason" name="reason" required
+            placeholder="e.g. spec checker is wrong here, will revisit"
+            style="width: 100%; padding: .4rem; font-family: inherit;"></p>
+  <p><button type="submit"
+       style="padding: .4rem 1rem; background: #b00; color: #fff; border: 0;
+              border-radius: 3px; cursor: pointer;">pin to Active</button></p>
+</form>"#,
+            id = esc(id),
+            actor = esc(name),
+        ),
+        None => r#"<h2>override</h2>
+<p class="muted">Set <code>LEX_TEA_USER=&lt;name&gt;</code> in the
+server's environment to enable human override actions. The
+attestation log will record the override under that name.</p>"#.into(),
+    };
+
     let body = format!(
         r#"<nav class="crumb"><a href="/">activity</a> / <strong class="mono">{id_short}…</strong></nav>
 <h1>{name}</h1>
@@ -570,7 +601,8 @@ pub(crate) fn stage_html_handler(state: &State, id: &str) -> Response<Cursor<Vec
 <table>
   <thead><tr><th>kind</th><th>result</th><th>by</th><th>ts</th></tr></thead>
   <tbody>{att_rows}</tbody>
-</table>"#,
+</table>
+{pin_form}"#,
         id_short = esc(&format!("{id:.16}")),
         name = esc(&meta.name),
         sig = esc(&meta.sig_id),
@@ -580,6 +612,108 @@ pub(crate) fn stage_html_handler(state: &State, id: &str) -> Response<Cursor<Vec
         n = atts.len(),
     );
     html_response(200, page(&meta.name, "", &body))
+}
+
+/// `POST /web/stage/<id>/pin` — handles the override form
+/// submission. Reads `LEX_TEA_USER` from the server env (since
+/// v3a is single-user mode), records an `Override` attestation,
+/// activates the stage, redirects back to the stage page so the
+/// reviewer sees the new attestation row.
+pub(crate) fn stage_pin_handler(
+    state: &State,
+    id: &str,
+    body: &str,
+) -> Response<Cursor<Vec<u8>>> {
+    let actor = match std::env::var("LEX_TEA_USER") {
+        Ok(n) if !n.is_empty() => n,
+        _ => return html_response(403, page("forbidden", "",
+            r#"<nav class="crumb"><a href="/">activity</a></nav>
+<h1>forbidden</h1>
+<p>Set <code>LEX_TEA_USER</code> on the server to enable overrides.</p>"#)),
+    };
+    // Decode the form-urlencoded `reason=...` body. Single field
+    // for v3a; multi-field forms get a real parser later.
+    let reason = body.split('&')
+        .find_map(|pair| pair.strip_prefix("reason="))
+        .map(percent_decode)
+        .filter(|s| !s.trim().is_empty());
+    let Some(reason) = reason else {
+        return html_response(400, page("bad request", "",
+            r#"<nav class="crumb"><a href="/">activity</a></nav>
+<h1>bad request</h1>
+<p>The override form requires a <code>reason</code>.</p>"#));
+    };
+
+    let store = state.store.lock().unwrap();
+    if store.get_metadata(id).is_err() {
+        return html_response(404, page("not found", "",
+            &format!(r#"<nav class="crumb"><a href="/">activity</a></nav><pre>unknown stage `{}`</pre>"#,
+                esc(id))));
+    }
+    if let Err(e) = store.activate(id) {
+        return html_response(500, page("error", "",
+            &format!("<pre>activate: {}</pre>", esc(&e.to_string()))));
+    }
+    let log = match store.attestation_log() {
+        Ok(l) => l,
+        Err(e) => return html_response(500, page("error", "",
+            &format!("<pre>{}</pre>", esc(&e.to_string())))),
+    };
+    let attestation = lex_vcs::Attestation::new(
+        id.to_string(), None, None,
+        AttestationKind::Override {
+            actor,
+            reason,
+            target_attestation_id: None,
+        },
+        AttestationResult::Passed,
+        lex_vcs::ProducerDescriptor {
+            tool: "lex-tea pin".into(),
+            version: env!("CARGO_PKG_VERSION").into(),
+            model: None,
+        },
+        None,
+    );
+    if let Err(e) = log.put(&attestation) {
+        return html_response(500, page("error", "",
+            &format!("<pre>persist override: {}</pre>", esc(&e.to_string()))));
+    }
+    // 303 See Other → redirect the form POST to a GET on the
+    // stage page so a refresh doesn't repost the same override.
+    Response::from_data(Vec::new())
+        .with_status_code(303)
+        .with_header(
+            tiny_http::Header::from_bytes(&b"Location"[..],
+                format!("/web/stage/{}", id).as_bytes()).unwrap(),
+        )
+}
+
+/// Inline percent-decoder for x-www-form-urlencoded values. Just
+/// enough to handle `+` → space and `%XX` → byte. Doesn't support
+/// nested encoding or Unicode normalization; the override form
+/// has one field of free text and that's all this needs.
+fn percent_decode(s: &str) -> String {
+    let mut out = Vec::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'+' => { out.push(b' '); i += 1; }
+            b'%' if i + 2 < bytes.len() => {
+                let hi = (bytes[i + 1] as char).to_digit(16);
+                let lo = (bytes[i + 2] as char).to_digit(16);
+                if let (Some(h), Some(l)) = (hi, lo) {
+                    out.push((h * 16 + l) as u8);
+                    i += 3;
+                } else {
+                    out.push(bytes[i]);
+                    i += 1;
+                }
+            }
+            b => { out.push(b); i += 1; }
+        }
+    }
+    String::from_utf8(out).unwrap_or_default()
 }
 
 // ---- shared helpers -----------------------------------------------
@@ -594,9 +728,10 @@ fn kind_short(k: &AttestationKind) -> String {
         AttestationKind::Examples { count, .. } => format!("Examples({count})"),
         AttestationKind::DiffBody { input_count, .. } => format!("DiffBody({input_count})"),
         AttestationKind::SandboxRun { effects } => {
-            let names: Vec<&str> = effects.iter().map(|s| s.as_str()).collect();
+            let names: Vec<&str> = effects.iter().map(String::as_str).collect();
             format!("SandboxRun([{}])", names.join(","))
         }
+        AttestationKind::Override { actor, .. } => format!("Override({actor})"),
     }
 }
 

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -1050,6 +1050,12 @@ fn cmd_store(fmt: &OutputFormat, args: &[String]) -> Result<()> {
 /// `GET /v1/stage/<id>` and `GET /v1/stage/<id>/attestations`.
 fn cmd_stage(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let (root, rest, _, _) = parse_store_flag(args);
+    // `lex stage pin <id> ...` — human override (#172). Detect it
+    // as a leading positional so the existing `lex stage <id>` and
+    // `lex stage <id> --attestations` shapes keep working unchanged.
+    if rest.first().map(String::as_str) == Some("pin") {
+        return cmd_stage_pin(fmt, &root, &rest[1..]);
+    }
     let attestations_mode = rest.iter().any(|a| a == "--attestations");
     let id = rest
         .iter()
@@ -1092,6 +1098,9 @@ fn cmd_stage(fmt: &OutputFormat, args: &[String]) -> Result<()> {
                         let joined: Vec<&str> = effects.iter().map(String::as_str).collect();
                         format!("SandboxRun([{}])", joined.join(","))
                     }
+                    lex_vcs::AttestationKind::Override { actor, .. } => {
+                        format!("Override({actor})")
+                    }
                 };
                 let result = match &a.result {
                     lex_vcs::AttestationResult::Passed => "passed".to_string(),
@@ -1118,6 +1127,95 @@ fn cmd_stage(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     });
     acli::emit_or_text("stage", v.clone(), fmt, || {
         println!("{}", serde_json::to_string_pretty(&v).unwrap());
+    });
+    Ok(())
+}
+
+/// `lex stage pin <id> --reason "..." [--actor <name>]` —
+/// human override (#172, lex-tea v3a). Activates the stage and
+/// records an `Override` attestation alongside whatever
+/// existing attestations the stage already has. The pin
+/// itself is auditable: `lex attest filter --kind override`
+/// returns every override the human(s) have issued.
+///
+/// `actor` defaults to `$LEX_TEA_USER`; falling back errors so
+/// a pin can't land anonymously.
+fn cmd_stage_pin(
+    fmt: &OutputFormat,
+    root: &std::path::Path,
+    args: &[String],
+) -> Result<()> {
+    let mut id: Option<String> = None;
+    let mut reason: Option<String> = None;
+    let mut actor: Option<String> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--reason" => { reason = args.get(i + 1).cloned(); i += 2; }
+            "--actor"  => { actor  = args.get(i + 1).cloned(); i += 2; }
+            other if id.is_none() => { id = Some(other.to_string()); i += 1; }
+            other => bail!("unexpected arg `{other}`"),
+        }
+    }
+    let id = id.ok_or_else(|| anyhow!(
+        "usage: lex stage pin <stage_id> --reason \"...\" [--actor NAME]"
+    ))?;
+    let reason = reason.ok_or_else(|| anyhow!(
+        "lex stage pin: --reason required (overrides need a paper trail)"
+    ))?;
+    let actor = actor
+        .or_else(|| std::env::var("LEX_TEA_USER").ok())
+        .ok_or_else(|| anyhow!(
+            "lex stage pin: actor unknown — pass --actor NAME or set LEX_TEA_USER"
+        ))?;
+
+    let store = Store::open(root)
+        .with_context(|| format!("opening store at {}", root.display()))?;
+    // Verify the stage exists; refuse to pin something that's not
+    // even there so a typo can't accidentally activate the wrong
+    // sig later.
+    let _ = store.get_metadata(&id)
+        .with_context(|| format!("unknown stage `{id}`"))?;
+
+    // Activate first (the actual override action), then record the
+    // audit. Order matters: if activate fails, no audit is written;
+    // if audit fails after a successful activate, the user retries
+    // and the attestation_id is content-addressed so re-puts dedup.
+    store.activate(&id)
+        .with_context(|| format!("activate stage `{id}`"))?;
+
+    let producer = lex_vcs::ProducerDescriptor {
+        tool: "lex stage pin".into(),
+        version: env!("CARGO_PKG_VERSION").into(),
+        model: None,
+    };
+    let attestation = lex_vcs::Attestation::new(
+        id.clone(), None, None,
+        lex_vcs::AttestationKind::Override {
+            actor: actor.clone(),
+            reason: reason.clone(),
+            target_attestation_id: None,
+        },
+        // Override is a *fact* about the human's choice, not a
+        // pass/fail of code. Use Passed for "the override was
+        // recorded successfully" — Failed/Inconclusive don't
+        // apply to administrative actions.
+        lex_vcs::AttestationResult::Passed,
+        producer, None,
+    );
+    let log = store.attestation_log()?;
+    log.put(&attestation)?;
+
+    let data = serde_json::json!({
+        "pinned": &id,
+        "actor": &actor,
+        "reason": &reason,
+        "attestation_id": &attestation.attestation_id,
+    });
+    let id_for_text = id.clone();
+    let actor_for_text = actor.clone();
+    acli::emit_or_text("stage", data, fmt, move || {
+        println!("→ pinned `{id_for_text:.16}…` (actor: {actor_for_text})");
     });
     Ok(())
 }
@@ -1221,6 +1319,7 @@ fn attestation_kind_tag(k: &lex_vcs::AttestationKind) -> &'static str {
         TypeCheck         => "type_check",
         EffectAudit       => "effect_audit",
         SandboxRun { .. } => "sandbox_run",
+        Override { .. }   => "override",
     }
 }
 

--- a/crates/lex-cli/tests/stage_pin.rs
+++ b/crates/lex-cli/tests/stage_pin.rs
@@ -1,0 +1,149 @@
+//! `lex stage pin` — human override action (lex-tea v3a, #172).
+//! Activates the stage and records an `Override` attestation
+//! that downstream `lex attest filter --kind override` can find.
+
+use std::process::Command;
+use tempfile::tempdir;
+
+fn lex_bin() -> &'static str { env!("CARGO_BIN_EXE_lex") }
+
+fn publish(store: &std::path::Path, src: &std::path::Path) -> serde_json::Value {
+    let out = Command::new(lex_bin())
+        .args([
+            "--output", "json",
+            "publish",
+            "--store", store.to_str().unwrap(),
+            src.to_str().unwrap(),
+        ])
+        .output().unwrap();
+    assert!(out.status.success(), "publish failed: {}", String::from_utf8_lossy(&out.stderr));
+    serde_json::from_slice(&out.stdout).unwrap()
+}
+
+fn first_stage_id(publish_out: &serde_json::Value) -> String {
+    publish_out.pointer("/data/ops/0/kind/stage_id")
+        .and_then(|v| v.as_str())
+        .expect("stage_id in publish output")
+        .to_string()
+}
+
+#[test]
+fn stage_pin_records_override_attestation() {
+    let store = tempdir().unwrap();
+    let src = store.path().join("a.lex");
+    std::fs::write(&src, "fn fac(n :: Int) -> Int { 1 }\n").unwrap();
+    let pub_out = publish(store.path(), &src);
+    let stage_id = first_stage_id(&pub_out);
+
+    let out = Command::new(lex_bin())
+        .args([
+            "--output", "json",
+            "stage", "pin", &stage_id,
+            "--reason", "spec checker is wrong here",
+            "--actor", "alice",
+            "--store", store.path().to_str().unwrap(),
+        ])
+        .output().unwrap();
+    assert!(out.status.success(), "pin failed: {}", String::from_utf8_lossy(&out.stderr));
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v.pointer("/data/pinned").unwrap(), &stage_id);
+    assert_eq!(v.pointer("/data/actor").unwrap(), "alice");
+    assert_eq!(v.pointer("/data/reason").unwrap(), "spec checker is wrong here");
+
+    // The Override attestation should now be queryable via attest
+    // filter and show up alongside the auto-emitted TypeCheck.
+    let out = Command::new(lex_bin())
+        .args([
+            "--output", "json",
+            "attest", "filter",
+            "--store", store.path().to_str().unwrap(),
+            "--kind", "override",
+        ])
+        .output().unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let count = v.pointer("/data/count").unwrap().as_u64().unwrap();
+    assert_eq!(count, 1, "expected exactly one Override attestation");
+    let att = v.pointer("/data/attestations/0").unwrap();
+    assert_eq!(att["kind"]["kind"], "override");
+    assert_eq!(att["kind"]["actor"], "alice");
+    assert_eq!(att["kind"]["reason"], "spec checker is wrong here");
+    assert_eq!(att["produced_by"]["tool"], "lex stage pin");
+    assert_eq!(att["stage_id"], stage_id);
+}
+
+#[test]
+fn stage_pin_uses_lex_tea_user_env_when_actor_omitted() {
+    let store = tempdir().unwrap();
+    let src = store.path().join("a.lex");
+    std::fs::write(&src, "fn fac(n :: Int) -> Int { 1 }\n").unwrap();
+    let pub_out = publish(store.path(), &src);
+    let stage_id = first_stage_id(&pub_out);
+
+    let out = Command::new(lex_bin())
+        .args([
+            "stage", "pin", &stage_id,
+            "--reason", "policy override",
+            "--store", store.path().to_str().unwrap(),
+        ])
+        .env("LEX_TEA_USER", "bob-from-env")
+        .output().unwrap();
+    assert!(out.status.success(), "pin failed: {}", String::from_utf8_lossy(&out.stderr));
+}
+
+#[test]
+fn stage_pin_fails_without_actor_or_env() {
+    // No --actor and no LEX_TEA_USER → refuse. Anonymous overrides
+    // would defeat the audit story.
+    let store = tempdir().unwrap();
+    let src = store.path().join("a.lex");
+    std::fs::write(&src, "fn fac(n :: Int) -> Int { 1 }\n").unwrap();
+    let pub_out = publish(store.path(), &src);
+    let stage_id = first_stage_id(&pub_out);
+
+    let out = Command::new(lex_bin())
+        .args([
+            "stage", "pin", &stage_id,
+            "--reason", "x",
+            "--store", store.path().to_str().unwrap(),
+        ])
+        .env_remove("LEX_TEA_USER")
+        .output().unwrap();
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("actor"), "stderr should mention actor: {stderr}");
+}
+
+#[test]
+fn stage_pin_requires_reason() {
+    let store = tempdir().unwrap();
+    let src = store.path().join("a.lex");
+    std::fs::write(&src, "fn fac(n :: Int) -> Int { 1 }\n").unwrap();
+    let pub_out = publish(store.path(), &src);
+    let stage_id = first_stage_id(&pub_out);
+
+    let out = Command::new(lex_bin())
+        .args([
+            "stage", "pin", &stage_id,
+            "--actor", "alice",
+            "--store", store.path().to_str().unwrap(),
+        ])
+        .output().unwrap();
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("reason"), "stderr should mention reason: {stderr}");
+}
+
+#[test]
+fn stage_pin_fails_on_unknown_stage() {
+    let store = tempdir().unwrap();
+    let out = Command::new(lex_bin())
+        .args([
+            "stage", "pin", "no_such_stage",
+            "--reason", "x",
+            "--actor", "alice",
+            "--store", store.path().to_str().unwrap(),
+        ])
+        .output().unwrap();
+    assert!(!out.status.success());
+}

--- a/crates/lex-vcs/src/attestation.rs
+++ b/crates/lex-vcs/src/attestation.rs
@@ -124,6 +124,24 @@ pub enum AttestationKind {
     SandboxRun {
         effects: BTreeSet<String>,
     },
+    /// Human-issued override (lex-tea v3, #172). Records that a
+    /// human took an action that bypassed an automatic verdict
+    /// — e.g. activating a stage despite a `Spec::Failed` or
+    /// `TypeCheck::Failed` attestation. Subject to the same
+    /// trust trail as agent attestations: the audit fact lives
+    /// in the log alongside what it overrode.
+    ///
+    /// `actor` is the human's identifier (today: `LEX_TEA_USER`
+    /// env var or `--actor` flag; v3b adds session auth).
+    /// `target_attestation_id` points at the attestation being
+    /// overridden, when one exists; for unconditional pins
+    /// (e.g. activate-by-default) it can be `None`.
+    Override {
+        actor: String,
+        reason: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        target_attestation_id: Option<AttestationId>,
+    },
 }
 
 /// Verification method for [`AttestationKind::Spec`]. Mirrors the


### PR DESCRIPTION
## Summary

First slice of #172 — give humans a typed, auditable way to override an
AI-agent-first VCS gate. Adds an `Override` `AttestationKind` and the
three surfaces that emit it.

- **CLI**: `lex stage pin <stage_id> --reason "..." [--actor NAME]`
  activates the stage and writes an `Override` attestation. Actor falls
  back to `$LEX_TEA_USER`. Missing actor or missing reason are hard
  errors so the audit trail can never be anonymous.
- **Web**: stage page grows a pin form (only when `LEX_TEA_USER` is set
  on the server) that POSTs to `/web/stage/<id>/pin` and 303s back to
  the stage view.
- **Visibility**: new overrides surface in `lex attest filter --kind
  override` and the existing `GET /v1/attest` endpoints, so AI
  reviewers can see *why* a stage was pushed past a failing check.

This is intentionally narrow:

- ✅ override attestation kind + producer wiring
- ✅ CLI + web + visibility
- ⏳ defer/block on a stage (v3b)
- ⏳ users.json-backed actor identity (v3b)

## Test plan

- [x] `cargo test -p lex-cli --test stage_pin` — 5 new integration
      tests (happy path, env fallback, anonymous refused, missing
      reason refused, unknown stage refused)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [ ] CI green

https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5

---
_Generated by [Claude Code](https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5)_