### PR TITLE
feat: lex stage defer/block/unblock — triage attestations (lex-tea v3b, #172)

### DIFF
--- a/crates/lex-api/src/web.rs
+++ b/crates/lex-api/src/web.rs
@@ -732,6 +732,9 @@ fn kind_short(k: &AttestationKind) -> String {
             format!("SandboxRun([{}])", names.join(","))
         }
         AttestationKind::Override { actor, .. } => format!("Override({actor})"),
+        AttestationKind::Defer { actor, .. } => format!("Defer({actor})"),
+        AttestationKind::Block { actor, .. } => format!("Block({actor})"),
+        AttestationKind::Unblock { actor, .. } => format!("Unblock({actor})"),
     }
 }
 

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -1050,11 +1050,21 @@ fn cmd_store(fmt: &OutputFormat, args: &[String]) -> Result<()> {
 /// `GET /v1/stage/<id>` and `GET /v1/stage/<id>/attestations`.
 fn cmd_stage(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let (root, rest, _, _) = parse_store_flag(args);
-    // `lex stage pin <id> ...` — human override (#172). Detect it
-    // as a leading positional so the existing `lex stage <id>` and
-    // `lex stage <id> --attestations` shapes keep working unchanged.
-    if rest.first().map(String::as_str) == Some("pin") {
-        return cmd_stage_pin(fmt, &root, &rest[1..]);
+    // `lex stage pin|defer|block|unblock <id> ...` — human triage
+    // actions (#172). Detect them as a leading positional so the
+    // existing `lex stage <id>` and `lex stage <id> --attestations`
+    // shapes keep working unchanged.
+    if let Some(action) = rest.first().map(String::as_str) {
+        match action {
+            "pin"     => return cmd_stage_pin(fmt, &root, &rest[1..]),
+            "defer"   => return cmd_stage_decision(
+                fmt, &root, &rest[1..], StageDecision::Defer),
+            "block"   => return cmd_stage_decision(
+                fmt, &root, &rest[1..], StageDecision::Block),
+            "unblock" => return cmd_stage_decision(
+                fmt, &root, &rest[1..], StageDecision::Unblock),
+            _ => {}
+        }
     }
     let attestations_mode = rest.iter().any(|a| a == "--attestations");
     let id = rest
@@ -1100,6 +1110,15 @@ fn cmd_stage(fmt: &OutputFormat, args: &[String]) -> Result<()> {
                     }
                     lex_vcs::AttestationKind::Override { actor, .. } => {
                         format!("Override({actor})")
+                    }
+                    lex_vcs::AttestationKind::Defer { actor, .. } => {
+                        format!("Defer({actor})")
+                    }
+                    lex_vcs::AttestationKind::Block { actor, .. } => {
+                        format!("Block({actor})")
+                    }
+                    lex_vcs::AttestationKind::Unblock { actor, .. } => {
+                        format!("Unblock({actor})")
                     }
                 };
                 let result = match &a.result {
@@ -1177,6 +1196,16 @@ fn cmd_stage_pin(
     let _ = store.get_metadata(&id)
         .with_context(|| format!("unknown stage `{id}`"))?;
 
+    // Refuse to pin a blocked stage. The block is only meaningful
+    // if it actually stops the activation it's supposed to prevent.
+    let log = store.attestation_log()?;
+    let existing = log.list_for_stage(&id)?;
+    if lex_vcs::is_stage_blocked(&existing) {
+        bail!(
+            "lex stage pin: stage `{id}` is blocked — run `lex stage unblock {id} --reason \"...\"` first"
+        );
+    }
+
     // Activate first (the actual override action), then record the
     // audit. Order matters: if activate fails, no audit is written;
     // if audit fails after a successful activate, the user retries
@@ -1216,6 +1245,118 @@ fn cmd_stage_pin(
     let actor_for_text = actor.clone();
     acli::emit_or_text("stage", data, fmt, move || {
         println!("→ pinned `{id_for_text:.16}…` (actor: {actor_for_text})");
+    });
+    Ok(())
+}
+
+/// Triage decisions a human can record on a stage. Mirrors the
+/// `Defer`/`Block`/`Unblock` `AttestationKind` variants.
+#[derive(Clone, Copy)]
+enum StageDecision {
+    Defer,
+    Block,
+    Unblock,
+}
+
+impl StageDecision {
+    fn verb(self) -> &'static str {
+        match self {
+            Self::Defer => "defer",
+            Self::Block => "block",
+            Self::Unblock => "unblock",
+        }
+    }
+
+    fn past(self) -> &'static str {
+        match self {
+            Self::Defer => "deferred",
+            Self::Block => "blocked",
+            Self::Unblock => "unblocked",
+        }
+    }
+}
+
+/// `lex stage <defer|block|unblock> <id> --reason "..." [--actor NAME]`
+/// — human triage actions (#172, lex-tea v3b).
+///
+/// Defer/Block/Unblock all record an attestation against the stage
+/// without changing its status. Block additionally makes future
+/// `lex stage pin` calls refuse until an `unblock` is recorded.
+/// The append-only attestation log makes the full triage history
+/// queryable via `lex attest filter --kind block` etc.
+fn cmd_stage_decision(
+    fmt: &OutputFormat,
+    root: &std::path::Path,
+    args: &[String],
+    decision: StageDecision,
+) -> Result<()> {
+    let mut id: Option<String> = None;
+    let mut reason: Option<String> = None;
+    let mut actor: Option<String> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--reason" => { reason = args.get(i + 1).cloned(); i += 2; }
+            "--actor"  => { actor  = args.get(i + 1).cloned(); i += 2; }
+            other if id.is_none() => { id = Some(other.to_string()); i += 1; }
+            other => bail!("unexpected arg `{other}`"),
+        }
+    }
+    let verb = decision.verb();
+    let id = id.ok_or_else(|| anyhow!(
+        "usage: lex stage {verb} <stage_id> --reason \"...\" [--actor NAME]"
+    ))?;
+    let reason = reason.ok_or_else(|| anyhow!(
+        "lex stage {verb}: --reason required (triage decisions need a paper trail)"
+    ))?;
+    let actor = actor
+        .or_else(|| std::env::var("LEX_TEA_USER").ok())
+        .ok_or_else(|| anyhow!(
+            "lex stage {verb}: actor unknown — pass --actor NAME or set LEX_TEA_USER"
+        ))?;
+
+    let store = Store::open(root)
+        .with_context(|| format!("opening store at {}", root.display()))?;
+    let _ = store.get_metadata(&id)
+        .with_context(|| format!("unknown stage `{id}`"))?;
+
+    let kind = match decision {
+        StageDecision::Defer => lex_vcs::AttestationKind::Defer {
+            actor: actor.clone(), reason: reason.clone(),
+        },
+        StageDecision::Block => lex_vcs::AttestationKind::Block {
+            actor: actor.clone(), reason: reason.clone(),
+        },
+        StageDecision::Unblock => lex_vcs::AttestationKind::Unblock {
+            actor: actor.clone(), reason: reason.clone(),
+        },
+    };
+    let producer = lex_vcs::ProducerDescriptor {
+        tool: format!("lex stage {verb}"),
+        version: env!("CARGO_PKG_VERSION").into(),
+        model: None,
+    };
+    let attestation = lex_vcs::Attestation::new(
+        id.clone(), None, None,
+        kind,
+        lex_vcs::AttestationResult::Passed,
+        producer, None,
+    );
+    let log = store.attestation_log()?;
+    log.put(&attestation)?;
+
+    let data = serde_json::json!({
+        "stage_id": &id,
+        "decision": verb,
+        "actor": &actor,
+        "reason": &reason,
+        "attestation_id": &attestation.attestation_id,
+    });
+    let id_for_text = id.clone();
+    let actor_for_text = actor.clone();
+    let past = decision.past();
+    acli::emit_or_text("stage", data, fmt, move || {
+        println!("→ {past} `{id_for_text:.16}…` (actor: {actor_for_text})");
     });
     Ok(())
 }
