### PR TITLE
chore: prepare workspace for crates.io publication (v0.2.0)

### DIFF
--- a/.github/workflows/crates-io.yml
+++ b/.github/workflows/crates-io.yml
@@ -1,0 +1,79 @@
+name: crates.io publish
+
+# Triggered by the same `v*` tags as release.yml. Walks the
+# 10 publishable crates in topological dependency order and
+# runs `cargo publish` on each. The internal-only crates
+# (core-syntax, core-compiler, lex-stdlib, lex-cli,
+# conformance) carry `publish = false` so they're skipped by
+# `cargo publish --workspace` semantics if anyone ever tries
+# that path.
+#
+# Requires repo secret `CARGO_REGISTRY_TOKEN` — generate at
+# https://crates.io/me/tokens with scopes
+# `publish-new` + `publish-update`.
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (e.g. v0.1.0). Required for manual runs."
+        required: true
+      dry_run:
+        description: "Set to 'true' to dry-run (no actual publish). Default false."
+        required: false
+        default: "false"
+
+jobs:
+  publish:
+    name: cargo publish
+    runs-on: ubuntu-latest
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name || github.event.inputs.tag }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Verify token is set
+        if: github.event.inputs.dry_run != 'true'
+        run: |
+          if [ -z "$CARGO_REGISTRY_TOKEN" ]; then
+            echo "::error::CARGO_REGISTRY_TOKEN secret is not configured"
+            exit 1
+          fi
+
+      - name: Publish crates in topological order
+        shell: bash
+        run: |
+          set -e
+          DRY_FLAG=""
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            DRY_FLAG="--dry-run"
+            echo "DRY RUN — no crates will actually be published."
+          fi
+          # `cargo publish` since 1.71 waits for the new version
+          # to appear in the registry index before exiting, so
+          # we don't need explicit sleeps between crates.
+          # `--locked` enforces Cargo.lock consistency.
+          for crate in \
+            lex-syntax \
+            lex-ast \
+            lex-types \
+            lex-bytecode \
+            lex-runtime \
+            lex-trace \
+            lex-vcs \
+            lex-store \
+            lex-api \
+            spec-checker
+          do
+            echo "::group::publish $crate"
+            cargo publish $DRY_FLAG --locked -p "$crate"
+            echo "::endgroup::"
+          done

--- a/.github/workflows/crates-io.yml
+++ b/.github/workflows/crates-io.yml
@@ -34,7 +34,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.ref_name || github.event.inputs.tag }}
+          # On tag push, github.ref_name *is* the tag — that's what
+          # we want. On workflow_dispatch, github.ref_name is the
+          # branch the dispatch was started from (truthy), which
+          # would short-circuit the `||` and ignore inputs.tag. Be
+          # explicit so manual dry-runs check out the requested tag.
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,89 @@ All notable changes to lex-lang. The format follows
 versioning follows [SemVer](https://semver.org/) (pre-1.0; minor
 bumps may carry breaking changes when justified).
 
-## [Unreleased]
+## [0.2.0] — 2026-05-06
 
