### PR TITLE
feat: users.json-backed actor identity (lex-tea v3d, #172)

### DIFF
--- a/crates/lex-api/src/handlers.rs
+++ b/crates/lex-api/src/handlers.rs
@@ -21,6 +21,11 @@ use tiny_http::{Header, Method, Request, Response};
 
 pub struct State {
     pub store: Mutex<Store>,
+    /// Filesystem root of the store. Held alongside the `Store`
+    /// itself so handlers that need to read store-level files
+    /// (e.g. `users.json` for actor auth) don't have to round-
+    /// trip through the lock.
+    pub root: PathBuf,
     /// In-memory merge sessions, keyed by MergeSessionId. Sessions
     /// are ephemeral by design (#134 foundation): they live for the
     /// lifetime of the server process and are GC'd on commit. A
@@ -45,7 +50,8 @@ pub struct ApiMergeSession {
 impl State {
     pub fn open(root: PathBuf) -> anyhow::Result<Self> {
         Ok(Self {
-            store: Mutex::new(Store::open(root)?),
+            store: Mutex::new(Store::open(&root)?),
+            root,
             sessions: Mutex::new(HashMap::new()),
         })
     }
@@ -85,10 +91,18 @@ pub fn handle(state: Arc<State>, mut req: Request) -> std::io::Result<()> {
     let path = url.split('?').next().unwrap_or("").to_string();
     let query = url.split_once('?').map(|(_, q)| q.to_string()).unwrap_or_default();
 
+    // `X-Lex-User` is the v3d session identifier — set by humans
+    // operating the web UI through whatever proxy fronts auth, or
+    // by AI agents calling the JSON API. We pluck it once here so
+    // every handler can take it as a borrowed string.
+    let x_lex_user = req.headers().iter()
+        .find(|h| h.field.equiv("x-lex-user"))
+        .map(|h| h.value.as_str().to_string());
+
     let mut body = String::new();
     let _ = req.as_reader().read_to_string(&mut body);
 
-    let resp = route(&state, &method, &path, &query, &body);
+    let resp = route(&state, &method, &path, &query, &body, x_lex_user.as_deref());
     req.respond(resp)
 }
 
@@ -98,6 +112,7 @@ fn route(
     path: &str,
     query: &str,
     body: &str,
+    x_lex_user: Option<&str>,
 ) -> Response<std::io::Cursor<Vec<u8>>> {
     match (method, path) {
         // ---- lex-tea v2 (HTML browser) ------------------------
@@ -132,7 +147,7 @@ fn route(
                 "unblock" => crate::web::WebStageDecision::Unblock,
                 _ => unreachable!("matched in outer guard"),
             };
-            crate::web::stage_decision_handler(state, id, body, decision)
+            crate::web::stage_decision_handler(state, id, body, decision, x_lex_user)
         }
         // ---- JSON API -----------------------------------------
         (Method::Get, "/v1/health") => json_response(200, &serde_json::json!({"ok": true})),

--- a/crates/lex-api/src/web.rs
+++ b/crates/lex-api/src/web.rs
@@ -686,23 +686,40 @@ impl WebStageDecision {
 }
 
 /// `POST /web/stage/<id>/{pin,defer,block,unblock}` — handles
-/// the human-triage form submissions. Reads `LEX_TEA_USER` from
-/// the server env, records the appropriate attestation, and
-/// (for `pin` only) activates the stage. Redirects back to the
-/// stage page so a refresh doesn't repost the action.
+/// the human-triage form submissions. Picks the actor from the
+/// `X-Lex-User` request header (preferred, set by the proxy or
+/// programmatic client) or falls back to the `LEX_TEA_USER`
+/// server env. If `<store>/users.json` exists the resolved name
+/// must be in it. Records the appropriate attestation, and (for
+/// `pin` only) activates the stage. Redirects back to the stage
+/// page so a refresh doesn't repost the action.
 pub(crate) fn stage_decision_handler(
     state: &State,
     id: &str,
     body: &str,
     decision: WebStageDecision,
+    x_lex_user: Option<&str>,
 ) -> Response<Cursor<Vec<u8>>> {
-    let actor = match std::env::var("LEX_TEA_USER") {
-        Ok(n) if !n.is_empty() => n,
-        _ => return html_response(403, page("forbidden", "",
+    let actor = x_lex_user
+        .map(|s| s.to_string())
+        .filter(|s| !s.is_empty())
+        .or_else(|| std::env::var("LEX_TEA_USER").ok())
+        .filter(|s| !s.is_empty());
+    let Some(actor) = actor else {
+        return html_response(403, page("forbidden", "",
             r#"<nav class="crumb"><a href="/">activity</a></nav>
 <h1>forbidden</h1>
-<p>Set <code>LEX_TEA_USER</code> on the server to enable triage actions.</p>"#)),
+<p>No actor identified. Send <code>X-Lex-User</code> on the request, or set <code>LEX_TEA_USER</code> on the server.</p>"#));
     };
+    if let Ok(Some(users)) = lex_store::users::load(&state.root) {
+        if !users.knows(&actor) {
+            return html_response(403, page("forbidden", "",
+                &format!(r#"<nav class="crumb"><a href="/">activity</a></nav>
+<h1>forbidden</h1>
+<p>Actor <code>{}</code> is not listed in <code>users.json</code>.</p>"#,
+                    esc(&actor))));
+        }
+    }
     let reason = body.split('&')
         .find_map(|pair| pair.strip_prefix("reason="))
         .map(percent_decode)

--- a/crates/lex-api/tests/web_users_json.rs
+++ b/crates/lex-api/tests/web_users_json.rs
@@ -1,0 +1,109 @@
+//! Web triage with `users.json` + `X-Lex-User` header (lex-tea
+//! v3d, #172). One test by design — `LEX_TEA_USER` is process-
+//! global so multiple tests in the same binary would race. The
+//! header path doesn't have that risk but we exercise both here
+//! to keep the cost flat.
+
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpStream};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use lex_api::handlers::State;
+use serde_json::json;
+use tempfile::TempDir;
+
+struct Server {
+    addr: SocketAddr,
+    _join: Option<thread::JoinHandle<()>>,
+}
+
+fn start_server() -> (Server, TempDir) {
+    let tmp = TempDir::new().unwrap();
+    // Write users.json *before* opening the store so a future
+    // refactor that loads it on State::open still sees it.
+    let users = json!({
+        "users": [
+            {"name": "alice", "role": "human"},
+            {"name": "lexbot", "role": "agent"},
+        ]
+    });
+    std::fs::write(tmp.path().join("users.json"),
+        serde_json::to_vec_pretty(&users).unwrap()).unwrap();
+
+    let server = tiny_http::Server::http(("127.0.0.1", 0))
+        .expect("bind ephemeral port");
+    let addr: SocketAddr = match server.server_addr() {
+        tiny_http::ListenAddr::IP(addr) => addr,
+        _ => panic!("expected IP listener"),
+    };
+    let state = Arc::new(State::open(tmp.path().to_path_buf()).unwrap());
+    let join = thread::spawn(move || {
+        lex_api::serve_on(server, state);
+    });
+    thread::sleep(Duration::from_millis(20));
+    (Server { addr, _join: Some(join) }, tmp)
+}
+
+fn http_with_user(addr: &SocketAddr, method: &str, path: &str, body: &str,
+    user: Option<&str>) -> (u16, String)
+{
+    let mut s = TcpStream::connect(addr).unwrap();
+    s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    let user_hdr = match user {
+        Some(u) => format!("X-Lex-User: {u}\r\n"),
+        None => String::new(),
+    };
+    let req = format!(
+        "{method} {path} HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/x-www-form-urlencoded\r\n{user_hdr}Content-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(), body
+    );
+    s.write_all(req.as_bytes()).unwrap();
+    let mut buf = String::new();
+    s.read_to_string(&mut buf).unwrap();
+    let (head, body) = buf.split_once("\r\n\r\n").unwrap_or((&buf, ""));
+    let status = head.split_whitespace().nth(1).unwrap_or("0").parse().unwrap_or(0);
+    (status, body.to_string())
+}
+
+#[test]
+fn web_users_json_gates_triage_actions() {
+    let (srv, _tmp) = start_server();
+
+    let src = "fn foo(n :: Int) -> Int { n }\n";
+    let (s, b) = http_with_user(&srv.addr, "POST", "/v1/publish",
+        &json!({"source": src, "activate": false}).to_string(), None);
+    assert_eq!(s, 200, "publish: {b}");
+    let v: serde_json::Value = serde_json::from_str(&b).unwrap();
+    let stage_id = v["ops"][0]["kind"]["stage_id"].as_str().unwrap().to_string();
+
+    // No header → 403 (no actor identified, since LEX_TEA_USER is
+    // unset in this test process).
+    let (s, _) = http_with_user(&srv.addr, "POST",
+        &format!("/web/stage/{stage_id}/defer"),
+        "reason=x", None);
+    assert_eq!(s, 403, "missing actor → 403");
+
+    // Header with unknown actor → 403 (users.json lookup fails).
+    let (s, b) = http_with_user(&srv.addr, "POST",
+        &format!("/web/stage/{stage_id}/defer"),
+        "reason=x", Some("eve"));
+    assert_eq!(s, 403, "unknown actor → 403: {b}");
+    assert!(b.contains("eve") || b.contains("users.json"),
+        "403 body should explain why: {b}");
+
+    // Header with known actor → 303.
+    let (s, _) = http_with_user(&srv.addr, "POST",
+        &format!("/web/stage/{stage_id}/defer"),
+        "reason=low%20priority", Some("alice"));
+    assert_eq!(s, 303, "known actor → 303");
+
+    // The stage page should now show the defer attestation under
+    // alice's name.
+    let (s, page) = http_with_user(&srv.addr, "GET",
+        &format!("/web/stage/{stage_id}"), "", Some("alice"));
+    assert_eq!(s, 200);
+    assert!(page.contains("Defer(alice)"),
+        "stage page should list alice's defer: not found");
+}

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -1150,6 +1150,34 @@ fn cmd_stage(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     Ok(())
 }
 
+/// Resolve and validate the actor for a triage action.
+/// Combines `--actor` and `LEX_TEA_USER` (in that order), and
+/// when `<root>/users.json` exists requires the resulting name
+/// to be in the file. Returns a printable error mentioning the
+/// command verb so the user can see which surface refused them.
+fn resolve_actor(
+    root: &std::path::Path,
+    supplied: Option<String>,
+    verb: &str,
+) -> Result<String> {
+    let actor = supplied
+        .or_else(|| std::env::var("LEX_TEA_USER").ok())
+        .ok_or_else(|| anyhow!(
+            "lex stage {verb}: actor unknown — pass --actor NAME or set LEX_TEA_USER"
+        ))?;
+    if let Some(users) = lex_store::users::load(root)
+        .with_context(|| format!("reading users.json at {}", root.display()))?
+    {
+        if !users.knows(&actor) {
+            bail!(
+                "lex stage {verb}: actor `{actor}` not listed in {}/users.json",
+                root.display()
+            );
+        }
+    }
+    Ok(actor)
+}
+
 /// `lex stage pin <id> --reason "..." [--actor <name>]` —
 /// human override (#172, lex-tea v3a). Activates the stage and
 /// records an `Override` attestation alongside whatever
@@ -1158,7 +1186,8 @@ fn cmd_stage(fmt: &OutputFormat, args: &[String]) -> Result<()> {
 /// returns every override the human(s) have issued.
 ///
 /// `actor` defaults to `$LEX_TEA_USER`; falling back errors so
-/// a pin can't land anonymously.
+/// a pin can't land anonymously. When `<store>/users.json`
+/// exists, the resolved name must be in the file (v3d, #172).
 fn cmd_stage_pin(
     fmt: &OutputFormat,
     root: &std::path::Path,
@@ -1182,11 +1211,7 @@ fn cmd_stage_pin(
     let reason = reason.ok_or_else(|| anyhow!(
         "lex stage pin: --reason required (overrides need a paper trail)"
     ))?;
-    let actor = actor
-        .or_else(|| std::env::var("LEX_TEA_USER").ok())
-        .ok_or_else(|| anyhow!(
-            "lex stage pin: actor unknown — pass --actor NAME or set LEX_TEA_USER"
-        ))?;
+    let actor = resolve_actor(root, actor, "pin")?;
 
     let store = Store::open(root)
         .with_context(|| format!("opening store at {}", root.display()))?;
@@ -1309,11 +1334,7 @@ fn cmd_stage_decision(
     let reason = reason.ok_or_else(|| anyhow!(
         "lex stage {verb}: --reason required (triage decisions need a paper trail)"
     ))?;
-    let actor = actor
-        .or_else(|| std::env::var("LEX_TEA_USER").ok())
-        .ok_or_else(|| anyhow!(
-            "lex stage {verb}: actor unknown — pass --actor NAME or set LEX_TEA_USER"
-        ))?;
+    let actor = resolve_actor(root, actor, verb)?;
 
     let store = Store::open(root)
         .with_context(|| format!("opening store at {}", root.display()))?;

--- a/crates/lex-cli/tests/users_json.rs
+++ b/crates/lex-cli/tests/users_json.rs
@@ -1,0 +1,148 @@
+//! `<store>/users.json` actor enforcement (lex-tea v3d, #172).
+//! When the file exists, `lex stage <pin|defer|block|unblock>`
+//! refuses unknown actors. When absent, behaviour matches v3a–v3c.
+
+use std::process::Command;
+use tempfile::tempdir;
+
+fn lex_bin() -> &'static str { env!("CARGO_BIN_EXE_lex") }
+
+fn publish(store: &std::path::Path, src: &std::path::Path) -> serde_json::Value {
+    let out = Command::new(lex_bin())
+        .args([
+            "--output", "json",
+            "publish",
+            "--store", store.to_str().unwrap(),
+            src.to_str().unwrap(),
+        ])
+        .output().unwrap();
+    assert!(out.status.success(), "publish: {}", String::from_utf8_lossy(&out.stderr));
+    serde_json::from_slice(&out.stdout).unwrap()
+}
+
+fn first_stage_id(publish_out: &serde_json::Value) -> String {
+    publish_out.pointer("/data/ops/0/kind/stage_id")
+        .and_then(|v| v.as_str())
+        .expect("stage_id")
+        .to_string()
+}
+
+fn write_users_json(store: &std::path::Path, names: &[&str]) {
+    let users: Vec<serde_json::Value> = names.iter()
+        .map(|n| serde_json::json!({"name": n, "role": "human"}))
+        .collect();
+    let body = serde_json::json!({"users": users});
+    std::fs::write(store.join("users.json"), serde_json::to_vec_pretty(&body).unwrap()).unwrap();
+}
+
+#[test]
+fn pin_with_known_actor_succeeds() {
+    let store = tempdir().unwrap();
+    let src = store.path().join("a.lex");
+    std::fs::write(&src, "fn fac(n :: Int) -> Int { 1 }\n").unwrap();
+    let pub_out = publish(store.path(), &src);
+    let stage_id = first_stage_id(&pub_out);
+    write_users_json(store.path(), &["alice", "bob"]);
+
+    let out = Command::new(lex_bin())
+        .args([
+            "stage", "pin", &stage_id,
+            "--reason", "spec wrong",
+            "--actor", "alice",
+            "--store", store.path().to_str().unwrap(),
+        ])
+        .env_remove("LEX_TEA_USER")
+        .output().unwrap();
+    assert!(out.status.success(), "pin: {}", String::from_utf8_lossy(&out.stderr));
+}
+
+#[test]
+fn pin_with_unknown_actor_refused() {
+    let store = tempdir().unwrap();
+    let src = store.path().join("a.lex");
+    std::fs::write(&src, "fn fac(n :: Int) -> Int { 1 }\n").unwrap();
+    let pub_out = publish(store.path(), &src);
+    let stage_id = first_stage_id(&pub_out);
+    write_users_json(store.path(), &["alice", "bob"]);
+
+    let out = Command::new(lex_bin())
+        .args([
+            "stage", "pin", &stage_id,
+            "--reason", "spec wrong",
+            "--actor", "eve",
+            "--store", store.path().to_str().unwrap(),
+        ])
+        .env_remove("LEX_TEA_USER")
+        .output().unwrap();
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("eve"), "stderr should name the offender: {stderr}");
+    assert!(stderr.contains("users.json"), "stderr should mention users.json: {stderr}");
+}
+
+#[test]
+fn defer_block_unblock_all_validate() {
+    // Same gate applies to every triage verb.
+    let store = tempdir().unwrap();
+    let src = store.path().join("a.lex");
+    std::fs::write(&src, "fn fac(n :: Int) -> Int { 1 }\n").unwrap();
+    let pub_out = publish(store.path(), &src);
+    let stage_id = first_stage_id(&pub_out);
+    write_users_json(store.path(), &["alice"]);
+
+    for verb in ["defer", "block", "unblock"] {
+        let out = Command::new(lex_bin())
+            .args([
+                "stage", verb, &stage_id,
+                "--reason", "x",
+                "--actor", "eve",
+                "--store", store.path().to_str().unwrap(),
+            ])
+            .env_remove("LEX_TEA_USER")
+            .output().unwrap();
+        assert!(!out.status.success(), "{verb} should refuse unknown actor");
+    }
+}
+
+#[test]
+fn lex_tea_user_env_must_also_be_listed() {
+    let store = tempdir().unwrap();
+    let src = store.path().join("a.lex");
+    std::fs::write(&src, "fn fac(n :: Int) -> Int { 1 }\n").unwrap();
+    let pub_out = publish(store.path(), &src);
+    let stage_id = first_stage_id(&pub_out);
+    write_users_json(store.path(), &["alice"]);
+
+    // LEX_TEA_USER=eve, but eve is not in users.json → refuse.
+    let out = Command::new(lex_bin())
+        .args([
+            "stage", "pin", &stage_id,
+            "--reason", "x",
+            "--store", store.path().to_str().unwrap(),
+        ])
+        .env("LEX_TEA_USER", "eve")
+        .output().unwrap();
+    assert!(!out.status.success());
+}
+
+#[test]
+fn no_users_json_keeps_v3c_behaviour() {
+    // Without the file, any --actor is accepted (existing flow).
+    let store = tempdir().unwrap();
+    let src = store.path().join("a.lex");
+    std::fs::write(&src, "fn fac(n :: Int) -> Int { 1 }\n").unwrap();
+    let pub_out = publish(store.path(), &src);
+    let stage_id = first_stage_id(&pub_out);
+
+    let out = Command::new(lex_bin())
+        .args([
+            "stage", "pin", &stage_id,
+            "--reason", "x",
+            "--actor", "anyone",
+            "--store", store.path().to_str().unwrap(),
+        ])
+        .env_remove("LEX_TEA_USER")
+        .output().unwrap();
+    assert!(out.status.success(),
+        "without users.json any actor works: {}", String::from_utf8_lossy(&out.stderr));
+}

--- a/crates/lex-store/src/lib.rs
+++ b/crates/lex-store/src/lib.rs
@@ -28,6 +28,7 @@
 mod store;
 mod model;
 mod branches;
+pub mod users;
 
 pub use lex_vcs::{OpId, Operation, OperationKind, OperationRecord, StageTransition};
 pub use model::{Lifecycle, Metadata, Spec, StageStatus, Test, Transition};

--- a/crates/lex-store/src/users.rs
+++ b/crates/lex-store/src/users.rs
@@ -1,0 +1,128 @@
+//! `<store>/users.json` — actor identity (lex-tea v3d, #172).
+//!
+//! Tightens the v3a–v3c `LEX_TEA_USER` env var auth: the env var
+//! (and the `--actor` flag) still nominate who took an action,
+//! but when `users.json` exists the nominated name must be in
+//! the file. Anonymous overrides aren't a regression we want.
+//! When the file is absent the surfaces fall back to the v3a–v3c
+//! "anyone with LEX_TEA_USER" behaviour so existing dev setups
+//! keep working.
+//!
+//! File schema (deliberately minimal):
+//!
+//! ```json
+//! {
+//!   "users": [
+//!     {"name": "alice", "role": "human"},
+//!     {"name": "lexbot", "role": "agent"}
+//!   ]
+//! }
+//! ```
+//!
+//! `role` is recorded but not enforced in v3d — it gives later
+//! slices a place to gate "only humans can pin" or similar
+//! without a schema migration.
+
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io;
+use std::path::Path;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UserRole {
+    Human,
+    Agent,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct User {
+    pub name: String,
+    pub role: UserRole,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UsersFile {
+    #[serde(default)]
+    pub users: Vec<User>,
+}
+
+/// Load `<root>/users.json`. Returns `Ok(None)` when the file is
+/// absent (the v3a–v3c "no auth wired up, use env-var fallback"
+/// regime); `Ok(Some(_))` when present, even if the user list is
+/// empty (an empty file is "auth wired up, nobody allowed").
+pub fn load(root: &Path) -> io::Result<Option<UsersFile>> {
+    let path = root.join("users.json");
+    if !path.exists() {
+        return Ok(None);
+    }
+    let bytes = fs::read(&path)?;
+    let file: UsersFile = serde_json::from_slice(&bytes)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData,
+            format!("parsing {}: {e}", path.display())))?;
+    Ok(Some(file))
+}
+
+impl UsersFile {
+    /// Look up a user by name. Names are case-sensitive — the file
+    /// is the spec.
+    pub fn find(&self, name: &str) -> Option<&User> {
+        self.users.iter().find(|u| u.name == name)
+    }
+
+    /// Whether this name is recognized. Convenience over `find` for
+    /// callers that just want a yes/no gate.
+    pub fn knows(&self, name: &str) -> bool {
+        self.find(name).is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn load_absent_returns_none() {
+        let tmp = tempdir().unwrap();
+        let got = load(tmp.path()).unwrap();
+        assert!(got.is_none());
+    }
+
+    #[test]
+    fn load_empty_file_returns_some_empty() {
+        let tmp = tempdir().unwrap();
+        std::fs::write(tmp.path().join("users.json"), r#"{"users":[]}"#).unwrap();
+        let got = load(tmp.path()).unwrap().unwrap();
+        assert_eq!(got.users.len(), 0);
+        assert!(!got.knows("alice"));
+    }
+
+    #[test]
+    fn round_trip_through_disk() {
+        let tmp = tempdir().unwrap();
+        let f = UsersFile {
+            users: vec![
+                User { name: "alice".into(), role: UserRole::Human },
+                User { name: "lexbot".into(), role: UserRole::Agent },
+            ],
+        };
+        std::fs::write(
+            tmp.path().join("users.json"),
+            serde_json::to_vec_pretty(&f).unwrap(),
+        ).unwrap();
+        let got = load(tmp.path()).unwrap().unwrap();
+        assert_eq!(got, f);
+        assert_eq!(got.find("alice").unwrap().role, UserRole::Human);
+        assert_eq!(got.find("lexbot").unwrap().role, UserRole::Agent);
+        assert!(!got.knows("eve"));
+    }
+
+    #[test]
+    fn malformed_json_is_an_error() {
+        let tmp = tempdir().unwrap();
+        std::fs::write(tmp.path().join("users.json"), "not json").unwrap();
+        let err = load(tmp.path()).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the v3 sub-arc of #172. v3a–v3c let anyone with
`LEX_TEA_USER` set claim any name; this slice introduces a
store-level `users.json` that gates every triage action (pin /
defer / block / unblock) against a real allow-list.

- **`lex_store::users` module**: schema is
  ```json
  {"users": [{"name": "alice", "role": "human"}]}
  ```
  `role` is `human | agent`, recorded but not enforced in v3d —
  gives later slices a place to gate "only humans can pin"
  without a schema migration.
- **CLI**: `lex stage <pin|defer|block|unblock>` resolves the
  actor from `--actor` ∪ `LEX_TEA_USER` (unchanged), then
  validates membership when `<store>/users.json` exists.
  Backwards-compatible: without the file, v3a–v3c behaviour is
  preserved.
- **Web**: the triage handler accepts an `X-Lex-User` request
  header (preferred for programmatic clients and proxies) in
  addition to the existing `LEX_TEA_USER` env var. Same
  `users.json` membership gate. Forms still POST without the
  header and rely on the env-var fallback for single-user dev.
- **`State`** now carries the store root so handlers can read
  `users.json` without round-tripping through the store lock.

## Test plan

- [x] `cargo test -p lex-store --lib users` — 4 unit tests
      (absent / empty / round-trip / malformed)
- [x] `cargo test -p lex-cli --test users_json` — 5 integration
      tests (known accepted / unknown refused / all four verbs
      validated / `LEX_TEA_USER` also gated / no-file = v3c
      behaviour)
- [x] `cargo test -p lex-api --test web_users_json` — 1
      end-to-end test (single-test-by-design: process-global
      env vars would race)
- [x] `cargo test -p lex-cli --test stage_pin` (v3a) +
      `--test stage_decision` (v3b) still pass
- [x] `cargo test -p lex-api --test web_triage` (v3c) still
      passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [ ] CI green

https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5

---
_Generated by [Claude Code](https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5)_