@@ -1320,6 +1461,9 @@ fn attestation_kind_tag(k: &lex_vcs::AttestationKind) -> &'static str {
         EffectAudit       => "effect_audit",
         SandboxRun { .. } => "sandbox_run",
         Override { .. }   => "override",
+        Defer { .. }      => "defer",
+        Block { .. }      => "block",
+        Unblock { .. }    => "unblock",
     }
 }
 

--- a/crates/lex-cli/tests/stage_decision.rs
+++ b/crates/lex-cli/tests/stage_decision.rs
@@ -1,0 +1,182 @@
+//! `lex stage defer|block|unblock` — human triage actions (lex-tea v3b, #172).
+//! Records a Defer/Block/Unblock attestation. Block additionally
+//! makes `lex stage pin` refuse until an Unblock supersedes it.
+
+use std::process::Command;
+use tempfile::tempdir;
+
+fn lex_bin() -> &'static str { env!("CARGO_BIN_EXE_lex") }
+
+fn publish(store: &std::path::Path, src: &std::path::Path) -> serde_json::Value {
+    let out = Command::new(lex_bin())
+        .args([
+            "--output", "json",
+            "publish",
+            "--store", store.to_str().unwrap(),
+            src.to_str().unwrap(),
+        ])
+        .output().unwrap();
+    assert!(out.status.success(), "publish failed: {}", String::from_utf8_lossy(&out.stderr));
+    serde_json::from_slice(&out.stdout).unwrap()
+}
+
+fn first_stage_id(publish_out: &serde_json::Value) -> String {
+    publish_out.pointer("/data/ops/0/kind/stage_id")
+        .and_then(|v| v.as_str())
+        .expect("stage_id in publish output")
+        .to_string()
+}
+
+fn run_decision(verb: &str, store: &std::path::Path, stage_id: &str, reason: &str, actor: &str)
+    -> std::process::Output
+{
+    Command::new(lex_bin())
+        .args([
+            "--output", "json",
+            "stage", verb, stage_id,
+            "--reason", reason,
+            "--actor", actor,
+            "--store", store.to_str().unwrap(),
+        ])
+        .output().unwrap()
+}
+
+fn count_of_kind(store: &std::path::Path, kind: &str) -> u64 {
+    let out = Command::new(lex_bin())
+        .args([
+            "--output", "json",
+            "attest", "filter",
+            "--store", store.to_str().unwrap(),
+            "--kind", kind,
+        ])
+        .output().unwrap();
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    v.pointer("/data/count").unwrap().as_u64().unwrap()
+}
+
+#[test]
+fn stage_defer_records_defer_attestation() {
+    let store = tempdir().unwrap();
+    let src = store.path().join("a.lex");
+    std::fs::write(&src, "fn fac(n :: Int) -> Int { 1 }\n").unwrap();
+    let pub_out = publish(store.path(), &src);
+    let stage_id = first_stage_id(&pub_out);
+
+    let out = run_decision("defer", store.path(), &stage_id, "revisit next sprint", "alice");
+    assert!(out.status.success(), "defer failed: {}", String::from_utf8_lossy(&out.stderr));
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v.pointer("/data/decision").unwrap(), "defer");
+    assert_eq!(v.pointer("/data/actor").unwrap(), "alice");
+
+    assert_eq!(count_of_kind(store.path(), "defer"), 1);
+}
+
+#[test]
+fn stage_block_then_pin_refuses() {
+    let store = tempdir().unwrap();
+    let src = store.path().join("a.lex");
+    std::fs::write(&src, "fn fac(n :: Int) -> Int { 1 }\n").unwrap();
+    let pub_out = publish(store.path(), &src);
+    let stage_id = first_stage_id(&pub_out);
+
+    let out = run_decision("block", store.path(), &stage_id, "spec wrong", "alice");
+    assert!(out.status.success(), "block failed: {}", String::from_utf8_lossy(&out.stderr));
+    assert_eq!(count_of_kind(store.path(), "block"), 1);
+
+    let out = Command::new(lex_bin())
+        .args([
+            "stage", "pin", &stage_id,
+            "--reason", "ship anyway",
+            "--actor", "bob",
+            "--store", store.path().to_str().unwrap(),
+        ])
+        .output().unwrap();
+    assert!(!out.status.success(), "pin should refuse a blocked stage");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("blocked"), "stderr should mention blocked: {stderr}");
+}
+
+#[test]
+fn stage_unblock_clears_block() {
+    let store = tempdir().unwrap();
+    let src = store.path().join("a.lex");
+    std::fs::write(&src, "fn fac(n :: Int) -> Int { 1 }\n").unwrap();
+    let pub_out = publish(store.path(), &src);
+    let stage_id = first_stage_id(&pub_out);
+
+    assert!(run_decision("block", store.path(), &stage_id, "wait for review", "alice")
+        .status.success());
+    // Sleep one second so the unblock has a strictly later timestamp
+    // than the block — the resolver picks "latest" by timestamp.
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+    assert!(run_decision("unblock", store.path(), &stage_id, "review done", "alice")
+        .status.success());
+
+    let out = Command::new(lex_bin())
+        .args([
+            "stage", "pin", &stage_id,
+            "--reason", "ship",
+            "--actor", "bob",
+            "--store", store.path().to_str().unwrap(),
+        ])
+        .output().unwrap();
+    assert!(out.status.success(),
+        "pin should succeed after unblock: {}", String::from_utf8_lossy(&out.stderr));
+}
+
+#[test]
+fn stage_decision_requires_reason() {
+    let store = tempdir().unwrap();
+    let src = store.path().join("a.lex");
+    std::fs::write(&src, "fn fac(n :: Int) -> Int { 1 }\n").unwrap();
+    let pub_out = publish(store.path(), &src);
+    let stage_id = first_stage_id(&pub_out);
+
+    for verb in ["defer", "block", "unblock"] {
+        let out = Command::new(lex_bin())
+            .args([
+                "stage", verb, &stage_id,
+                "--actor", "alice",
+                "--store", store.path().to_str().unwrap(),
+            ])
+            .output().unwrap();
+        assert!(!out.status.success(), "{verb} without --reason should fail");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(stderr.contains("reason"),
+            "{verb} stderr should mention reason: {stderr}");
+    }
+}
+
+#[test]
+fn stage_decision_requires_actor() {
+    let store = tempdir().unwrap();
+    let src = store.path().join("a.lex");
+    std::fs::write(&src, "fn fac(n :: Int) -> Int { 1 }\n").unwrap();
+    let pub_out = publish(store.path(), &src);
+    let stage_id = first_stage_id(&pub_out);
+
+    for verb in ["defer", "block", "unblock"] {
+        let out = Command::new(lex_bin())
+            .args([
+                "stage", verb, &stage_id,
+                "--reason", "x",
+                "--store", store.path().to_str().unwrap(),
+            ])
+            .env_remove("LEX_TEA_USER")
+            .output().unwrap();
+        assert!(!out.status.success(), "{verb} without actor should fail");
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(stderr.contains("actor"),
+            "{verb} stderr should mention actor: {stderr}");
+    }
+}
+
+#[test]
+fn stage_decision_fails_on_unknown_stage() {
+    let store = tempdir().unwrap();
+    for verb in ["defer", "block", "unblock"] {
+        let out = run_decision(verb, store.path(), "no_such_stage", "x", "alice");
+        assert!(!out.status.success(), "{verb} on unknown stage should fail");
+    }
+}

