### PR TITLE
spec-checker ADTs (#208) + refinement types (#209) + canonical AST wire format (#206 slice 1)

### DIFF
--- a/crates/lex-ast/src/canon_print.rs
+++ b/crates/lex-ast/src/canon_print.rs
@@ -130,6 +130,12 @@ impl Printer {
                     }
                 }
             }
+            TypeExpr::Refined { base, binding, predicate } => {
+                self.ty(base);
+                write!(self.out, "{{{} | ", binding).unwrap();
+                self.expr(predicate);
+                write!(self.out, "}}").unwrap();
+            }
         }
     }
 

--- a/crates/lex-ast/src/canonical.rs
+++ b/crates/lex-ast/src/canonical.rs
@@ -74,6 +74,17 @@ pub enum TypeExpr {
     Tuple { items: Vec<TypeExpr> },
     Function { params: Vec<TypeExpr>, effects: Vec<Effect>, ret: Box<TypeExpr> },
     Union { variants: Vec<UnionVariant> },
+    /// Refinement type (#209). Carries the predicate as a canonical
+    /// expression so `lex-vcs` content-addressing picks up changes
+    /// to the refinement just like changes to the base type. The
+    /// type checker treats the refined type as its base for
+    /// structural unification (slice 1); slice 2 plumbs static
+    /// discharge through the spec-checker.
+    Refined {
+        base: Box<TypeExpr>,
+        binding: String,
+        predicate: Box<CExpr>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/lex-ast/src/canonicalize.rs
+++ b/crates/lex-ast/src/canonicalize.rs
@@ -106,6 +106,11 @@ fn canonicalize_type(t: &s::TypeExpr) -> TypeExpr {
             vs.sort_by(|a, b| a.name.cmp(&b.name));
             TypeExpr::Union { variants: vs }
         }
+        s::TypeExpr::Refined { base, binding, predicate } => TypeExpr::Refined {
+            base: Box::new(canonicalize_type(base)),
+            binding: binding.clone(),
+            predicate: Box::new(canonicalize_expr(predicate)),
+        },
     }
 }
 

--- a/crates/lex-ast/src/ids.rs
+++ b/crates/lex-ast/src/ids.rs
@@ -211,5 +211,18 @@ fn walk_type<'a>(t: &'a TypeExpr, parent: &NodeId, out: &mut Vec<(NodeId, NodeRe
                 idx += 1;
             }
         }
+        TypeExpr::Refined { base, predicate, .. } => {
+            // The base type and predicate are children for NodeId
+            // attribution. The binding name is metadata, not a node.
+            let id = parent.child(idx);
+            out.push((id.clone(), NodeRef::TypeExpr(base)));
+            walk_type(base, &id, out);
+            idx += 1;
+            // Walk into the predicate so its sub-expressions get NodeIds
+            // too — same pattern as walking a function body.
+            let pid = parent.child(idx);
+            out.push((pid.clone(), NodeRef::CExpr(predicate)));
+            walk_expr(predicate, &pid, out);
+        }
     }
 }

--- a/crates/lex-bytecode/src/compiler.rs
+++ b/crates/lex-bytecode/src/compiler.rs
@@ -111,6 +111,17 @@ pub fn compile_program(stages: &[a::Stage]) -> Program {
                 // Filled in at the end of the compile pass, once `code`
                 // and `locals_count` are final. See #222.
                 body_hash: crate::program::ZERO_BODY_HASH,
+                // Per-param refinement predicates for runtime check
+                // (#209 slice 3). Lifted directly from each param's
+                // `TypeExpr::Refined` if present; `None` otherwise.
+                refinements: fd.params.iter().map(|p| match &p.ty {
+                    a::TypeExpr::Refined { binding, predicate, .. } =>
+                        Some(crate::program::Refinement {
+                            binding: binding.clone(),
+                            predicate: (**predicate).clone(),
+                        }),
+                    _ => None,
+                }).collect(),
             });
         }
     }
@@ -566,6 +577,11 @@ impl<'a> FnCompiler<'a> {
             effects: Vec::new(),
             // See #222: filled in at the end of the compile pass.
             body_hash: crate::program::ZERO_BODY_HASH,
+            // Lambdas don't carry refinements at the surface today
+            // (closure params don't accept `Type{x | ...}` syntax in
+            // the parser). #209 stays focused on top-level fn decls;
+            // closure-param refinements are a follow-up.
+            refinements: Vec::new(),
         });
 
         // Emit code at the lambda site: load each captured local, then MakeClosure.
@@ -1032,6 +1048,9 @@ impl<'a> FnCompiler<'a> {
             code,
             effects: Vec::new(),
             body_hash,
+            // Trampolines (flow.sequential / parallel / etc.) don't
+            // surface refined params at this layer.
+            refinements: Vec::new(),
         });
         fn_id
     }

