### PR TITLE
fix: type-driven validation for std.{json,toml,yaml}.parse[T] (#168)

### DIFF
--- a/crates/lex-api/src/handlers.rs
+++ b/crates/lex-api/src/handlers.rs
@@ -225,8 +225,11 @@ pub(crate) fn publish_handler(state: &State, body: &str) -> Response<std::io::Cu
     let prog = match load_program_from_str(&req.source) {
         Ok(p) => p, Err(e) => return error_response(400, format!("syntax error: {e}")),
     };
-    let stages = canonicalize_program(&prog);
-    if let Err(errs) = lex_types::check_program(&stages) {
+    // #168: rewrite stdlib parse calls to parse_strict so the
+    // bytecode emitted from these stages enforces required-field
+    // checks at runtime.
+    let mut stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_and_rewrite_program(&mut stages) {
         return error_with_detail(422, "type errors", serde_json::to_value(&errs).unwrap());
     }
 

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -363,8 +363,10 @@ fn cmd_run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
             &format!("would call `{func}` in {path}"), actions);
     }
     let prog = read_program(path)?;
-    let stages = canonicalize_program(&prog);
-    if let Err(errs) = lex_types::check_program(&stages) {
+    // #168: rewrite stdlib parse calls during type-check so the
+    // runtime sees the strict (validated) shape.
+    let mut stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_and_rewrite_program(&mut stages) {
         let arr: Vec<serde_json::Value> = errs.iter()
             .map(|e| serde_json::to_value(e).unwrap()).collect();
         let data = serde_json::json!({ "phase": "type-check", "errors": arr });
@@ -917,8 +919,13 @@ fn cmd_publish(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         "usage: lex publish [--store DIR] [--branch NAME] [--activate] <file>"))?;
 
     let prog = read_program(path)?;
-    let stages = canonicalize_program(&prog);
-    if let Err(errs) = lex_types::check_program(&stages) {
+    // #168: type-check *and* rewrite stdlib parse calls so a
+    // typed `toml.parse[T]` validates required fields before
+    // returning Ok. The mutation lands in the canonical AST so
+    // every downstream consumer (bytecode compile, store
+    // publish) sees the strict shape.
+    let mut stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_and_rewrite_program(&mut stages) {
         let arr: Vec<serde_json::Value> = errs.iter()
             .map(|e| serde_json::to_value(e).unwrap()).collect();
         let data = serde_json::json!({ "phase": "type-check", "errors": arr });

--- a/crates/lex-runtime/tests/std_parse_typed.rs
+++ b/crates/lex-runtime/tests/std_parse_typed.rs
@@ -1,0 +1,175 @@
+//! `check_and_rewrite_program` — full type-driven `parse[T]` (#168).
+//!
+//! When the type-checker can see that a `<module>.parse(s)` call
+//! returns `Result[Record{...}, _]`, the rewrite pass mutates
+//! the AST so the bytecode emits `<module>.parse_strict(s, [fields])`
+//! instead. The runtime then validates required fields before
+//! returning `Ok`, replacing the pre-#168 silent-incomplete-record
+//! behavior with a proper `Err`.
+//!
+//! Pinned on the rubric (formerly OSS Auditor) repro.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::sync::Arc;
+
+fn run_with_rewrite(src: &str, fn_name: &str, args: Vec<Value>) -> Value {
+    let prog = parse_source(src).expect("parse");
+    let mut stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_and_rewrite_program(&mut stages) {
+        panic!("type errors:\n{errs:#?}");
+    }
+    let bc = Arc::new(compile_program(&stages));
+    let handler = DefaultHandler::new(Policy::pure()).with_program(Arc::clone(&bc));
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(fn_name, args).unwrap_or_else(|e| panic!("call {fn_name}: {e}"))
+}
+
+fn err_msg(v: &Value) -> &str {
+    match v {
+        Value::Variant { name, args } if name == "Err" => match &args[0] {
+            Value::Str(s) => s.as_str(),
+            other => panic!("expected Err(Str), got {other:?}"),
+        },
+        other => panic!("expected Err, got {other:?}"),
+    }
+}
+
+fn ok(v: &Value) -> &Value {
+    match v {
+        Value::Variant { name, args } if name == "Ok" => &args[0],
+        other => panic!("expected Ok, got {other:?}"),
+    }
+}
+
+const TOML_SRC: &str = r#"
+import "std.toml" as toml
+
+type Manifest = { license :: Str, version :: Str }
+
+# Plain parse — but the rewrite turns this into parse_strict.
+fn extract(s :: Str) -> Result[Manifest, Str] { toml.parse(s) }
+"#;
+
+#[test]
+fn toml_parse_t_validates_required_fields_after_rewrite() {
+    // The rubric scenario: TOML has `version` but no `license`.
+    // Pre-#168, plain `toml.parse[Manifest]` returned
+    // `Ok(incomplete)` and panicked at field access. After the
+    // rewrite, the type-checker injects the required-fields list
+    // and the runtime returns Err naming the missing field.
+    let src = "version = \"0.1.0\"\n";
+    let v = run_with_rewrite(TOML_SRC, "extract", vec![Value::Str(src.into())]);
+    let detail = err_msg(&v);
+    assert!(detail.contains("missing required field"),
+        "rewritten parse should reject incomplete records: {detail}");
+    assert!(detail.contains("license"),
+        "error should name the missing field: {detail}");
+}
+
+#[test]
+fn toml_parse_t_passes_when_all_fields_present() {
+    let src = "license = \"EUPL-1.2\"\nversion = \"0.1.0\"\n";
+    let v = run_with_rewrite(TOML_SRC, "extract", vec![Value::Str(src.into())]);
+    let m = ok(&v);
+    match m {
+        Value::Record(fields) => {
+            assert!(fields.contains_key("license"));
+            assert!(fields.contains_key("version"));
+        }
+        other => panic!("expected Record, got {other:?}"),
+    }
+}
+
+const YAML_SRC: &str = r#"
+import "std.yaml" as yaml
+
+type Cargo = { name :: Str, version :: Str }
+
+fn extract(s :: Str) -> Result[Cargo, Str] { yaml.parse(s) }
+"#;
+
+#[test]
+fn yaml_parse_t_validates_required_fields_after_rewrite() {
+    let src = "name: foo\n";
+    let v = run_with_rewrite(YAML_SRC, "extract", vec![Value::Str(src.into())]);
+    let detail = err_msg(&v);
+    assert!(detail.contains("version"),
+        "yaml rewrite should also reject missing field: {detail}");
+}
+
+const JSON_SRC: &str = r#"
+import "std.json" as json
+
+type Person = { name :: Str, age :: Int }
+
+fn extract(s :: Str) -> Result[Person, Str] { json.parse(s) }
+"#;
+
+#[test]
+fn json_parse_t_validates_required_fields_after_rewrite() {
+    let src = r#"{"name": "alice"}"#;
+    let v = run_with_rewrite(JSON_SRC, "extract", vec![Value::Str(src.into())]);
+    let detail = err_msg(&v);
+    assert!(detail.contains("age"),
+        "json rewrite should also reject missing field: {detail}");
+}
+
+const NESTED_MATCH_SRC: &str = r#"
+import "std.toml" as toml
+
+type Manifest = { license :: Str, version :: Str }
+
+# The rubric scenario, expressed with the let-annotation idiom
+# Lex's parser actually supports (a let-binding with type
+# annotation pins T; pattern-level annotations like
+# `Ok(m :: Manifest)` aren't accepted by the grammar).
+fn extract(s :: Str) -> Str {
+  let parsed :: Result[Manifest, Str] := toml.parse(s)
+  match parsed {
+    Ok(m) => m.license,
+    Err(e) => e,
+  }
+}
+"#;
+
+#[test]
+fn toml_parse_t_inferred_via_let_annotation() {
+    // Pre-#168, this would silently produce an incomplete record
+    // and panic on `m.license` access. After the rewrite, the
+    // parse itself returns Err naming the missing field and the
+    // match arm forwards it as the function's Str result.
+    let src = "version = \"0.1.0\"\n";
+    let v = run_with_rewrite(NESTED_MATCH_SRC, "extract",
+        vec![Value::Str(src.into())]);
+    match &v {
+        Value::Str(s) => {
+            assert!(s.contains("missing required field") || s.contains("license"),
+                "expected an error path: {s}");
+        }
+        other => panic!("expected Str, got {other:?}"),
+    }
+}
+
+#[test]
+fn untyped_parse_call_is_not_rewritten() {
+    // No type annotation guiding T → no rewrite → plain parse
+    // semantics preserved. This pins that the rewrite is purely
+    // type-driven and doesn't change other code paths.
+    let src = r#"
+import "std.toml" as toml
+
+# Result type is Result[T, Str] with T as a free variable; the
+# rewrite pass only fires when T resolves to a known Record. Here
+# nothing constrains T, so parse returns Ok(whatever-was-parsed).
+fn passthrough(s :: Str) -> Result[a, Str] { toml.parse(s) }
+"#;
+    let prog = parse_source(src).expect("parse");
+    let mut stages = canonicalize_program(&prog);
+    let pt = lex_types::check_and_rewrite_program(&mut stages)
+        .expect("type-check");
+    assert!(pt.parse_required_fields.is_empty(),
+        "untyped parse call should not be in the rewrite map");
+}

--- a/crates/lex-types/src/checker.rs
+++ b/crates/lex-types/src/checker.rs
@@ -8,11 +8,21 @@ use crate::types::*;
 use crate::unifier::{UnifyError, Unifier};
 use indexmap::IndexMap;
 use lex_ast as a;
+use std::collections::HashMap;
 
 /// Result of checking a whole program.
 pub struct ProgramTypes {
     pub fn_signatures: IndexMap<String, Scheme>,
     pub type_env: TypeEnv,
+    /// For #168: per-call required-fields map for `module.parse(s)`
+    /// calls whose inferred result type is `Result[Record{...}, _]`.
+    /// Keyed by `&CExpr as *const _ as usize` so callers can do an
+    /// O(1) pointer-equality lookup during a separate AST rewrite
+    /// pass. Empty unless any matching call sites were found.
+    ///
+    /// See [`check_and_rewrite_program`] for the function that
+    /// populates this and applies the rewrite in one step.
+    pub parse_required_fields: HashMap<usize, Vec<String>>,
 }
 
 pub fn check_program(stages: &[a::Stage]) -> Result<ProgramTypes, Vec<TypeError>> {
@@ -32,6 +42,7 @@ pub fn check_program(stages: &[a::Stage]) -> Result<ProgramTypes, Vec<TypeError>
                         eff_vars: collect_eff_vars(&ty),
                         ty,
                     });
+                    tcx.module_aliases.insert(i.alias.clone(), mod_name.to_string());
                 }
             }
         }