--- a/crates/lex-vcs/src/attestation.rs
+++ b/crates/lex-vcs/src/attestation.rs
@@ -142,6 +142,60 @@ pub enum AttestationKind {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         target_attestation_id: Option<AttestationId>,
     },
+    /// `lex stage defer` (lex-tea v3b, #172). Records that a human
+    /// looked at the stage and chose to revisit it later. No state
+    /// change — purely an audit/triage signal so dashboards and AI
+    /// reviewers can see "this isn't abandoned, it's snoozed."
+    Defer {
+        actor: String,
+        reason: String,
+    },
+    /// `lex stage block` (lex-tea v3b, #172). Records that a human
+    /// has decided this stage should not activate. `lex stage pin`
+    /// and any other activation path consults the attestation log
+    /// and refuses while a Block is the latest decision for the
+    /// stage. Reversed by [`AttestationKind::Unblock`].
+    Block {
+        actor: String,
+        reason: String,
+    },
+    /// `lex stage unblock` (lex-tea v3b, #172). Counterpart to
+    /// [`AttestationKind::Block`]. The attestation log is append-
+    /// only, so we encode "block lifted" as a separate, later fact
+    /// rather than mutating the original block.
+    Unblock {
+        actor: String,
+        reason: String,
+    },
+}
+
+/// Walk a stage's attestations and return whether the latest
+/// Block/Unblock decision is currently a Block. Used by
+/// activation paths (e.g. `lex stage pin`) to refuse when a
+/// human has signalled the stage shouldn't ship.
+///
+/// "Latest" is defined by `timestamp`, which matches what users
+/// see in `lex stage <id> --attestations`. Ties go to Unblock so
+/// retrying an unblock right after a block (same wall-clock
+/// second) doesn't leave the stage stuck.
+pub fn is_stage_blocked(attestations: &[Attestation]) -> bool {
+    let mut latest: Option<&Attestation> = None;
+    for a in attestations {
+        if !matches!(a.kind, AttestationKind::Block { .. } | AttestationKind::Unblock { .. }) {
+            continue;
+        }
+        match latest {
+            None => latest = Some(a),
+            Some(prev) if a.timestamp > prev.timestamp => latest = Some(a),
+            Some(prev) if a.timestamp == prev.timestamp
+                && matches!(a.kind, AttestationKind::Unblock { .. }) =>
+            {
+                latest = Some(a);
+            }
+            _ => {}
+        }
+    }
+    matches!(latest.map(|a| &a.kind), Some(AttestationKind::Block { .. }))
 }
 
 /// Verification method for [`AttestationKind::Spec`]. Mirrors the
