### PR TITLE
feat: lex merge defer — per-conflict shortcut (#181)

### DIFF
--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -180,7 +180,7 @@ fn print_usage() {
     println!("  store-merge <src> <dst> [--commit] [--json]  three-way merge between two branches in");
     println!("                                     the store; conflicts as JSON. --commit applies a");
     println!("                                     clean merge; refuses if any conflicts remain.");
-    println!("  merge {{start|status|resolve|commit}}");
+    println!("  merge {{start|status|resolve|defer|commit}}");
     println!("                                     stateful merge for agent loops (#134); persists");
     println!("                                     a session under <store>/merges/<merge_id>.json");
     println!();

--- a/crates/lex-cli/src/merge.rs
+++ b/crates/lex-cli/src/merge.rs
@@ -87,12 +87,13 @@ fn parse_store_arg(args: &[String]) -> (PathBuf, Vec<String>) {
 
 pub fn cmd_merge(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let sub = args.first().ok_or_else(||
-        anyhow!("usage: lex merge {{start|status|resolve|commit}} ..."))?;
+        anyhow!("usage: lex merge {{start|status|resolve|defer|commit}} ..."))?;
     let rest = &args[1..];
     match sub.as_str() {
         "start"   => cmd_start(fmt, rest),
         "status"  => cmd_status(fmt, rest),
         "resolve" => cmd_resolve(fmt, rest),
+        "defer"   => cmd_defer(fmt, rest),
         "commit"  => cmd_commit(fmt, rest),
         other => bail!("unknown `lex merge` subcommand: {other}"),
     }
@@ -238,6 +239,61 @@ fn cmd_resolve(fmt: &OutputFormat, args: &[String]) -> Result<()> {
             println!("  {mark} {}", v.conflict_id);
         }
         println!("remaining: {}", remaining_for_text.len());
+    });
+    Ok(())
+}
+
+/// `lex merge defer <merge_id> <conflict_id> [--store DIR]` —
+/// per-conflict shortcut that submits `Resolution::Defer` against
+/// a single conflict (#181). Equivalent to feeding `lex merge
+/// resolve` a one-line JSON file but ergonomic for the common
+/// "I don't have an opinion on this conflict, leave it for
+/// review" workflow that would otherwise require a tempfile.
+fn cmd_defer(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    let (root, rest) = parse_store_arg(args);
+    let mut positional: Vec<String> = Vec::with_capacity(2);
+    let mut i = 0;
+    while i < rest.len() {
+        match rest[i].as_str() {
+            other if !other.starts_with("--") && positional.len() < 2 => {
+                positional.push(other.to_string());
+                i += 1;
+            }
+            other => bail!("unexpected arg `{other}`"),
+        }
+    }
+    let merge_id = positional.first().ok_or_else(||
+        anyhow!("usage: lex merge defer <merge_id> <conflict_id>"))?.clone();
+    let conflict_id = positional.get(1).ok_or_else(||
+        anyhow!("usage: lex merge defer <merge_id> <conflict_id>"))?.clone();
+
+    let mut file = load_merge(&root, &merge_id)?;
+    let pairs = vec![(conflict_id.clone(), lex_vcs::Resolution::Defer)];
+    let verdicts = file.session.resolve(pairs);
+    let remaining: Vec<lex_vcs::ConflictRecord> = file.session
+        .remaining_conflicts()
+        .into_iter()
+        .cloned()
+        .collect();
+    save_merge(&root, &file)?;
+
+    let data = serde_json::json!({
+        "verdicts":            verdicts,
+        "remaining_conflicts": remaining,
+    });
+    let conflict_id_for_text = conflict_id.clone();
+    let verdict_for_text = verdicts.first().cloned();
+    acli_mod::emit_or_text("merge", data, fmt, move || {
+        match verdict_for_text {
+            Some(v) if v.accepted => println!("✓ deferred {conflict_id_for_text}"),
+            Some(v) => {
+                let why = v.rejection
+                    .map(|r| format!("{r:?}"))
+                    .unwrap_or_else(|| "rejected".into());
+                println!("✗ {conflict_id_for_text}: {why}");
+            }
+            None => println!("(no verdict returned)"),
+        }
     });
     Ok(())
 }

--- a/crates/lex-cli/tests/merge_cli.rs
+++ b/crates/lex-cli/tests/merge_cli.rs
@@ -227,3 +227,83 @@ fn merge_status_unknown_id_errors() {
         .output().unwrap();
     assert!(!out.status.success());
 }