@@ -69,10 +80,166 @@ pub fn check_program(stages: &[a::Stage]) -> Result<ProgramTypes, Vec<TypeError>
     }
 
     if errors.is_empty() {
-        Ok(ProgramTypes { fn_signatures: signatures, type_env: tcx.type_env })
+        // #168: walk pending parse-call records and resolve each
+        // call's return type now that all unification has settled.
+        // A call shows up here only if the call site syntactically
+        // looks like `<alias>.parse(s)` for an alias bound to one
+        // of {json, toml, yaml} via the import pass.
+        let mut parse_required_fields = HashMap::new();
+        for (call_ptr, ret_ty) in &tcx.pending_parse_calls {
+            if let Some(fields) = extract_record_fields_from_result(&tcx.u, &tcx.type_env, ret_ty) {
+                parse_required_fields.insert(*call_ptr, fields);
+            }
+        }
+        Ok(ProgramTypes {
+            fn_signatures: signatures,
+            type_env: tcx.type_env,
+            parse_required_fields,
+        })
     } else {
         Err(errors)
     }
+}
+
+/// Type-check `stages` and rewrite every `module.parse(s)` call
+/// where the inferred T is a Record into the equivalent
+/// `module.parse_strict(s, [field_names])` (#168). Existing
+/// [`check_program`] keeps the old immutable signature for tests
+/// and tools that don't want the AST rewritten.
+pub fn check_and_rewrite_program(
+    stages: &mut [a::Stage],
+) -> Result<ProgramTypes, Vec<TypeError>> {
+    // Borrow as immutable for the type-check pass — the side-table
+    // it produces is keyed by `*const CExpr as usize`, and the Vec
+    // backing storage doesn't move between this borrow and the
+    // mutable one below.
+    let pt = check_program(&*stages)?;
+    if !pt.parse_required_fields.is_empty() {
+        rewrite_parse_calls(stages, &pt.parse_required_fields);
+    }
+    Ok(pt)
+}
+
+/// Walk `stages` mutably and, for every `CExpr::Call` whose
+/// pointer (cast to `usize`) is a key in `required`, rewrite it
+/// from `module.parse(s)` into `module.parse_strict(s, [...])`.
+///
+/// Assumptions:
+///
+/// - The `usize` keys come from the same physical AST passed
+///   here. This is true when called from
+///   [`check_and_rewrite_program`].
+/// - Every key corresponds to a call whose callee is
+///   `FieldAccess(_, "parse")`. The type-checker only inserts
+///   keys when this holds, so we panic if the assumption is
+///   violated — that's a checker bug, not a user error.
+fn rewrite_parse_calls(stages: &mut [a::Stage], required: &HashMap<usize, Vec<String>>) {
+    for stage in stages.iter_mut() {
+        if let a::Stage::FnDecl(fd) = stage {
+            rewrite_in_expr(&mut fd.body, required);
+        }
+    }
+}
+
+fn rewrite_in_expr(expr: &mut a::CExpr, required: &HashMap<usize, Vec<String>>) {
+    let ptr = expr as *const a::CExpr as usize;
+    let do_rewrite = required.get(&ptr).cloned();
+    // Recurse into children first; rewriting the call itself
+    // doesn't touch the source-arg, so the order doesn't change
+    // semantics — but processing children up front means a
+    // hypothetical nested parse-of-parse still gets rewritten
+    // correctly.
+    match expr {
+        a::CExpr::Call { callee, args } => {
+            rewrite_in_expr(callee, required);
+            for a in args.iter_mut() { rewrite_in_expr(a, required); }
+        }
+        a::CExpr::Let { value, body, .. } => {
+            rewrite_in_expr(value, required);
+            rewrite_in_expr(body, required);
+        }
+        a::CExpr::Match { scrutinee, arms } => {
+            rewrite_in_expr(scrutinee, required);
+            for arm in arms.iter_mut() { rewrite_in_expr(&mut arm.body, required); }
+        }
+        a::CExpr::Block { statements, result } => {
+            for s in statements.iter_mut() { rewrite_in_expr(s, required); }
+            rewrite_in_expr(result, required);
+        }
+        a::CExpr::Constructor { args, .. } => {
+            for a in args.iter_mut() { rewrite_in_expr(a, required); }
+        }
+        a::CExpr::RecordLit { fields } => {
+            for f in fields.iter_mut() { rewrite_in_expr(&mut f.value, required); }
+        }
+        a::CExpr::TupleLit { items } | a::CExpr::ListLit { items } => {
+            for it in items.iter_mut() { rewrite_in_expr(it, required); }
+        }
+        a::CExpr::FieldAccess { value, .. } => rewrite_in_expr(value, required),
+        a::CExpr::Lambda { body, .. } => rewrite_in_expr(body, required),
+        a::CExpr::BinOp { lhs, rhs, .. } => {
+            rewrite_in_expr(lhs, required);
+            rewrite_in_expr(rhs, required);
+        }
+        a::CExpr::UnaryOp { expr, .. } => rewrite_in_expr(expr, required),
+        a::CExpr::Return { value } => rewrite_in_expr(value, required),
+        a::CExpr::Literal { .. } | a::CExpr::Var { .. } => {}
+    }
+    if let Some(fields) = do_rewrite {
+        match expr {
+            a::CExpr::Call { callee, args } => {
+                if let a::CExpr::FieldAccess { field, .. } = callee.as_mut() {
+                    debug_assert_eq!(field, "parse",
+                        "rewrite_in_expr: only `.parse` calls should be in the table");
+                    *field = "parse_strict".to_string();
+                }
+                args.push(a::CExpr::ListLit {
+                    items: fields.into_iter()
+                        .map(|f| a::CExpr::Literal {
+                            value: a::CLit::Str { value: f },
+                        })
+                        .collect(),
+                });
+            }
+            _ => unreachable!("rewrite table key must point to a Call expression"),
+        }
+    }
+}
+
+/// Given an inferred return type from a `module.parse(s)` call,
+/// resolve through the unifier and any type aliases, then look
+/// for `Result[Record{...}, _]`. Returns the field names if the
+/// shape matches; `None` otherwise.
+fn extract_record_fields_from_result(
+    u: &Unifier,
+    env: &TypeEnv,
+    ty: &Ty,
+) -> Option<Vec<String>> {
+    let resolved = u.resolve(ty);
+    let Ty::Con(ref name, ref args) = resolved else { return None; };
+    if name != "Result" || args.len() != 2 { return None; }
+    let ok_ty = u.resolve(&args[0]);
+    let unfolded = unfold_record_alias_static(env, ok_ty);
+    if let Ty::Record(fields) = unfolded {
+        Some(fields.keys().cloned().collect())
+    } else {
+        None
+    }
+}
+
+/// Standalone version of `Checker::unfold_record_alias` —
+/// resolves a `Ty::Con` whose definition is a record alias to
+/// the underlying record. Module-level helper because we need it
+/// after the `Checker` has been moved/destructured.
+fn unfold_record_alias_static(env: &TypeEnv, ty: Ty) -> Ty {
+    if let Ty::Con(ref n, _) = ty {
+        if let Some(td) = env.types.get(n) {
+            if let TypeDefKind::Alias(inner @ Ty::Record(_)) = &td.kind {
+                return inner.clone();
+            }
+        }
+    }
+    ty
 }
 
 fn collect_vars(t: &Ty) -> Vec<TyVarId> {
@@ -144,6 +311,18 @@ struct Checker {
     u: Unifier,
     type_env: TypeEnv,
     globals: IndexMap<String, Scheme>,
+    /// Imported alias → canonical module name (e.g. `cfg` → `toml`).
+    /// Populated during the import pass; consulted by `check_call`
+    /// to recognise `cfg.parse(...)` as a stdlib parse call.
+    module_aliases: IndexMap<String, String>,
+    /// For #168: every `<alias>.parse(s)` call where alias is in
+    /// `module_aliases` and maps to {json, toml, yaml}, recorded
+    /// here as `(call_pointer_as_usize, return_type_var)`. After
+    /// the whole program type-checks, we walk this and resolve
+    /// each return type through the unifier — at that point any
+    /// `Result[Manifest, _]` constraints from match patterns or
+    /// let-annotations have settled.
+    pending_parse_calls: Vec<(usize, Ty)>,
 }
 
 impl Checker {
@@ -152,6 +331,8 @@ impl Checker {
             u: Unifier::new(),
             type_env: TypeEnv::new_with_builtins(),
             globals: IndexMap::new(),
+            module_aliases: IndexMap::new(),
+            pending_parse_calls: Vec::new(),
         }
     }
 
@@ -167,6 +348,22 @@ impl Checker {
             }
         }
         ty
