### PR TITLE
fix(ci): make crates.io publish workflow idempotent

### DIFF
--- a/.github/workflows/crates-io.yml
+++ b/.github/workflows/crates-io.yml
@@ -62,10 +62,22 @@ jobs:
             DRY_FLAG="--dry-run"
             echo "DRY RUN — no crates will actually be published."
           fi
+          # Derive the version to publish from the workspace
+          # Cargo.toml so the workflow stays in sync with whatever
+          # tag was pushed.
+          WANT_VERSION=$(awk '/^\[workspace\.package\]/{f=1;next} /^\[/{f=0} f && /^version = /{gsub(/"/,"",$3); print $3; exit}' Cargo.toml)
+          echo "Target version: $WANT_VERSION"
           # `cargo publish` since 1.71 waits for the new version
           # to appear in the registry index before exiting, so
           # we don't need explicit sleeps between crates.
           # `--locked` enforces Cargo.lock consistency.
+          #
+          # Idempotency: before each publish, ask crates.io if
+          # the version is already there. If yes, skip — this
+          # turns a partial-success run (e.g. timeout halfway
+          # through) into a fixable retry rather than a wedge
+          # where re-running fails on every crate that already
+          # landed.
           for crate in \
             lex-syntax \
             lex-ast \
@@ -79,6 +91,13 @@ jobs:
             spec-checker
           do
             echo "::group::publish $crate"
-            cargo publish $DRY_FLAG --locked -p "$crate"
+            status=$(curl -fsS -o /dev/null -w "%{http_code}" \
+              "https://crates.io/api/v1/crates/$crate/$WANT_VERSION" \
+              -H "User-Agent: lex-lang-crates-io-workflow" || echo "000")
+            if [ "$status" = "200" ] && [ -z "$DRY_FLAG" ]; then
+              echo "::notice::$crate $WANT_VERSION already on crates.io — skipping"
+            else
+              cargo publish $DRY_FLAG --locked -p "$crate"
+            fi
             echo "::endgroup::"
           done


### PR DESCRIPTION
## Summary

The first `v0.2.0` run of `crates-io.yml` published 9 of 10
crates and stopped before `spec-checker`. Re-triggering the
workflow as-is would fail on the very first step (`cargo
publish lex-syntax`) because that version is already uploaded
— wedging recovery from any partial-success run.

## Fix

Before each `cargo publish`, ask crates.io if the target
version exists. If yes, skip. The workflow now:

- Derives the version from `[workspace.package].version` in
  `Cargo.toml` rather than hard-coding `0.2.0`. Future bumps
  Just Work.
- Skips already-published crates so re-runs are no-ops on the
  ones that landed and only retry the ones that didn't.
- Still actually publishes anything missing — including a
  finishing run for the partially-completed `v0.2.0` release.

## Operator step after merge

Re-trigger the `crates.io publish` workflow against the
existing `v0.2.0` tag:

1. Actions tab → "crates.io publish" → "Run workflow"
2. Use workflow from `main`
3. `tag: v0.2.0`, `dry_run: false`
4. Run

Expected output: 9 `::notice::<crate> 0.2.0 already on
crates.io — skipping` lines, plus one real `cargo publish` for
`spec-checker`.

## Test plan

- [x] Local `cargo publish --dry-run -p spec-checker` succeeds
  cleanly (the underlying crate is fine; only the workflow
  needed the idempotency fix).
- [ ] Manually trigger the workflow with `dry_run: true` to
  confirm the new shape parses + the API check returns 200 for
  the 9 already-published crates.
- [ ] Manually trigger with `dry_run: false` to actually publish
  `spec-checker`.

https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5

---
_Generated by [Claude Code](https://claude.ai/code/session_0167B5z6hL7MJbiWquoipbt5)_