### PR TITLE
feat: web UI parity for defer/block/unblock (lex-tea v3c, #172)

### DIFF
--- a/crates/lex-api/src/handlers.rs
+++ b/crates/lex-api/src/handlers.rs
@@ -113,11 +113,26 @@ fn route(
             let id = &p["/web/stage/".len()..];
             crate::web::stage_html_handler(state, id)
         }
-        // lex-tea v3a: human override pin (#172). HTML form
-        // posts to /web/stage/<id>/pin with `reason` body.
-        (Method::Post, p) if p.starts_with("/web/stage/") && p.ends_with("/pin") => {
-            let id = &p["/web/stage/".len()..p.len() - "/pin".len()];
-            crate::web::stage_pin_handler(state, id, body)
+        // lex-tea v3 human-triage actions (#172). HTML forms post
+        // to /web/stage/<id>/{pin,defer,block,unblock} with a
+        // `reason` body. All four share one handler; the verb in
+        // the path picks the AttestationKind.
+        (Method::Post, p) if p.starts_with("/web/stage/") && (
+            p.ends_with("/pin") || p.ends_with("/defer")
+            || p.ends_with("/block") || p.ends_with("/unblock")
+        ) => {
+            let prefix_len = "/web/stage/".len();
+            let last_slash = p.rfind('/').unwrap_or(p.len());
+            let id = &p[prefix_len..last_slash];
+            let verb = &p[last_slash + 1..];
+            let decision = match verb {
+                "pin"     => crate::web::WebStageDecision::Pin,
+                "defer"   => crate::web::WebStageDecision::Defer,
+                "block"   => crate::web::WebStageDecision::Block,
+                "unblock" => crate::web::WebStageDecision::Unblock,
+                _ => unreachable!("matched in outer guard"),
+            };
+            crate::web::stage_decision_handler(state, id, body, decision)
         }
         // ---- JSON API -----------------------------------------
         (Method::Get, "/v1/health") => json_response(200, &serde_json::json!({"ok": true})),

--- a/crates/lex-api/src/web.rs
+++ b/crates/lex-api/src/web.rs
@@ -556,35 +556,66 @@ pub(crate) fn stage_html_handler(state: &State, id: &str) -> Response<Cursor<Vec
         }
     }
 
-    // Override form (lex-tea v3a, #172). Renders only when a
-    // user identifier is set via `LEX_TEA_USER`; without one the
-    // pin handler refuses the action anyway, so showing a button
-    // would be misleading. Single-user-mode for v3a; v3b adds
-    // sessions + `<store>/users.json`.
+    // Triage forms (lex-tea v3a/v3b/v3c, #172). Render only when
+    // a user identifier is set via `LEX_TEA_USER`; without one the
+    // handlers refuse the action anyway, so showing buttons would
+    // be misleading. Single-user-mode for now; users.json-backed
+    // auth is a follow-up.
     let actor = std::env::var("LEX_TEA_USER").ok();
