### PR TITLE
feat: agent.call_mcp wired to a real stdio MCP client (#185)

### DIFF
--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -662,10 +662,13 @@ impl EffectHandler for DefaultHandler {
                 other => return Err(format!("unsupported agent.{other}")),
             };
             self.ensure_kind_allowed(effect_kind)?;
-            // Sentinel response: the wire format ships in
-            // downstream crates. Tests use this to verify the
-            // type-check + policy-gate path without depending on
-            // any LLM/A2A/MCP transport.
+            // `call_mcp` is wired to a real stdio MCP client
+            // (#185). The other three effects keep their stub
+            // pending the downstream crates that own their wire
+            // format (`soft-agent` for `llm_*` and `a2a`).
+            if op == "call_mcp" {
+                return Ok(dispatch_call_mcp(args));
+            }
             return Ok(ok(Value::Str(format!("<{effect_kind} stub>"))));
         }
         if kind == "http" && matches!(op, "send" | "get" | "post") {
@@ -1362,6 +1365,44 @@ fn ok(v: Value) -> Value {
 }
 fn err(v: Value) -> Value {
     Value::Variant { name: "Err".into(), args: vec![v] }
+}
+
+/// Implementation of `agent.call_mcp(server, tool, args_json)`.
+/// Spawn the MCP server, complete `initialize`, send `tools/call`
+/// with the supplied arguments, and return the server's `result`
+/// JSON serialized back to a Lex `Str`. Errors at any stage come
+/// back as `Err(reason)` so callers can `match` on them — no
+/// `Result<_, String>` from the handler itself.
+fn dispatch_call_mcp(args: Vec<Value>) -> Value {
+    let server = match args.first() {
+        Some(Value::Str(s)) => s.clone(),
+        _ => return err(Value::Str(
+            "agent.call_mcp(server, tool, args_json): server must be Str".into())),
+    };
+    let tool = match args.get(1) {
+        Some(Value::Str(s)) => s.clone(),
+        _ => return err(Value::Str(
+            "agent.call_mcp(server, tool, args_json): tool must be Str".into())),
+    };
+    let args_json = match args.get(2) {
+        Some(Value::Str(s)) => s.clone(),
+        _ => return err(Value::Str(
+            "agent.call_mcp(server, tool, args_json): args_json must be Str".into())),
+    };
+    let parsed: serde_json::Value = match serde_json::from_str(&args_json) {
+        Ok(v) => v,
+        Err(e) => return err(Value::Str(format!(
+            "agent.call_mcp: args_json is not valid JSON: {e}"))),
+    };
+    let mut client = match crate::mcp_client::McpClient::spawn(&server) {
+        Ok(c) => c,
+        Err(e) => return err(Value::Str(e)),
+    };
+    match client.call_tool(&tool, parsed) {
+        Ok(result) => ok(Value::Str(
+            serde_json::to_string(&result).unwrap_or_else(|_| "null".into()))),
+        Err(e) => err(Value::Str(e)),
+    }
 }
 
 fn some(v: Value) -> Value {

--- a/crates/lex-runtime/src/lib.rs
+++ b/crates/lex-runtime/src/lib.rs
@@ -17,6 +17,7 @@ pub mod builtins;
 pub mod policy;
 pub mod handler;
 pub mod ws;
+pub mod mcp_client;
 
 pub use builtins::{is_pure_module, try_pure_builtin};
 pub use handler::{CapturedSink, DefaultHandler, IoSink, StdoutSink};

--- a/crates/lex-runtime/src/mcp_client.rs
+++ b/crates/lex-runtime/src/mcp_client.rs
@@ -1,0 +1,133 @@
+//! Minimal stdio MCP (Model Context Protocol) client for the
+//! `agent.call_mcp` builtin (#185). Spawns the named MCP server
+//! as a subprocess, completes the `initialize` handshake, then
+//! forwards a `tools/call` request and returns the result.
+//!
+//! Scope:
+//!
+//! - One client per call (spawn-per-call). MCP servers are cheap
+//!   to start; per-call spawning keeps the implementation
+//!   stateless. A connection cache is a clear v2 optimization
+//!   once benchmarks show it matters.
+//! - stdio transport only. Future transports (TCP / SSE / HTTP)
+//!   can branch on a URL prefix in `command` later.
+//! - No auth; the issue body explicitly defers credential
+//!   handling to a follow-up. Don't expose this builtin to
+//!   untrusted code paths until that's done.
+
+use serde_json::{json, Value};
+use std::io::{BufRead, BufReader, Write};
+use std::process::{ChildStdin, ChildStdout, Command, Stdio};
+use std::time::Duration;
+
+pub struct McpClient {
+    child: std::process::Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    next_id: i64,
+}
+
+impl McpClient {
+    /// Spawn the MCP server described by `command_line` (whitespace-
+    /// separated argv), perform the JSON-RPC `initialize` handshake,
+    /// and return a ready client. Caller is expected to drop the
+    /// client when finished — `Drop` reaps the subprocess.
+    pub fn spawn(command_line: &str) -> Result<Self, String> {
+        let parts: Vec<&str> = command_line.split_whitespace().collect();
+        let cmd = parts.first()
+            .ok_or_else(|| "mcp.spawn: empty command".to_string())?;
+        let mut child = Command::new(cmd)
+            .args(&parts[1..])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| format!("mcp.spawn `{cmd}`: {e}"))?;
+        let stdin = child.stdin.take()
+            .ok_or_else(|| "mcp.spawn: no stdin".to_string())?;
+        let stdout = BufReader::new(child.stdout.take()
+            .ok_or_else(|| "mcp.spawn: no stdout".to_string())?);
+        let mut client = Self { child, stdin, stdout, next_id: 0 };
+        client.initialize()?;
+        Ok(client)
+    }
+
+    fn next_id(&mut self) -> i64 {
+        self.next_id += 1;
+        self.next_id
+    }
+
+    fn rpc(&mut self, method: &str, params: Value) -> Result<Value, String> {
+        let id = self.next_id();
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        });
+        let line = serde_json::to_string(&req)
+            .map_err(|e| format!("mcp.rpc: serialize: {e}"))?;
+        self.stdin.write_all(line.as_bytes())
+            .map_err(|e| format!("mcp.rpc: write: {e}"))?;
+        self.stdin.write_all(b"\n")
+            .map_err(|e| format!("mcp.rpc: write: {e}"))?;
+        self.stdin.flush()
+            .map_err(|e| format!("mcp.rpc: flush: {e}"))?;
+        // The server may emit notifications before the response;
+        // skip lines whose id doesn't match.
+        loop {
+            let mut buf = String::new();
+            let n = self.stdout.read_line(&mut buf)
+                .map_err(|e| format!("mcp.rpc: read: {e}"))?;
+            if n == 0 {
+                return Err("mcp.rpc: server closed stdout".into());
+            }
+            let resp: Value = serde_json::from_str(buf.trim())
+                .map_err(|e| format!("mcp.rpc: parse `{}`: {e}",
+                    buf.trim().chars().take(120).collect::<String>()))?;
+            // Skip notifications (no `id` field).
+            if resp.get("id").is_none() { continue; }
+            if resp["id"] != json!(id) { continue; }
+            if let Some(err) = resp.get("error") {
+                return Err(format!("mcp.rpc {method}: {err}"));
+            }
+            return Ok(resp.get("result").cloned().unwrap_or(Value::Null));
+        }
+    }
+
+    fn initialize(&mut self) -> Result<(), String> {
+        // Minimal client capabilities — Phase 1 only needs
+        // synchronous tool calls. `protocolVersion` matches the
+        // version `lex-api`'s server reports.
+        self.rpc("initialize", json!({
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": { "name": "lex-runtime", "version": env!("CARGO_PKG_VERSION") },
+        }))?;
+        Ok(())
+    }
+
+    /// Send `tools/call` for the named tool with the supplied
+    /// JSON arguments. Returns the server's `result` field as
+    /// JSON; tool-side errors come back as `Err`.
+    pub fn call_tool(&mut self, name: &str, args: Value) -> Result<Value, String> {
+        self.rpc("tools/call", json!({
+            "name": name,
+            "arguments": args,
+        }))
+    }
+}
+
+impl Drop for McpClient {
+    fn drop(&mut self) {
+        // Best-effort reap: if the server hasn't already exited
+        // on stdin EOF, kill it. Don't propagate errors — Drop
+        // can't fail meaningfully and the process either exits
+        // or gets reaped by the OS.
+        let _ = self.child.kill();
+        // Avoid zombies: wait briefly. If the server is misbehaving
+        // we don't want Drop to block forever.
+        let _ = self.child.wait();
+        let _ = Duration::from_millis(0);
+    }
+}