+
+#[test]
+fn merge_defer_resolves_one_conflict_and_blocks_commit() {
+    // `lex merge defer <merge_id> <conflict_id>` is the per-
+    // conflict shortcut that #181 calls out: same effect as
+    // putting `Resolution::Defer` in a resolutions file but no
+    // tempfile dance for the common "park this for review" path.
+    let store = tempdir().unwrap();
+    modify_modify_setup(store.path());
+    let v = merge_start(store.path(), "feature", lex_store::DEFAULT_BRANCH);
+    let merge_id = v.pointer("/data/merge_id").unwrap().as_str().unwrap().to_string();
+    let conflict_id = v.pointer("/data/conflicts/0/conflict_id").unwrap().as_str().unwrap().to_string();
+
+    let out = Command::new(lex_bin())
+        .args([
+            "--output", "json",
+            "merge", "defer",
+            "--store", store.path().to_str().unwrap(),
+            &merge_id,
+            &conflict_id,
+        ])
+        .output().unwrap();
+    assert!(out.status.success(), "defer: {}", String::from_utf8_lossy(&out.stderr));
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let verdict = v.pointer("/data/verdicts/0").unwrap();
+    assert_eq!(verdict["accepted"], true, "defer should be accepted: {v}");
+    assert_eq!(verdict["conflict_id"], conflict_id);
+
+    // Defer leaves the conflict in remaining_conflicts so commit
+    // refuses — that's the whole point: punt-to-human, not auto-
+    // resolve.
+    let out = Command::new(lex_bin())
+        .args([
+            "merge", "commit",
+            "--store", store.path().to_str().unwrap(),
+            &merge_id,
+        ])
+        .output().unwrap();
+    assert!(!out.status.success(), "commit must refuse a deferred conflict");
+}
+
+#[test]
+fn merge_defer_unknown_conflict_returns_rejection_verdict() {
+    let store = tempdir().unwrap();
+    modify_modify_setup(store.path());
+    let v = merge_start(store.path(), "feature", lex_store::DEFAULT_BRANCH);
+    let merge_id = v.pointer("/data/merge_id").unwrap().as_str().unwrap().to_string();
+
+    let out = Command::new(lex_bin())
+        .args([
+            "--output", "json",
+            "merge", "defer",
+            "--store", store.path().to_str().unwrap(),
+            &merge_id,
+            "no_such_conflict",
+        ])
+        .output().unwrap();
+    // Per-conflict rejection lives in the verdict JSON, not the
+    // process exit — matches `lex merge resolve` shape.
+    assert!(out.status.success(),
+        "defer should print verdict, not exit-fail: {}",
+        String::from_utf8_lossy(&out.stderr));
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let verdict = v.pointer("/data/verdicts/0").unwrap();
+    assert_eq!(verdict["accepted"], false, "rejection expected: {v}");
+}
+
+#[test]
+fn merge_defer_requires_both_args() {
+    let store = tempdir().unwrap();
+    let out = Command::new(lex_bin())
+        .args([
+            "merge", "defer",
+            "--store", store.path().to_str().unwrap(),
+        ])
+        .output().unwrap();
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("usage"), "stderr should have usage: {stderr}");
+}


### PR DESCRIPTION
## Summary

Closes the smaller half of #181 (the v3 follow-up). The original
#172 acceptance criteria called out `lex merge defer` as part of
the symmetric action set; the v3 sub-arc shipped stage-level
triage but left the per-conflict merge verb behind.

`lex merge defer <merge_id> <conflict_id>` is the one-conflict
ergonomic shortcut for feeding a single-entry resolutions file
to `lex merge resolve`. Same engine — `Resolution::Defer`
plumbed through.

The existing per-conflict verdict shape is preserved: callers
distinguish "deferred" (`verdict.accepted = true`, conflict
still in `remaining_conflicts`) from "rejected" (e.g. unknown
`conflict_id` → `verdict.accepted = false`).

Producer-block (`/policy.json` + `lex policy block-producer` +
activity-feed renderer) is the larger half of #181 and lands in
a follow-up PR.

## Test plan

- [x] `cargo test -p lex-cli --test merge_cli` — 3 new tests
      (happy path leaves conflict in remaining + commit refuses;
      unknown conflict returns rejection verdict; missing args
      errors with usage)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [ ] CI green

https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5

---
_Generated by [Claude Code](https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5)_