--- a/crates/lex-bytecode/src/program.rs
+++ b/crates/lex-bytecode/src/program.rs
@@ -62,6 +62,27 @@ pub struct Function {
     /// depend on the closure literal's source location (#222).
     #[serde(default = "zero_body_hash")]
     pub body_hash: BodyHash,
+    /// Per-parameter refinement predicates (#209 slice 3). `Some(r)`
+    /// for params declared with `Type{x | predicate}`, `None`
+    /// otherwise. The VM evaluates these at `Op::Call` time before
+    /// pushing the frame; failure raises `VmError::RefinementFailed`
+    /// and the tracer records a verdict event with the same shape
+    /// as a runtime gate's `gate.verdict`.
+    #[serde(default)]
+    pub refinements: Vec<Option<Refinement>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Refinement {
+    /// The bound variable name from `Type{binding | predicate}`.
+    pub binding: String,
+    /// The predicate, stored as a canonical-AST `CExpr`. The VM
+    /// interprets it directly via a small tree-walk evaluator —
+    /// no separate compile pass needed since predicates are pure
+    /// expressions over a single binding plus, eventually, the
+    /// surrounding call-site context (slice 3 supports the
+    /// binding only).
+    pub predicate: lex_ast::CExpr,
 }
 
 fn zero_body_hash() -> BodyHash { ZERO_BODY_HASH }

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -19,6 +19,19 @@ pub enum VmError {
     Effect(String),
     #[error("call stack overflow: recursion depth exceeded ({0})")]
     CallStackOverflow(u32),
+    /// Refinement predicate failed at a call boundary (#209 slice 3).
+    /// Surfaced when a function declares `param :: Type{x | predicate}`,
+    /// the call-site arg couldn't be discharged statically (slice 2),
+    /// and the runtime evaluator finds the predicate is `false` for
+    /// the actual argument value. The `verdict` mirrors the shape of
+    /// `gate.verdict`-style records in `lex-trace`.
+    #[error("refinement violated: argument {param_index} of `{fn_name}` (binding `{binding}`): {reason}")]
+    RefinementFailed {
+        fn_name: String,
+        param_index: usize,
+        binding: String,
+        reason: String,
+    },
 }
 
 /// Maximum simultaneous call frames. Defends against unbounded
@@ -174,6 +187,116 @@ fn hash_call_args(args: &[Value]) -> [u8; 16] {
     out
 }
 
+/// Evaluate a refinement predicate at runtime against the actual
+/// argument value (#209 slice 3). Mirrors `lex_types::discharge`'s
+/// static evaluator but operates on `Value` directly.
+///
+/// Returns `Ok(true)` / `Ok(false)` for a clean boolean verdict, or
+/// `Err(reason)` if the predicate references something the runtime
+/// can't resolve (free variable beyond the binding, unsupported AST
+/// node). Callers map `Ok(false)` and `Err` to `VmError::RefinementFailed`.
+fn eval_refinement(
+    predicate: &lex_ast::CExpr,
+    binding: &str,
+    arg: &Value,
+) -> Result<bool, String> {
+    match eval_refinement_inner(predicate, binding, arg) {
+        Ok(Value::Bool(b)) => Ok(b),
+        Ok(other) => Err(format!("predicate didn't reduce to a Bool, got {other:?}")),
+        Err(e) => Err(e),
+    }
+}
+
+fn eval_refinement_inner(
+    e: &lex_ast::CExpr,
+    binding: &str,
+    arg: &Value,
+) -> Result<Value, String> {
+    use lex_ast::{CExpr, CLit};
+    match e {
+        CExpr::Literal { value } => Ok(match value {
+            CLit::Int { value } => Value::Int(*value),
+            CLit::Float { value } => Value::Float(value.parse().unwrap_or(0.0)),
+            CLit::Bool { value } => Value::Bool(*value),
+            CLit::Str { value } => Value::Str(value.clone()),
+            CLit::Bytes { value } => Value::Str(value.clone()), // hex; unusual in predicates
+            CLit::Unit => Value::Unit,
+        }),
+        CExpr::Var { name } if name == binding => Ok(arg.clone()),
+        CExpr::Var { name } => Err(format!(
+            "predicate references free var `{name}`; runtime check \
+             only resolves the binding (slice 4 will plumb call-site \
+             context)")),
+        CExpr::UnaryOp { op, expr } => {
+            let v = eval_refinement_inner(expr, binding, arg)?;
+            match (op.as_str(), v) {
+                ("not", Value::Bool(b)) => Ok(Value::Bool(!b)),
+                ("-", Value::Int(n)) => Ok(Value::Int(-n)),
+                ("-", Value::Float(n)) => Ok(Value::Float(-n)),
+                (o, v) => Err(format!("unsupported unary `{o}` on {v:?}")),
+            }
+        }
+        CExpr::BinOp { op, lhs, rhs } => {
+            // Short-circuit `and` / `or` for the same reasons as the
+            // static evaluator.
+            if op == "and" || op == "or" {
+                let l = eval_refinement_inner(lhs, binding, arg)?;
+                let lb = match l {
+                    Value::Bool(b) => b,
+                    other => return Err(format!("`{op}` on non-bool: {other:?}")),
+                };
+                if op == "and" && !lb { return Ok(Value::Bool(false)); }
+                if op == "or"  &&  lb { return Ok(Value::Bool(true));  }
+                let r = eval_refinement_inner(rhs, binding, arg)?;
+                return match r {
+                    Value::Bool(b) => Ok(Value::Bool(b)),
+                    other => Err(format!("`{op}` on non-bool: {other:?}")),
+                };
+            }
+            let l = eval_refinement_inner(lhs, binding, arg)?;
+            let r = eval_refinement_inner(rhs, binding, arg)?;
+            apply_refinement_binop(op, &l, &r)
+        }
+        // Other AST forms (Call, Let, Match, FieldAccess, Lambda,
+        // Block, Constructors, Records, Tuples, Lists, Return) need
+        // a more general evaluator that can call back into the VM.
+        // Out of scope for slice 3; a future slice may unify this
+        // with the spec-checker's gate evaluator.
+        other => Err(format!("unsupported predicate node: {other:?}")),
+    }
+}
+
+fn apply_refinement_binop(op: &str, l: &Value, r: &Value) -> Result<Value, String> {
+    use Value::*;
+    match (op, l, r) {
+        ("+", Int(a), Int(b)) => Ok(Int(a + b)),
+        ("-", Int(a), Int(b)) => Ok(Int(a - b)),
+        ("*", Int(a), Int(b)) => Ok(Int(a * b)),
+        ("/", Int(a), Int(b)) if *b != 0 => Ok(Int(a / b)),
+        ("%", Int(a), Int(b)) if *b != 0 => Ok(Int(a % b)),
+        ("+", Float(a), Float(b)) => Ok(Float(a + b)),
+        ("-", Float(a), Float(b)) => Ok(Float(a - b)),
+        ("*", Float(a), Float(b)) => Ok(Float(a * b)),
+        ("/", Float(a), Float(b)) => Ok(Float(a / b)),
+
+        ("==", a, b) => Ok(Bool(a == b)),
+        ("!=", a, b) => Ok(Bool(a != b)),
+
+        ("<",  Int(a), Int(b)) => Ok(Bool(a < b)),
+        ("<=", Int(a), Int(b)) => Ok(Bool(a <= b)),
+        (">",  Int(a), Int(b)) => Ok(Bool(a > b)),
+        (">=", Int(a), Int(b)) => Ok(Bool(a >= b)),
+
+        ("<",  Float(a), Float(b)) => Ok(Bool(a < b)),
+        ("<=", Float(a), Float(b)) => Ok(Bool(a <= b)),
+        (">",  Float(a), Float(b)) => Ok(Bool(a > b)),
+        (">=", Float(a), Float(b)) => Ok(Bool(a >= b)),
+
+        (op, a, b) => Err(format!(
+            "unsupported binop `{op}` on {a:?} and {b:?}")),
+    }
+}
+
 fn const_str(constants: &[Const], idx: u32) -> String {
     match constants.get(idx as usize) {
         Some(Const::NodeId(s)) | Some(Const::Str(s)) => s.clone(),
@@ -272,6 +395,34 @@ impl<'a> Vm<'a> {
         if args.len() != f.arity as usize {
             return Err(VmError::Panic(format!("arity mismatch calling {}", f.name)));
         }
+        // Refinement runtime check at the public entry point too
+        // (#209 slice 3). `Op::Call` checks for in-program calls;
+        // this branch covers `vm.call("entry", ...)` from the host
+        // and the reentrant `invoke_closure_value` path. Same
+        // semantics, same error shape.
+        let f_name = f.name.clone();
+        let refinements = f.refinements.clone();
+        for (i, refinement) in refinements.iter().enumerate() {
+            if let Some(r) = refinement {
+                let arg = args.get(i).cloned().unwrap_or(Value::Unit);
+                match eval_refinement(&r.predicate, &r.binding, &arg) {
+                    Ok(true) => {}
+                    Ok(false) => return Err(VmError::RefinementFailed {
+                        fn_name: f_name,
+                        param_index: i,
+                        binding: r.binding.clone(),
+                        reason: format!("predicate failed for {} = {arg:?}", r.binding),
+                    }),
+                    Err(reason) => return Err(VmError::RefinementFailed {
+                        fn_name: f_name,
+                        param_index: i,
+                        binding: r.binding.clone(),
+                        reason,
+                    }),
+                }
+            }
+        }
+        let f = &self.program.functions[fn_id as usize];
         let mut locals = vec![Value::Unit; f.locals_count.max(f.arity) as usize];
         for (i, v) in args.into_iter().enumerate() { locals[i] = v; }
         // Record the depth before pushing — this is what `run` will
@@ -549,6 +700,42 @@ impl<'a> Vm<'a> {
                         self.handler.note_call_budget(budget_cost)
                             .map_err(VmError::Effect)?;
                     }
+                    // Refinement runtime check (#209 slice 3). Each
+                    // param's `Option<Refinement>` is evaluated against
+                    // the actual arg before the frame is pushed. The
+                    // tracer sees the call enter; failure surfaces as
+                    // `VmError::RefinementFailed` *before* the body
+                    // starts, which means an erroring trace shows the
+                    // call as enter+exit_err with the verdict reason
+                    // (same shape as `gate.verdict`).
+                    let refinements = self.program.functions[fn_id as usize]
+                        .refinements.clone();
+                    for (i, refinement) in refinements.iter().enumerate() {
+                        if let Some(r) = refinement {
+                            let arg = args.get(i).cloned().unwrap_or(Value::Unit);
+                            match eval_refinement(&r.predicate, &r.binding, &arg) {
+                                Ok(true) => { /* satisfied, continue */ }
+                                Ok(false) => {
+                                    return Err(VmError::RefinementFailed {
+                                        fn_name: callee_name.clone(),
+                                        param_index: i,
+                                        binding: r.binding.clone(),
+                                        reason: format!(
+                                            "predicate failed for {} = {arg:?}",
+                                            r.binding),
+                                    });
+                                }
+                                Err(reason) => {
+                                    return Err(VmError::RefinementFailed {
+                                        fn_name: callee_name.clone(),
+                                        param_index: i,
+                                        binding: r.binding.clone(),
+                                        reason,
+                                    });
+                                }
+                            }
+                        }
+                    }
                     // Pure-fn memoization (#229): if the callee declares
                     // no effects, hash the args and consult the cache.
                     // On hit, push the cached value, emit synthetic
@@ -588,6 +775,32 @@ impl<'a> Vm<'a> {
                     if budget_cost > 0 {
                         self.handler.note_call_budget(budget_cost)
                             .map_err(VmError::Effect)?;
+                    }
+                    // Refinement runtime check on tail calls too
+                    // (#209 slice 3). Same shape as Op::Call.
+                    let refinements = self.program.functions[fn_id as usize]
+                        .refinements.clone();
+                    for (i, refinement) in refinements.iter().enumerate() {
+                        if let Some(r) = refinement {
+                            let arg = args.get(i).cloned().unwrap_or(Value::Unit);
+                            match eval_refinement(&r.predicate, &r.binding, &arg) {
+                                Ok(true) => {}
+                                Ok(false) => return Err(VmError::RefinementFailed {
+                                    fn_name: callee_name.clone(),
+                                    param_index: i,
+                                    binding: r.binding.clone(),
+                                    reason: format!(
+                                        "predicate failed for {} = {arg:?}",
+                                        r.binding),
+                                }),
+                                Err(reason) => return Err(VmError::RefinementFailed {
+                                    fn_name: callee_name.clone(),
+                                    param_index: i,
+                                    binding: r.binding.clone(),
+                                    reason,
+                                }),
+                            }
+                        }
                     }
                     // A tail call closes the current call's trace frame and
                     // opens a new one in its place — preserves the caller's

--- a/crates/lex-cli/src/audit.rs
+++ b/crates/lex-cli/src/audit.rs
@@ -472,5 +472,10 @@ fn render_type(t: &TypeExpr) -> String {
             }).collect();
             parts.join(" | ")
         }
+        TypeExpr::Refined { base, binding, .. } => {
+            // Compact diagnostic form (#209 slice 1). Full predicate
+            // is in the canonical AST and contributes to OpId hashing.
+            format!("{}{{{} | …}}", render_type(base), binding)
+        }
     }
 }

--- a/crates/lex-runtime/tests/refinement_runtime.rs
+++ b/crates/lex-runtime/tests/refinement_runtime.rs
@@ -1,0 +1,149 @@
+//! Acceptance tests for #209 slice 3: runtime residual checks for
+//! refinement predicates that couldn't be discharged statically.
+//!
+//! Slice 2 catches literal-arg violations at compile time
+//! (`withdraw(-5)` rejected before bytecode emission). Slice 3
+//! catches the rest at the call boundary in the VM: any function
+//! declaring `param :: Type{x | predicate}` evaluates the predicate
+//! against the actual arg before pushing a frame. Failures raise
+//! `VmError::RefinementFailed` with diagnostics naming the function,
+//! parameter index, binding, and the offending value.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, vm::VmError, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::sync::Arc;
+
+fn compile_and_call(src: &str, fn_name: &str, args: Vec<Value>) -> Result<Value, VmError> {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors: {errs:#?}");
+    }
+    let bc = Arc::new(compile_program(&stages));
+    let handler = DefaultHandler::new(Policy::permissive())
+        .with_program(Arc::clone(&bc));
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(fn_name, args)
+}
+
+const POSITIVE_INT_SRC: &str = r#"
+fn pos(amount :: Int{x | x > 0}) -> Int { amount }
+"#;
+
+#[test]
+fn satisfying_runtime_arg_passes() {
+    // Non-literal arg path: slice 2 defers, slice 3 checks at runtime.
+    // Calling `pos(7)` from Rust skips the static-discharge layer
+    // entirely (we hand the VM a `Value::Int(7)` directly), so this
+    // exercises the slice-3 runtime evaluator.
+    let v = compile_and_call(POSITIVE_INT_SRC, "pos", vec![Value::Int(7)])
+        .expect("7 satisfies x > 0");
+    assert_eq!(v, Value::Int(7));
+}
+
+#[test]
+fn violating_runtime_arg_raises_refinement_failed() {
+    // `pos(-3)` invoked at runtime — the bytecode VM evaluates the
+    // refinement and rejects.
+    let err = compile_and_call(POSITIVE_INT_SRC, "pos", vec![Value::Int(-3)])
+        .expect_err("expected RefinementFailed");
+    match err {
+        VmError::RefinementFailed { fn_name, param_index, binding, reason } => {
+            assert_eq!(fn_name, "pos");
+            assert_eq!(param_index, 0);
+            assert_eq!(binding, "x");
+            assert!(reason.contains("-3"),
+                "reason should name the failing value; got: {reason}");
+        }
+        other => panic!("expected RefinementFailed, got {other:?}"),
+    }
+}
+
+#[test]
+fn satisfying_arg_via_call_chain_passes() {
+    // Caller passes a runtime-computed value that happens to satisfy
+    // the refinement. The VM check fires during the inner call.
+    let src = r#"
+fn pos(amount :: Int{x | x > 0}) -> Int { amount }
+fn add_one(n :: Int) -> Int { pos(n + 1) }
+"#;
+    let v = compile_and_call(src, "add_one", vec![Value::Int(5)])
+        .expect("5 + 1 = 6 satisfies x > 0");
+    assert_eq!(v, Value::Int(6));
+}
+
+#[test]
+fn violating_arg_via_call_chain_raises() {
+    // The runtime-computed value fails the predicate.
+    let src = r#"
+fn pos(amount :: Int{x | x > 0}) -> Int { amount }
+fn maybe_negate(n :: Int) -> Int { pos(n - 100) }
+"#;
+    let err = compile_and_call(src, "maybe_negate", vec![Value::Int(5)])
+        .expect_err("5 - 100 = -95 violates x > 0");
+    assert!(matches!(err, VmError::RefinementFailed { .. }));
+}
+
+#[test]
+fn compound_predicate_runtime_check_holds() {
+    let src = r#"
+fn bounded(x :: Int{n | n > 0 and n <= 100}) -> Int { x }
+"#;
+    let v = compile_and_call(src, "bounded", vec![Value::Int(50)])
+        .expect("50 in (0, 100]");
+    assert_eq!(v, Value::Int(50));
+}
+
+#[test]
+fn compound_predicate_runtime_check_lower_bound_fails() {
+    let src = r#"
+fn bounded(x :: Int{n | n > 0 and n <= 100}) -> Int { x }
+"#;
+    let err = compile_and_call(src, "bounded", vec![Value::Int(0)])
+        .expect_err("0 is not > 0");
+    assert!(matches!(err, VmError::RefinementFailed { .. }));
+}
+
+#[test]
+fn compound_predicate_runtime_check_upper_bound_fails() {
+    let src = r#"
+fn bounded(x :: Int{n | n > 0 and n <= 100}) -> Int { x }
+"#;
+    let err = compile_and_call(src, "bounded", vec![Value::Int(101)])
+        .expect_err("101 is not <= 100");
+    assert!(matches!(err, VmError::RefinementFailed { .. }));
+}
+
+#[test]
+fn refinement_with_external_var_in_predicate_defers_to_runtime_error() {
+    // Predicate references an unbound `balance` — slice 3's runtime
+    // evaluator can't resolve it (just like slice 2 deferred). Surface
+    // as RefinementFailed with a clear "free var" reason. Future work:
+    // slice 4 plumbs call-site context bindings.
+    let src = r#"
+fn withdraw(amount :: Int{x | x > 0 and x <= balance}) -> Int { amount }
+"#;
+    let err = compile_and_call(src, "withdraw", vec![Value::Int(50)])
+        .expect_err("predicate references free `balance`");
+    match err {
+        VmError::RefinementFailed { reason, .. } => {
+            assert!(reason.contains("balance"),
+                "reason should name the unresolved free var; got: {reason}");
+        }
+        other => panic!("expected RefinementFailed, got {other:?}"),
+    }
+}
+
+#[test]
+fn function_without_refinement_skips_check() {
+    // Sanity: a function with no refined params works exactly as before;
+    // the runtime check is a no-op when `refinements` is empty.
+    let src = r#"
+fn id(x :: Int) -> Int { x }
+"#;
+    let v = compile_and_call(src, "id", vec![Value::Int(-100)])
+        .expect("no refinement → no check");
+    assert_eq!(v, Value::Int(-100));
+}

--- a/crates/lex-syntax/src/loader.rs
+++ b/crates/lex-syntax/src/loader.rs
@@ -356,6 +356,15 @@ impl<'a> Mangler<'a> {
                     })
                     .collect(),
             ),
