### PR TITLE
ci: skip already-published crates in publish loop

### DIFF
--- a/.github/workflows/crates-io.yml
+++ b/.github/workflows/crates-io.yml
@@ -66,6 +66,14 @@ jobs:
           # to appear in the registry index before exiting, so
           # we don't need explicit sleeps between crates.
           # `--locked` enforces Cargo.lock consistency.
+          #
+          # Re-run robustness: before each `cargo publish`, check
+          # crates.io for the (crate, version) tuple. If it already
+          # exists, skip — `cargo publish` would error out with
+          # "crate version already uploaded" otherwise. This makes
+          # the workflow safe to re-trigger after partial failures
+          # (rate-limit hits, network blips, single-crate compile
+          # errors).
           for crate in \
             lex-syntax \
             lex-ast \
@@ -79,6 +87,14 @@ jobs:
             spec-checker
           do
             echo "::group::publish $crate"
+            ver=$(cargo metadata --no-deps --format-version 1 \
+              | jq -r ".packages[] | select(.name == \"$crate\") | .version")
+            if [ -z "$DRY_FLAG" ] && curl -sf -o /dev/null \
+                "https://crates.io/api/v1/crates/$crate/$ver"; then
+              echo "$crate $ver already on crates.io — skipping"
+              echo "::endgroup::"
+              continue
+            fi
             cargo publish $DRY_FLAG --locked -p "$crate"
             echo "::endgroup::"
           done


### PR DESCRIPTION
## Summary

Follow-up to #193. Makes \`crates-io.yml\` safe to re-trigger after partial failures.

## Background

The v0.2.0 release hit crates.io's \"10 new crates per 10 min\" rate limit at the 7th crate (\`lex-vcs\`). Re-running the existing workflow would re-fail at the first crate (\`cargo publish\` errors with \"crate version already uploaded\" on the previously-successful ones) rather than skipping to the un-published tail.

## Change

Before each \`cargo publish\`, GET \`crates.io/api/v1/crates/<name>/<version>\`:
- 200 → already published, skip.
- 404 → publish.

Honors \`--dry-run\` by skipping the existence check (so the cargo dry-run path is unaffected).

## Test plan

- [ ] CI green
- [ ] After v0.2.1 (or any future release): re-running the workflow on the same tag is a no-op for already-published crates.