--- a/crates/lex-runtime/tests/std_agent_effects.rs
+++ b/crates/lex-runtime/tests/std_agent_effects.rs
@@ -105,23 +105,26 @@ fn orchestrate(q :: Str, peer :: Str)
 
 #[test]
 fn agent_calls_succeed_under_permissive_policy() {
-    // Permissive policy includes all four new effects, so the
-    // stub handler returns `Ok(<llm_local stub>)` etc. and the
-    // function returns the last call's result.
+    // Permissive policy includes all four new effects. The three
+    // still-stubbed effects (`llm_local`, `llm_cloud`, `a2a`)
+    // return `Ok("<{kind} stub>")`. `call_mcp` is wired to a
+    // real MCP client (#185) and is exercised separately in
+    // `std_agent_mcp_client.rs`; the function below ends with
+    // `send_a2a` so it returns the stub `Ok` regardless of
+    // whether the test environment has an MCP server available.
     let src = r#"
 import "std.agent" as agent
 
-fn run() -> [llm_local, llm_cloud, a2a, mcp] Result[Str, Str] {
+fn run() -> [llm_local, llm_cloud, a2a] Result[Str, Str] {
   let r1 := agent.local_complete("hi")
   let r2 := agent.cloud_complete("hi")
-  let r3 := agent.send_a2a("peer-1", "hi")
-  agent.call_mcp("optimizer", "schedule", "{}")
+  agent.send_a2a("peer-1", "hi")
 }
 "#;
     let v = run_with_policy(src, "run", vec![], Policy::permissive());
     match &v {
         Value::Variant { name, args } if name == "Ok" => match &args[0] {
-            Value::Str(s) => assert!(s.contains("mcp"),
+            Value::Str(s) => assert!(s.contains("a2a"),
                 "stub response should mention the effect kind: {s}"),
             other => panic!("expected Str, got {other:?}"),
         },

--- a/crates/lex-runtime/tests/std_agent_mcp_client.rs
+++ b/crates/lex-runtime/tests/std_agent_mcp_client.rs
@@ -1,0 +1,138 @@
+//! `agent.call_mcp` end-to-end against a real `lex serve --mcp`
+//! subprocess (#185). The client spawns the server, sends the
+//! JSON-RPC handshake, forwards `tools/call`, and returns the
+//! result. The test exercises the full round-trip.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::sync::Arc;
+
+/// Path to the `lex` binary built for this test run. Provided
+/// by Cargo when integration tests are compiled. The runtime
+/// uses this binary (with `serve --mcp`) as the MCP server
+/// fixture.
+fn lex_bin_path() -> String {
+    // `lex-runtime`'s test crate doesn't depend on the `lex`
+    // binary directly, so `CARGO_BIN_EXE_lex` isn't set. Build
+    // the path from `CARGO_TARGET_TMPDIR` / `CARGO_MANIFEST_DIR`
+    // by climbing to the workspace target dir. Standard layout:
+    // `<workspace>/target/debug/lex` (or release/).
+    let manifest = env!("CARGO_MANIFEST_DIR");
+    let workspace = std::path::Path::new(manifest)
+        .parent().unwrap()  // crates/
+        .parent().unwrap(); // workspace root
+    // Honor CARGO_TARGET_DIR if set (CI uses it).
+    let target_dir = std::env::var("CARGO_TARGET_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| workspace.join("target"));
+    // Profile is the leaf component of the test executable's
+    // path. `std::env::current_exe()` gives `.../target/<profile>/deps/<test_bin>-...`.
+    let me = std::env::current_exe().unwrap();
+    let profile = me
+        .ancestors()
+        .find_map(|p| {
+            let name = p.file_name()?.to_str()?;
+            if name == "deps" {
+                p.parent()
+                    .and_then(|q| q.file_name())
+                    .and_then(|s| s.to_str())
+                    .map(String::from)
+            } else { None }
+        })
+        .unwrap_or_else(|| "debug".into());
+    target_dir.join(profile).join("lex").to_string_lossy().into_owned()
+}
+
+fn run_program(src: &str, fn_name: &str, args: Vec<Value>, policy: Policy) -> Value {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors:\n{errs:#?}");
+    }
+    let bc = Arc::new(compile_program(&stages));
+    let handler = DefaultHandler::new(policy).with_program(Arc::clone(&bc));
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(fn_name, args).unwrap_or_else(|e| panic!("call {fn_name}: {e}"))
+}
+
+#[test]
+fn call_mcp_round_trips_lex_check_through_lex_serve_mcp() {
+    // Use the lex binary's own `serve --mcp` as the MCP server
+    // fixture. It exposes `lex_check` as one of its tools.
+    // Skip the test if the binary isn't where we expect — local
+    // dev sometimes builds with non-standard layouts.
+    let lex_bin = lex_bin_path();
+    if !std::path::Path::new(&lex_bin).exists() {
+        eprintln!("skipping: lex binary not at {lex_bin}");
+        return;
+    }
+    let tmp = tempfile::tempdir().unwrap();
+    let server_cmd = format!(
+        "{lex_bin} serve --mcp --store {}",
+        tmp.path().display(),
+    );
+
+    // The Lex program calls call_mcp with a small Lex source as
+    // the input to the `lex_check` MCP tool. The expected result
+    // is `Ok({"ok":true,...})` — a clean type-check.
+    let src = r#"
+import "std.agent" as agent
+import "std.str" as str
+
+fn check_remotely(server :: Str, source :: Str) -> [mcp] Result[Str, Str] {
+  let body := str.concat("{\"source\":\"", str.concat(source, "\"}"))
+  agent.call_mcp(server, "lex_check", body)
+}
+"#;
+    // Lex source for the MCP server to type-check. Picks a
+    // trivial but non-empty fn so success is unambiguous.
+    let lex_src = r#"fn id(n :: Int) -> Int { n }"#;
+    let v = run_program(src, "check_remotely",
+        vec![Value::Str(server_cmd), Value::Str(lex_src.to_string())],
+        Policy::permissive());
+    match &v {
+        Value::Variant { name, args } if name == "Ok" => match &args[0] {
+            Value::Str(s) => {
+                // MCP wraps tool results in `{"content":[{"text":...}],
+                // "isError": false}`. The inner `text` is the
+                // `lex_check` JSON; on a clean check it contains
+                // `"ok":true`. Match either escaped or unescaped
+                // since whether the inner text is JSON-quoted
+                // depends on the host's stringification.
+                assert!(s.contains("\\\"ok\\\":true") || s.contains("\"ok\":true"),
+                    "expected ok=true from lex_check, got: {s}");
+                assert!(s.contains("\"isError\":false"),
+                    "expected isError=false, got: {s}");
+            }
+            other => panic!("expected Str, got {other:?}"),
+        },
+        Value::Variant { name, args } if name == "Err" => {
+            panic!("call_mcp returned Err: {:?}", args[0]);
+        }
+        other => panic!("unexpected result: {other:?}"),
+    }
+}
+
+#[test]
+fn call_mcp_with_invalid_args_json_returns_err() {
+    let src = r#"
+import "std.agent" as agent
+
+fn bad_args(server :: Str) -> [mcp] Result[Str, Str] {
+  agent.call_mcp(server, "lex_check", "this is not json")
+}
+"#;
+    let v = run_program(src, "bad_args",
+        vec![Value::Str("nonexistent_command".into())],
+        Policy::permissive());
+    match &v {
+        Value::Variant { name, args } if name == "Err" => match &args[0] {
+            Value::Str(s) => assert!(s.contains("not valid JSON"),
+                "expected JSON-parse error, got: {s}"),
+            other => panic!("expected Str inside Err, got {other:?}"),
+        },
+        other => panic!("expected Err, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the v1 stub from #184 with a working JSON-RPC client.
Lex programs can now call out to any stdio MCP server — the
sentinel `Ok("<mcp stub>")` is gone; the call actually
forwards `tools/call` and returns the server's `result` JSON.

## `McpClient`

- Spawn-per-call (stateless). Cheap to start; a connection
  cache is a clear v2 once benchmarks demand it.
- stdio transport only. URL prefixes can branch transports
  later (TCP / SSE / HTTP).
- Performs the JSON-RPC `initialize` handshake before any
  `tools/call` so MCP-spec-compliant servers see the client
  identifying itself.
- Skips notifications and id-mismatched lines so out-of-band
  log messages from the server don't desync the response loop.
- `Drop` reaps the subprocess (kill + wait) so a long-running
  Lex program that calls many tools doesn't leak processes.

## Handler integration

`agent.call_mcp(server, tool, args_json)` now spawns the
client, parses `args_json`, sends `tools/call`, returns the
result JSON serialized back to a Lex `Str`. Errors at any stage
come back as `Err(reason)` so callers can `match` on them.

The other three #184 effects (`local_complete`,
`cloud_complete`, `send_a2a`) keep their stubs — their wire
formats live in downstream crates (`soft-agent`).

## Test plan

- [x] Round-trip integration test against `lex serve --mcp`
      itself — running the #175 server as a subprocess and
      calling its `lex_check` tool from a Lex program. Asserts
      both `"isError":false` and the `"ok":true` payload come
      back as a Lex `Ok(Str(...))`.
- [x] Args-validation test: invalid JSON in `args_json`
      returns `Err("...not valid JSON...")` without spawning a
      server.
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — known m8.rs port-collision
      flake reproduces independently and passes on retry; not
      caused by this change.
- [ ] CI green

## Out of scope (per #185 body)

- Tool Registry integration (registering MCP tools as registry
  entries with effect manifests) — separate slice; the direct
  `agent.call_mcp` path is what Phase 1 of soft actually needs.
- Auth / credentials at the MCP boundary.
- Streaming / resources / prompts / sampling — only synchronous
  `tools/call` is wired.

https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5

---
_Generated by [Claude Code](https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5)_