+            TypeExpr::Refined { base, binding, predicate } => TypeExpr::Refined {
+                base: Box::new(self.mangle_type_expr(*base)),
+                binding,
+                // The predicate is an expression; its names are
+                // resolved during type-check, not loader-time, so
+                // it passes through unchanged here. Slice 2 wires
+                // up discharge through the spec-checker.
+                predicate,
+            },
         }
     }
 

--- a/crates/lex-syntax/src/parser.rs
+++ b/crates/lex-syntax/src/parser.rs
@@ -207,6 +207,11 @@ impl Parser {
     }
 
     fn parse_type_expr(&mut self) -> Result<TypeExpr, ParseError> {
+        let base = self.parse_type_expr_base()?;
+        self.maybe_wrap_refinement(base)
+    }
+
+    fn parse_type_expr_base(&mut self) -> Result<TypeExpr, ParseError> {
         self.skip_newlines();
         match self.peek() {
             Some(TokenKind::LBrace) => self.parse_record_type(),
@@ -253,6 +258,35 @@ impl Parser {
             }
             other => Err(self.error(format!("expected type expression, got {other:?}"))),
         }
+    }
+
+    /// Refinement type postfix (#209): `BaseType{binding | predicate}`.
+    ///
+    /// Disambiguates from a function body's opening brace by peeking
+    /// three tokens ahead — refinement requires `{ Ident |`, a body
+    /// begins with `{ <expr-starting-token>`. This means a refinement
+    /// binding name can't start with `|`, but that's fine since
+    /// identifiers don't.
+    fn maybe_wrap_refinement(&mut self, base: TypeExpr) -> Result<TypeExpr, ParseError> {
+        let next0 = self.tokens.get(self.idx).map(|t| &t.kind);
+        let next1 = self.tokens.get(self.idx + 1).map(|t| &t.kind);
+        let next2 = self.tokens.get(self.idx + 2).map(|t| &t.kind);
+        let is_refinement_lookahead = matches!(next0, Some(TokenKind::LBrace))
+            && matches!(next1, Some(TokenKind::Ident(_)))
+            && matches!(next2, Some(TokenKind::Bar));
+        if !is_refinement_lookahead {
+            return Ok(base);
+        }
+        self.bump(); // `{`
+        let binding = self.expect_ident("for refinement binding")?;
+        self.expect(&TokenKind::Bar, "after refinement binding")?;
+        let predicate = self.parse_expr()?;
+        self.expect(&TokenKind::RBrace, "to close refinement")?;
+        Ok(TypeExpr::Refined {
+            base: Box::new(base),
+            binding,
+            predicate: Box::new(predicate),
+        })
     }
 
     fn parse_record_type(&mut self) -> Result<TypeExpr, ParseError> {

--- a/crates/lex-syntax/src/printer.rs
+++ b/crates/lex-syntax/src/printer.rs
@@ -145,6 +145,12 @@ impl Printer {
                     }
                 }
             }
+            TypeExpr::Refined { base, binding, predicate } => {
+                self.type_expr(base);
+                write!(self.out, "{{{} | ", binding).unwrap();
+                self.expr(predicate);
+                write!(self.out, "}}").unwrap();
+            }
         }
     }
 

--- a/crates/lex-syntax/src/syntax.rs
+++ b/crates/lex-syntax/src/syntax.rs
@@ -72,6 +72,19 @@ pub enum TypeExpr {
         ret: Box<TypeExpr>,
     },
     Union(Vec<UnionVariant>),
+    /// Refinement type (#209): a base type plus a predicate the
+    /// inhabitant must satisfy. `Int{x | x > 0 and x <= balance}`
+    /// parses with `base = Named { name: "Int", args: [] }`,
+    /// `binding = "x"`, and `predicate = (x > 0) and (x <= balance)`.
+    /// Slice 1 stores the refinement; the type checker treats the
+    /// refined type as its base. Slice 2 wires up static discharge
+    /// via the spec-checker's gate evaluator; slice 3 adds the
+    /// residual runtime check at call boundaries.
+    Refined {
+        base: Box<TypeExpr>,
+        binding: String,
+        predicate: Box<Expr>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/lex-types/src/checker.rs
+++ b/crates/lex-types/src/checker.rs
@@ -65,6 +65,10 @@ pub fn check_program(stages: &[a::Stage]) -> Result<ProgramTypes, Vec<TypeError>
         if let a::Stage::FnDecl(fd) = stage {
             let scheme = function_scheme(fd);
             tcx.globals.insert(fd.name.clone(), scheme);
+            // #209 slice 2: keep the original params so call-site
+            // refinement discharge can see the predicate before it
+            // gets stripped to its base type by `ty_from_canon`.
+            tcx.fn_params.insert(fd.name.clone(), fd.params.clone());
         }
     }
 