+    }
+
+    /// Whether `callee` is a `<alias>.parse` field access where
+    /// `<alias>` was imported from one of the stdlib modules whose
+    /// `parse` returns `Result[T, Str]` and whose `parse_strict`
+    /// shape exists for #168 enforcement (json / toml / yaml).
+    fn is_module_parse_call(&self, callee: &a::CExpr) -> bool {
+        if let a::CExpr::FieldAccess { value, field } = callee {
+            if field != "parse" { return false; }
+            if let a::CExpr::Var { name } = value.as_ref() {
+                if let Some(module) = self.module_aliases.get(name) {
+                    return matches!(module.as_str(), "json" | "toml" | "yaml");
+                }
+            }
+        }
+        false
     }
 
     /// Unify two types, asymmetrically coercing an anonymous record
@@ -280,7 +477,7 @@ impl Checker {
                 Err(TypeError::UnknownIdentifier { at_node: node_id.into(), name: name.clone() })
             }
             a::CExpr::Constructor { name, args } => self.check_constructor(name, args, node_id, locals, effs),
-            a::CExpr::Call { callee, args } => self.check_call(callee, args, node_id, locals, effs),
+            a::CExpr::Call { callee, args } => self.check_call(e, callee, args, node_id, locals, effs),
             a::CExpr::Let { name, ty, value, body } => {
                 let v_ty = self.check_expr(value, node_id, locals, effs)?;
                 if let Some(declared) = ty {
@@ -509,12 +706,25 @@ impl Checker {
 
     fn check_call(
         &mut self,
+        call_expr: &a::CExpr,
         callee: &a::CExpr,
         args: &[a::CExpr],
         node_id: &str,
         locals: &mut IndexMap<String, Ty>,
         effs: &mut EffectSet,
     ) -> Result<Ty, TypeError> {
+        // #168: snapshot the call's address before the recursive
+        // descent so we can later rewrite this exact node. Pointer
+        // identity is only meaningful while the AST stays put,
+        // which it does until check_program returns and the AST
+        // is handed back to the caller. `is_module_parse_call`
+        // recognises `<alias>.parse` where alias was bound to one
+        // of {json, toml, yaml} during the import pass.
+        let parse_call_ptr = if self.is_module_parse_call(callee) {
+            Some(call_expr as *const a::CExpr as usize)
+        } else {
+            None
+        };
         let callee_ty = self.check_expr(callee, node_id, locals, effs)?;
         let resolved = self.u.resolve(&callee_ty);
         match resolved {
@@ -538,6 +748,16 @@ impl Checker {
                 // *post-binding* set when propagating to the caller.
                 let resolved_effects = self.u.resolve_effects(&effects);
                 effs.extend(&resolved_effects);
+                // #168: snapshot the post-arg-unification return type
+                // for stdlib parse calls. Resolution to the eventual
+                // `Result[Record{...}, _]` shape happens at the end
+                // of `check_program` once the whole program's
+                // unification has settled — match-pattern annotations
+                // and let-type-annotations may bind T after this
+                // point.
+                if let Some(ptr) = parse_call_ptr {
+                    self.pending_parse_calls.push((ptr, (*ret).clone()));
+                }
                 Ok(*ret)
             }
             Ty::Var(_) => {

--- a/crates/lex-types/src/lib.rs
+++ b/crates/lex-types/src/lib.rs
@@ -9,6 +9,6 @@ pub mod error;
 pub mod builtins;
 pub mod checker;
 
-pub use checker::{check_program, ProgramTypes};
+pub use checker::{check_and_rewrite_program, check_program, ProgramTypes};
 pub use error::TypeError;
 pub use types::{EffectSet, Prim, Scheme, Ty, TyVarId};


### PR DESCRIPTION
## Summary

Closes the full type-driven half of #168. The tactical
`parse_strict` shipped earlier (#174) required callers to
duplicate `T`'s field names by hand; the rubric pilot reported
that the signature `Result[Manifest, Str]` should be enough.

This slice makes it so. When the type-checker can see that a
`<module>.parse(s)` call returns `Result[Record{...}, _]`, a
new AST-rewrite pass mutates the call into
`<module>.parse_strict(s, [field_names])`. The bytecode emits
the strict variant and the runtime returns `Err` naming the
missing field instead of returning `Ok(incomplete)` and
panicking at field access.

## Implementation

- `Checker` tracks two new things: `module_aliases` (alias →
  canonical module name, populated during the import pass) and
  `pending_parse_calls` (per-call address + return-type pairs
  populated during `check_call`).
- After all unification has settled, the side-table is walked
  and each call's resolved return type is matched against
  `Result[Record{fields}, _]`. Aliases (`type Manifest = {...}`)
  are unfolded so user-declared record types work.
- Required-fields map keyed by `*const CExpr as usize`. Pointer
  identity stays valid as long as the AST isn't relocated
  between type-check and rewrite, which holds inside the new
  `check_and_rewrite_program(&mut [Stage])` entry point.
- `rewrite_in_expr` is the recursive walk that mutates each
  matched `Call`: callee field name flips `parse → parse_strict`
  and a `ListLit` of string literals is appended as a second
  argument. Untouched if the side-table lacks the call's
  pointer.
- Wired into the three production entry points: `lex publish`,
  `lex run`, and `POST /v1/publish`. Tests that don't need the
  rewrite stay on the original `check_program(&[Stage])`.

## Test plan

- [x] `cargo test -p lex-runtime --test std_parse_typed` —
      6 new tests covering json / toml / yaml, including the
      rubric-style `let parsed :: Result[Manifest, Str] := ...`
      idiom that's the actual form Lex's grammar supports
      (`Ok(m :: Manifest)` pattern annotation isn't accepted by
      the parser).
- [x] `cargo test -p lex-runtime --test std_parse_strict` —
      pre-existing `parse_strict` tests still pass (they use
      `check_program` without rewrite, pinning the old
      semantics).
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [ ] CI green

## Out of scope

- `Option[F]` auto-wrap for absent fields. The #168 acceptance
  list mentions it but it's a separable concern (changes
  `from_json` semantics, not the type-driven plumbing). File a
  follow-up if rubric needs it before the next milestone.

https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5

---
_Generated by [Claude Code](https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5)_