@@ -848,5 +902,104 @@ mod tests {
 
         let listing = log.list_for_stage(&"stage-abc".to_string()).unwrap();
         assert_eq!(listing.len(), 2, "both passing and failing evidence must persist");
+    }
+
+    fn human_decision(kind: AttestationKind, ts: u64) -> Attestation {
+        Attestation::with_timestamp(
+            "stage-abc",
+            None, None,
+            kind,
+            AttestationResult::Passed,
+            ProducerDescriptor {
+                tool: "lex stage".into(),
+                version: "0.1.0".into(),
+                model: None,
+            },
+            None,
+            ts,
+        )
+    }
+
+    #[test]
+    fn is_stage_blocked_empty_log_is_false() {
+        assert!(!is_stage_blocked(&[]));
+    }
+
+    #[test]
+    fn is_stage_blocked_only_unrelated_attestations() {
+        // TypeCheck/Override attestations don't gate activation —
+        // only Block/Unblock do.
+        let attestations = vec![
+            typecheck_passed(),
+            human_decision(
+                AttestationKind::Override {
+                    actor: "alice".into(),
+                    reason: "ship".into(),
+                    target_attestation_id: None,
+                },
+                500,
+            ),
+        ];
+        assert!(!is_stage_blocked(&attestations));
+    }
+
+    #[test]
+    fn is_stage_blocked_block_alone_blocks() {
+        let attestations = vec![human_decision(
+            AttestationKind::Block { actor: "alice".into(), reason: "x".into() },
+            500,
+        )];
+        assert!(is_stage_blocked(&attestations));
+    }
+
+    #[test]
+    fn is_stage_blocked_later_unblock_clears_block() {
+        let attestations = vec![
+            human_decision(
+                AttestationKind::Block { actor: "alice".into(), reason: "x".into() },
+                500,
+            ),
+            human_decision(
+                AttestationKind::Unblock { actor: "alice".into(), reason: "ok".into() },
+                600,
+            ),
+        ];
+        assert!(!is_stage_blocked(&attestations));
+    }
+
+    #[test]
+    fn is_stage_blocked_later_block_re_blocks() {
+        let attestations = vec![
+            human_decision(
+                AttestationKind::Block { actor: "a".into(), reason: "1".into() },
+                500,
+            ),
+            human_decision(
+                AttestationKind::Unblock { actor: "a".into(), reason: "2".into() },
+                600,
+            ),
+            human_decision(
+                AttestationKind::Block { actor: "a".into(), reason: "3".into() },
+                700,
+            ),
+        ];
+        assert!(is_stage_blocked(&attestations));
+    }
+
+    #[test]
+    fn is_stage_blocked_unblock_wins_at_same_timestamp() {
+        // Tie-break favours Unblock so a hasty re-attempt at the
+        // same wall-clock second can't strand the stage.
+        let attestations = vec![
+            human_decision(
+                AttestationKind::Block { actor: "a".into(), reason: "1".into() },
+                500,
+            ),
+            human_decision(
+                AttestationKind::Unblock { actor: "a".into(), reason: "2".into() },
+                500,
+            ),
+        ];
+        assert!(!is_stage_blocked(&attestations));
     }
 }