@@ -333,6 +337,12 @@ struct Checker {
     /// `Result[Manifest, _]` constraints from match patterns or
     /// let-annotations have settled.
     pending_parse_calls: Vec<(usize, Ty)>,
+    /// Per-function param list, retained so call-site discharge can
+    /// see refinement predicates (#209 slice 2). The main `globals`
+    /// scheme strips refinements (`Refined` unifies as its base);
+    /// this side-table keeps the pre-stripped `TypeExpr` available
+    /// for static discharge of literal arguments.
+    fn_params: IndexMap<String, Vec<a::Param>>,
 }
 
 impl Checker {
@@ -343,6 +353,7 @@ impl Checker {
             globals: IndexMap::new(),
             module_aliases: IndexMap::new(),
             pending_parse_calls: Vec::new(),
+            fn_params: IndexMap::new(),
         }
     }
 
@@ -757,6 +768,31 @@ impl Checker {
                     let at = self.check_expr(a, node_id, locals, effs)?;
                     if let Err(err) = self.unify_with_record_coercion(&at, p) {
                         return Err(mismatch_err(node_id, err, &self.u, vec![format!("argument {} of call", i + 1)]));
+                    }
+                }
+                // #209 slice 2: refinement discharge for direct named
+                // calls. Look up the callee's original params (kept
+                // pre-strip in `fn_params`), and for each refined
+                // param attempt static discharge against the call
+                // arg. Refuted = type error; Deferred = pass (slice
+                // 3 will add a runtime residual check).
+                if let a::CExpr::Var { name: callee_name } = callee {
+                    if let Some(callee_params) = self.fn_params.get(callee_name).cloned() {
+                        for (i, (param, arg)) in callee_params.iter().zip(args.iter()).enumerate() {
+                            if let a::TypeExpr::Refined { binding, predicate, .. } = &param.ty {
+                                let outcome = crate::discharge::try_discharge(
+                                    predicate, binding, arg);
+                                if let crate::discharge::DischargeOutcome::Refuted { reason } = outcome {
+                                    return Err(TypeError::RefinementViolation {
+                                        at_node: node_id.into(),
+                                        fn_name: callee_name.clone(),
+                                        param_index: i,
+                                        binding: binding.clone(),
+                                        reason,
+                                    });
+                                }
+                            }
+                        }
                     }
                 }
                 // Re-resolve effects after unifying args: an effect-row

--- a/crates/lex-types/src/discharge.rs
+++ b/crates/lex-types/src/discharge.rs
@@ -1,0 +1,200 @@
+//! Static discharge of refinement-type predicates (#209 slice 2).
+//!
+//! Given a refined parameter type `Int{x | x > 0}` and a call-site
+//! argument `5`, this module evaluates the predicate with the binding
+//! bound to the argument's value and returns whether the call site
+//! satisfies, violates, or can't statically decide the constraint.
+//!
+//! Scope (deliberately small for v1):
+//!
+//! - **Argument shape**: only `CLit` literals (`Int`, `Float`, `Bool`,
+//!   `Str`). Anything else — variables, calls, arithmetic — defers
+//!   to slice 3's runtime residual check.
+//! - **Predicate shape**: literals, the bound variable, binary
+//!   arithmetic / comparison, boolean `and` / `or` with short-circuit,
+//!   `not`. Anything else defers.
+//! - **Free variables**: the predicate must reference *only* its
+//!   binding. Other identifiers (`balance`, `ceiling`, etc.) defer
+//!   — slice 2 doesn't try to evaluate them. Slice 3 will plumb
+//!   call-site context bindings.
+//!
+//! The deliberate fall-through to "deferred" is what makes this slice
+//! ship-able: anything we can't reason about cleanly stays a
+//! type-check pass and waits for slice 3's runtime check, rather
+//! than blocking type-check on cases we can't yet handle.
+
+use lex_ast::{CExpr, CLit};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum DischargeOutcome {
+    /// Predicate evaluated to `true` with the binding bound to the
+    /// argument value. Static check succeeds; no runtime work.
+    Proved,
+    /// Predicate evaluated to `false`. The call-site argument
+    /// definitely violates the refinement — surface as a type error.
+    Refuted { reason: String },
+    /// Couldn't decide statically. Slice 3 will emit a residual
+    /// runtime check at the call boundary; this slice just lets
+    /// type-check pass.
+    Deferred { reason: String },
+}
+
+/// Try to discharge `predicate` with `binding_name` bound to `arg`.
+/// `arg` is the CallExpr's argument expression — only literal forms
+/// (`CLit`) participate in static discharge; anything else defers.
+pub fn try_discharge(
+    predicate: &CExpr,
+    binding_name: &str,
+    arg: &CExpr,
+) -> DischargeOutcome {
+    let v = match arg_to_concrete(arg) {
+        Some(v) => v,
+        None => return DischargeOutcome::Deferred {
+            reason: "argument is not a literal; static discharge can't \
+                     evaluate it (slice 3 will add a runtime check)".into(),
+        },
+    };
+    match eval(predicate, binding_name, &v) {
+        Ok(Concrete::Bool(true)) => DischargeOutcome::Proved,
+        Ok(Concrete::Bool(false)) => DischargeOutcome::Refuted {
+            reason: format!(
+                "predicate failed for {} = {}",
+                binding_name, v.show()),
+        },
+        Ok(other) => DischargeOutcome::Deferred {
+            reason: format!("predicate didn't reduce to a Bool (got {})",
+                other.show()),
+        },
+        Err(e) => DischargeOutcome::Deferred { reason: e },
+    }
+}
+
+/// Reduce a call-site argument expression to a `Concrete` value if
+/// it's a literal or a sign-flipped literal. Lex parses `-5` as
+/// `UnaryOp { op: "-", expr: Literal { Int(5) } }` rather than a
+/// negative literal, so we fold that one shape inline. Anything
+/// more involved (arithmetic, var refs) defers — slice 3 territory.
+fn arg_to_concrete(e: &CExpr) -> Option<Concrete> {
+    match e {
+        CExpr::Literal { value } => Some(Concrete::from_lit(value)),
+        CExpr::UnaryOp { op, expr } if op == "-" => match expr.as_ref() {
+            CExpr::Literal { value: CLit::Int { value } } =>
+                Some(Concrete::Int(-value)),
+            CExpr::Literal { value: CLit::Float { value } } => {
+                value.parse::<f64>().ok().map(|f| Concrete::Float(-f))
+            }
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum Concrete {
+    Int(i64),
+    Float(f64),
+    Bool(bool),
+    Str(String),
+}
+
+impl Concrete {
+    fn from_lit(l: &CLit) -> Self {
+        match l {
+            CLit::Int { value } => Concrete::Int(*value),
+            CLit::Float { value } => Concrete::Float(value.parse().unwrap_or(0.0)),
+            CLit::Bool { value } => Concrete::Bool(*value),
+            CLit::Str { value } => Concrete::Str(value.clone()),
+            // Bytes / Unit are unusual in refinement contexts; surface
+            // as Unit so the predicate evaluator defers cleanly.
+            _ => Concrete::Bool(false),
+        }
+    }
+    fn show(&self) -> String {
+        match self {
+            Concrete::Int(n) => format!("{n}"),
+            Concrete::Float(f) => format!("{f}"),
+            Concrete::Bool(b) => format!("{b}"),
+            Concrete::Str(s) => format!("{s:?}"),
+        }
+    }
+}
+
+/// Tiny tree-walk evaluator for a predicate `CExpr` with a single
+/// in-scope binding. Returns `Err` for unsupported forms (caller
+/// folds these into `Deferred`).
+fn eval(e: &CExpr, name: &str, value: &Concrete) -> Result<Concrete, String> {
+    match e {
+        CExpr::Literal { value: lit } => Ok(Concrete::from_lit(lit)),
+        CExpr::Var { name: n } => {
+            if n == name { Ok(value.clone()) }
+            else { Err(format!("predicate references free var `{n}`; \
+                                slice 2 only supports the binding itself")) }
+        }
+        CExpr::UnaryOp { op, expr } => {
+            let v = eval(expr, name, value)?;
+            match (op.as_str(), v) {
+                ("not", Concrete::Bool(b)) => Ok(Concrete::Bool(!b)),
+                ("-",   Concrete::Int(n)) => Ok(Concrete::Int(-n)),
+                ("-",   Concrete::Float(n)) => Ok(Concrete::Float(-n)),
+                (o, v) => Err(format!("unsupported unary `{o}` on {}", v.show())),
+            }
+        }
+        CExpr::BinOp { op, lhs, rhs } => {
+            // Short-circuit `and` / `or` so the right side never
+            // gets evaluated when the left already decides.
+            if op == "and" || op == "or" {
+                let l = eval(lhs, name, value)?;
+                let lb = match l {
+                    Concrete::Bool(b) => b,
+                    other => return Err(format!("`{op}` on non-bool: {}", other.show())),
+                };
+                if op == "and" && !lb { return Ok(Concrete::Bool(false)); }
+                if op == "or"  &&  lb { return Ok(Concrete::Bool(true));  }
+                let r = eval(rhs, name, value)?;
+                return match r {
+                    Concrete::Bool(b) => Ok(Concrete::Bool(b)),
+                    other => Err(format!("`{op}` on non-bool: {}", other.show())),
+                };
+            }
+            let l = eval(lhs, name, value)?;
+            let r = eval(rhs, name, value)?;
+            apply_binop(op, &l, &r)
+        }
+        // Anything else (Call, Let, Match, FieldAccess, Lambda, Block,
+        // Constructors, Records, Tuples, Lists, Return) is out of
+        // slice-2 scope. Slice 3's runtime check handles these by
+        // falling back to actual evaluation under the host VM.
+        _ => Err(format!("unsupported predicate node: {e:?}")),
+    }
+}
+
+fn apply_binop(op: &str, l: &Concrete, r: &Concrete) -> Result<Concrete, String> {
+    use Concrete::*;
+    match (op, l, r) {
+        ("+", Int(a), Int(b)) => Ok(Int(a + b)),
+        ("-", Int(a), Int(b)) => Ok(Int(a - b)),
+        ("*", Int(a), Int(b)) => Ok(Int(a * b)),
+        ("/", Int(a), Int(b)) if *b != 0 => Ok(Int(a / b)),
+        ("%", Int(a), Int(b)) if *b != 0 => Ok(Int(a % b)),
+        ("+", Float(a), Float(b)) => Ok(Float(a + b)),
+        ("-", Float(a), Float(b)) => Ok(Float(a - b)),
+        ("*", Float(a), Float(b)) => Ok(Float(a * b)),
+        ("/", Float(a), Float(b)) => Ok(Float(a / b)),
+
+        ("==", a, b) => Ok(Bool(a == b)),
+        ("!=", a, b) => Ok(Bool(a != b)),
+
+        ("<",  Int(a), Int(b)) => Ok(Bool(a < b)),
+        ("<=", Int(a), Int(b)) => Ok(Bool(a <= b)),
+        (">",  Int(a), Int(b)) => Ok(Bool(a > b)),
+        (">=", Int(a), Int(b)) => Ok(Bool(a >= b)),
+
+        ("<",  Float(a), Float(b)) => Ok(Bool(a < b)),
+        ("<=", Float(a), Float(b)) => Ok(Bool(a <= b)),
+        (">",  Float(a), Float(b)) => Ok(Bool(a > b)),
+        (">=", Float(a), Float(b)) => Ok(Bool(a >= b)),
+
+        (op, a, b) => Err(format!(
+            "unsupported binop `{op}` on {} and {}", a.show(), b.show())),
+    }
+}

--- a/crates/lex-types/src/env.rs
+++ b/crates/lex-types/src/env.rs
@@ -239,5 +239,17 @@ pub fn ty_from_canon(t: &lex_ast::TypeExpr, params: &[String]) -> Ty {
             // Unions on the RHS of type-decls; not in arbitrary positions.
             Ty::Unit
         }
+        lex_ast::TypeExpr::Refined { base, .. } => {
+            // #209 slice 1: refinement types unify structurally as
+            // their base type. The predicate is parsed and stored in
+            // the AST (so `lex-vcs` content-addressing picks up
+            // refinement edits), but static discharge and runtime
+            // residual checks land in slices 2 and 3 of #209. The
+            // unification behavior here means a function declaring
+            // `Int{x | x > 0}` interoperates with plain `Int` callers
+            // — the predicate is informational until discharge is
+            // wired up.
+            ty_from_canon(base, params)
+        }
     }
 }

--- a/crates/lex-types/src/error.rs
+++ b/crates/lex-types/src/error.rs
@@ -51,6 +51,18 @@ pub enum TypeError {
         at_node: String,
         name: String,
     },
+    /// Refinement-type predicate provably violated at a call site
+    /// (#209 slice 2). The type checker statically discharged the
+    /// refinement and found the literal argument doesn't satisfy the
+    /// predicate. Slice 3 will add residual runtime checks for
+    /// arguments that can't be discharged statically.
+    RefinementViolation {
+        at_node: String,
+        fn_name: String,
+        param_index: usize,
+        binding: String,
+        reason: String,
+    },
 }
 
 impl TypeError {
@@ -66,7 +78,8 @@ impl TypeError {
             | TypeError::EffectNotDeclared { at_node, .. }
             | TypeError::InfiniteType { at_node, .. }
             | TypeError::AmbiguousType { at_node, .. }
-            | TypeError::RecursiveTypeWithoutConstructor { at_node, .. } => at_node,
+            | TypeError::RecursiveTypeWithoutConstructor { at_node, .. }
+            | TypeError::RefinementViolation { at_node, .. } => at_node,
         }
     }
 }
