### PR TITLE
feat: lex policy block-producer + activity-feed blocked tag (#181)

### DIFF
--- a/crates/lex-api/src/web.rs
+++ b/crates/lex-api/src/web.rs
@@ -55,6 +55,7 @@ th { color: #666; font-weight: 500; background: #fafafa; }
 .tag.fail { background: #fdd; color: #800; }
 .tag.inc { background: #ffd; color: #850; }
 .tag.kind { background: #eef0f3; color: #445; }
+.tag.blocked { background: #444; color: #fff; }
 .empty { color: #aaa; font-style: italic; padding: 1rem; }
 .summary { display: flex; gap: 1.5rem; margin: 1rem 0; }
 .stat { padding: .5rem 1rem; background: #fafafa; border-radius: 4px; min-width: 110px; }
@@ -131,6 +132,12 @@ pub(crate) fn activity_handler(state: &State) -> Response<Cursor<Vec<u8>>> {
     };
     let mut atts = log.list_all().unwrap_or_default();
     atts.sort_by_key(|a| std::cmp::Reverse(a.timestamp));
+    // #181: producers on the local policy block list keep their
+    // attestations in the log (audit trail intact) but every row
+    // gets a `blocked` tag in the feed so reviewers can filter
+    // them out by eye.
+    let policy = lex_store::policy::load(&state.root)
+        .ok().flatten().unwrap_or_default();
 
     // Headline counters: pass / fail / inconclusive in the last 24h.
     // 24h from "now" via wall clock; small enough to be glanceable,
@@ -160,10 +167,15 @@ pub(crate) fn activity_handler(state: &State) -> Response<Cursor<Vec<u8>>> {
                 | AttestationResult::Inconclusive { detail } => esc(detail),
                 AttestationResult::Passed => esc(&a.produced_by.tool),
             };
+            let blocked_tag = if policy.is_blocked(&a.produced_by.tool) {
+                r#" <span class="tag blocked" title="producer is on the policy block list">blocked</span>"#
+            } else {
+                ""
+            };
             rows.push_str(&format!(
                 r#"<tr>
                   <td class="muted mono">{ts}</td>
-                  <td><span class="tag kind">{kind}</span></td>
+                  <td><span class="tag kind">{kind}</span>{blocked_tag}</td>
                   <td><span class="tag {css}">{result}</span> <span class="muted">{summary}</span></td>
                   <td class="mono"><a href="/web/stage/{stage}">{stage:.16}…</a></td>
                 </tr>"#,

--- a/crates/lex-api/tests/web_blocked_producer.rs
+++ b/crates/lex-api/tests/web_blocked_producer.rs
@@ -1,0 +1,80 @@
+//! Activity feed renders a `blocked` tag next to attestation
+//! rows whose producer is in `<store>/policy.json` (#181).
+
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpStream};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use lex_api::handlers::State;
+use serde_json::json;
+use tempfile::TempDir;
+
+struct Server { addr: SocketAddr, _join: Option<thread::JoinHandle<()>> }
+
+fn start_server(tmp: &TempDir) -> Server {
+    let server = tiny_http::Server::http(("127.0.0.1", 0))
+        .expect("bind ephemeral port");
+    let addr: SocketAddr = match server.server_addr() {
+        tiny_http::ListenAddr::IP(addr) => addr,
+        _ => panic!("expected IP listener"),
+    };
+    let state = Arc::new(State::open(tmp.path().to_path_buf()).unwrap());
+    let join = thread::spawn(move || {
+        lex_api::serve_on(server, state);
+    });
+    thread::sleep(Duration::from_millis(20));
+    Server { addr, _join: Some(join) }
+}
+
+fn http(addr: &SocketAddr, method: &str, path: &str, body: &str) -> (u16, String) {
+    let mut s = TcpStream::connect(addr).unwrap();
+    s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    let req = format!(
+        "{method} {path} HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(), body
+    );
+    s.write_all(req.as_bytes()).unwrap();
+    let mut buf = String::new();
+    s.read_to_string(&mut buf).unwrap();
+    let (head, body) = buf.split_once("\r\n\r\n").unwrap_or((&buf, ""));
+    let status = head.split_whitespace().nth(1).unwrap_or("0").parse().unwrap_or(0);
+    (status, body.to_string())
+}
+
+#[test]
+fn activity_feed_tags_blocked_producers() {
+    // Publish a stage. The store-write gate auto-emits a TypeCheck
+    // attestation whose producer tool is "lex publish".
+    let tmp = TempDir::new().unwrap();
+    let srv = start_server(&tmp);
+    let src = "fn foo(n :: Int) -> Int { n }\n";
+    let (s, _) = http(&srv.addr, "POST", "/v1/publish",
+        &json!({"source": src, "activate": false}).to_string());
+    assert_eq!(s, 200);
+
+    // Initially, no policy.json → no `blocked` tag in the feed.
+    let (s, b) = http(&srv.addr, "GET", "/", "");
+    assert_eq!(s, 200);
+    assert!(!b.contains(r#"class="tag blocked""#),
+        "no policy.json → no blocked tag: {b}");
+
+    // Drop a policy.json blocking "lex-store" — the producer
+    // tool name the store-write gate uses for auto-TypeCheck.
+    let policy = json!({
+        "blocked_producers": [{
+            "tool": "lex-store",
+            "reason": "test",
+            "blocked_at": 1,
+        }]
+    });
+    std::fs::write(tmp.path().join("policy.json"),
+        serde_json::to_vec_pretty(&policy).unwrap()).unwrap();
+
+    // Now the feed should tag the row blocked.
+    let (s, b) = http(&srv.addr, "GET", "/", "");
+    assert_eq!(s, 200);
+    assert!(b.contains(r#"class="tag blocked""#),
+        "policy.json with `lex-store` should tag row as blocked: {b}");
+}

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -101,6 +101,7 @@ fn run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         "branch" => branch::cmd_branch(fmt, &args[1..]),
         "store-merge" => branch::cmd_store_merge(fmt, &args[1..]),
         "merge" => merge::cmd_merge(fmt, &args[1..]),
+        "policy" => cmd_policy(fmt, &args[1..]),
         "log" => branch::cmd_log(fmt, &args[1..]),
         "op" => op::cmd_op(fmt, &args[1..]),
         "repl" => repl::cmd_repl(&args[1..]),
@@ -183,6 +184,9 @@ fn print_usage() {
     println!("  merge {{start|status|resolve|commit}}");
     println!("                                     stateful merge for agent loops (#134); persists");
     println!("                                     a session under <store>/merges/<merge_id>.json");
+    println!("  policy {{block-producer|unblock-producer|list}}");
+    println!("                                     manage <store>/policy.json — list of producers");
+    println!("                                     whose attestations are tagged `blocked` (#181)");
     println!();
     println!("policy flags (run, replay):");
     println!("  --allow-effects k1,k2,...   permit these effect kinds");
@@ -1486,6 +1490,126 @@ fn attestation_kind_tag(k: &lex_vcs::AttestationKind) -> &'static str {
         Block { .. }      => "block",
         Unblock { .. }    => "unblock",
     }
+}
+
+/// `lex policy {block-producer|unblock-producer|list}` — manage
+/// the local trust policy at `<store>/policy.json` (#181). The
+/// list is consulted at attestation-read time: producers on it
+/// keep their attestations in the log (audit trail intact) but
+/// the activity feed and other consumers tag those rows
+/// `blocked`. Enforcement is local; nothing is mutated in the
+/// attestation log itself.
+fn cmd_policy(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    let sub = args.first().ok_or_else(|| anyhow!(
+        "usage: lex policy {{block-producer <name> --reason \"...\" | unblock-producer <name> | list}} [--store DIR]"
+    ))?;
+    let rest = &args[1..];
+    match sub.as_str() {
+        "block-producer"   => cmd_policy_block(fmt, rest),
+        "unblock-producer" => cmd_policy_unblock(fmt, rest),
+        "list"             => cmd_policy_list(fmt, rest),
+        other => bail!("unknown `lex policy` subcommand: {other}"),
+    }
+}
+
+fn cmd_policy_block(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    let (root, rest, _, _) = parse_store_flag(args);
+    let mut name: Option<String> = None;
+    let mut reason: Option<String> = None;
+    let mut i = 0;
+    while i < rest.len() {
+        match rest[i].as_str() {
+            "--reason" => { reason = rest.get(i + 1).cloned(); i += 2; }
+            other if name.is_none() && !other.starts_with("--") => {
+                name = Some(other.to_string()); i += 1;
+            }
+            other => bail!("unexpected arg `{other}`"),
+        }
+    }
+    let name = name.ok_or_else(|| anyhow!(
+        "usage: lex policy block-producer <name> --reason \"...\""
+    ))?;
+    let reason = reason.ok_or_else(|| anyhow!(
+        "lex policy block-producer: --reason required"
+    ))?;
+    let mut policy = lex_store::policy::load(&root)
+        .with_context(|| format!("reading policy.json at {}", root.display()))?
+        .unwrap_or_default();
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let was_already_blocked = policy.is_blocked(&name);
+    policy.block(name.clone(), reason.clone(), now);
+    lex_store::policy::save(&root, &policy)
+        .with_context(|| format!("writing policy.json at {}", root.display()))?;
+
+    let data = serde_json::json!({
+        "tool": &name,
+        "reason": &reason,
+        "blocked_at": now,
+        "newly_blocked": !was_already_blocked,
+    });
+    let name_for_text = name.clone();
+    acli::emit_or_text("policy", data, fmt, move || {
+        if was_already_blocked {
+            println!("(already blocked) {name_for_text}");
+        } else {
+            println!("→ blocked producer `{name_for_text}`");
+        }
+    });
+    Ok(())
+}
+
+fn cmd_policy_unblock(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    let (root, rest, _, _) = parse_store_flag(args);
+    let name = rest.iter()
+        .find(|a| !a.starts_with("--"))
+        .ok_or_else(|| anyhow!("usage: lex policy unblock-producer <name>"))?
+        .clone();
+    let mut policy = lex_store::policy::load(&root)
+        .with_context(|| format!("reading policy.json at {}", root.display()))?
+        .unwrap_or_default();
+    let removed = policy.unblock(&name);
+    if removed {
+        lex_store::policy::save(&root, &policy)
+            .with_context(|| format!("writing policy.json at {}", root.display()))?;
+    }
+    let data = serde_json::json!({
+        "tool": &name,
+        "was_blocked": removed,
+    });
+    let name_for_text = name.clone();
+    acli::emit_or_text("policy", data, fmt, move || {
+        if removed {
+            println!("→ unblocked producer `{name_for_text}`");
+        } else {
+            println!("(not blocked) {name_for_text}");
+        }
+    });
+    Ok(())
+}
+
+fn cmd_policy_list(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    let (root, _rest, _, _) = parse_store_flag(args);
+    let policy = lex_store::policy::load(&root)
+        .with_context(|| format!("reading policy.json at {}", root.display()))?
+        .unwrap_or_default();
+    let data = serde_json::json!({
+        "blocked_producers": &policy.blocked_producers,
+        "count": policy.blocked_producers.len(),
+    });
+    let entries = policy.blocked_producers.clone();
+    acli::emit_or_text("policy", data, fmt, move || {
+        if entries.is_empty() {
+            println!("(no blocked producers)");
+            return;
+        }
+        for p in &entries {
+            println!("{}\tsince={}\treason={}", p.tool, p.blocked_at, p.reason);
+        }
+    });
+    Ok(())
 }
 
 fn attestation_result_tag(r: &lex_vcs::AttestationResult) -> &'static str {

--- a/crates/lex-cli/tests/policy.rs
+++ b/crates/lex-cli/tests/policy.rs
@@ -1,0 +1,133 @@
+//! `lex policy {block-producer|unblock-producer|list}` — local
+//! trust policy at `<store>/policy.json` (#181).
+
+use std::process::Command;
+use tempfile::tempdir;
+
+fn lex_bin() -> &'static str { env!("CARGO_BIN_EXE_lex") }
+
+fn run(args: &[&str]) -> std::process::Output {
+    Command::new(lex_bin()).args(args).output().unwrap()
+}
+
+#[test]
+fn block_producer_creates_policy_json() {
+    let store = tempdir().unwrap();
+    let out = run(&[
+        "--output", "json",
+        "policy", "block-producer", "buggy-bot",
+        "--reason", "false positives",
+        "--store", store.path().to_str().unwrap(),
+    ]);
+    assert!(out.status.success(), "block: {}", String::from_utf8_lossy(&out.stderr));
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v.pointer("/data/tool").unwrap(), "buggy-bot");
+    assert_eq!(v.pointer("/data/newly_blocked").unwrap(), true);
+
+    // policy.json should now exist on disk.
+    let policy_path = store.path().join("policy.json");
+    assert!(policy_path.exists(), "policy.json should be created");
+
+    // Re-blocking the same tool is a no-op.
+    let out = run(&[
+        "--output", "json",
+        "policy", "block-producer", "buggy-bot",
+        "--reason", "still buggy",
+        "--store", store.path().to_str().unwrap(),
+    ]);
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v.pointer("/data/newly_blocked").unwrap(), false);
+}
+
+#[test]
+fn unblock_producer_removes_entry() {
+    let store = tempdir().unwrap();
+    assert!(run(&[
+        "policy", "block-producer", "bot",
+        "--reason", "x",
+        "--store", store.path().to_str().unwrap(),
+    ]).status.success());
+
+    let out = run(&[
+        "--output", "json",
+        "policy", "unblock-producer", "bot",
+        "--store", store.path().to_str().unwrap(),
+    ]);
+    assert!(out.status.success(), "unblock: {}", String::from_utf8_lossy(&out.stderr));
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v.pointer("/data/was_blocked").unwrap(), true);
+
+    // Listing should now be empty.
+    let out = run(&[
+        "--output", "json",
+        "policy", "list",
+        "--store", store.path().to_str().unwrap(),
+    ]);
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v.pointer("/data/count").unwrap(), 0);
+}
+
+#[test]
+fn list_shows_all_blocked_producers() {
+    let store = tempdir().unwrap();
+    for (tool, reason) in [("a", "r1"), ("b", "r2"), ("c", "r3")] {
+        assert!(run(&[
+            "policy", "block-producer", tool,
+            "--reason", reason,
+            "--store", store.path().to_str().unwrap(),
+        ]).status.success());
+    }
+    let out = run(&[
+        "--output", "json",
+        "policy", "list",
+        "--store", store.path().to_str().unwrap(),
+    ]);
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v.pointer("/data/count").unwrap(), 3);
+    let tools: Vec<&str> = v.pointer("/data/blocked_producers").unwrap()
+        .as_array().unwrap().iter()
+        .map(|p| p["tool"].as_str().unwrap())
+        .collect();
+    assert_eq!(tools, vec!["a", "b", "c"]);
+}
+
+#[test]
+fn list_on_empty_store_returns_empty() {
+    let store = tempdir().unwrap();
+    let out = run(&[
+        "--output", "json",
+        "policy", "list",
+        "--store", store.path().to_str().unwrap(),
+    ]);
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v.pointer("/data/count").unwrap(), 0);
+}
+
+#[test]
+fn block_requires_reason() {
+    let store = tempdir().unwrap();
+    let out = run(&[
+        "policy", "block-producer", "bot",
+        "--store", store.path().to_str().unwrap(),
+    ]);
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("reason"), "stderr should mention reason: {stderr}");
+}
+
+#[test]
+fn unblock_unknown_producer_succeeds_idempotently() {
+    let store = tempdir().unwrap();
+    let out = run(&[
+        "--output", "json",
+        "policy", "unblock-producer", "ghost",
+        "--store", store.path().to_str().unwrap(),
+    ]);
+    assert!(out.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v.pointer("/data/was_blocked").unwrap(), false);
+}

--- a/crates/lex-store/src/lib.rs
+++ b/crates/lex-store/src/lib.rs
@@ -29,6 +29,7 @@ mod store;
 mod model;
 mod branches;
 pub mod users;
+pub mod policy;
 
 pub use lex_vcs::{OpId, Operation, OperationKind, OperationRecord, StageTransition};
 pub use model::{Lifecycle, Metadata, Spec, StageStatus, Test, Transition};

--- a/crates/lex-store/src/policy.rs
+++ b/crates/lex-store/src/policy.rs
@@ -1,0 +1,171 @@
+//! `<store>/policy.json` — local trust policy (#181, originally
+//! called out in the v3 acceptance criteria for #172).
+//!
+//! v3 introduced human-issued attestations (`Override`, `Defer`,
+//! `Block`, `Unblock`); v3 follow-up adds the inverse: the human
+//! can signal that *agent*-issued attestations from a specific
+//! producer shouldn't be trusted. Enforcement is at attestation-
+//! read time — the on-disk attestation log keeps the original
+//! record, and consumers (web activity feed, CI gates, etc.)
+//! consult the policy to decide whether to surface a `blocked`
+//! tag or filter the row out.
+//!
+//! File schema (deliberately small, mirroring `users.json`):
+//!
+//! ```json
+//! {
+//!   "blocked_producers": [
+//!     {"tool": "buggy-bot", "reason": "false positives", "blocked_at": 1714960000}
+//!   ]
+//! }
+//! ```
+//!
+//! Matching is against `Attestation::produced_by.tool`. `model`
+//! is intentionally not part of the match key in v1 — the tool
+//! identifier is stable across model upgrades. Add a `model`
+//! field if a future use case actually needs it.
+
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::{self, Write};
+use std::path::Path;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BlockedProducer {
+    /// Matched against `ProducerDescriptor::tool`.
+    pub tool: String,
+    pub reason: String,
+    /// Wall-clock seconds since epoch when the block was added.
+    /// Useful for "blocked since X" rendering in the activity feed.
+    pub blocked_at: u64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PolicyFile {
+    #[serde(default)]
+    pub blocked_producers: Vec<BlockedProducer>,
+}
+
+/// Load `<root>/policy.json`. Returns `Ok(None)` when absent
+/// (no policy → no blocks); `Ok(Some(default))` when the file
+/// exists but is empty/has no blocks.
+pub fn load(root: &Path) -> io::Result<Option<PolicyFile>> {
+    let path = root.join("policy.json");
+    if !path.exists() {
+        return Ok(None);
+    }
+    let bytes = fs::read(&path)?;
+    let file: PolicyFile = serde_json::from_slice(&bytes)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData,
+            format!("parsing {}: {e}", path.display())))?;
+    Ok(Some(file))
+}
+
+/// Atomic write: tempfile + rename so a crashed write never
+/// leaves a half-truncated `policy.json`. Same pattern the
+/// attestation log uses.
+pub fn save(root: &Path, file: &PolicyFile) -> io::Result<()> {
+    fs::create_dir_all(root)?;
+    let path = root.join("policy.json");
+    let tmp = path.with_extension("json.tmp");
+    let bytes = serde_json::to_vec_pretty(file)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    {
+        let mut f = fs::File::create(&tmp)?;
+        f.write_all(&bytes)?;
+        f.sync_all()?;
+    }
+    fs::rename(&tmp, &path)
+}
+
+impl PolicyFile {
+    /// Whether the named tool is on the block list.
+    pub fn is_blocked(&self, tool: &str) -> bool {
+        self.blocked_producers.iter().any(|p| p.tool == tool)
+    }
+
+    /// Look up the block entry, if any. Useful for "blocked
+    /// since X — reason: Y" rendering.
+    pub fn find(&self, tool: &str) -> Option<&BlockedProducer> {
+        self.blocked_producers.iter().find(|p| p.tool == tool)
+    }
+
+    /// Add a producer to the block list. Idempotent: blocking an
+    /// already-blocked tool is a no-op (preserves the original
+    /// `blocked_at`); the new reason is dropped. Callers that
+    /// want to update a reason should `unblock` then `block`.
+    pub fn block(&mut self, tool: String, reason: String, now: u64) {
+        if self.is_blocked(&tool) {
+            return;
+        }
+        self.blocked_producers.push(BlockedProducer {
+            tool,
+            reason,
+            blocked_at: now,
+        });
+    }
+
+    /// Remove a producer from the block list. Returns whether
+    /// the entry was present.
+    pub fn unblock(&mut self, tool: &str) -> bool {
+        let before = self.blocked_producers.len();
+        self.blocked_producers.retain(|p| p.tool != tool);
+        before != self.blocked_producers.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn load_absent_returns_none() {
+        let tmp = tempdir().unwrap();
+        assert!(load(tmp.path()).unwrap().is_none());
+    }
+
+    #[test]
+    fn round_trip_through_disk() {
+        let tmp = tempdir().unwrap();
+        let mut f = PolicyFile::default();
+        f.block("bot-a".into(), "false positives".into(), 1000);
+        f.block("bot-b".into(), "stale model".into(), 2000);
+        save(tmp.path(), &f).unwrap();
+        let got = load(tmp.path()).unwrap().unwrap();
+        assert_eq!(got, f);
+        assert!(got.is_blocked("bot-a"));
+        assert!(!got.is_blocked("not-blocked"));
+        assert_eq!(got.find("bot-b").unwrap().reason, "stale model");
+    }
+
+    #[test]
+    fn block_is_idempotent() {
+        let mut f = PolicyFile::default();
+        f.block("bot".into(), "first reason".into(), 100);
+        f.block("bot".into(), "second reason — ignored".into(), 200);
+        assert_eq!(f.blocked_producers.len(), 1);
+        // Original blocked_at + reason preserved.
+        let entry = f.find("bot").unwrap();
+        assert_eq!(entry.blocked_at, 100);
+        assert_eq!(entry.reason, "first reason");
+    }
+
+    #[test]
+    fn unblock_removes_entry() {
+        let mut f = PolicyFile::default();
+        f.block("bot".into(), "x".into(), 1);
+        assert!(f.unblock("bot"));
+        assert!(!f.is_blocked("bot"));
+        // Second unblock is a no-op and returns false.
+        assert!(!f.unblock("bot"));
+    }
+
+    #[test]
+    fn malformed_json_is_an_error() {
+        let tmp = tempdir().unwrap();
+        std::fs::write(tmp.path().join("policy.json"), "{ not json").unwrap();
+        let err = load(tmp.path()).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the larger half of #181 (the v3 follow-up). Pairs with
PR #182 (`lex merge defer`) — together they clear the two
acceptance criteria from #172 that the v3 sub-arc skipped.

- **New `lex_store::policy` module**: `<store>/policy.json`
  carries a list of blocked producers
  `{tool, reason, blocked_at}`. Same load / save / atomic-write
  idioms as `users.json`.
- **CLI**:
  - `lex policy block-producer <name> --reason "..."` —
    idempotent. Returns `newly_blocked: bool` so callers can
    tell "added now" from "already there".
  - `lex policy unblock-producer <name>` — returns
    `was_blocked: bool` so dashboards can tell "no-op" from
    "removed".
  - `lex policy list` — `{blocked_producers, count}`.
- **Activity feed** (`GET /`) renders a dark `blocked` tag next
  to attestation rows whose `produced_by.tool` is on the list.
  Enforcement is read-time only — the attestation log keeps
  every record, so the audit trail stays intact even after a
  producer falls out of trust.
- **CSS**: new `.tag.blocked` style.

## Test plan

- [x] `cargo test -p lex-store --lib policy` — 5 unit tests
      (round-trip, idempotent block, unblock returns presence,
      malformed JSON errors)
- [x] `cargo test -p lex-cli --test policy` — 6 integration
      tests (create / unblock / list / empty / require reason /
      unblock-unknown)
- [x] `cargo test -p lex-api --test web_blocked_producer` —
      1 end-to-end test that publishes a stage, asserts no
      `blocked` tag without `policy.json`, drops `policy.json`
      blocking the auto-TypeCheck producer (`lex-store`),
      reloads the feed, and asserts the tag now appears.
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [ ] CI green

Closes both #181 acceptance criteria when combined with #182.

https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5

---
_Generated by [Claude Code](https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5)_