### PR TITLE
spec-checker: quantify over lists (#208 slice 2)

### DIFF
--- a/crates/spec-checker/src/ast.rs
+++ b/crates/spec-checker/src/ast.rs
@@ -35,6 +35,11 @@ pub enum SpecType {
     /// resolves `expr.field` against `Value::Record`'s `IndexMap`,
     /// which preserves insertion order.
     Record { fields: Vec<(String, SpecType)> },
+    /// List of an element type (#208). Quantifying over a list lets
+    /// specs reason about agent collections — outstanding orders,
+    /// active charging sessions, message queues — via `length`,
+    /// `head`, `tail`, and indexed access (`xs[i]`).
+    List { element: Box<SpecType> },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -54,6 +59,12 @@ pub enum SpecExpr {
     /// drilling into `Value::Record`'s field map; fails-loudly if the
     /// underlying value isn't a record or doesn't contain the field.
     FieldAccess { value: Box<SpecExpr>, field: String },
+    /// Indexed access on a list-typed expression (#208). `xs[i]`
+    /// evaluates to the i-th element of the list (zero-based).
+    /// Out-of-bounds indices fail loudly via Inconclusive — agents
+    /// that want defensive behavior wrap with a `length(xs) > i`
+    /// check.
+    Index { list: Box<SpecExpr>, index: Box<SpecExpr> },
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/spec-checker/src/checker.rs
+++ b/crates/spec-checker/src/checker.rs
@@ -192,6 +192,19 @@ fn sample(ty: &SpecType, rng: &mut DetRng) -> Value {
             }
             Value::Record(out)
         }
+        // List sampling generates a length in [0, 8] and recurses on
+        // each element. The cap matches the small-bounded discipline
+        // the rest of `sample` uses (Int is in [-1000, 1000], Str is
+        // ≤ 5 chars) — the prover's intent is finding counterexamples
+        // quickly, not stress-testing throughput.
+        SpecType::List { element } => {
+            let len = (rng.next_u64() % 9) as usize;
+            let mut out = Vec::with_capacity(len);
+            for _ in 0..len {
+                out.push(sample(element, rng));
+            }
+            Value::List(out)
+        }
     }
 }
 
@@ -227,6 +240,10 @@ fn eval(
             // Materialize args.
             let mut argv = Vec::new();
             for a in args { argv.push(eval(a, bindings, bc, policy)?); }
+            // Spec-builtin list ops (#208) — same intercept as the
+            // gate path so random-input proofs and per-action gates
+            // see consistent semantics.
+            if let Some(v) = crate::gate::list_builtin(func, &argv) { return v; }
             // Run the Lex function with a fresh VM (cheap: program is shared).
             let handler = DefaultHandler::new(policy.clone());
             let mut vm = Vm::with_handler(bc, Box::new(handler));
@@ -245,6 +262,23 @@ fn eval(
                 }),
                 other => Err(format!("field access `.{field}` on non-record: {other:?}")),
             }
+        }
+        SpecExpr::Index { list, index } => {
+            // Mirror of the gate path's list-indexing (#208 slice 2).
+            let xs = eval(list, bindings, bc, policy)?;
+            let i = eval(index, bindings, bc, policy)?;
+            let xs = match xs {
+                Value::List(xs) => xs,
+                other => return Err(format!("index on non-list: {other:?}")),
+            };
+            let i = match i {
+                Value::Int(n) => n,
+                other => return Err(format!("list index must be Int: {other:?}")),
+            };
+            if i < 0 || (i as usize) >= xs.len() {
+                return Err(format!("list index {i} out of bounds (length {})", xs.len()));
+            }
+            Ok(xs[i as usize].clone())
         }
     }
 }