@@ -89,6 +102,9 @@ impl std::fmt::Display for TypeError {
             TypeError::InfiniteType { at_node } => write!(f, "infinite type (occurs check) at {at_node}"),
             TypeError::AmbiguousType { at_node } => write!(f, "ambiguous type at {at_node}"),
             TypeError::RecursiveTypeWithoutConstructor { at_node, name } => write!(f, "recursive type {name} has no constructor at {at_node}"),
+            TypeError::RefinementViolation { at_node, fn_name, param_index, binding, reason } =>
+                write!(f, "refinement violated at {at_node}: argument {} of `{fn_name}` (binding `{binding}`): {reason}",
+                    param_index + 1),
         }
     }
 }

--- a/crates/lex-types/src/lib.rs
+++ b/crates/lex-types/src/lib.rs
@@ -8,6 +8,7 @@ pub mod env;
 pub mod error;
 pub mod builtins;
 pub mod checker;
+pub mod discharge;
 
 pub use checker::{check_and_rewrite_program, check_program, ProgramTypes};
 pub use error::TypeError;

--- a/crates/lex-types/tests/refinement_types.rs
+++ b/crates/lex-types/tests/refinement_types.rs
@@ -57,21 +57,136 @@ fn pay(amount :: Int{x | x > 0 and x <= 100}) -> Int { amount }
 
 #[test]
 fn refined_param_unifies_as_its_base_type_for_now() {
-    // Slice 1: refined types are structurally equal to their base.
-    // A function declaring `Int{x | x > 0}` accepts plain Int callers
-    // and type-checks. Slice 2 will tighten this so static-known
-    // violations are rejected.
+    // Refined types unify structurally as their base, so a non-literal
+    // call (where slice-2 discharge can't decide) type-checks. Use a
+    // local var so the call defers to slice 3's runtime check.
+    let src = r#"
+fn withdraw(amount :: Int{x | x > 0}) -> Int { amount }
+fn caller(input :: Int) -> Int { withdraw(input) }
+"#;
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    // Type-check should pass: refined Int unifies as Int and the
+    // non-literal arg defers to runtime (slice 3 territory).
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("expected type-check pass (non-literal arg defers to \
+                runtime check); got: {errs:#?}");
+    }
+}
+
+// ---- #209 slice 2: static discharge of literal arguments ---------
+
+#[test]
+fn literal_arg_satisfying_predicate_proves_statically() {
+    // The headline acceptance criterion: `withdraw(5)` against
+    // `amount > 0` proves at compile time, no runtime cost.
+    let src = r#"
+fn withdraw(amount :: Int{x | x > 0}) -> Int { amount }
+fn caller() -> Int { withdraw(5) }
+"#;
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("expected static discharge to prove `5 > 0`; \
+                got: {errs:#?}");
+    }
+}
+
+#[test]
+fn literal_arg_violating_predicate_is_refuted_statically() {
+    // Pre-slice-2 this type-checked silently; now `withdraw(-5)`
+    // is rejected at compile time because the type checker can
+    // evaluate the predicate `x > 0` with `x = -5` and see it's
+    // false. The headline correctness win.
     let src = r#"
 fn withdraw(amount :: Int{x | x > 0}) -> Int { amount }
 fn caller() -> Int { withdraw(-5) }
 "#;
     let prog = parse_source(src).expect("parse");
     let stages = canonicalize_program(&prog);
-    // Type-check should pass: refined Int unifies as Int.
-    if let Err(errs) = lex_types::check_program(&stages) {
-        panic!("expected type-check pass (slice 1 unifies refined as \
-                base); got: {errs:#?}");
-    }
+    let errs = match lex_types::check_program(&stages) {
+        Ok(_) => panic!("expected type-check to fail"),
+        Err(e) => e,
+    };
+    let viol = errs.iter().find(|e| matches!(e,
+        lex_types::TypeError::RefinementViolation { .. }));
+    assert!(viol.is_some(),
+        "expected RefinementViolation; got: {errs:#?}");
+}
+
+#[test]
+fn compound_predicate_proves_when_all_clauses_hold() {
+    let src = r#"
+fn pay(amount :: Int{x | x > 0 and x <= 100}) -> Int { amount }
+fn caller() -> Int { pay(50) }
+"#;
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    lex_types::check_program(&stages).expect("50 satisfies (>0 and <=100)");
+}
+
+#[test]
+fn compound_predicate_refutes_on_upper_bound() {
+    let src = r#"
+fn pay(amount :: Int{x | x > 0 and x <= 100}) -> Int { amount }
+fn caller() -> Int { pay(150) }
+"#;
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    let errs = match lex_types::check_program(&stages) {
+        Ok(_) => panic!("expected type-check to fail"),
+        Err(e) => e,
+    };
+    assert!(errs.iter().any(|e| matches!(e,
+        lex_types::TypeError::RefinementViolation { .. })),
+        "expected RefinementViolation for 150 > 100; got: {errs:#?}");
+}
+
+#[test]
+fn predicate_with_external_var_defers_to_runtime() {
+    // The predicate references `balance`, which isn't the binding.
+    // Slice 2's discharge engine doesn't try to resolve external
+    // identifiers; it defers to slice 3's runtime check. The literal
+    // arg by itself doesn't statically violate the part the engine
+    // *can* see, so the call type-checks.
+    //
+    // This intentionally documents a slice-2 limitation: agents that
+    // want richer discharge today should rewrite predicates so all
+    // free variables are the binding (e.g. inline `balance` as a
+    // numeric constant). Slice 3 will plumb call-site context.
+    let src = r#"
+fn withdraw(amount :: Int{x | x > 0 and x <= balance}) -> Int { amount }
+fn caller() -> Int { withdraw(50) }
+"#;
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    lex_types::check_program(&stages).expect(
+        "external `balance` should defer; the bound predicate `x > 0` \
+         alone is satisfied by 50, so no static refutation");
+}
+
+#[test]
+fn refutation_error_names_the_binding_and_reason() {
+    let src = r#"
+fn pos(amount :: Int{x | x > 0}) -> Int { amount }
+fn caller() -> Int { pos(-3) }
+"#;
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    let errs = match lex_types::check_program(&stages) {
+        Ok(_) => panic!("expected type-check to fail"),
+        Err(e) => e,
+    };
+    let v = errs.iter().find_map(|e| match e {
+        lex_types::TypeError::RefinementViolation {
+            fn_name, binding, reason, ..
+        } => Some((fn_name.clone(), binding.clone(), reason.clone())),
+        _ => None,
+    }).expect("expected RefinementViolation");
+    assert_eq!(v.0, "pos");
+    assert_eq!(v.1, "x");
+    assert!(v.2.contains("-3"),
+        "reason should name the failing arg value; got: {}", v.2);
 }
 
 #[test]