-    let pin_form = match &actor {
+    let triage_form = match &actor {
         Some(name) => format!(
-            r#"<h2>override</h2>
-<p class="muted">Pin this stage to Active and record an Override
-attestation under your name. Auditable: shows up under
-<code>kind=override</code> in <code>lex attest filter</code>.</p>
+            r#"<h2>triage</h2>
+<p class="muted">Record a human decision against this stage.
+All four actions write an auditable attestation under your name
+queryable via <code>lex attest filter --kind &lt;kind&gt;</code>.
+<strong>pin</strong> additionally activates the stage; the others
+just record the decision. <strong>block</strong> prevents future
+pins until <strong>unblock</strong> is recorded.</p>
+<p class="muted">actor: <span class="mono">{actor}</span></p>
 <form method="post" action="/web/stage/{id}/pin">
-  <p><strong>actor:</strong> <span class="mono">{actor}</span></p>
-  <p><label for="reason">reason:</label><br>
-     <input type="text" id="reason" name="reason" required
+  <p><label for="pin-reason">pin reason:</label><br>
+     <input type="text" id="pin-reason" name="reason" required
             placeholder="e.g. spec checker is wrong here, will revisit"
             style="width: 100%; padding: .4rem; font-family: inherit;"></p>
   <p><button type="submit"
        style="padding: .4rem 1rem; background: #b00; color: #fff; border: 0;
               border-radius: 3px; cursor: pointer;">pin to Active</button></p>
+</form>
+<form method="post" action="/web/stage/{id}/defer">
+  <p><label for="defer-reason">defer reason:</label><br>
+     <input type="text" id="defer-reason" name="reason" required
+            placeholder="e.g. low priority, revisit next sprint"
+            style="width: 100%; padding: .4rem; font-family: inherit;"></p>
+  <p><button type="submit"
+       style="padding: .4rem 1rem; background: #555; color: #fff; border: 0;
+              border-radius: 3px; cursor: pointer;">defer</button></p>
+</form>
+<form method="post" action="/web/stage/{id}/block">
+  <p><label for="block-reason">block reason:</label><br>
+     <input type="text" id="block-reason" name="reason" required
+            placeholder="e.g. blocks until external review lands"
+            style="width: 100%; padding: .4rem; font-family: inherit;"></p>
+  <p><button type="submit"
+       style="padding: .4rem 1rem; background: #800; color: #fff; border: 0;
+              border-radius: 3px; cursor: pointer;">block</button></p>
+</form>
+<form method="post" action="/web/stage/{id}/unblock">
+  <p><label for="unblock-reason">unblock reason:</label><br>
+     <input type="text" id="unblock-reason" name="reason" required
+            placeholder="e.g. external review landed"
+            style="width: 100%; padding: .4rem; font-family: inherit;"></p>
+  <p><button type="submit"
+       style="padding: .4rem 1rem; background: #060; color: #fff; border: 0;
+              border-radius: 3px; cursor: pointer;">unblock</button></p>
 </form>"#,
             id = esc(id),
             actor = esc(name),
         ),
-        None => r#"<h2>override</h2>
+        None => r#"<h2>triage</h2>
 <p class="muted">Set <code>LEX_TEA_USER=&lt;name&gt;</code> in the
-server's environment to enable human override actions. The
-attestation log will record the override under that name.</p>"#.into(),
+server's environment to enable human triage actions (pin / defer /
+block / unblock). The attestation log records every decision under
+that name.</p>"#.into(),
     };
 
     let body = format!(
@@ -602,7 +633,7 @@ attestation log will record the override under that name.</p>"#.into(),
   <thead><tr><th>kind</th><th>result</th><th>by</th><th>ts</th></tr></thead>
   <tbody>{att_rows}</tbody>
 </table>
-{pin_form}"#,
+{triage_form}"#,
         id_short = esc(&format!("{id:.16}")),
         name = esc(&meta.name),
         sig = esc(&meta.sig_id),
@@ -614,25 +645,64 @@ attestation log will record the override under that name.</p>"#.into(),
     html_response(200, page(&meta.name, "", &body))
 }
 
