### PR TITLE
cli: lex canonical encode/decode + --from-canonical flag (#206 slices 2+3)

### DIFF
--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -220,6 +220,30 @@ fn read_program(path: &str) -> Result<SynProgram> {
     }
 }
 
+/// Load a program as canonical AST stages, choosing between the
+/// text parser and the canonical-AST decoder by `from_canonical`
+/// (#206 slice 3). Both paths produce the same `Vec<Stage>` shape;
+/// the difference is whether the parse step runs at all. Agents
+/// that build canonical AST directly avoid parser-bug blast radius
+/// and skip a CPU-bound step, which is part of the slice-1
+/// motivation.
+fn load_stages(path: &str, from_canonical: bool) -> Result<Vec<lex_ast::Stage>> {
+    if from_canonical {
+        let bytes = if path == "-" {
+            let mut buf = Vec::new();
+            std::io::stdin().read_to_end(&mut buf).context("reading stdin")?;
+            buf
+        } else {
+            std::fs::read(path).map_err(|e| anyhow!("read {path}: {e}"))?
+        };
+        lex_ast::canonical_format::decode_program(&bytes)
+            .map_err(|e| anyhow!("decode {path}: {e}"))
+    } else {
+        let prog = read_program(path)?;
+        Ok(canonicalize_program(&prog))
+    }
+}
+
 fn cmd_parse(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let path = args.first().ok_or_else(|| anyhow!("usage: lex parse <file>"))?;
     let prog = read_program(path)?;
@@ -232,9 +256,26 @@ fn cmd_parse(fmt: &OutputFormat, args: &[String]) -> Result<()> {
 }
 
 fn cmd_check(fmt: &OutputFormat, args: &[String]) -> Result<()> {
-    let path = args.first().ok_or_else(|| anyhow!("usage: lex check <file>"))?;
-    let prog = read_program(path)?;
-    let stages = canonicalize_program(&prog);
+    // #206 slice 3: `--from-canonical` reads the program as
+    // canonical-AST bytes instead of `.lex` text.
+    let mut from_canonical = false;
+    let mut path: Option<&str> = None;
+    let mut iter = args.iter();
+    while let Some(a) = iter.next() {
+        match a.as_str() {
+            "--from-canonical" => { from_canonical = true; }
+            other if !other.starts_with("--") => {
+                if path.is_some() {
+                    bail!("usage: lex check [--from-canonical] <file>");
+                }
+                path = Some(other);
+            }
+            other => bail!("unknown flag `{other}` for `lex check`"),
+        }
+    }
+    let path = path.ok_or_else(|| anyhow!(
+        "usage: lex check [--from-canonical] <file>"))?;
+    let stages = load_stages(path, from_canonical)?;
     match lex_types::check_program(&stages) {
         Ok(_) => {
             let summary = effects_summary(&stages);
@@ -341,8 +382,8 @@ fn suggest_grants(s: &EffectsSummary) -> String {
 }
 
 fn cmd_run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
-    let (policy, positional, trace, max_steps, dry_run) = parse_run_flags(args)?;
-    let path = positional.first().ok_or_else(|| anyhow!("usage: lex run [policy] <file> <fn> [args]"))?;
+    let (policy, positional, trace, max_steps, dry_run, from_canonical) = parse_run_flags(args)?;
+    let path = positional.first().ok_or_else(|| anyhow!("usage: lex run [policy] [--from-canonical] <file> <fn> [args]"))?;
     let func = positional.get(1).ok_or_else(|| anyhow!("missing function name"))?;
     if dry_run {
         let actions = vec![serde_json::json!({
@@ -363,10 +404,12 @@ fn cmd_run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         acli::emit_dry_run("run", fmt,
             &format!("would call `{func}` in {path}"), actions);
     }
-    let prog = read_program(path)?;
+    // #206 slice 3: load via text parser or canonical-AST decoder.
+    // Both paths produce the same Vec<Stage>; the typecheck and
+    // compile pipeline is identical from this point on.
+    let mut stages = load_stages(path, from_canonical)?;
     // #168: rewrite stdlib parse calls during type-check so the
     // runtime sees the strict (validated) shape.
-    let mut stages = canonicalize_program(&prog);
     if let Err(errs) = lex_types::check_and_rewrite_program(&mut stages) {
         let arr: Vec<serde_json::Value> = errs.iter()
             .map(|e| serde_json::to_value(e).unwrap()).collect();
@@ -437,12 +480,13 @@ fn cmd_run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
 }
 
 #[allow(clippy::type_complexity)]
-fn parse_run_flags(args: &[String]) -> Result<(Policy, Vec<String>, bool, Option<u64>, bool)> {
+fn parse_run_flags(args: &[String]) -> Result<(Policy, Vec<String>, bool, Option<u64>, bool, bool)> {
     let mut policy = Policy::pure();
     let mut positional = Vec::new();
     let mut trace = false;
     let mut max_steps: Option<u64> = None;
     let mut dry_run = false;
+    let mut from_canonical = false;
     let mut i = 0;
     while i < args.len() {
         let a = &args[i];
@@ -489,10 +533,18 @@ fn parse_run_flags(args: &[String]) -> Result<(Policy, Vec<String>, bool, Option
             }
             "--trace" => { trace = true; i += 1; }
             "--dry-run" => { dry_run = true; i += 1; }
+            "--from-canonical" => {
+                // #206 slice 3: read the program as canonical-AST
+                // bytes instead of `.lex` text. The path argument
+                // points to the bytes file (or `-` for stdin); the
+                // text parser is bypassed entirely on this path.
+                from_canonical = true;
+                i += 1;
+            }
             _ => { positional.push(a.clone()); i += 1; }
         }
     }
-    Ok((policy, positional, trace, max_steps, dry_run))
+    Ok((policy, positional, trace, max_steps, dry_run, from_canonical))
 }
 
 fn cmd_trace(fmt: &OutputFormat, args: &[String]) -> Result<()> {

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -104,6 +104,7 @@ fn run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         "policy" => cmd_policy(fmt, &args[1..]),
         "log" => branch::cmd_log(fmt, &args[1..]),
         "op" => op::cmd_op(fmt, &args[1..]),
+        "canonical" => cmd_canonical(fmt, &args[1..]),
         "repl" => repl::cmd_repl(&args[1..]),
         "watch" => watch::cmd_watch(&args[1..]),
         "help" | "--help" | "-h" => { print_usage(); Ok(()) }
@@ -519,6 +520,155 @@ fn cmd_diff(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         println!("{}", serde_json::to_string_pretty(&data).unwrap());
     });
     Ok(())
+}
+
+/// `lex canonical <encode|decode>` dispatcher (#206 slice 2).
+fn cmd_canonical(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    let sub = args.first().ok_or_else(|| anyhow!(
+        "usage: lex canonical <encode|decode> ..."))?;
+    match sub.as_str() {
+        "encode" => cmd_canonical_encode(fmt, &args[1..]),
+        "decode" => cmd_canonical_decode(fmt, &args[1..]),
+        other => bail!("unknown `lex canonical` action `{other}`; \
+                       expected `encode` or `decode`"),
+    }
+}
+
+/// `lex canonical encode <text-file> [--out <bytes-file>]` (#206 slice 2).
+///
+/// Parses a `.lex` source file, canonicalizes it, and emits the
+/// versioned canonical-AST byte representation. Without `--out`,
+/// writes raw bytes to stdout (suitable for piping into another
+/// agent process or `lex canonical decode`); with `--out`, writes
+/// to the named file.
+///
+/// JSON-output mode (`--output json`) emits a structured envelope
+/// instead — `{ "ok": true, "bytes_b64": "..." }` — so agent
+/// harnesses can capture the canonical bytes without dealing with
+/// raw-bytes-on-stdout encoding issues.
+fn cmd_canonical_encode(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    let mut path: Option<&str> = None;
+    let mut out_path: Option<&str> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--out" => {
+                out_path = Some(args.get(i + 1).map(|s| s.as_str())
+                    .ok_or_else(|| anyhow!("--out needs a path"))?);
+                i += 2;
+            }
+            s if s.starts_with("--") => bail!("unknown flag `{s}` for `lex canonical encode`"),
+            _ => {
+                if path.is_some() {
+                    bail!("usage: lex canonical encode <text-file> [--out <bytes-file>]");
+                }
+                path = Some(args[i].as_str());
+                i += 1;
+            }
+        }
+    }
+    let path = path.ok_or_else(|| anyhow!(
+        "usage: lex canonical encode <text-file> [--out <bytes-file>]"))?;
+
+    let prog = read_program(path)?;
+    let stages = canonicalize_program(&prog);
+    let bytes = lex_ast::canonical_format::encode_program(&stages);
+
+    if let Some(out) = out_path {
+        std::fs::write(out, &bytes)
+            .map_err(|e| anyhow!("write {out}: {e}"))?;
+        let data = serde_json::json!({
+            "ok": true,
+            "out": out,
+            "bytes": bytes.len(),
+            "stages": stages.len(),
+        });
+        acli::emit_or_text("canonical-encode", data, fmt, || {
+            println!("wrote {} bytes to {out}", bytes.len());
+        });
+    } else {
+        match fmt {
+            OutputFormat::Json => {
+                let b64 = encode_b64(&bytes);
+                let data = serde_json::json!({
+                    "ok": true,
+                    "bytes_b64": b64,
+                    "stages": stages.len(),
+                });
+                acli::emit_or_text("canonical-encode", data, fmt, || {});
+            }
+            _ => {
+                use std::io::Write;
+                std::io::stdout().write_all(&bytes)
+                    .map_err(|e| anyhow!("stdout: {e}"))?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// `lex canonical decode <bytes-file>` (#206 slice 2).
+///
+/// Reads the canonical-AST byte representation from a file, decodes
+/// it, and prints the program back in `.lex` text form via
+/// `lex_ast::print_stages`. The text output is a debugger /
+/// new-developer affordance — round-tripping `text → canonical → text`
+/// produces semantically equivalent (but not necessarily byte-identical)
+/// source, since the canonical form drops insignificant whitespace
+/// and comment placement.
+fn cmd_canonical_decode(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    let path = args.first().ok_or_else(|| anyhow!(
+        "usage: lex canonical decode <bytes-file>"))?;
+    let bytes = std::fs::read(path)
+        .map_err(|e| anyhow!("read {path}: {e}"))?;
+    let stages = lex_ast::canonical_format::decode_program(&bytes)
+        .map_err(|e| anyhow!("decode {path}: {e}"))?;
+    let text = lex_ast::print_stages(&stages);
+    let data = serde_json::json!({
+        "ok": true,
+        "stages": stages.len(),
+        "text": &text,
+    });
+    acli::emit_or_text("canonical-decode", data, fmt, || {
+        print!("{text}");
+    });
+    Ok(())
+}
+
+/// Tiny base64 encoder for the JSON envelope output. Avoids adding
+/// a `base64` crate dep just for this CLI surface — standard
+/// alphabet (RFC 4648 §4), padded.
+fn encode_b64(bytes: &[u8]) -> String {
+    const A: &[u8; 64] =
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
+    let mut i = 0;
+    while i + 3 <= bytes.len() {
+        let b0 = bytes[i] as usize;
+        let b1 = bytes[i + 1] as usize;
+        let b2 = bytes[i + 2] as usize;
+        out.push(A[b0 >> 2] as char);
+        out.push(A[((b0 & 0b11) << 4) | (b1 >> 4)] as char);
+        out.push(A[((b1 & 0b1111) << 2) | (b2 >> 6)] as char);
+        out.push(A[b2 & 0b111111] as char);
+        i += 3;
+    }
+    let rem = bytes.len() - i;
+    if rem == 1 {
+        let b0 = bytes[i] as usize;
+        out.push(A[b0 >> 2] as char);
+        out.push(A[(b0 & 0b11) << 4] as char);
+        out.push('=');
+        out.push('=');
+    } else if rem == 2 {
+        let b0 = bytes[i] as usize;
+        let b1 = bytes[i + 1] as usize;
+        out.push(A[b0 >> 2] as char);
+        out.push(A[((b0 & 0b11) << 4) | (b1 >> 4)] as char);
+        out.push(A[(b1 & 0b1111) << 2] as char);
+        out.push('=');
+    }
+    out
 }
 
 fn cmd_hash(fmt: &OutputFormat, args: &[String]) -> Result<()> {

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -260,8 +260,7 @@ fn cmd_check(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     // canonical-AST bytes instead of `.lex` text.
     let mut from_canonical = false;
     let mut path: Option<&str> = None;
-    let mut iter = args.iter();
-    while let Some(a) = iter.next() {
+    for a in args {
         match a.as_str() {
             "--from-canonical" => { from_canonical = true; }
             other if !other.starts_with("--") => {

--- a/crates/lex-cli/tests/canonical_cli.rs
+++ b/crates/lex-cli/tests/canonical_cli.rs
@@ -157,3 +157,74 @@ fn unknown_subaction_lists_valid_choices() {
     assert!(stderr.contains("encode") && stderr.contains("decode"),
         "stderr should hint at valid subactions; got: {stderr}");
 }
+
+// ---- #206 slice 3: --from-canonical on existing commands ----------
+
+#[test]
+fn check_from_canonical_typechecks_bytes_input() {
+    // Encode a `.lex` source then run `lex check --from-canonical`
+    // against the bytes. The text parser shouldn't run on the
+    // receiver path — that's the slice's whole point.
+    let src = tmp_text("check_canon_in", SOURCE);
+    let canon = tmp_path("check_canon_bytes");
+    let (code, _, _) = run(&[
+        "canonical", "encode", src.to_str().unwrap(),
+        "--out", canon.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0);
+
+    let (code, stdout, stderr) = run(&[
+        "check", "--from-canonical", canon.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0, "stderr: {stderr}");
+    let s = String::from_utf8_lossy(&stdout);
+    assert!(s.contains("ok"),
+        "expected 'ok' from check; got: {s}");
+}
+
+#[test]
+fn run_from_canonical_executes_function() {
+    let src = tmp_text("run_canon_in", SOURCE);
+    let canon = tmp_path("run_canon_bytes");
+    let (code, _, _) = run(&[
+        "canonical", "encode", src.to_str().unwrap(),
+        "--out", canon.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0);
+
+    let (code, stdout, stderr) = run(&[
+        "run", "--from-canonical", canon.to_str().unwrap(), "run",
+    ]);
+    assert_eq!(code, 0, "stderr: {stderr}");
+    let s = String::from_utf8_lossy(&stdout);
+    // `run()` returns add(2, 3) = 5.
+    assert!(s.trim().contains('5'),
+        "expected output to contain 5; got: {s:?}");
+}
+
+#[test]
+fn run_from_canonical_rejects_text_input() {
+    // Pointing `--from-canonical` at a `.lex` text file fails the
+    // version-byte check at decode. The CLI surfaces a typed error
+    // rather than a confusing parse failure.
+    let src = tmp_text("run_canon_wrong_kind", SOURCE);
+    let (code, _, stderr) = run(&[
+        "run", "--from-canonical", src.to_str().unwrap(), "run",
+    ]);
+    assert_ne!(code, 0);
+    assert!(stderr.to_lowercase().contains("decode") ||
+            stderr.contains("version"),
+        "stderr should explain the decode failure; got: {stderr}");
+}
+
+#[test]
+fn check_from_canonical_rejects_text_input() {
+    let src = tmp_text("check_canon_wrong_kind", SOURCE);
+    let (code, _, stderr) = run(&[
+        "check", "--from-canonical", src.to_str().unwrap(),
+    ]);
+    assert_ne!(code, 0);
+    assert!(stderr.to_lowercase().contains("decode") ||
+            stderr.contains("version"),
+        "stderr should explain the decode failure; got: {stderr}");
+}

--- a/crates/lex-cli/tests/canonical_cli.rs
+++ b/crates/lex-cli/tests/canonical_cli.rs
@@ -1,0 +1,159 @@
+//! End-to-end tests for the `lex canonical encode` / `lex canonical
+//! decode` CLI subcommands (#206 slice 2).
+//!
+//! Encode reads a `.lex` file and emits canonical-AST bytes (raw on
+//! stdout, base64 in JSON envelope, or to a file with `--out`).
+//! Decode reads canonical bytes and prints `.lex` text via
+//! `print_stages`. Round-tripping `text → canonical → text` produces
+//! semantically equivalent source (insignificant whitespace and
+//! comments are dropped — that's the canonical form's whole point).
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+fn lex_bin() -> &'static str { env!("CARGO_BIN_EXE_lex") }
+
+fn run(args: &[&str]) -> (i32, Vec<u8>, String) {
+    let out = Command::new(lex_bin())
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn lex");
+    (
+        out.status.code().unwrap_or(-1),
+        out.stdout,
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+fn tmp_text(name: &str, text: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!("lex_canonical_test_{name}.lex"));
+    let mut f = std::fs::File::create(&p).expect("create tmp");
+    f.write_all(text.as_bytes()).expect("write tmp");
+    p
+}
+
+fn tmp_path(name: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!("lex_canonical_test_{name}.canon"));
+    // Make sure no stale file from a prior run carries over.
+    let _ = std::fs::remove_file(&p);
+    p
+}
+
+const SOURCE: &str = "fn add(x :: Int, y :: Int) -> Int { x + y }\n\
+                      fn run() -> Int { add(2, 3) }\n";
+
+#[test]
+fn encode_to_file_writes_versioned_bytes() {
+    let src = tmp_text("encode_file_in", SOURCE);
+    let out = tmp_path("encode_file_out");
+    let (code, _, stderr) = run(&[
+        "canonical", "encode", src.to_str().unwrap(),
+        "--out", out.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0, "stderr: {stderr}");
+    let bytes = std::fs::read(&out).expect("read out");
+    assert!(!bytes.is_empty());
+    assert_eq!(bytes[0], 1, "version byte should be 1");
+    assert!(bytes.len() > 10, "payload should be more than just the version");
+}
+
+#[test]
+fn encode_without_out_writes_raw_bytes_to_stdout() {
+    let src = tmp_text("encode_stdout_in", SOURCE);
+    let (code, stdout, stderr) = run(&[
+        "canonical", "encode", src.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert!(!stdout.is_empty());
+    assert_eq!(stdout[0], 1, "version byte first");
+}
+
+#[test]
+fn encode_json_output_emits_base64_envelope() {
+    let src = tmp_text("encode_json_in", SOURCE);
+    let (code, stdout, _stderr) = run(&[
+        "--output", "json",
+        "canonical", "encode", src.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0);
+    let s = String::from_utf8_lossy(&stdout).to_string();
+    let v: serde_json::Value = serde_json::from_str(&s)
+        .unwrap_or_else(|e| panic!("expected JSON envelope; parse error {e}; got: {s}"));
+    // The acli envelope nests payload under `data`.
+    let data = &v["data"];
+    assert_eq!(data["ok"], true);
+    let b64 = data["bytes_b64"].as_str()
+        .expect("data.bytes_b64 string field");
+    assert!(!b64.is_empty());
+    // The first 12 bits (version byte 0x01 + start of '[' = 0x5b)
+    // are 0b000000_010101 = "AV" in base64. Anything past that
+    // depends on what JSON tokens follow; we don't need to pin it
+    // for this test — the round-trip test below already covers
+    // structural fidelity.
+    assert!(b64.starts_with("AV"),
+        "expected base64 to start with AV (version byte 1 followed by '['); got: {b64}");
+}
+
+#[test]
+fn round_trip_decode_after_encode_returns_text() {
+    let src = tmp_text("rt_in", SOURCE);
+    let canon = tmp_path("rt_out");
+
+    let (code, _, _) = run(&[
+        "canonical", "encode", src.to_str().unwrap(),
+        "--out", canon.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0);
+
+    let (code, stdout, stderr) = run(&[
+        "canonical", "decode", canon.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0, "stderr: {stderr}");
+    let text = String::from_utf8_lossy(&stdout);
+    // The semantic content survives: function names + arity present.
+    assert!(text.contains("fn add"), "decoded text should contain `fn add`; got:\n{text}");
+    assert!(text.contains("fn run"), "decoded text should contain `fn run`; got:\n{text}");
+    assert!(text.contains("Int"));
+}
+
+#[test]
+fn decode_unknown_version_surfaces_clear_error() {
+    let bad = tmp_path("bad_version");
+    std::fs::write(&bad, [99u8, b'{', b'}']).unwrap();
+    let (code, _, stderr) = run(&[
+        "canonical", "decode", bad.to_str().unwrap(),
+    ]);
+    assert_ne!(code, 0, "should fail");
+    assert!(stderr.contains("unsupported canonical-AST version") ||
+            stderr.contains("decode"),
+        "stderr should mention the decode failure; got: {stderr}");
+}
+
+#[test]
+fn decode_empty_file_surfaces_clear_error() {
+    let empty = tmp_path("empty");
+    std::fs::write(&empty, []).unwrap();
+    let (code, _, stderr) = run(&[
+        "canonical", "decode", empty.to_str().unwrap(),
+    ]);
+    assert_ne!(code, 0);
+    assert!(stderr.to_lowercase().contains("empty") ||
+            stderr.contains("no version byte") ||
+            stderr.contains("decode"),
+        "stderr should mention empty input; got: {stderr}");
+}
+
+#[test]
+fn unknown_subaction_lists_valid_choices() {
+    let (code, _, stderr) = run(&[
+        "canonical", "transmogrify",
+    ]);
+    assert_ne!(code, 0);
+    assert!(stderr.contains("encode") && stderr.contains("decode"),
+        "stderr should hint at valid subactions; got: {stderr}");
+}


### PR DESCRIPTION
## Summary

Bundles two #206 slices on the same branch — independent commits, stacked because the work happened back-to-back without a review pause.

| Commit | Slice | Scope |
|---|---|---|
| `d4451a2` | slice 2 | `lex canonical encode` / `lex canonical decode` subcommands |
| `b5c93d6` | slice 3 | `--from-canonical` flag on `lex check` and `lex run` |

After this PR, the only #206 work left is binary encodings (CBOR / postcard) for compactness — purely an optimization that requires a payload-size driver to motivate.

## Slice 2 — `lex canonical encode|decode` (`d4451a2`)

**`lex canonical encode <text-file> [--out <bytes-file>]`** — parses, canonicalizes, encodes. Without `--out`, writes raw bytes to stdout (suitable for piping); with `--out`, writes to the named file. JSON-output mode (`--output json`) emits a structured envelope with the bytes base64-encoded so agent harnesses don't have to deal with raw-bytes-on-stdout encoding issues.

**`lex canonical decode <bytes-file>`** — reads canonical bytes, decodes, prints the program back in `.lex` text form via `lex_ast::print_stages`. Round-trip `text → canonical → text` produces semantically equivalent source.

Inline base64 encoder for the JSON envelope path (~30 LOC, RFC 4648 standard alphabet) — avoids adding a `base64` crate dep just for this CLI surface.

## Slice 3 — `--from-canonical` flag on `check` and `run` (`b5c93d6`)

`lex check --from-canonical <bytes>` and `lex run --from-canonical <bytes>` skip the text parser entirely on the receiver side: read canonical-AST bytes, decode, type-check, compile, run. Same pipeline from the type-check step on; the parser-bug blast radius shrinks to zero on the canonical-AST path.

```bash
# Author side (text parse runs once):
lex canonical encode app.lex --out app.canon

# Wire / store: ship `app.canon` bytes.

# Receiver side (no text parser, no .lex file needed):
lex check --from-canonical app.canon
lex run   --from-canonical app.canon main 42
```

This is the agent-deployment story #206 has been building toward: agents emit canonical AST; the runtime accepts it directly.

New `load_stages(path, from_canonical)` helper unifies the two loading paths into a `Vec<Stage>` either way. Both paths support `-` for stdin.

## Out of scope (final #206 slice)

- **CBOR / postcard binary encodings.** Slice 1's JSON-flavored bytes share `lex-vcs`'s OpId encoding, so swapping to a more compact format would require migrating both at once. Not urgent without a payload-size or parse-speed driver.
- `lex compile --from-canonical` — `compile` isn't currently a subcommand; `check` covers the type-check path and `run` covers the execute path. If the issue's literal `compile` spelling matters, it'd be a thin alias.
- `lex-vcs::compute_diff` operating on canonical AST directly.

## Test plan

- [x] 7 new tests in slice 2 covering encode/decode paths, JSON envelope, error surfaces.
- [x] 4 new tests in slice 3 covering `--from-canonical` on `check` and `run`, plus typed error when given text input.
- [x] Workspace test suite: **990 passing, 0 failed**.

## Closes

Substantive progress on #206. Final remaining slice is binary encoding compactness — only worth doing if a real driver shows up.

https://claude.ai/code/session_016SGtf28wA4CgAem65XrjPt