--- a/crates/lex-types/tests/refinement_types.rs
+++ b/crates/lex-types/tests/refinement_types.rs
@@ -1,0 +1,153 @@
+//! Acceptance tests for #209 slice 1: parser + AST plumbing for
+//! refinement types.
+//!
+//! Slice scope: signatures with `Type{x | predicate}` parse, survive
+//! canonicalization, and pass through the type checker by unifying
+//! structurally as their base type. Static discharge (proving
+//! `withdraw(5)` against `amount > 0` at the call site) and the
+//! residual runtime check at call boundaries land in slices 2 and 3.
+//!
+//! What this slice deliberately does *not* test:
+//!   - Static discharge of the predicate at call sites.
+//!   - Runtime residual checks recorded in lex-trace.
+//!   - lex-vcs `ChangeEffectSig` carrying refinement diffs (the
+//!     canonical AST already includes the predicate, so OpId hashing
+//!     picks up changes — but the surfaced diagnostic shape is a
+//!     slice-3 concern).
+
+use lex_ast::canonicalize_program;
+use lex_ast::TypeExpr;
+use lex_syntax::parse_source;
+
+#[test]
+fn signature_with_refined_int_param_parses() {
+    let src = r#"
+fn withdraw(amount :: Int{x | x > 0}) -> Int { amount }
+"#;
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    let fd = match &stages[0] {
+        lex_ast::Stage::FnDecl(fd) => fd,
+        other => panic!("expected FnDecl, got {other:?}"),
+    };
+    let param_ty = &fd.params[0].ty;
+    match param_ty {
+        TypeExpr::Refined { base, binding, .. } => {
+            assert_eq!(binding, "x");
+            assert!(matches!(base.as_ref(), TypeExpr::Named { name, .. } if name == "Int"));
+        }
+        other => panic!("expected Refined param type, got {other:?}"),
+    }
+}
+
+#[test]
+fn refinement_with_compound_predicate_parses() {
+    // The headline example from #209: `Int{x | x > 0 and x <= balance}`.
+    let src = r#"
+fn pay(amount :: Int{x | x > 0 and x <= 100}) -> Int { amount }
+"#;
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    let fd = match &stages[0] {
+        lex_ast::Stage::FnDecl(fd) => fd,
+        _ => unreachable!(),
+    };
+    assert!(matches!(&fd.params[0].ty, TypeExpr::Refined { .. }));
+}
+
+#[test]
+fn refined_param_unifies_as_its_base_type_for_now() {
+    // Slice 1: refined types are structurally equal to their base.
+    // A function declaring `Int{x | x > 0}` accepts plain Int callers
+    // and type-checks. Slice 2 will tighten this so static-known
+    // violations are rejected.
+    let src = r#"
+fn withdraw(amount :: Int{x | x > 0}) -> Int { amount }
+fn caller() -> Int { withdraw(-5) }
+"#;
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    // Type-check should pass: refined Int unifies as Int.
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("expected type-check pass (slice 1 unifies refined as \
+                base); got: {errs:#?}");
+    }
+}
+
+#[test]
+fn refinement_on_list_type_parses() {
+    // From the issue: `List[T]{xs | length(xs) > 0}` — refinement
+    // on a parametric type. Confirms the postfix lookahead works
+    // after a generic-arg-bearing base.
+    let src = r#"
+fn first(xs :: List[Int]{ys | true}) -> Int { 0 }
+"#;
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    let fd = match &stages[0] {
+        lex_ast::Stage::FnDecl(fd) => fd,
+        _ => unreachable!(),
+    };
+    match &fd.params[0].ty {
+        TypeExpr::Refined { base, binding, .. } => {
+            assert_eq!(binding, "ys");
+            assert!(matches!(base.as_ref(), TypeExpr::Named { name, args }
+                if name == "List" && args.len() == 1));
+        }
+        other => panic!("expected Refined, got {other:?}"),
+    }
+}
+
+#[test]
+fn function_body_braces_are_not_mistaken_for_refinement() {
+    // Disambiguation guard: `-> Int { body }` is a function with body,
+    // not `Int{body}` refinement. Refinements need `{ Ident |` ahead;
+    // bodies don't have that lookahead shape.
+    let src = r#"
+fn answer() -> Int { 42 }
+"#;
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    let fd = match &stages[0] {
+        lex_ast::Stage::FnDecl(fd) => fd,
+        _ => unreachable!(),
+    };
+    assert!(matches!(&fd.return_type, TypeExpr::Named { name, .. } if name == "Int"));
+}
+
+#[test]
+fn refinement_on_return_type_parses() {
+    let src = r#"
+fn pos() -> Int{x | x > 0} { 7 }
+"#;
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    let fd = match &stages[0] {
+        lex_ast::Stage::FnDecl(fd) => fd,
+        _ => unreachable!(),
+    };
+    assert!(matches!(&fd.return_type, TypeExpr::Refined { .. }));
+}
+
+#[test]
+fn predicate_is_carried_through_canonicalization() {
+    // The refinement predicate must reach the canonical AST so
+    // lex-vcs's content-addressing picks up changes to it. Two
+    // signatures differing only in the predicate produce structurally
+    // distinct canonical TypeExprs.
+    let src_a = "fn f(x :: Int{n | n > 0}) -> Int { x }";
+    let src_b = "fn f(x :: Int{n | n > 1}) -> Int { x }";
+    let stages_a = canonicalize_program(&parse_source(src_a).expect("parse"));
+    let stages_b = canonicalize_program(&parse_source(src_b).expect("parse"));
+    let ty_a = match &stages_a[0] {
+        lex_ast::Stage::FnDecl(fd) => &fd.params[0].ty,
+        _ => unreachable!(),
+    };
+    let ty_b = match &stages_b[0] {
+        lex_ast::Stage::FnDecl(fd) => &fd.params[0].ty,
+        _ => unreachable!(),
+    };
+    assert_ne!(ty_a, ty_b,
+        "refinement predicates must reach the canonical AST so changes \
+         to them perturb the type's identity");
+}

--- a/crates/lex-vcs/src/compute_diff.rs
+++ b/crates/lex-vcs/src/compute_diff.rs
@@ -323,5 +323,12 @@ fn render_type(t: &TypeExpr) -> String {
             Some(p) => format!("{}({})", v.name, render_type(p)),
             None => v.name.clone(),
         }).collect::<Vec<_>>().join(" | "),
+        TypeExpr::Refined { base, binding, .. } => {
+            // Render compactly: `Base{x | …}`. The full predicate is
+            // captured in the canonical AST and contributes to
+            // OpId hashing via lex-vcs's content-addressing — this
+            // string is for diagnostics only. (#209 slice 1)
+            format!("{}{{{} | …}}", render_type(base), binding)
+        }
     }
 }

--- a/crates/spec-checker/src/ast.rs
+++ b/crates/spec-checker/src/ast.rs
@@ -40,6 +40,14 @@ pub enum SpecType {
     /// active charging sessions, message queues — via `length`,
     /// `head`, `tail`, and indexed access (`xs[i]`).
     List { element: Box<SpecType> },
+    /// Named user type (#208 slice 3). Refers to a user-defined ADT
+    /// from the host program (e.g. `Message`, `Order`). The gate
+    /// evaluator inspects the value's variant tag at match time;
+    /// no compile-time variant table is needed for the gate path.
+    /// The random-input prover (`check_spec`) can't sample arbitrary
+    /// user types and fails out — those tests should provide
+    /// concrete bindings instead.
+    Named { name: String },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -65,6 +73,32 @@ pub enum SpecExpr {
     /// that want defensive behavior wrap with a `length(xs) > i`
     /// check.
     Index { list: Box<SpecExpr>, index: Box<SpecExpr> },
+    /// Pattern match on a sum-typed expression (#208 slice 3). Arms
+    /// are tried in order; the first matching arm's body is the
+    /// result. A `_` wildcard pattern is exhaustive. Variant
+    /// patterns (`Charge(x)`) bind positional args by name in the
+    /// arm's body. Non-exhaustive matches fall through to
+    /// Inconclusive at evaluation time.
+    Match { scrutinee: Box<SpecExpr>, arms: Vec<MatchArm> },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MatchArm {
+    pub pattern: SpecPattern,
+    pub body: SpecExpr,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SpecPattern {
+    /// `_` — matches anything, binds nothing.
+    Wildcard,
+    /// `Variant(x, y)` — matches `Value::Variant { name, args }`
+    /// where `name == self.name` and `args.len() == bindings.len()`.
+    /// Each binding name is bound to the corresponding positional
+    /// arg in the arm's body. `Variant()` (no parens) and `Variant`
+    /// (no args) parse identically; both have `bindings: vec![]`.
+    Variant { name: String, bindings: Vec<String> },
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/spec-checker/src/checker.rs
+++ b/crates/spec-checker/src/checker.rs
@@ -205,6 +205,18 @@ fn sample(ty: &SpecType, rng: &mut DetRng) -> Value {
             }
             Value::List(out)
         }
+        // #208 slice 3: random sampling over user-defined ADTs needs
+        // a variant table that the spec language doesn't carry. The
+        // gate path doesn't need it (concrete bindings come from the
+        // caller) but the offline prover does. For v1 we surface a
+        // sentinel value; the random-input prover treats this as
+        // "type not sampleable" and skips the spec. Specs that
+        // quantify over `Named` types should be evaluated via the
+        // gate path (`evaluate_gate_compiled`) with concrete inputs.
+        SpecType::Named { name } => Value::Variant {
+            name: format!("__unsampled_{name}"),
+            args: Vec::new(),
+        },
     }
 }
 
@@ -279,6 +291,18 @@ fn eval(
                 return Err(format!("list index {i} out of bounds (length {})", xs.len()));
             }
             Ok(xs[i as usize].clone())
+        }
+        SpecExpr::Match { scrutinee, arms } => {
+            // Mirror of the gate path's match (#208 slice 3).
+            let v = eval(scrutinee, bindings, bc, policy)?;
+            for arm in arms {
+                if let Some(extra) = crate::gate::pattern_match(&arm.pattern, &v) {
+                    let mut next = bindings.clone();
+                    for (k, vv) in extra { next.insert(k, vv); }
+                    return eval(&arm.body, &next, bc, policy);
+                }
+            }
+            Err(format!("non-exhaustive match: no arm matched value {v:?}"))
         }
     }
 }