--- a/crates/spec-checker/src/gate.rs
+++ b/crates/spec-checker/src/gate.rs
@@ -197,6 +197,28 @@ fn eval_body(
             other => Err(format!("not on non-bool: {other:?}")),
         },
         SpecExpr::BinOp { op, lhs, rhs } => {
+            // Short-circuit `and` / `or` so guard expressions like
+            // `length(xs) == 0 or xs[0] > 0` don't evaluate the
+            // second arm when the first already decides the result.
+            // Matches the conventional boolean-operator semantics —
+            // and the gate use case where the second arm may
+            // legitimately error on the values the first arm
+            // exists to filter out (#208 slice 2).
+            if matches!(op, SpecOp::And | SpecOp::Or) {
+                let a = eval_body(lhs, bindings, bc, policy, new_tracer)?;
+                let av = match a {
+                    Value::Bool(b) => b,
+                    other => return Err(format!(
+                        "{} on non-bool lhs: {other:?}", op.as_str())),
+                };
+                if matches!(op, SpecOp::And) && !av { return Ok(Value::Bool(false)); }
+                if matches!(op, SpecOp::Or)  &&  av { return Ok(Value::Bool(true));  }
+                let b = eval_body(rhs, bindings, bc, policy, new_tracer)?;
+                return match b {
+                    Value::Bool(bb) => Ok(Value::Bool(bb)),
+                    other => Err(format!("{} on non-bool rhs: {other:?}", op.as_str())),
+                };
+            }
             let a = eval_body(lhs, bindings, bc, policy, new_tracer)?;
             let b = eval_body(rhs, bindings, bc, policy, new_tracer)?;
             apply_binop(*op, a, b)
@@ -204,12 +226,26 @@ fn eval_body(
         SpecExpr::Call { func, args } => {
             let mut argv = Vec::new();
             for a in args { argv.push(eval_body(a, bindings, bc, policy, new_tracer)?); }
+            // Spec-builtin list operations (#208). `length`, `head`,
+            // and `tail` are intercepted before falling through to a
+            // host VM call so specs can reason about list-shaped
+            // bindings without the host program needing those names.
+            // Identical name-shadowing behavior to lex's stdlib —
+            // user code can still define a function `length` and
+            // reference it from a spec, but a spec call to `length(xs)`
+            // where `xs` is a `Value::List` resolves to the builtin.
+            if let Some(v) = list_builtin(func, &argv) { return v; }
             let handler = DefaultHandler::new(policy.clone());
             let mut vm = Vm::with_handler(bc, Box::new(handler));
             if let Some(make_tracer) = new_tracer {
                 vm.set_tracer(make_tracer());
             }
             vm.call(func, argv).map_err(|e| format!("call `{func}`: {e}"))
+        }
+        SpecExpr::Index { list, index } => {
+            let xs = eval_body(list, bindings, bc, policy, new_tracer)?;
+            let i = eval_body(index, bindings, bc, policy, new_tracer)?;
+            list_index(xs, i)
         }
         SpecExpr::FieldAccess { value, field } => {
             // Drill into a record-typed binding (#208). Fails loudly
@@ -228,6 +264,63 @@ fn eval_body(
             }
         }
     }
+}
+
+/// Spec-builtin list operations (#208). Returns `Some(result)` if
+/// `func` names a builtin (`length`, `head`, `tail`) and the args
+/// shape matches; returns `None` to indicate the call should fall
+/// through to a host VM dispatch.
+pub(crate) fn list_builtin(func: &str, args: &[Value]) -> Option<Result<Value, String>> {
+    match func {
+        "length" => {
+            if args.len() != 1 {
+                return Some(Err(format!("length: expected 1 arg, got {}", args.len())));
+            }
+            match &args[0] {
+                Value::List(xs) => Some(Ok(Value::Int(xs.len() as i64))),
+                // Not a list — fall through to host dispatch in case
+                // the user defined their own `length` function.
+                _ => None,
+            }
+        }
+        "head" => {
+            if args.len() != 1 { return None; }
+            match &args[0] {
+                Value::List(xs) => Some(match xs.first() {
+                    Some(v) => Ok(v.clone()),
+                    None => Err("head: empty list".into()),
+                }),
+                _ => None,
+            }
+        }
+        "tail" => {
+            if args.len() != 1 { return None; }
+            match &args[0] {
+                Value::List(xs) => Some(match xs.split_first() {
+                    Some((_, rest)) => Ok(Value::List(rest.to_vec())),
+                    None => Err("tail: empty list".into()),
+                }),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+fn list_index(list: Value, index: Value) -> Result<Value, String> {
+    let xs = match list {
+        Value::List(xs) => xs,
+        other => return Err(format!("index `[..]` on non-list: {}", short_value(&other))),
+    };
+    let i = match index {
+        Value::Int(n) => n,
+        other => return Err(format!("list index must be Int, got {}", short_value(&other))),
+    };
+    if i < 0 || (i as usize) >= xs.len() {
+        return Err(format!(
+            "list index {i} out of bounds (length {})", xs.len()));
+    }
+    Ok(xs[i as usize].clone())
 }
 
 fn apply_binop(op: SpecOp, a: Value, b: Value) -> Result<Value, String> {
@@ -611,6 +704,163 @@ mod tests {
             GateVerdict::Inconclusive { reason, .. } => {
                 assert!(reason.contains("non-record"),
                     "reason should call out non-record; got: {reason}");
+            }
+            other => panic!("expected Inconclusive, got {other:?}"),
+        }
+    }
+
+    // ---- #208 slice 2: list-typed bindings ---------------------------
+
+    /// Build a `Value::List` from a slice of values.
+    fn lst(items: &[Value]) -> Value {
+        Value::List(items.to_vec())
+    }
+
+    #[test]
+    fn list_quantifier_type_parses() {
+        let spec = parse_spec(r#"
+            spec ok {
+              forall xs :: List[Int] : true
+            }
+        "#).unwrap();
+        let v = evaluate_gate(&[spec], &b([
+            ("xs", lst(&[Value::Int(1), Value::Int(2)])),
+        ]), "");
+        assert_eq!(v, GateVerdict::Allow);
+    }
+
+    #[test]
+    fn length_builtin_returns_list_length() {
+        let spec = parse_spec(r#"
+            spec at_least_one {
+              forall xs :: List[Int] : length(xs) > 0
+            }
+        "#).unwrap();
+        let allow = evaluate_gate(std::slice::from_ref(&spec), &b([
+            ("xs", lst(&[Value::Int(7)])),
+        ]), "");
+        assert_eq!(allow, GateVerdict::Allow);
+        let deny = evaluate_gate(&[spec], &b([
+            ("xs", lst(&[])),
+        ]), "");
+        assert!(matches!(deny, GateVerdict::Deny { .. }));
+    }
+
+    #[test]
+    fn indexed_access_reads_list_element() {
+        let spec = parse_spec(r#"
+            spec head_positive {
+              forall xs :: List[Int] : xs[0] > 0
+            }
+        "#).unwrap();
+        let allow = evaluate_gate(std::slice::from_ref(&spec), &b([
+            ("xs", lst(&[Value::Int(5), Value::Int(10)])),
+        ]), "");
+        assert_eq!(allow, GateVerdict::Allow);
+        let deny = evaluate_gate(&[spec], &b([
+            ("xs", lst(&[Value::Int(0), Value::Int(10)])),
+        ]), "");
+        assert!(matches!(deny, GateVerdict::Deny { .. }));
+    }
+
+    #[test]
+    fn head_and_tail_builtins_work() {
+        // `head(xs) >= length(tail(xs))` — silly but exercises both
+        // builtins together with a length() over the tail.
+        let spec = parse_spec(r#"
+            spec shape {
+              forall xs :: List[Int] :
+                length(xs) > 0 and head(xs) >= length(tail(xs))
+            }
+        "#).unwrap();
+        // [3, 1, 2]: head=3, tail=[1,2] → length 2; 3 >= 2 ✓
+        let allow = evaluate_gate(std::slice::from_ref(&spec), &b([
+            ("xs", lst(&[Value::Int(3), Value::Int(1), Value::Int(2)])),
+        ]), "");
+        assert_eq!(allow, GateVerdict::Allow);
+        // [1, 1, 2, 3]: head=1, tail=[1,2,3] → length 3; 1 >= 3 ✗
+        let deny = evaluate_gate(&[spec], &b([
+            ("xs", lst(&[Value::Int(1), Value::Int(1),
+                         Value::Int(2), Value::Int(3)])),
+        ]), "");
+        assert!(matches!(deny, GateVerdict::Deny { .. }));
+    }
+
+    #[test]
+    fn list_of_records_lets_specs_quantify_structured_collections() {
+        // The pattern motivated by the issue's "for every charging
+        // session in active_sessions, station.power_drawn ≤ station.budget"
+        // example. The spec checks the *first* session's invariant —
+        // a per-element forall is slice 3's territory; this slice
+        // verifies the structural plumbing (List of Record + indexed
+        // access + field access) composes.
+        let spec = parse_spec(r#"
+            spec first_session_within_budget {
+              forall sessions :: List[{ power :: Int, budget :: Int }] :
+                length(sessions) == 0 or sessions[0].power <= sessions[0].budget
+            }
+        "#).unwrap();
+        let mut session = indexmap::IndexMap::new();
+        session.insert("power".into(), Value::Int(50));
+        session.insert("budget".into(), Value::Int(80));
+        let allow = evaluate_gate(std::slice::from_ref(&spec), &b([
+            ("sessions", Value::List(vec![Value::Record(session.clone())])),
+        ]), "");
+        assert_eq!(allow, GateVerdict::Allow);
+
+        let mut over = indexmap::IndexMap::new();
+        over.insert("power".into(), Value::Int(120));
+        over.insert("budget".into(), Value::Int(80));
+        let deny = evaluate_gate(&[spec], &b([
+            ("sessions", Value::List(vec![Value::Record(over)])),
+        ]), "");
+        assert!(matches!(deny, GateVerdict::Deny { .. }));
+    }
+
+    #[test]
+    fn empty_list_passes_when_predicate_is_vacuous() {
+        // Verifies the `length(xs) == 0 or ...` short-circuit pattern
+        // used to make per-list predicates well-defined on empties.
+        let spec = parse_spec(r#"
+            spec ok_or_empty {
+              forall xs :: List[Int] : length(xs) == 0 or xs[0] > 0
+            }
+        "#).unwrap();
+        let v = evaluate_gate(&[spec], &b([("xs", lst(&[]))]), "");
+        assert_eq!(v, GateVerdict::Allow);
+    }
+
+    #[test]
+    fn out_of_bounds_index_is_inconclusive() {
+        let spec = parse_spec(r#"
+            spec needs_two {
+              forall xs :: List[Int] : xs[1] > 0
+            }
+        "#).unwrap();
+        let v = evaluate_gate(&[spec], &b([
+            ("xs", lst(&[Value::Int(5)])),  // length 1; xs[1] OOB
+        ]), "");
+        match v {
+            GateVerdict::Inconclusive { reason, .. } => {
+                assert!(reason.contains("out of bounds"),
+                    "expected OOB diagnostic; got: {reason}");
+            }
+            other => panic!("expected Inconclusive, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn head_of_empty_list_is_inconclusive() {
+        let spec = parse_spec(r#"
+            spec head_pos {
+              forall xs :: List[Int] : head(xs) > 0
+            }
+        "#).unwrap();
+        let v = evaluate_gate(&[spec], &b([("xs", lst(&[]))]), "");
+        match v {
+            GateVerdict::Inconclusive { reason, .. } => {
+                assert!(reason.contains("empty list"),
+                    "expected empty-list diagnostic; got: {reason}");
             }
             other => panic!("expected Inconclusive, got {other:?}"),
         }

--- a/crates/spec-checker/src/parser.rs
+++ b/crates/spec-checker/src/parser.rs
@@ -167,6 +167,17 @@ impl Parser {
             "Float" => Ok(SpecType::Float),
             "Bool" => Ok(SpecType::Bool),
             "Str" => Ok(SpecType::Str),
+            "List" => {
+                // `List[T]` — element type in brackets.
+                if !self.eat(&TokenKind::LBracket) {
+                    return Err(self.err("expected `[` after `List`"));
+                }
+                let elem = self.parse_spec_type()?;
+                if !self.eat(&TokenKind::RBracket) {
+                    return Err(self.err("expected `]` to close `List[...]`"));
+                }
+                Ok(SpecType::List { element: Box::new(elem) })
+            }
             other => Err(self.err(format!("unknown spec type `{other}`"))),
         }
     }
@@ -309,6 +320,17 @@ impl Parser {
                     self.bump();
                     let field = self.expect_ident("after `.`")?;
                     e = SpecExpr::FieldAccess { value: Box::new(e), field };
+                }
+                Some(TokenKind::LBracket) => {
+                    // `xs[i]` indexed access (#208). The expression
+                    // inside brackets is parsed at full precedence so
+                    // `xs[i + 1]`, `xs[length(xs) - 1]`, etc. work.
+                    self.bump();
+                    let index = self.parse_expr()?;
+                    if !self.eat(&TokenKind::RBracket) {
+                        return Err(self.err("expected `]` to close index"));
+                    }
+                    e = SpecExpr::Index { list: Box::new(e), index: Box::new(index) };
                 }
                 _ => break,
             }

--- a/crates/spec-checker/src/smt.rs
+++ b/crates/spec-checker/src/smt.rs
@@ -55,15 +55,16 @@ fn smt_type(t: &SpecType) -> &'static str {
         SpecType::Float => "Real",
         SpecType::Bool => "Bool",
         SpecType::Str => "String",
-        // #208: SMT-LIB encoding for record types isn't implemented in
-        // this slice. SMT supports records via the `Record`/datatype
-        // declaration, but mapping `SpecType::Record` into SMT-LIB
-        // datatypes needs name management for nested records and
-        // accessor function generation. Out of scope for v1; the SMT
-        // path stays scalar-only. Specs that use records are still
-        // evaluable via the gate path (`evaluate_gate_compiled`),
-        // which is what soft-agent uses.
+        // #208: SMT-LIB encoding for record / list types isn't
+        // implemented in this slice. SMT supports both via datatype
+        // declarations + sequences, but mapping the spec types into
+        // SMT-LIB needs name management for nested records and
+        // accessor / `seq.nth` generation. Out of scope for v1;
+        // the SMT path stays scalar-only. Specs that use these types
+        // are still evaluable via the gate path
+        // (`evaluate_gate_compiled`), which is what soft-agent uses.
         SpecType::Record { .. } => "<unsupported-Record>",
+        SpecType::List { .. } => "<unsupported-List>",
     }
 }
 
@@ -107,9 +108,14 @@ fn expr_to_smt(e: &SpecExpr) -> String {
         }
         // #208: see `smt_type`. Record field access maps to SMT-LIB
         // datatype accessors which need the datatype declarations
-        // smt_type doesn't currently emit. Out of scope for v1.
+        // smt_type doesn't currently emit. List ops likewise map to
+        // `seq.length` / `seq.nth` — same out-of-scope rationale.
         SpecExpr::FieldAccess { value, field } => {
             format!("(<unsupported-FieldAccess> {} {})", expr_to_smt(value), field)
+        }
+        SpecExpr::Index { list, index } => {
+            format!("(<unsupported-Index> {} {})",
+                expr_to_smt(list), expr_to_smt(index))
         }
     }
 }


### PR DESCRIPTION
## Summary

Second slice of #208. Adds `forall xs :: List[T]` quantification plus `length(xs)`, `head(xs)`, `tail(xs)`, and `xs[i]` indexed access — the second of the three structured-quantification cases the issue calls out. Slice 1 (records) already merged via #232; slice 3 (ADTs / sum-types) is the remaining piece.

## Surface added

- `SpecType::List { element: Box<SpecType> }` — list type for quantifier headers; nests (`List[List[Int]]` works).
- `SpecExpr::Index { list, index }` — `xs[i]` indexed access.
- `length` / `head` / `tail` are **spec-builtins**, intercepted in the `Call` dispatch path before falling through to host-VM dispatch. Same name-shadowing discipline as lex stdlib: a user-defined `length(xs)` only takes effect when `xs` *isn't* a list (the builtin matches first when the arg is `Value::List`).

## Bug fix surfaced by the new tests

The `and` / `or` operators in spec bodies were **not** short-circuiting. The natural guard pattern `length(xs) == 0 or xs[0] > 0` always evaluated `xs[0]` even on empty lists, surfacing as an out-of-bounds `Inconclusive`. Now they short-circuit, matching conventional boolean-operator semantics: the second arm can legitimately error on values the first arm exists to filter out.

This was a latent bug pre-#208; the empty-list test made it visible.

## Out of scope (deferred to slice 3 of #208)

- **ADTs / sum-types**: pattern-style quantification (`forall msg :: Message, match msg { Charge(s) => ..., ... }`). The remaining language item from the issue.
- **Per-element forall on lists**: spec body `forall i :: Int where 0 <= i and i < length(xs) : xs[i] > 0`. The current quantifier mixes universal-over-types with the binding source; richer per-element forall needs the spec language to grow `let`-bound iteration or proper bounded quantification. Filed mentally as a follow-up.
- **SMT-LIB encoding**: same out-of-scope rationale as slice 1's records — placeholder `<unsupported-*>` in the SMT path. Specs that use lists are still evaluable via the gate path (`evaluate_gate_compiled`), which is what `soft-agent` uses.

## Test plan

- [x] 8 new tests in `gate::tests` cover `length` / `head` / `tail` builtins, `Index`, `List[Record]` composition (the headline "active sessions" pattern from the issue background), the empty-list short-circuit pattern, and OOB / empty-list diagnostics.
- [x] Workspace test suite: **940 passing, 0 failed**.
- [x] Existing slice-1 record tests still pass.

## Closes

Doesn't close #208 yet — slice 3 (ADTs) is the remaining language item. The acceptance criteria mapping after this slice:

- ✅ Spec quantifies over a record-typed binding without flattening (slice 1).
- ✅ Spec quantifies over a `List[T]` with `length` / `head` / index access (this slice).
- ⏳ Sum-type pattern matching in spec body (slice 3).
- ⏳ Performance: P95 evaluation under 20 ms (will measure across the three slices once all three are in tree; today's gate eval is single-digit-µs for representative specs).
- ⏳ `soft-agent`'s `BindingsFn` becomes optional — depends on #208 fully complete plus a soft-side migration.

https://claude.ai/code/session_016SGtf28wA4CgAem65XrjPt

---
_Generated by [Claude Code](https://claude.ai/code/session_016SGtf28wA4CgAem65XrjPt)_