-/// `POST /web/stage/<id>/pin` — handles the override form
-/// submission. Reads `LEX_TEA_USER` from the server env (since
-/// v3a is single-user mode), records an `Override` attestation,
-/// activates the stage, redirects back to the stage page so the
-/// reviewer sees the new attestation row.
-pub(crate) fn stage_pin_handler(
+/// Which human-triage action a `POST /web/stage/<id>/<verb>` is
+/// requesting. Drives both the recorded `AttestationKind` and
+/// whether the stage gets activated.
+#[derive(Clone, Copy)]
+pub(crate) enum WebStageDecision {
+    Pin,
+    Defer,
+    Block,
+    Unblock,
+}
+
+impl WebStageDecision {
+    fn verb(self) -> &'static str {
+        match self {
+            Self::Pin => "pin",
+            Self::Defer => "defer",
+            Self::Block => "block",
+            Self::Unblock => "unblock",
+        }
+    }
+    fn tool(self) -> &'static str {
+        match self {
+            Self::Pin => "lex-tea pin",
+            Self::Defer => "lex-tea defer",
+            Self::Block => "lex-tea block",
+            Self::Unblock => "lex-tea unblock",
+        }
+    }
+    fn kind(self, actor: String, reason: String) -> AttestationKind {
+        match self {
+            Self::Pin => AttestationKind::Override {
+                actor, reason, target_attestation_id: None,
+            },
+            Self::Defer => AttestationKind::Defer { actor, reason },
+            Self::Block => AttestationKind::Block { actor, reason },
+            Self::Unblock => AttestationKind::Unblock { actor, reason },
+        }
+    }
+}
+
+/// `POST /web/stage/<id>/{pin,defer,block,unblock}` — handles
+/// the human-triage form submissions. Reads `LEX_TEA_USER` from
+/// the server env, records the appropriate attestation, and
+/// (for `pin` only) activates the stage. Redirects back to the
+/// stage page so a refresh doesn't repost the action.
+pub(crate) fn stage_decision_handler(
     state: &State,
     id: &str,
     body: &str,
+    decision: WebStageDecision,
 ) -> Response<Cursor<Vec<u8>>> {
     let actor = match std::env::var("LEX_TEA_USER") {
         Ok(n) if !n.is_empty() => n,
         _ => return html_response(403, page("forbidden", "",
             r#"<nav class="crumb"><a href="/">activity</a></nav>
 <h1>forbidden</h1>
-<p>Set <code>LEX_TEA_USER</code> on the server to enable overrides.</p>"#)),
+<p>Set <code>LEX_TEA_USER</code> on the server to enable triage actions.</p>"#)),
     };
-    // Decode the form-urlencoded `reason=...` body. Single field
-    // for v3a; multi-field forms get a real parser later.
     let reason = body.split('&')
         .find_map(|pair| pair.strip_prefix("reason="))
         .map(percent_decode)
@@ -641,7 +711,7 @@ pub(crate) fn stage_pin_handler(
         return html_response(400, page("bad request", "",
             r#"<nav class="crumb"><a href="/">activity</a></nav>
 <h1>bad request</h1>
-<p>The override form requires a <code>reason</code>.</p>"#));
+<p>This form requires a <code>reason</code>.</p>"#));
     };
 
     let store = state.store.lock().unwrap();
@@ -650,25 +720,35 @@ pub(crate) fn stage_pin_handler(
             &format!(r#"<nav class="crumb"><a href="/">activity</a></nav><pre>unknown stage `{}`</pre>"#,
                 esc(id))));
     }
-    if let Err(e) = store.activate(id) {
-        return html_response(500, page("error", "",
-            &format!("<pre>activate: {}</pre>", esc(&e.to_string()))));
-    }
     let log = match store.attestation_log() {
         Ok(l) => l,
         Err(e) => return html_response(500, page("error", "",
             &format!("<pre>{}</pre>", esc(&e.to_string())))),
     };
+    if matches!(decision, WebStageDecision::Pin) {
+        // Refuse to pin a blocked stage — same gate as the CLI.
+        // Web users have to record an Unblock first.
+        let existing = log.list_for_stage(&id.to_string()).unwrap_or_default();
+        if lex_vcs::is_stage_blocked(&existing) {
+            return html_response(409, page("blocked", "",
+                &format!(r#"<nav class="crumb"><a href="/">activity</a> /
+<a href="/web/stage/{id}">{id_short}…</a></nav>
+<h1>stage is blocked</h1>
+<p>Record an <strong>unblock</strong> first, then re-try the pin.</p>"#,
+                    id = esc(id),
+                    id_short = esc(&format!("{id:.16}")))));
+        }
+        if let Err(e) = store.activate(id) {
+            return html_response(500, page("error", "",
+                &format!("<pre>activate: {}</pre>", esc(&e.to_string()))));
+        }
+    }
     let attestation = lex_vcs::Attestation::new(
         id.to_string(), None, None,
-        AttestationKind::Override {
-            actor,
-            reason,
-            target_attestation_id: None,
-        },
+        decision.kind(actor, reason),
         AttestationResult::Passed,
         lex_vcs::ProducerDescriptor {
-            tool: "lex-tea pin".into(),
+            tool: decision.tool().into(),
             version: env!("CARGO_PKG_VERSION").into(),
             model: None,
         },
@@ -676,10 +756,9 @@ pub(crate) fn stage_pin_handler(
     );
     if let Err(e) = log.put(&attestation) {
         return html_response(500, page("error", "",
-            &format!("<pre>persist override: {}</pre>", esc(&e.to_string()))));
+            &format!("<pre>persist {}: {}</pre>",
+                decision.verb(), esc(&e.to_string()))));
     }
-    // 303 See Other → redirect the form POST to a GET on the
-    // stage page so a refresh doesn't repost the same override.
     Response::from_data(Vec::new())
         .with_status_code(303)
         .with_header(

--- a/crates/lex-api/tests/web_triage.rs
+++ b/crates/lex-api/tests/web_triage.rs
@@ -1,0 +1,144 @@
+//! Web UI parity for human-triage actions (lex-tea v3c, #172).
+//! One test in this binary, by design — `LEX_TEA_USER` is process-
+//! global, so we set it once, exercise all four endpoints, and
+//! restore it. Splitting into multiple `#[test]` functions would
+//! race on the env var.
+
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpStream};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use lex_api::handlers::State;
+use serde_json::json;
+use tempfile::TempDir;
+
+struct Server {
+    addr: SocketAddr,
+    _join: Option<thread::JoinHandle<()>>,
+    _server_holder: Arc<()>,
+}
+
+fn start_server() -> (Server, TempDir) {
+    let tmp = TempDir::new().unwrap();
+    let server = tiny_http::Server::http(("127.0.0.1", 0))
+        .expect("bind ephemeral port");
+    let addr: SocketAddr = match server.server_addr() {
+        tiny_http::ListenAddr::IP(addr) => addr,
+        _ => panic!("expected IP listener"),
+    };
+    let state = Arc::new(State::open(tmp.path().to_path_buf()).unwrap());
+    let join = thread::spawn(move || {
+        lex_api::serve_on(server, state);
+    });
+    thread::sleep(Duration::from_millis(20));
+    (Server { addr, _join: Some(join), _server_holder: Arc::new(()) }, tmp)
+}
+
+fn http(addr: &SocketAddr, method: &str, path: &str, body: &str) -> (u16, String) {
+    let mut s = TcpStream::connect(addr).unwrap();
+    s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    let req = format!(
+        "{method} {path} HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/x-www-form-urlencoded\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(), body
+    );
+    s.write_all(req.as_bytes()).unwrap();
+    let mut buf = String::new();
+    s.read_to_string(&mut buf).unwrap();
+    let (head, body) = buf.split_once("\r\n\r\n").unwrap_or((&buf, ""));
+    let status = head.split_whitespace().nth(1).unwrap_or("0").parse().unwrap_or(0);
+    (status, body.to_string())
+}
+
+#[test]
+fn web_triage_pin_defer_block_unblock_end_to_end() {
+    // Capture the prior value so the restoration at the end is
+    // exact, not a blanket remove. Other tests in this binary may
+    // not depend on it but a future refactor might.
+    let prior = std::env::var("LEX_TEA_USER").ok();
+    std::env::set_var("LEX_TEA_USER", "alice");
+
+    let result = std::panic::catch_unwind(|| {
+        let (srv, _tmp) = start_server();
+
+        // Publish a stage to act on.
+        let src = "fn foo(n :: Int) -> Int { n }\n";
+        let (s, b) = http(&srv.addr, "POST", "/v1/publish",
+            &json!({"source": src, "activate": false}).to_string());
+        assert_eq!(s, 200, "publish: {b}");
+        let v: serde_json::Value = serde_json::from_str(&b).unwrap();
+        let stage_id = v["ops"][0]["kind"]["stage_id"].as_str().unwrap().to_string();
+
+        // The stage page should show all four triage forms when
+        // LEX_TEA_USER is set.
+        let (s, page) = http(&srv.addr, "GET", &format!("/web/stage/{stage_id}"), "");
+        assert_eq!(s, 200);
+        for verb in ["pin", "defer", "block", "unblock"] {
+            assert!(page.contains(&format!("/web/stage/{stage_id}/{verb}")),
+                "stage page should expose {verb} form: not found");
+        }
+        assert!(page.contains("alice"), "actor name should appear: {page}");
+
+        // POST defer → 303 redirect, no state change, defer
+        // attestation persisted.
+        let (s, _) = http(&srv.addr, "POST",
+            &format!("/web/stage/{stage_id}/defer"),
+            "reason=low%20priority");
+        assert_eq!(s, 303, "defer should 303");
+
+        // POST block → 303, then pin should refuse with 409.
+        let (s, _) = http(&srv.addr, "POST",
+            &format!("/web/stage/{stage_id}/block"),
+            "reason=needs%20review");
+        assert_eq!(s, 303, "block should 303");
+
+        let (s, b) = http(&srv.addr, "POST",
+            &format!("/web/stage/{stage_id}/pin"),
+            "reason=ship");
+        assert_eq!(s, 409, "pin should 409 when blocked: {b}");
+        assert!(b.contains("blocked"), "409 body should mention blocked: {b}");
+
+        // POST unblock → 303. Sleep ≥1s so the unblock has a
+        // strictly later timestamp than the block.
+        thread::sleep(Duration::from_millis(1100));
+        let (s, _) = http(&srv.addr, "POST",
+            &format!("/web/stage/{stage_id}/unblock"),
+            "reason=cleared");
+        assert_eq!(s, 303, "unblock should 303");
+
+        // Now pin succeeds → 303.
+        let (s, _) = http(&srv.addr, "POST",
+            &format!("/web/stage/{stage_id}/pin"),
+            "reason=ship");
+        assert_eq!(s, 303, "pin should succeed after unblock");
+
+        // The stage page should now show one of each kind.
+        let (s, page) = http(&srv.addr, "GET", &format!("/web/stage/{stage_id}"), "");
+        assert_eq!(s, 200);
+        for kind in ["Defer(alice)", "Block(alice)", "Unblock(alice)", "Override(alice)"] {
+            assert!(page.contains(kind), "stage page should list {kind}: not found");
+        }
+
+        // Missing reason → 400.
+        let (s, _) = http(&srv.addr, "POST",
+            &format!("/web/stage/{stage_id}/defer"),
+            "");
+        assert_eq!(s, 400);
+
+        // Unknown stage → 404.
+        let (s, _) = http(&srv.addr, "POST",
+            "/web/stage/no_such_stage/defer",
+            "reason=x");
+        assert_eq!(s, 404);
+    });
+
+    // Restore env regardless of test outcome.
+    match prior {
+        Some(v) => std::env::set_var("LEX_TEA_USER", v),
+        None => std::env::remove_var("LEX_TEA_USER"),
+    }
+    if let Err(e) = result {
+        std::panic::resume_unwind(e);
+    }
+}


### PR DESCRIPTION
## Summary

Mirrors the CLI's v3b triage actions in the web UI so a human
reviewing a stage in the browser can pin / defer / block /
unblock without dropping back to the terminal.

- **Stage detail page** renders four forms when `LEX_TEA_USER`
  is set on the server. Without it, no buttons — same gate as
  v3a's pin form.
- **One handler, four routes**: POST
  `/web/stage/<id>/{pin,defer,block,unblock}` all go through
  `stage_decision_handler`. The verb in the path picks the
  `AttestationKind`. Pin keeps its existing semantics: activate
  + `Override`. The other three record their attestation only.
- **Block enforcement parity**: pin now consults
  `lex_vcs::is_stage_blocked` first. A blocked stage returns 409
  with a "record an unblock first" page, matching the CLI
  behaviour from v3b (#178).
- **Single end-to-end test** exercises every endpoint, the
  block→unblock→pin flow, missing-reason 400, and unknown-stage
  404. One test on purpose: `LEX_TEA_USER` is process-global, so
  multiple tests in the same binary would race.

`users.json`-backed actor identity (the "set `LEX_TEA_USER` once
and anyone hitting the server is them" gap) is the next slice
and will retire the env-var fallback for production use.

## Test plan

- [x] `cargo test -p lex-api --test web_triage` (1 new
      end-to-end test)
- [x] `cargo test -p lex-cli --test stage_decision`
      (existing v3b CLI tests still pass)
- [x] `cargo test -p lex-cli --test stage_pin` (existing v3a
      tests still pass)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [ ] CI green

https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5

---
_Generated by [Claude Code](https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5)_