-### Added
+First public release on crates.io. The 10 library crates listed
+in [`crates published`](#crates-published-in-this-release) ship
+at this version; the rest carry `publish = false`.
 
+### Added — agent-runtime primitives (#184–#192)
+
+Driven by the `soft` proposal's request for a typed substrate
+to build agent runtimes on. The four `std.agent` builtins below
+each carry their own effect tag so a function declared
+`[llm_local, a2a]` cannot accidentally reach `[llm_cloud]` or
+`[mcp]`; the type-checker enforces this at compile time.
+
+- **`std.agent` module** with effect-typed builtins (#184):
+  - `agent.local_complete(prompt) :: [llm_local] Result[Str, Str]`
+  - `agent.cloud_complete(prompt) :: [llm_cloud] Result[Str, Str]`
+  - `agent.send_a2a(peer, payload) :: [a2a] Result[Str, Str]`
+  - `agent.call_mcp(server, tool, args_json) :: [mcp] Result[Str, Str]`
+- **Real stdio MCP client** behind `agent.call_mcp` (#185).
+  JSON-RPC 2.0 over a subprocess; spawn-per-call. Connection
+  cache is a v2 follow-up pending downstream benchmarks.
+- **Spec-checker as a runtime gate** (#186). New
+  `evaluate_gate(specs, bindings, lex_source) -> GateVerdict`
+  API: per-action `Allow / Deny / Inconclusive` verdicts in
+  single-digit milliseconds for small spec sets. The randomized
+  property checker stays as the offline tool.
+- **Type-driven `parse[T]` validation** for `std.{json,toml,yaml}`
+  (#168, #188). When the inferred result type is
+  `Result[Record{...}, _]` the type-checker rewrites the call to
+  validate required fields before returning `Ok`.
+- **`docs/design/trace-vs-vcs.md`** (#187) — traces stay out of
+  the op log; cross-store sync uses attestations for metadata
+  plus content-addressed blob copy for the trace JSON. No new
+  resolver needed.
+
+### Crates published in this release
+
+- `lex-syntax` — tokenizer + parser
+- `lex-ast` — canonical AST + content-addressed identity
+- `lex-types` — type system + effect inference
+- `lex-bytecode` — bytecode compiler + VM
+- `lex-runtime` — effect handler runtime + capability policy
+- `lex-trace` — trace tree + replay
+- `lex-vcs` — agent-native VCS (typed op log + attestation graph)
+- `lex-store` — on-disk store (stages, branches, traces)
+- `lex-api` — HTTP/JSON + MCP server surface
+- `spec-checker` — property checker + runtime gate
+
+Internal crates (`core-syntax`, `core-compiler`, `lex-stdlib`,
+`lex-cli`, `conformance`) carry `publish = false`. Install the
+`lex` binary via `cargo install --git
+https://github.com/alpibrusl/lex-lang lex-cli` until a binary
+release flow is in place.
+
+### Added — agent-native VCS, lex-tea v3 (#172, #181)
+
+- **`Override` / `Defer` / `Block` / `Unblock` attestation kinds**
+  (#177, #178). Human triage actions are first-class
+  attestations, queryable via `lex attest filter --kind ...`.
+- **`lex stage pin / defer / block / unblock`** CLI commands;
+  `lex stage pin` consults `lex_vcs::is_stage_blocked` and
+  refuses to activate a blocked stage.
+- **Web UI parity** for triage actions on `/web/stage/<id>`
+  (#179).
+- **`<store>/users.json`** actor-identity gate (#180).
+  `LEX_TEA_USER` env var and `X-Lex-User` header both validated
+  against the file when present; v3a–v3c behaviour preserved
+  when absent.
+- **`lex merge defer <merge_id> <conflict_id>`** per-conflict
+  shortcut (#182). `Resolution::Defer` plumbed through.
+- **`<store>/policy.json`** producer block list (#183). The
+  activity feed renders a `blocked` tag next to attestation
+  rows whose `produced_by.tool` is on the list. Read-time
+  enforcement; the attestation log keeps every record.
+- **`lex policy block-producer / unblock-producer / list`** CLI
+  commands.
+
+### Added — earlier
+
+- **MCP server** (`lex serve --mcp`) exposing the v1 JSON API as
+  MCP tools (#175, #171).
+- **Closures-as-values in record fields** (#176, #169).
 - **Agent-native VCS, tier-2 — full rollout.** Closes #128 (and
   sub-issues #129-#134). The store goes from a snapshot-of-functions
   database to a **typed event log with first-class intent and
@@ -399,5 +478,5 @@ the changelog itself was started; entries are coarse-grained.
 - `SECURITY.md` threat model with deployment recommendations.
 - `cargo fuzz` CI for parser + type checker (60 s/PR, 5 min nightly).
 
-[Unreleased]: https://github.com/alpibrusl/lex-lang/compare/v0.1.0...HEAD
+[0.2.0]: https://github.com/alpibrusl/lex-lang/releases/tag/v0.2.0
 [0.1.0]: https://github.com/alpibrusl/lex-lang/releases/tag/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,14 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "EUPL-1.2"
+repository = "https://github.com/alpibrusl/lex-lang"
+homepage = "https://github.com/alpibrusl/lex-lang"
+authors = ["Alpibrupa <https://github.com/alpibrupa>"]
+keywords = ["lex", "agent", "effects", "language"]
+categories = ["compilers", "development-tools"]
 
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/crates/conformance/Cargo.toml
+++ b/crates/conformance/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "conformance"
+publish = false
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/core-compiler/Cargo.toml
+++ b/crates/core-compiler/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "core-compiler"
+publish = false
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/core-syntax/Cargo.toml
+++ b/crates/core-syntax/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "core-syntax"
+publish = false
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/lex-api/Cargo.toml
+++ b/crates/lex-api/Cargo.toml
@@ -1,8 +1,14 @@
 [package]
 name = "lex-api"
+description = "HTTP/JSON + MCP server surface for the Lex toolchain."
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 serde.workspace = true
@@ -10,14 +16,14 @@ serde_json.workspace = true
 anyhow.workspace = true
 indexmap.workspace = true
 tiny_http = "0.12"
-lex-syntax = { path = "../lex-syntax" }
-lex-ast = { path = "../lex-ast" }
-lex-types = { path = "../lex-types" }
-lex-bytecode = { path = "../lex-bytecode" }
-lex-runtime = { path = "../lex-runtime" }
-lex-store = { path = "../lex-store" }
-lex-trace = { path = "../lex-trace" }
-lex-vcs = { path = "../lex-vcs" }
+lex-syntax = { path = "../lex-syntax", version = "0.2.0" }
+lex-ast = { path = "../lex-ast", version = "0.2.0" }
+lex-types = { path = "../lex-types", version = "0.2.0" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.2.0" }
+lex-runtime = { path = "../lex-runtime", version = "0.2.0" }
+lex-store = { path = "../lex-store", version = "0.2.0" }
+lex-trace = { path = "../lex-trace", version = "0.2.0" }
+lex-vcs = { path = "../lex-vcs", version = "0.2.0" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/lex-ast/Cargo.toml
+++ b/crates/lex-ast/Cargo.toml
@@ -1,8 +1,14 @@
 [package]
 name = "lex-ast"
+description = "Canonical AST + content-addressed identity for Lex programs."
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 serde.workspace = true
@@ -10,4 +16,4 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-syntax = { path = "../lex-syntax" }
+lex-syntax = { path = "../lex-syntax", version = "0.2.0" }

--- a/crates/lex-bytecode/Cargo.toml
+++ b/crates/lex-bytecode/Cargo.toml
@@ -1,16 +1,22 @@
 [package]
 name = "lex-bytecode"
+description = "Bytecode compiler + VM for Lex."
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-ast = { path = "../lex-ast" }
-lex-types = { path = "../lex-types" }
+lex-ast = { path = "../lex-ast", version = "0.2.0" }
+lex-types = { path = "../lex-types", version = "0.2.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax" }
+lex-syntax = { path = "../lex-syntax", version = "0.2.0" }

--- a/crates/lex-cli/Cargo.toml
+++ b/crates/lex-cli/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "lex-cli"
+publish = false
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -1,8 +1,14 @@
 [package]
 name = "lex-runtime"
+description = "Effect handler runtime + capability policy for Lex."
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 serde.workspace = true
@@ -29,10 +35,10 @@ toml = "0.9"
 serde_yaml = "0.9"
 csv = "1"
 rusqlite = { version = "0.36", features = ["bundled"] }
-lex-bytecode = { path = "../lex-bytecode" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.2.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax" }
-lex-ast = { path = "../lex-ast" }
-lex-types = { path = "../lex-types" }
+lex-syntax = { path = "../lex-syntax", version = "0.2.0" }
+lex-ast = { path = "../lex-ast", version = "0.2.0" }
+lex-types = { path = "../lex-types", version = "0.2.0" }
 tempfile = "3"

--- a/crates/lex-stdlib/Cargo.toml
+++ b/crates/lex-stdlib/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "lex-stdlib"
+publish = false
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/lex-store/Cargo.toml
+++ b/crates/lex-store/Cargo.toml
@@ -1,8 +1,14 @@
 [package]
 name = "lex-store"
+description = "Content-addressed on-disk store for Lex stages, branches, and traces."
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 serde.workspace = true
@@ -10,11 +16,11 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-ast = { path = "../lex-ast" }
-lex-trace = { path = "../lex-trace" }
-lex-types = { path = "../lex-types" }
-lex-vcs = { path = "../lex-vcs" }
+lex-ast = { path = "../lex-ast", version = "0.2.0" }
+lex-trace = { path = "../lex-trace", version = "0.2.0" }
+lex-types = { path = "../lex-types", version = "0.2.0" }
+lex-vcs = { path = "../lex-vcs", version = "0.2.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax" }
+lex-syntax = { path = "../lex-syntax", version = "0.2.0" }
 tempfile = "3"

--- a/crates/lex-syntax/Cargo.toml
+++ b/crates/lex-syntax/Cargo.toml
@@ -1,8 +1,14 @@
 [package]
 name = "lex-syntax"
+description = "Tokenizer + parser for the Lex programming language."
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 serde.workspace = true

--- a/crates/lex-trace/Cargo.toml
+++ b/crates/lex-trace/Cargo.toml
@@ -1,8 +1,14 @@
 [package]
 name = "lex-trace"
+description = "Run-time trace tree + replay for Lex programs."
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 serde.workspace = true
@@ -10,9 +16,9 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-bytecode = { path = "../lex-bytecode" }
-lex-ast = { path = "../lex-ast" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.2.0" }
+lex-ast = { path = "../lex-ast", version = "0.2.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax" }
-lex-runtime = { path = "../lex-runtime" }
+lex-syntax = { path = "../lex-syntax", version = "0.2.0" }
+lex-runtime = { path = "../lex-runtime", version = "0.2.0" }

--- a/crates/lex-types/Cargo.toml
+++ b/crates/lex-types/Cargo.toml
@@ -1,15 +1,21 @@
 [package]
 name = "lex-types"
+description = "Type system + effect inference for Lex."
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-ast = { path = "../lex-ast" }
+lex-ast = { path = "../lex-ast", version = "0.2.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax" }
+lex-syntax = { path = "../lex-syntax", version = "0.2.0" }

--- a/crates/lex-vcs/Cargo.toml
+++ b/crates/lex-vcs/Cargo.toml
@@ -1,12 +1,18 @@
 [package]
 name = "lex-vcs"
+description = "Agent-native version control: typed op log + attestation graph."
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
-lex-ast = { path = "../lex-ast" }
-lex-types = { path = "../lex-types" }
+lex-ast = { path = "../lex-ast", version = "0.2.0" }
+lex-types = { path = "../lex-types", version = "0.2.0" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
@@ -15,4 +21,4 @@ indexmap.workspace = true
 
 [dev-dependencies]
 tempfile = "3"
-lex-syntax = { path = "../lex-syntax" }
+lex-syntax = { path = "../lex-syntax", version = "0.2.0" }

--- a/crates/spec-checker/Cargo.toml
+++ b/crates/spec-checker/Cargo.toml
@@ -1,8 +1,14 @@
 [package]
 name = "spec-checker"
+description = "Property-based and runtime-gate checker for Lex specs."
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 serde.workspace = true
@@ -10,11 +16,11 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-syntax = { path = "../lex-syntax" }
-lex-ast = { path = "../lex-ast" }
-lex-types = { path = "../lex-types" }
-lex-bytecode = { path = "../lex-bytecode" }
-lex-runtime = { path = "../lex-runtime" }
+lex-syntax = { path = "../lex-syntax", version = "0.2.0" }
+lex-ast = { path = "../lex-ast", version = "0.2.0" }
+lex-types = { path = "../lex-types", version = "0.2.0" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.2.0" }
+lex-runtime = { path = "../lex-runtime", version = "0.2.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax" }
+lex-syntax = { path = "../lex-syntax", version = "0.2.0" }


### PR DESCRIPTION
## Summary

Prepares the workspace for publication to crates.io. First public
release as `v0.2.0` (bumping past the never-tagged `0.1.0`
pre-launch baseline).

## Packaging changes

- **Workspace `[workspace.package]`** gains `repository`,
  `homepage`, `authors`, `keywords`, `categories`. Each library
  `Cargo.toml` inherits via `.workspace = true` and adds a
  per-crate `description`.
- **Internal-only crates** (`core-syntax`, `core-compiler`,
  `lex-stdlib`, `lex-cli`, `conformance`) get `publish = false`:
  - `core-compiler` and `conformance` are name-collisions on
    crates.io.
  - `lex-stdlib` / `lex-cli` aren't useful as libraries
    downstream. (`lex` binary install path: `cargo install
    --git https://github.com/alpibrusl/lex-lang lex-cli`.)
- **Internal path-deps** include `version = "0.2.0"` so
  `cargo publish` strips the path and keeps the version
  reference.

## CI / release flow

New `.github/workflows/crates-io.yml` triggered by `v*` tag
push. Walks the 10 publishable crates in topological dependency
order and runs `cargo publish` on each. Requires
`CARGO_REGISTRY_TOKEN` repo secret. Manual `workflow_dispatch`
with `dry_run: true` lets us rehearse before tagging.

## CHANGELOG

New `[0.2.0] — 2026-05-06` section consolidating everything
from the previous `[Unreleased]` plus the agent-runtime
primitives from #184–#192.

## Crates published in this release

  `lex-syntax` / `lex-ast` / `lex-types` / `lex-bytecode` /
  `lex-runtime` / `lex-trace` / `lex-vcs` / `lex-store` /
  `lex-api` / `spec-checker`

## What you need to do after merge

1. **Add `CARGO_REGISTRY_TOKEN`** as a repo secret (Settings →
   Secrets and variables → Actions). Token from
   https://crates.io/me/tokens with `publish-new` +
   `publish-update` scopes.
2. **Recommended dry-run**: Actions tab → `crates.io publish` →
   "Run workflow" → set `dry_run: true` → Run.
3. **Push tag `v0.2.0`** to trigger the real publish.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo package --no-verify -p lex-syntax` (smoke test the
  package metadata is acceptable to crates.io)
- [ ] CI green
- [ ] Manual workflow dry-run after merge

https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5

---
_Generated by [Claude Code](https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5)_