--- a/crates/spec-checker/src/gate.rs
+++ b/crates/spec-checker/src/gate.rs
@@ -247,6 +247,22 @@ fn eval_body(
             let i = eval_body(index, bindings, bc, policy, new_tracer)?;
             list_index(xs, i)
         }
+        SpecExpr::Match { scrutinee, arms } => {
+            // #208 slice 3: dispatch on `Value::Variant`'s tag.
+            // Wildcard arms always match. Variant arms match by name
+            // and arity, binding positional args by name in the body.
+            let v = eval_body(scrutinee, bindings, bc, policy, new_tracer)?;
+            for arm in arms {
+                if let Some(extra) = pattern_match(&arm.pattern, &v) {
+                    let mut next = bindings.clone();
+                    for (k, vv) in extra { next.insert(k, vv); }
+                    return eval_body(&arm.body, &next, bc, policy, new_tracer);
+                }
+            }
+            Err(format!(
+                "non-exhaustive match: no arm matched value {}",
+                short_value(&v)))
+        }
         SpecExpr::FieldAccess { value, field } => {
             // Drill into a record-typed binding (#208). Fails loudly
             // if the value isn't a record or the field is missing —
@@ -261,6 +277,29 @@ fn eval_body(
                 other => Err(format!(
                     "field access `.{field}` on non-record: {}",
                     short_value(&other))),
+            }
+        }
+    }
+}
+
+/// Try to match a pattern against a value (#208 slice 3). Returns
+/// `Some(bindings)` on success — the bindings to add to the
+/// arm's lexical environment — or `None` if the pattern doesn't
+/// match. The caller falls through to the next arm on `None`.
+pub(crate) fn pattern_match(pat: &crate::ast::SpecPattern, v: &Value)
+    -> Option<Vec<(String, Value)>>
+{
+    use crate::ast::SpecPattern;
+    match pat {
+        SpecPattern::Wildcard => Some(Vec::new()),
+        SpecPattern::Variant { name, bindings } => {
+            match v {
+                Value::Variant { name: vn, args } if vn == name && args.len() == bindings.len() => {
+                    Some(bindings.iter().cloned()
+                        .zip(args.iter().cloned())
+                        .collect())
+                }
+                _ => None,
             }
         }
     }
@@ -864,5 +903,157 @@ mod tests {
             }
             other => panic!("expected Inconclusive, got {other:?}"),
         }