--- a/crates/lex-vcs/src/lib.rs
+++ b/crates/lex-vcs/src/lib.rs
@@ -44,8 +44,8 @@ mod predicate;
 
 pub use apply::{apply, ApplyError, NewHead};
 pub use attestation::{
-    Attestation, AttestationId, AttestationKind, AttestationLog, AttestationResult, ContentHash,
-    Cost, ProducerDescriptor, Signature, SpecId, SpecMethod,
+    is_stage_blocked, Attestation, AttestationId, AttestationKind, AttestationLog,
+    AttestationResult, ContentHash, Cost, ProducerDescriptor, Signature, SpecId, SpecMethod,
 };
 pub use compute_diff::{compute_diff, effect_label, render_signature};
 pub use diff_report::DiffReport;


### PR DESCRIPTION
## Summary

Builds on the v3a slice (#177) by adding the rest of the human
triage actions for the AI-agent-first VCS — *without* dropping
out of the audit story.

- **New `AttestationKind` variants**: `Defer`, `Block`, `Unblock`.
  Same shape as `Override` (actor + reason). Append-only, so the
  full triage history stays queryable.
- **CLI**:
  - `lex stage defer <id> --reason "..."` — "snoozed, revisit
    later" — pure record, no state change.
  - `lex stage block <id> --reason "..."` — "should not ship".
  - `lex stage unblock <id> --reason "..."` — lifts an active
    block.
  - All three honour `LEX_TEA_USER` like `pin` does, and refuse
    to land anonymously.
- **Enforcement**: `lex stage pin` now consults the attestation
  log via `lex_vcs::is_stage_blocked` and refuses to activate a
  blocked stage. The user has to `unblock` first.
- **Resolver**: `is_stage_blocked` walks the attestation log and
  returns whether the latest Block/Unblock fact for the stage is
  a Block. Ties on `timestamp` favour Unblock so a same-second
  retry can't strand a stage.
- **Visibility**: every new kind streams through the existing
  `/v1/attest` and `lex attest filter --kind …` paths for free.

Web UI buttons for these actions are deferred to v3c, where they
land alongside the users.json-backed actor identity (the
"`LEX_TEA_USER` is one env var away from anyone" gap that v3a
called out in its body).

## Test plan

- [x] `cargo test -p lex-vcs --lib attestation` (6 new
      `is_stage_blocked` unit tests including the same-timestamp
      tie-break)
- [x] `cargo test -p lex-cli --test stage_decision` (6 new
      integration tests: defer happy path, block→pin refused,
      block→unblock→pin works, missing reason refused, missing
      actor refused, unknown stage refused)
- [x] `cargo test -p lex-cli --test stage_pin` (existing v3a
      tests still pass)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [ ] CI green

https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5

---
_Generated by [Claude Code](https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5)_