+    }
+
+    // ---- #208 slice 3: ADT pattern matching --------------------------
+
+    /// Build a `Value::Variant` with the given name and positional args.
+    fn variant(name: &str, args: Vec<Value>) -> Value {
+        Value::Variant { name: name.into(), args }
+    }
+
+    #[test]
+    fn named_type_in_quantifier_parses() {
+        let spec = parse_spec(r#"
+            spec ok {
+              forall msg :: Message : true
+            }
+        "#).unwrap();
+        let v = evaluate_gate(&[spec], &b([
+            ("msg", variant("Heartbeat", vec![])),
+        ]), "");
+        assert_eq!(v, GateVerdict::Allow);
+    }
+
+    #[test]
+    fn match_dispatches_on_variant_name() {
+        // Two arms: Charge(amount) returns amount > 0; Telemetry(_)
+        // is unconditionally true. Wildcard catches the rest.
+        let spec = parse_spec(r#"
+            spec valid_msg {
+              forall msg :: Message :
+                match msg {
+                  Charge(amount) => amount > 0,
+                  Telemetry(payload) => true,
+                  _ => false,
+                }
+            }
+        "#).unwrap();
+        let allow_charge = evaluate_gate(std::slice::from_ref(&spec), &b([
+            ("msg", variant("Charge", vec![Value::Int(50)])),
+        ]), "");
+        assert_eq!(allow_charge, GateVerdict::Allow);
+
+        let deny_negative = evaluate_gate(std::slice::from_ref(&spec), &b([
+            ("msg", variant("Charge", vec![Value::Int(-1)])),
+        ]), "");
+        assert!(matches!(deny_negative, GateVerdict::Deny { .. }));
+
+        let allow_telemetry = evaluate_gate(std::slice::from_ref(&spec), &b([
+            ("msg", variant("Telemetry", vec![Value::Str("ok".into())])),
+        ]), "");
+        assert_eq!(allow_telemetry, GateVerdict::Allow);
+
+        let deny_unknown = evaluate_gate(&[spec], &b([
+            ("msg", variant("UnknownTopic", vec![])),
+        ]), "");
+        assert!(matches!(deny_unknown, GateVerdict::Deny { .. }));
+    }
+
+    #[test]
+    fn variant_pattern_binds_positional_args() {
+        // `Charge(amount, station)` binds two args; the body
+        // references both. Confirms multi-arg variant patterns work.
+        let spec = parse_spec(r#"
+            spec budget_match {
+              forall msg :: Message :
+                match msg {
+                  Charge(amount, budget) => amount <= budget,
+                  _ => true,
+                }
+            }
+        "#).unwrap();
+        let allow = evaluate_gate(std::slice::from_ref(&spec), &b([
+            ("msg", variant("Charge", vec![Value::Int(50), Value::Int(100)])),
+        ]), "");
+        assert_eq!(allow, GateVerdict::Allow);
+        let deny = evaluate_gate(&[spec], &b([
+            ("msg", variant("Charge", vec![Value::Int(150), Value::Int(100)])),
+        ]), "");
+        assert!(matches!(deny, GateVerdict::Deny { .. }));
+    }
+
+    #[test]
+    fn variant_arity_mismatch_falls_through_to_next_arm() {
+        // `Charge(x)` (1 arg) doesn't match a `Charge(a, b)` value
+        // (2 args). The wildcard fallback catches it.
+        let spec = parse_spec(r#"
+            spec arity_check {
+              forall msg :: Message :
+                match msg {
+                  Charge(x) => x > 0,
+                  _ => true,
+                }
+            }
+        "#).unwrap();
+        let v = evaluate_gate(&[spec], &b([
+            ("msg", variant("Charge", vec![Value::Int(1), Value::Int(2)])),
+        ]), "");
+        assert_eq!(v, GateVerdict::Allow);
+    }
+
+    #[test]
+    fn non_exhaustive_match_is_inconclusive() {
+        // No wildcard, no matching variant — no arm fires.
+        let spec = parse_spec(r#"
+            spec only_charge {
+              forall msg :: Message :
+                match msg {
+                  Charge(_) => true,
+                }
+            }
+        "#).unwrap();
+        let v = evaluate_gate(&[spec], &b([
+            ("msg", variant("OtherTopic", vec![])),
+        ]), "");
+        match v {
+            GateVerdict::Inconclusive { reason, .. } => {
+                assert!(reason.contains("non-exhaustive"),
+                    "expected non-exhaustive diagnostic; got: {reason}");
+            }
+            other => panic!("expected Inconclusive, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_match_drills_into_variant_payload_record() {
+        // `Charge(s)` binds `s`, which is itself a record. The arm
+        // body uses `s.power <= s.budget` — combines slice 1
+        // (FieldAccess) with slice 3 (variant binding). Models the
+        // soft "for every charging session" pattern.
+        let spec = parse_spec(r#"
+            spec station_match {
+              forall msg :: Message :
+                match msg {
+                  Charge(s) => s.power <= s.budget,
+                  _ => true,
+                }
+            }
+        "#).unwrap();
+        let mut session = indexmap::IndexMap::new();
+        session.insert("power".into(), Value::Int(60));
+        session.insert("budget".into(), Value::Int(100));
+        let allow = evaluate_gate(std::slice::from_ref(&spec), &b([
+            ("msg", variant("Charge", vec![Value::Record(session)])),
+        ]), "");
+        assert_eq!(allow, GateVerdict::Allow);
+
+        let mut over = indexmap::IndexMap::new();
+        over.insert("power".into(), Value::Int(160));
+        over.insert("budget".into(), Value::Int(100));
+        let deny = evaluate_gate(&[spec], &b([
+            ("msg", variant("Charge", vec![Value::Record(over)])),
+        ]), "");
+        assert!(matches!(deny, GateVerdict::Deny { .. }));
     }
 }

--- a/crates/spec-checker/src/parser.rs
+++ b/crates/spec-checker/src/parser.rs
@@ -178,6 +178,14 @@ impl Parser {
                 }
                 Ok(SpecType::List { element: Box::new(elem) })
             }
+            // #208 slice 3: any other capitalized ident is treated as
+            // a user-defined ADT name (`Message`, `Order`, …). The
+            // gate path uses the value's runtime variant tag for
+            // discrimination, so no compile-time variant table is
+            // needed; the random-input prover doesn't enumerate these.
+            other if other.chars().next().is_some_and(|c| c.is_ascii_uppercase()) => {
+                Ok(SpecType::Named { name: other.to_string() })
+            }
             other => Err(self.err(format!("unknown spec type `{other}`"))),
         }
     }
@@ -352,6 +360,7 @@ impl Parser {
             },
             Some(TokenKind::True) => { self.bump(); Ok(SpecExpr::BoolLit { value: true }) }
             Some(TokenKind::False) => { self.bump(); Ok(SpecExpr::BoolLit { value: false }) }
+            Some(TokenKind::Match) => self.parse_match(),
             Some(TokenKind::Ident(_)) => {
                 let name = self.expect_ident("")?;
                 Ok(SpecExpr::Var { name })
@@ -366,6 +375,73 @@ impl Parser {
             }
             other => Err(self.err(format!("expected primary expression, got {other:?}"))),
         }
+    }
+
+    /// Parse `match scrutinee { Pattern => body, _ => body, ... }`
+    /// (#208 slice 3). Arms are separated by `,`; trailing comma OK.
+    fn parse_match(&mut self) -> Result<SpecExpr, SpecParseError> {
+        self.bump(); // consume `match`
+        let scrutinee = self.parse_expr()?;
+        if !self.eat(&TokenKind::LBrace) {
+            return Err(self.err("expected `{` after match scrutinee"));
+        }
+        let mut arms: Vec<crate::ast::MatchArm> = Vec::new();
+        self.skip_newlines();
+        while !matches!(self.peek(), Some(TokenKind::RBrace)) {
+            let pattern = self.parse_pattern()?;
+            if !self.eat(&TokenKind::FatArrow) {
+                return Err(self.err("expected `=>` after match pattern"));
+            }
+            let body = self.parse_expr()?;
+            arms.push(crate::ast::MatchArm { pattern, body });
+            self.skip_newlines();
+            if !self.eat(&TokenKind::Comma) { break; }
+            self.skip_newlines();
+        }
+        if !self.eat(&TokenKind::RBrace) {
+            return Err(self.err("expected `}` to close match"));
+        }
+        Ok(SpecExpr::Match {
+            scrutinee: Box::new(scrutinee),
+            arms,
+        })
+    }
+
+    /// Parse a single pattern: `_`, `Variant`, `Variant(a, b, ...)`.
+    fn parse_pattern(&mut self) -> Result<crate::ast::SpecPattern, SpecParseError> {
+        self.skip_newlines();
+        if self.eat(&TokenKind::Underscore) {
+            return Ok(crate::ast::SpecPattern::Wildcard);
+        }
+        let name = self.expect_ident("for variant pattern")?;
+        let bindings = if self.eat(&TokenKind::LParen) {
+            let mut bs = Vec::new();
+            self.skip_newlines();
+            if !matches!(self.peek(), Some(TokenKind::RParen)) {
+                bs.push(self.parse_variant_binding()?);
+                while self.eat(&TokenKind::Comma) {
+                    bs.push(self.parse_variant_binding()?);
+                }
+            }
+            if !self.eat(&TokenKind::RParen) {
+                return Err(self.err("expected `)` to close variant pattern"));
+            }
+            bs
+        } else {
+            Vec::new()
+        };
+        Ok(crate::ast::SpecPattern::Variant { name, bindings })
+    }
+
+    /// Parse a single binding inside a variant pattern: either an
+    /// ident name or `_` for "ignore this positional arg". Internally
+    /// `_` is bound to the literal name `_`; the body never references
+    /// it, so collisions across `_` bindings are inert.
+    fn parse_variant_binding(&mut self) -> Result<String, SpecParseError> {
+        if self.eat(&TokenKind::Underscore) {
+            return Ok("_".to_string());
+        }
+        self.expect_ident("for variant binding")
     }
 
     fn peek_kw(&self, name: &str) -> bool {

--- a/crates/spec-checker/src/smt.rs
+++ b/crates/spec-checker/src/smt.rs
@@ -55,16 +55,17 @@ fn smt_type(t: &SpecType) -> &'static str {
         SpecType::Float => "Real",
         SpecType::Bool => "Bool",
         SpecType::Str => "String",
-        // #208: SMT-LIB encoding for record / list types isn't
-        // implemented in this slice. SMT supports both via datatype
-        // declarations + sequences, but mapping the spec types into
-        // SMT-LIB needs name management for nested records and
-        // accessor / `seq.nth` generation. Out of scope for v1;
-        // the SMT path stays scalar-only. Specs that use these types
-        // are still evaluable via the gate path
-        // (`evaluate_gate_compiled`), which is what soft-agent uses.
+        // #208: SMT-LIB encoding for record / list / named (ADT)
+        // types isn't implemented. SMT supports all three via
+        // datatype declarations + sequences, but mapping the spec
+        // types into SMT-LIB needs name management and accessor
+        // function generation. Out of scope; the SMT path stays
+        // scalar-only. Specs that use these types are still
+        // evaluable via the gate path (`evaluate_gate_compiled`),
+        // which is what soft-agent uses.
         SpecType::Record { .. } => "<unsupported-Record>",
         SpecType::List { .. } => "<unsupported-List>",
+        SpecType::Named { .. } => "<unsupported-Named>",
     }
 }
 
@@ -116,6 +117,12 @@ fn expr_to_smt(e: &SpecExpr) -> String {
         SpecExpr::Index { list, index } => {
             format!("(<unsupported-Index> {} {})",
                 expr_to_smt(list), expr_to_smt(index))
+        }
+        SpecExpr::Match { scrutinee, arms } => {
+            // SMT-LIB match needs the datatype declared via declare-datatypes;
+            // out of scope for v1 — same rationale as the other variants.
+            let _ = arms;
+            format!("(<unsupported-Match> {})", expr_to_smt(scrutinee))
         }
     }
 }


### PR DESCRIPTION
## Summary

Bundles five slices on the same branch — independent commits, stacked because the work happened back-to-back without a review pause. Reviewable as one or split per commit.

| Commit | Issue | Scope |
|---|---|---|
| `51f5f92` | #208 slice 3 | spec-checker: ADT pattern matching in spec bodies |
| `1a91e9a` | #209 slice 1 | refinement types: parser + AST + canonical |
| `a1b851c` | #209 slice 2 | refinement types: static discharge of literal args |
| `6c96bdd` | #209 slice 3 | refinement types: runtime residual check |
| `5d145e9` | #206 slice 1 | canonical AST: stable binary wire format |

After this PR, **#208 and #209's language + runtime work are fully in tree**, and the agent-canonical-AST submission path from #206 is wired end-to-end. Remaining acceptance items on #206 are CBOR / CLI surfaces / lex-vcs streamlining (later slices).

## #208 slice 3 — ADT pattern matching (`51f5f92`)

`SpecType::Named { name }`, `SpecExpr::Match { scrutinee, arms }`, `SpecPattern::{Variant, Wildcard}`. Variant patterns match by name + arity, binding positional args by name. `_` is exhaustive fallback.

## #209 slices 1+2+3 — refinement types end-to-end

- **Slice 1 (`1a91e9a`)**: `TypeExpr::Refined { base, binding, predicate }` lifts refinement syntax to the AST. Postfix parse `BaseType{x | predicate}`, disambiguated from a function body's opening brace by 3-token lookahead. Canonical AST captures the predicate so `lex-vcs` content-addressing picks up edits to it.
- **Slice 2 (`a1b851c`)**: static discharge of literal-arg call sites. `withdraw(5)` against `amount > 0` proves at compile time; `withdraw(-5)` becomes `TypeError::RefinementViolation`. Non-literal args defer.
- **Slice 3 (`6c96bdd`)**: runtime residual check. `Function::refinements` carries per-param predicates into bytecode; the VM evaluates them at `Op::Call` / `Op::TailCall` / `Vm::invoke` and raises `VmError::RefinementFailed` on violation. Trace shape mirrors `gate.verdict`.

## #206 slice 1 — stable binary canonical-AST format (`5d145e9`)

`lex_ast::canonical_format::{encode_program, decode_program}` plus `CANONICAL_VERSION: u8 = 1`. The wire payload is `[version, canonical-JSON bytes...]` — same canonical form `lex-vcs` already uses for `OpId` / `StageId`, so the third #206 acceptance criterion ("op IDs are bit-identical across runs from canonical-AST input") holds by construction. Why JSON-flavored over CBOR for v1: identical content-addressing surface, zero new deps; the format can swap behind the same API later.

End-to-end test pins the issue's "agent submits ops without going through the text parser" criterion: parse + encode on the author side, decode + typecheck + compile + run on the receiver side, no `parse_source` call on the receiver path.

## Out of scope (future slices)

- **#206**: CBOR / postcard binary encodings for compactness; `lex compile --from-canonical` / `lex print --to-text` CLI subcommands; lex-vcs `compute_diff` streamlined for canonical-AST input.
- **#209**: predicate free-variable resolution at runtime (`x <= balance`); typed `lex-vcs` op for refinement edits; `Op::CallClosure` refinement check (lambdas don't accept refined params at the surface today).
- **#208**: P95 timing measurement with a soft-representative gate suite; `BindingsFn` migration in soft-agent (downstream).

## Test plan

- [x] 6 new tests for #208 slice 3 (spec-checker `gate::tests`).
- [x] 13 new tests for #209 slices 1 + 2 (`lex-types/tests/refinement_types.rs`).
- [x] 9 new tests for #209 slice 3 (`lex-runtime/tests/refinement_runtime.rs`).
- [x] 8 new tests for #206 slice 1 (`lex-ast/tests/canonical_format.rs`).
- [x] 3 new e2e tests for #206 slice 1 (`lex-runtime/tests/canonical_format_e2e.rs`).
- [x] Workspace test suite: **979 passing, 0 failed**.

## Closes

- #208 (language portion).
- #209 (language + runtime portion).
- Substantive progress on #206 (slice 1; CBOR / CLI / lex-vcs streamlining are slices 2+).

https://claude.ai/code/session_016SGtf28wA4CgAem65XrjPt