### PR TITLE
ed25519 signing for published stages (#227)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,6 @@ thiserror = "2"
 anyhow = "1"
 logos = "0.16"
 indexmap = { version = "2", features = ["serde"] }
+ed25519-dalek = { version = "2", default-features = false, features = ["std", "fast"] }
+getrandom = "0.2"
+hex = "0.4"

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -105,6 +105,7 @@ fn run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         "log" => branch::cmd_log(fmt, &args[1..]),
         "op" => op::cmd_op(fmt, &args[1..]),
         "canonical" => cmd_canonical(fmt, &args[1..]),
+        "keygen" => cmd_keygen(fmt, &args[1..]),
         "repl" => repl::cmd_repl(&args[1..]),
         "watch" => watch::cmd_watch(&args[1..]),
         "help" | "--help" | "-h" => { print_usage(); Ok(()) }
@@ -147,10 +148,15 @@ fn print_usage() {
     println!("  check <file>                       type-check; exit 0 or print errors");
     println!("  run [policy] <file> <fn> [args]    execute fn (args parsed as JSON)");
     println!("  hash <file>                        print stage canonical hashes");
-    println!("  publish [--store DIR] [--activate] <file>");
-    println!("                                     publish each stage to the store as Draft");
+    println!("  publish [--store DIR] [--branch NAME] [--activate] [--signing-key HEX] <file>");
+    println!("                                     publish each stage to the store as Draft;");
+    println!("                                     --signing-key (or LEX_SIGNING_KEY) attaches an");
+    println!("                                     Ed25519 signature over each StageId.");
+    println!("  keygen                             print a fresh Ed25519 keypair (hex)");
     println!("  store list [--store DIR]           list SigIds in the store");
-    println!("  store get [--store DIR] <stage>    print metadata + canonical AST for a StageId");
+    println!("  store get [--store DIR] [--require-signed] [--trusted-key HEX] <stage>");
+    println!("                                     print stage metadata + canonical AST;");
+    println!("                                     verify Ed25519 signature when present.");
     println!("  stage <stage> [--attestations]     print stage info, or list its attestations");
     println!("  attest filter [--kind K] [--result R] [--since T] [--store DIR]");
     println!("                                     cross-stage attestation queries");
@@ -658,15 +664,96 @@ fn cmd_canonical_encode(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     Ok(())
 }
 
-/// `lex canonical decode <bytes-file>` (#206 slice 2).
+// ---- #227: ed25519 keygen + signing helpers ----------------------
+
+/// `lex keygen` — print a fresh Ed25519 keypair as hex.
 ///
-/// Reads the canonical-AST byte representation from a file, decodes
-/// it, and prints the program back in `.lex` text form via
-/// `lex_ast::print_stages`. The text output is a debugger /
-/// new-developer affordance — round-tripping `text → canonical → text`
-/// produces semantically equivalent (but not necessarily byte-identical)
-/// source, since the canonical form drops insignificant whitespace
-/// and comment placement.
+/// Default text output is two lines:
+///
+///   `public_key  <hex>`
+///   `secret_key  <hex>`
+///
+/// JSON output emits `{ "public_key": "...", "secret_key": "..." }`.
+/// The secret key is printed once and never persisted by Lex itself —
+/// the caller is responsible for storing it (env var, secret manager,
+/// hardware token, etc.).
+fn cmd_keygen(fmt: &OutputFormat, _args: &[String]) -> Result<()> {
+    let kp = lex_vcs::Keypair::generate()
+        .map_err(|e| anyhow!("keygen: {e}"))?;
+    let data = serde_json::json!({
+        "public_key": kp.public_hex(),
+        "secret_key": kp.secret_hex(),
+    });
+    let pk = kp.public_hex();
+    let sk = kp.secret_hex();
+    acli::emit_or_text("keygen", data, fmt, move || {
+        println!("public_key  {pk}");
+        println!("secret_key  {sk}");
+    });
+    Ok(())
+}
+
+/// Resolve a signing key from the CLI flag, then env var, then None.
+/// Returns `Ok(None)` if neither is set so the caller can decide
+/// whether unsigned publish is allowed.
+fn resolve_signing_key(flag_value: Option<&str>) -> Result<Option<lex_vcs::Keypair>> {
+    let hex_str = match flag_value {
+        Some(v) => Some(v.to_string()),
+        None => std::env::var("LEX_SIGNING_KEY").ok(),
+    };
+    match hex_str {
+        Some(s) if !s.is_empty() => {
+            let kp = lex_vcs::Keypair::from_secret_hex(s.trim())
+                .map_err(|e| anyhow!(
+                    "invalid signing key (hex): {e}. \
+                     Expected 64 hex chars from `lex keygen`."))?;
+            Ok(Some(kp))
+        }
+        _ => Ok(None),
+    }
+}
+
+/// Apply `--require-signed` / `--trusted-key` policy to a stage's
+/// metadata. Returns `Ok(())` if the policy permits the stage:
+///
+/// * If `require_signed` is true and `metadata.signature` is `None`,
+///   error.
+/// * If `trusted_key` is set, the signature must be present, must
+///   verify, and the public key must match the trusted key.
+/// * If `require_signed` is true and a signature is present, the
+///   signature must verify.
+/// * Otherwise (no flags set, present-but-not-required signature),
+///   we still verify a present signature so that a corrupted record
+///   surfaces clearly rather than silently passing.
+fn verify_metadata_signature(
+    meta: &lex_store::Metadata,
+    require_signed: bool,
+    trusted_key: Option<&str>,
+) -> Result<()> {
+    match &meta.signature {
+        None => {
+            if require_signed {
+                bail!("stage `{}` is not signed (--require-signed/--trusted-key was set)",
+                    meta.stage_id);
+            }
+            Ok(())
+        }
+        Some(sig) => {
+            lex_vcs::verify_stage_id(&meta.stage_id, sig)
+                .map_err(|e| anyhow!(
+                    "signature on stage `{}` failed verification: {e}",
+                    meta.stage_id))?;
+            if let Some(trusted) = trusted_key {
+                if !sig.public_key.eq_ignore_ascii_case(trusted) {
+                    bail!("stage `{}` is signed by `{}`, not by trusted key `{}`",
+                        meta.stage_id, sig.public_key, trusted);
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
 fn cmd_canonical_decode(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let path = args.first().ok_or_else(|| anyhow!(
         "usage: lex canonical decode <bytes-file>"))?;
@@ -1105,19 +1192,24 @@ fn cmd_publish(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     use lex_vcs::ImportMap;
 
     let (root, rest, activate, dry_run) = parse_store_flag(args);
-    // Pull --branch off as well.
+    // Pull --branch and --signing-key off as well.
     let mut branch: Option<String> = None;
+    let mut signing_key_flag: Option<String> = None;
     let mut positional: Vec<String> = Vec::new();
     let mut it = rest.iter();
     while let Some(a) = it.next() {
         if a == "--branch" {
             branch = Some(it.next().ok_or_else(|| anyhow!("--branch needs a value"))?.clone());
+        } else if a == "--signing-key" {
+            signing_key_flag = Some(it.next()
+                .ok_or_else(|| anyhow!("--signing-key needs a hex value"))?.clone());
         } else {
             positional.push(a.clone());
         }
     }
     let path = positional.first().ok_or_else(|| anyhow!(
-        "usage: lex publish [--store DIR] [--branch NAME] [--activate] <file>"))?;
+        "usage: lex publish [--store DIR] [--branch NAME] [--activate] [--signing-key HEX] <file>"))?;
+    let signer = resolve_signing_key(signing_key_flag.as_deref())?;
 
     let prog = read_program(path)?;
     // #168: type-check *and* rewrite stdlib parse calls so a
@@ -1206,10 +1298,13 @@ fn cmd_publish(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         return Ok(());
     }
 
-    let outcome = store.publish_program(&branch, &stages, &report, &new_imports, activate)?;
+    let outcome = store.publish_program_signed(
+        &branch, &stages, &report, &new_imports, activate, signer.as_ref())?;
+    let signed = signer.as_ref().map(|kp| kp.public_hex());
     let data = serde_json::json!({
         "ops": outcome.ops,
         "head_op": outcome.head_op,
+        "signed_by": signed,
     });
     acli::emit_or_text("publish", data, fmt, || {});
     Ok(())
@@ -1239,13 +1334,37 @@ fn cmd_store(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         "get" => {
             let (root, rest, _, _) = parse_store_flag(rest);
             let store = Store::open(&root).with_context(|| format!("opening store at {}", root.display()))?;
-            let id = rest.first().ok_or_else(|| anyhow!("usage: lex store get <stage_id>"))?;
+            // #227 verification flags. `--require-signed` rejects an
+            // unsigned stage; `--trusted-key HEX` rejects any stage
+            // whose signature was made by a different key. Both are
+            // independent: `--trusted-key` implies signed.
+            let mut require_signed = false;
+            let mut trusted_key: Option<String> = None;
+            let mut positional: Vec<&String> = Vec::new();
+            let mut it = rest.iter();
+            while let Some(a) = it.next() {
+                if a == "--require-signed" {
+                    require_signed = true;
+                } else if a == "--trusted-key" {
+                    trusted_key = Some(it.next()
+                        .ok_or_else(|| anyhow!("--trusted-key needs a hex value"))?
+                        .clone());
+                    require_signed = true;
+                } else {
+                    positional.push(a);
+                }
+            }
+            let id = positional.first()
+                .ok_or_else(|| anyhow!(
+                    "usage: lex store get [--require-signed] [--trusted-key HEX] <stage_id>"))?;
             let meta = store.get_metadata(id)?;
+            verify_metadata_signature(&meta, require_signed, trusted_key.as_deref())?;
             let ast = store.get_ast(id)?;
             let v = serde_json::json!({
                 "metadata": serde_json::to_value(&meta)?,
                 "status": format!("{:?}", store.get_status(id)?).to_lowercase(),
                 "ast": serde_json::to_value(&ast)?,
+                "signature_verified": meta.signature.is_some(),
             });
             acli::emit_or_text("store", v.clone(), fmt, || {
                 println!("{}", serde_json::to_string_pretty(&v).unwrap());

--- a/crates/lex-cli/tests/signing.rs
+++ b/crates/lex-cli/tests/signing.rs
@@ -1,0 +1,327 @@
+//! End-to-end tests for `lex keygen`, `lex publish --signing-key`,
+//! and `lex store get --require-signed/--trusted-key` (#227).
+//!
+//! The signing story is small but layered: keygen produces fresh
+//! hex key material (deterministic length, random content); publish
+//! persists the signature into the stage's metadata; store get
+//! verifies signatures and rejects mismatches. The tests below pin
+//! the full chain — author signs, store verifies, tamper detected,
+//! wrong-key detected, unsigned-when-required detected.
+
+use std::process::{Command, Stdio};
+use tempfile::tempdir;
+
+fn lex_bin() -> &'static str { env!("CARGO_BIN_EXE_lex") }
+
+fn run(args: &[&str]) -> (i32, String, String) {
+    let out = Command::new(lex_bin())
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn lex");
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+const SOURCE: &str = "fn add(x :: Int, y :: Int) -> Int { x + y }\n";
+
+// ---- keygen ------------------------------------------------------
+
+#[test]
+fn keygen_produces_64_hex_char_keys() {
+    let (code, stdout, _) = run(&["--output", "json", "keygen"]);
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let pk = v.pointer("/data/public_key")
+        .or_else(|| v.get("public_key"))
+        .and_then(|x| x.as_str())
+        .expect("public_key");
+    let sk = v.pointer("/data/secret_key")
+        .or_else(|| v.get("secret_key"))
+        .and_then(|x| x.as_str())
+        .expect("secret_key");
+    assert_eq!(pk.len(), 64, "public key must be 64 hex chars");
+    assert_eq!(sk.len(), 64, "secret key must be 64 hex chars");
+    assert!(pk.chars().all(|c| c.is_ascii_hexdigit()));
+    assert!(sk.chars().all(|c| c.is_ascii_hexdigit()));
+    // Public must differ from secret — a paranoia check that the
+    // formatter didn't accidentally print the same field twice.
+    assert_ne!(pk, sk);
+}
+
+#[test]
+fn keygen_text_output_lists_both_keys() {
+    let (code, stdout, _) = run(&["keygen"]);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("public_key"));
+    assert!(stdout.contains("secret_key"));
+}
+
+#[test]
+fn two_keygens_produce_distinct_keys() {
+    let (_, a_out, _) = run(&["--output", "json", "keygen"]);
+    let (_, b_out, _) = run(&["--output", "json", "keygen"]);
+    let a: serde_json::Value = serde_json::from_str(&a_out).unwrap();
+    let b: serde_json::Value = serde_json::from_str(&b_out).unwrap();
+    let a_pk = a.pointer("/data/public_key").and_then(|x| x.as_str()).unwrap();
+    let b_pk = b.pointer("/data/public_key").and_then(|x| x.as_str()).unwrap();
+    assert_ne!(a_pk, b_pk, "keygen must produce fresh randomness each call");
+}
+
+// ---- publish + verify --------------------------------------------
+
+/// Generate a keypair and return (public_hex, secret_hex).
+fn fresh_keypair() -> (String, String) {
+    let (_, out, _) = run(&["--output", "json", "keygen"]);
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+    let pk = v.pointer("/data/public_key").and_then(|x| x.as_str()).unwrap().to_string();
+    let sk = v.pointer("/data/secret_key").and_then(|x| x.as_str()).unwrap().to_string();
+    (pk, sk)
+}
+
+/// Pull the first add_function stage_id out of the JSON envelope
+/// returned by `lex publish`. Used so tests don't have to depend on
+/// `--activate` having run.
+fn first_stage_id(publish_json: &str) -> String {
+    let v: serde_json::Value = serde_json::from_str(publish_json).unwrap();
+    let ops = v.pointer("/data/ops")
+        .or_else(|| v.get("ops"))
+        .and_then(|x| x.as_array())
+        .expect("ops array");
+    for op in ops {
+        if let Some(stg) = op.pointer("/kind/stage_id").and_then(|x| x.as_str()) {
+            return stg.to_string();
+        }
+    }
+    panic!("no stage_id found in publish output: {publish_json}");
+}
+
+/// Publish `SOURCE` under `--signing-key sk`, return the StageId
+/// of the published function stage.
+fn publish_signed(store_path: &std::path::Path, sk: &str) -> String {
+    let src = store_path.join("a.lex");
+    std::fs::write(&src, SOURCE).unwrap();
+    let (code, stdout, stderr) = run(&[
+        "--output", "json", "publish",
+        "--store", store_path.to_str().unwrap(),
+        "--signing-key", sk,
+        src.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0, "publish failed; stderr: {stderr}");
+    first_stage_id(&stdout)
+}
+
+fn publish_unsigned(store_path: &std::path::Path) -> String {
+    let src = store_path.join("a.lex");
+    std::fs::write(&src, SOURCE).unwrap();
+    let (code, stdout, stderr) = run(&[
+        "--output", "json", "publish",
+        "--store", store_path.to_str().unwrap(),
+        src.to_str().unwrap(),
+    ]);
+    assert_eq!(code, 0, "publish failed; stderr: {stderr}");
+    first_stage_id(&stdout)
+}
+
+#[test]
+fn publish_with_signing_key_persists_signature_in_metadata() {
+    let store = tempdir().unwrap();
+    let (pk, sk) = fresh_keypair();
+    let stage_id = publish_signed(store.path(), &sk);
+
+    let (code, stdout, _) = run(&[
+        "--output", "json", "store", "get",
+        "--store", store.path().to_str().unwrap(),
+        &stage_id,
+    ]);
+    assert_eq!(code, 0);
+    let v: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let sig = v.pointer("/data/metadata/signature")
+        .or_else(|| v.pointer("/metadata/signature"))
+        .expect("metadata.signature should be set on signed publish");
+    assert_eq!(sig["public_key"].as_str(), Some(pk.as_str()),
+        "metadata public key must match the signer");
+    assert_eq!(sig["signature"].as_str().unwrap().len(), 128,
+        "Ed25519 signature is 64 bytes => 128 hex chars");
+}
+
+#[test]
+fn publish_without_signing_key_persists_no_signature() {
+    let store = tempdir().unwrap();
+    let stage_id = publish_unsigned(store.path());
+    let (_, get_out, _) = run(&[
+        "--output", "json", "store", "get",
+        "--store", store.path().to_str().unwrap(),
+        &stage_id,
+    ]);
+    let g: serde_json::Value = serde_json::from_str(&get_out).unwrap();
+    let sig = g.pointer("/data/metadata/signature")
+        .or_else(|| g.pointer("/metadata/signature"));
+    assert!(sig.is_none() || sig.unwrap().is_null(),
+        "unsigned publish must not write a signature: got {sig:?}");
+}
+
+#[test]
+fn store_get_require_signed_accepts_signed_stage() {
+    let store = tempdir().unwrap();
+    let (_, sk) = fresh_keypair();
+    let stage_id = publish_signed(store.path(), &sk);
+
+    let (code, _, stderr) = run(&[
+        "--output", "json", "store", "get",
+        "--store", store.path().to_str().unwrap(),
+        "--require-signed",
+        &stage_id,
+    ]);
+    assert_eq!(code, 0, "stderr: {stderr}");
+}
+
+#[test]
+fn store_get_require_signed_rejects_unsigned_stage() {
+    let store = tempdir().unwrap();
+    let stage_id = publish_unsigned(store.path());
+    let (code, _, stderr) = run(&[
+        "store", "get",
+        "--store", store.path().to_str().unwrap(),
+        "--require-signed",
+        &stage_id,
+    ]);
+    assert_ne!(code, 0, "should refuse unsigned stage under --require-signed");
+    assert!(stderr.contains("not signed"),
+        "stderr should mention the missing signature; got: {stderr}");
+}
+
+#[test]
+fn store_get_trusted_key_accepts_matching_signer() {
+    let store = tempdir().unwrap();
+    let (pk, sk) = fresh_keypair();
+    let stage_id = publish_signed(store.path(), &sk);
+
+    let (code, _, stderr) = run(&[
+        "--output", "json", "store", "get",
+        "--store", store.path().to_str().unwrap(),
+        "--trusted-key", &pk,
+        &stage_id,
+    ]);
+    assert_eq!(code, 0, "stderr: {stderr}");
+}
+
+#[test]
+fn store_get_trusted_key_rejects_mismatched_signer() {
+    // Stage was signed by `signer_a`; consumer demands `signer_b`.
+    let store = tempdir().unwrap();
+    let (_pk_a, sk_a) = fresh_keypair();
+    let (pk_b, _sk_b) = fresh_keypair();
+    let stage_id = publish_signed(store.path(), &sk_a);
+
+    let (code, _, stderr) = run(&[
+        "store", "get",
+        "--store", store.path().to_str().unwrap(),
+        "--trusted-key", &pk_b,
+        &stage_id,
+    ]);
+    assert_ne!(code, 0, "wrong trusted key must be rejected");
+    assert!(stderr.contains("not by trusted key") || stderr.contains("trusted"),
+        "stderr should explain the trust mismatch; got: {stderr}");
+}
+
+#[test]
+fn store_get_detects_tampered_signature() {
+    // Publish, then corrupt the signature byte and re-read.
+    let store = tempdir().unwrap();
+    let (_, sk) = fresh_keypair();
+    let stage_id = publish_signed(store.path(), &sk);
+
+    // Find and rewrite the metadata file's `signature.signature` hex.
+    let stages_dir = store.path().join("stages");
+    let mut tampered = false;
+    'outer: for sig_dir in std::fs::read_dir(&stages_dir).unwrap() {
+        let imp = sig_dir.unwrap().path().join("implementations");
+        if !imp.exists() { continue; }
+        for f in std::fs::read_dir(&imp).unwrap() {
+            let p = f.unwrap().path();
+            if p.to_string_lossy().ends_with(".metadata.json") {
+                let s = std::fs::read_to_string(&p).unwrap();
+                let mut v: serde_json::Value = serde_json::from_str(&s).unwrap();
+                if let Some(obj) = v.get_mut("signature").and_then(|s| s.as_object_mut()) {
+                    let sig = obj.get_mut("signature").unwrap().as_str().unwrap().to_string();
+                    // Flip one hex char so the signature is structurally
+                    // valid (still 128 hex chars) but doesn't verify.
+                    let mut bytes = sig.into_bytes();
+                    bytes[10] = if bytes[10] == b'a' { b'b' } else { b'a' };
+                    let bumped = String::from_utf8(bytes).unwrap();
+                    obj.insert("signature".to_string(), serde_json::Value::String(bumped));
+                    std::fs::write(&p, serde_json::to_string_pretty(&v).unwrap()).unwrap();
+                    tampered = true;
+                    break 'outer;
+                }
+            }
+        }
+    }
+    assert!(tampered, "test setup: failed to find a metadata file to tamper with");
+
+    let (code, _, stderr) = run(&[
+        "store", "get",
+        "--store", store.path().to_str().unwrap(),
+        "--require-signed",
+        &stage_id,
+    ]);
+    assert_ne!(code, 0, "tampered signature must fail verification");
+    assert!(stderr.contains("failed verification") || stderr.contains("verify"),
+        "stderr should explain the verification failure; got: {stderr}");
+}
+
+#[test]
+fn lex_signing_key_env_var_is_picked_up() {
+    let store = tempdir().unwrap();
+    let (pk, sk) = fresh_keypair();
+    let src = store.path().join("a.lex");
+    std::fs::write(&src, SOURCE).unwrap();
+
+    let out = Command::new(lex_bin())
+        .args([
+            "--output", "json", "publish",
+            "--store", store.path().to_str().unwrap(),
+            src.to_str().unwrap(),
+        ])
+        .env("LEX_SIGNING_KEY", &sk)
+        .output()
+        .expect("spawn");
+    assert!(out.status.success(),
+        "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    let publish_stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    let stage_id = first_stage_id(&publish_stdout);
+    let (_, get_out, _) = run(&[
+        "--output", "json", "store", "get",
+        "--store", store.path().to_str().unwrap(),
+        "--trusted-key", &pk,
+        &stage_id,
+    ]);
+    let g: serde_json::Value = serde_json::from_str(&get_out).unwrap();
+    let sig_pk = g.pointer("/data/metadata/signature/public_key")
+        .or_else(|| g.pointer("/metadata/signature/public_key"))
+        .and_then(|x| x.as_str())
+        .expect("env-var-signed publish must persist signature");
+    assert_eq!(sig_pk, pk);
+}
+
+#[test]
+fn invalid_signing_key_hex_surfaces_clear_error() {
+    let store = tempdir().unwrap();
+    let src = store.path().join("a.lex");
+    std::fs::write(&src, SOURCE).unwrap();
+    let (code, _, stderr) = run(&[
+        "publish",
+        "--store", store.path().to_str().unwrap(),
+        "--signing-key", "not-hex",
+        src.to_str().unwrap(),
+    ]);
+    assert_ne!(code, 0);
+    assert!(stderr.contains("invalid signing key") ||
+            stderr.to_lowercase().contains("hex"),
+        "stderr should mention the bad hex; got: {stderr}");
+}

--- a/crates/lex-store/src/model.rs
+++ b/crates/lex-store/src/model.rs
@@ -66,6 +66,12 @@ pub struct Metadata {
     /// Free-form notes (e.g. "fixes overflow on n>20").
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub note: Option<String>,
+    /// Optional Ed25519 signature over the UTF-8 bytes of `stage_id`
+    /// (#227). Set on publish when the caller provides a signing key;
+    /// consumers verify via [`lex_vcs::verify_stage_id`]. Absence
+    /// means "unsigned" — policy decides whether to accept it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature: Option<lex_vcs::Signature>,
 }
 
 /// A test attached to a SigId (spec §4.4).

--- a/crates/lex-store/src/store.rs
+++ b/crates/lex-store/src/store.rs
@@ -105,6 +105,25 @@ impl Store {
     /// Idempotent: republishing the same canonical AST returns the same
     /// StageId without writing duplicates.
     pub fn publish(&self, stage: &Stage) -> Result<String, StoreError> {
+        self.publish_signed(stage, None)
+    }
+
+    /// Like [`Self::publish`] but optionally attaches an Ed25519
+    /// signature over the StageId (#227). When `signer` is `Some`,
+    /// the persisted metadata gets a `signature` field that
+    /// downstream consumers can verify via
+    /// [`lex_vcs::verify_stage_id`].
+    ///
+    /// Idempotency: if a metadata file already exists the signature
+    /// is *not* re-written. This preserves "republishing is a no-op"
+    /// even across different signers — promoting a signed stage
+    /// requires a fresh stage hash anyway, so a metadata overwrite
+    /// would be the wrong primitive.
+    pub fn publish_signed(
+        &self,
+        stage: &Stage,
+        signer: Option<&lex_vcs::Keypair>,
+    ) -> Result<String, StoreError> {
         let sig = sig_id(stage).ok_or(StoreError::CannotPublishImport)?;
         let stage_id = stage_id(stage).ok_or(StoreError::CannotPublishImport)?;
         let name = stage_name(stage).to_string();
@@ -120,12 +139,14 @@ impl Store {
             write_canonical_json(&ast_path, stage)?;
         }
         if !meta_path.exists() {
+            let signature = signer.map(|kp| kp.sign_stage_id(&stage_id));
             let metadata = Metadata {
                 stage_id: stage_id.clone(),
                 sig_id: sig.clone(),
                 name,
                 published_at: Self::now(),
                 note: None,
+                signature,
             };
             write_canonical_json(&meta_path, &metadata)?;
         }
@@ -457,6 +478,22 @@ impl Store {
         new_imports: &lex_vcs::ImportMap,
         activate: bool,
     ) -> Result<PublishOutcome, StoreError> {
+        self.publish_program_signed(branch, stages, diff, new_imports, activate, None)
+    }
+
+    /// Signed variant of [`Self::publish_program`] (#227). Every
+    /// stage written under this batch gets the same signer; per-stage
+    /// keys aren't supported because the agent identity model treats
+    /// a publish as a single authorial act.
+    pub fn publish_program_signed(
+        &self,
+        branch: &str,
+        stages: &[lex_ast::Stage],
+        diff: &lex_vcs::DiffReport,
+        new_imports: &lex_vcs::ImportMap,
+        activate: bool,
+        signer: Option<&lex_vcs::Keypair>,
+    ) -> Result<PublishOutcome, StoreError> {
         use std::collections::{BTreeMap, BTreeSet};
 
         // #130's write-time gate: verify the candidate program
@@ -510,7 +547,7 @@ impl Store {
             // produces or replaces one.
             if let Some(stg) = stage_for_kind(&kind, stages) {
                 if !matches!(stg, lex_ast::Stage::Import(_)) {
-                    self.publish(stg)?;
+                    self.publish_signed(stg, signer)?;
                     if activate {
                         if let Some(stage_id_str) = stage_id(stg) {
                             let _ = self.activate(&stage_id_str);

--- a/crates/lex-vcs/Cargo.toml
+++ b/crates/lex-vcs/Cargo.toml
@@ -18,6 +18,9 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
+ed25519-dalek.workspace = true
+getrandom.workspace = true
+hex.workspace = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/lex-vcs/src/lib.rs
+++ b/crates/lex-vcs/src/lib.rs
@@ -41,6 +41,7 @@ mod merge_session;
 mod op_log;
 mod operation;
 mod predicate;
+pub mod signing;
 
 pub use apply::{apply, ApplyError, NewHead};
 pub use attestation::{
@@ -58,6 +59,7 @@ pub use merge_session::{
     Resolution, ResolutionRejection,
 };
 pub use predicate::{evaluate, evaluate_with_resolver, IntentResolver, Predicate};
+pub use signing::{verify_stage_id, Keypair, SigningError};
 pub use op_log::OpLog;
 pub use operation::{
     EffectSet, ModuleRef, OpId, Operation, OperationRecord, OperationKind, SigId, StageId,

--- a/crates/lex-vcs/src/signing.rs
+++ b/crates/lex-vcs/src/signing.rs
@@ -1,0 +1,280 @@
+//! Ed25519 signing for stage authorship (#227).
+//!
+//! Lex's auditability story depends on knowing *who* published what.
+//! Content addressing answers "what did this stage say"; signing
+//! answers "who said it." A consumer can refuse stages that aren't
+//! signed (or that aren't signed by a trusted key) and the trail is
+//! cryptographic, not policy-only.
+//!
+//! # What gets signed
+//!
+//! The bytes of the [`StageId`] string itself — UTF-8 of the
+//! lowercase-hex SHA-256 that already content-addresses the stage.
+//! Signing the `StageId` instead of the AST means:
+//!
+//! * Independent of canonical-AST format changes: a future migration
+//!   to CBOR for the wire format doesn't invalidate signatures.
+//! * Cheap to verify: 64 hex chars in, single Ed25519 verify out.
+//! * Cross-tool reproducible: any tool that can compute the StageId
+//!   can verify the signature without parsing the AST.
+//!
+//! This matches Noether's approach so cross-ecosystem verification
+//! stays possible.
+//!
+//! # Hex encoding
+//!
+//! Public keys are 32 bytes → 64 hex chars. Signatures are 64 bytes
+//! → 128 hex chars. Lowercase, no `0x` prefix, matching the
+//! existing convention for [`crate::OpId`] / [`crate::StageId`].
+
+use crate::attestation::Signature;
+use ed25519_dalek::{Signer, SigningKey, Verifier, VerifyingKey, SECRET_KEY_LENGTH};
+
+/// Errors surfaced when keys, signatures, or verification go wrong.
+#[derive(Debug, thiserror::Error)]
+pub enum SigningError {
+    #[error("system entropy unavailable: {0}")]
+    Entropy(String),
+    #[error("public key must be {expected} hex chars (32 bytes), got {got}")]
+    PublicKeyLength { expected: usize, got: usize },
+    #[error("secret key must be {expected} hex chars (32 bytes), got {got}")]
+    SecretKeyLength { expected: usize, got: usize },
+    #[error("signature must be {expected} hex chars (64 bytes), got {got}")]
+    SignatureLength { expected: usize, got: usize },
+    #[error("invalid hex: {0}")]
+    BadHex(String),
+    #[error("invalid public key bytes")]
+    BadPublicKey,
+    #[error("signature did not verify against the given public key and stage id")]
+    VerifyFailed,
+}
+
+/// An Ed25519 keypair held in memory. The secret key is `[u8; 32]`
+/// — the 32-byte seed Ed25519 expands into a signing key. We never
+/// keep the expanded scalar around; every sign call regenerates it
+/// from the seed.
+pub struct Keypair {
+    inner: SigningKey,
+}
+
+impl std::fmt::Debug for Keypair {
+    // The secret seed never appears in Debug output. A panic message
+    // or stray `{:?}` should never be the path that leaks the key.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Keypair")
+            .field("public_key", &self.public_hex())
+            .field("secret_key", &"<redacted>")
+            .finish()
+    }
+}
+
+impl Keypair {
+    /// Generate a fresh keypair using the OS CSPRNG. Suitable for
+    /// `lex keygen`; production callers wanting deterministic keys
+    /// (test vectors, KAT) should use [`Keypair::from_secret_hex`].
+    pub fn generate() -> Result<Self, SigningError> {
+        let mut seed = [0u8; SECRET_KEY_LENGTH];
+        getrandom::getrandom(&mut seed)
+            .map_err(|e| SigningError::Entropy(e.to_string()))?;
+        Ok(Self::from_seed(&seed))
+    }
+
+    /// Build a keypair from a 32-byte seed. Useful for tests where a
+    /// known fixture key is needed; production callers should prefer
+    /// [`Keypair::generate`] or the hex-deserialise path.
+    pub fn from_seed(seed: &[u8; SECRET_KEY_LENGTH]) -> Self {
+        Self { inner: SigningKey::from_bytes(seed) }
+    }
+
+    /// Parse a hex-encoded 32-byte secret key (the seed).
+    pub fn from_secret_hex(hex_str: &str) -> Result<Self, SigningError> {
+        const EXPECTED: usize = SECRET_KEY_LENGTH * 2;
+        if hex_str.len() != EXPECTED {
+            return Err(SigningError::SecretKeyLength {
+                expected: EXPECTED, got: hex_str.len()
+            });
+        }
+        let bytes = hex::decode(hex_str)
+            .map_err(|e| SigningError::BadHex(e.to_string()))?;
+        let arr: [u8; SECRET_KEY_LENGTH] = bytes.try_into()
+            .expect("length-checked above");
+        Ok(Self::from_seed(&arr))
+    }
+
+    /// Lowercase-hex of the 32-byte secret seed. Treat as material —
+    /// this is what `lex keygen` prints to stdout exactly once.
+    pub fn secret_hex(&self) -> String {
+        hex::encode(self.inner.to_bytes())
+    }
+
+    /// Lowercase-hex of the 32-byte public key. Safe to publish.
+    pub fn public_hex(&self) -> String {
+        hex::encode(self.inner.verifying_key().to_bytes())
+    }
+
+    /// Sign the UTF-8 bytes of a `StageId` and return the wire-format
+    /// [`Signature`] record. The same record verifies via
+    /// [`verify_stage_id`].
+    pub fn sign_stage_id(&self, stage_id: &str) -> Signature {
+        let sig = self.inner.sign(stage_id.as_bytes());
+        Signature {
+            public_key: self.public_hex(),
+            signature: hex::encode(sig.to_bytes()),
+        }
+    }
+}
+
+/// Verify that `signature` is a valid Ed25519 signature over the
+/// UTF-8 bytes of `stage_id`, produced by the holder of the private
+/// key matching `signature.public_key`.
+///
+/// Returns `Ok(())` on success. The signature record is otherwise
+/// untrusted input: a callsite that wants to enforce *which* key
+/// signed has to check `signature.public_key` against an allowlist
+/// before or after this call.
+pub fn verify_stage_id(stage_id: &str, signature: &Signature) -> Result<(), SigningError> {
+    const PK_HEX_LEN: usize = 64;
+    const SIG_HEX_LEN: usize = 128;
+    if signature.public_key.len() != PK_HEX_LEN {
+        return Err(SigningError::PublicKeyLength {
+            expected: PK_HEX_LEN, got: signature.public_key.len(),
+        });
+    }
+    if signature.signature.len() != SIG_HEX_LEN {
+        return Err(SigningError::SignatureLength {
+            expected: SIG_HEX_LEN, got: signature.signature.len(),
+        });
+    }
+    let pk_bytes = hex::decode(&signature.public_key)
+        .map_err(|e| SigningError::BadHex(e.to_string()))?;
+    let sig_bytes = hex::decode(&signature.signature)
+        .map_err(|e| SigningError::BadHex(e.to_string()))?;
+    let pk_arr: [u8; 32] = pk_bytes.try_into().expect("length-checked");
+    let sig_arr: [u8; 64] = sig_bytes.try_into().expect("length-checked");
+    let pk = VerifyingKey::from_bytes(&pk_arr)
+        .map_err(|_| SigningError::BadPublicKey)?;
+    let sig = ed25519_dalek::Signature::from_bytes(&sig_arr);
+    pk.verify(stage_id.as_bytes(), &sig)
+        .map_err(|_| SigningError::VerifyFailed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> Keypair {
+        // Deterministic seed so test vectors are reproducible.
+        Keypair::from_seed(&[7u8; 32])
+    }
+
+    #[test]
+    fn generate_produces_distinct_keys() {
+        let a = Keypair::generate().unwrap();
+        let b = Keypair::generate().unwrap();
+        assert_ne!(a.public_hex(), b.public_hex(),
+            "two keygen calls must not produce identical keys");
+        assert_ne!(a.secret_hex(), b.secret_hex());
+    }
+
+    #[test]
+    fn public_and_secret_hex_lengths_are_canonical() {
+        let kp = fixture();
+        assert_eq!(kp.public_hex().len(), 64);
+        assert_eq!(kp.secret_hex().len(), 64);
+        assert!(kp.public_hex().chars().all(|c| c.is_ascii_hexdigit()));
+        assert!(kp.secret_hex().chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn sign_then_verify_round_trips() {
+        let kp = fixture();
+        let stage_id = "deadbeefcafef00d";
+        let sig = kp.sign_stage_id(stage_id);
+        assert_eq!(sig.public_key, kp.public_hex());
+        assert_eq!(sig.signature.len(), 128);
+        verify_stage_id(stage_id, &sig).expect("signature must verify");
+    }
+
+    #[test]
+    fn signing_is_deterministic_for_same_input() {
+        // Ed25519 is deterministic by RFC 8032: same key + same
+        // message ⇒ same signature. The agent-attestation story
+        // benefits from this — two harnesses signing the same
+        // StageId with the same key produce byte-identical evidence.
+        let kp = fixture();
+        let s1 = kp.sign_stage_id("stage-abc");
+        let s2 = kp.sign_stage_id("stage-abc");
+        assert_eq!(s1, s2);
+    }
+
+    #[test]
+    fn different_stage_ids_produce_different_signatures() {
+        let kp = fixture();
+        let a = kp.sign_stage_id("stage-A");
+        let b = kp.sign_stage_id("stage-B");
+        assert_ne!(a.signature, b.signature);
+    }
+
+    #[test]
+    fn verification_rejects_tampered_stage_id() {
+        let kp = fixture();
+        let sig = kp.sign_stage_id("real-stage-id");
+        let err = verify_stage_id("forged-stage-id", &sig).unwrap_err();
+        assert!(matches!(err, SigningError::VerifyFailed),
+            "tampered stage_id must fail verification, got {err:?}");
+    }
+
+    #[test]
+    fn verification_rejects_wrong_public_key() {
+        // The signature was made by `kp_a` but is presented under
+        // `kp_b`'s public key — a classic substitution attempt.
+        let kp_a = Keypair::from_seed(&[1u8; 32]);
+        let kp_b = Keypair::from_seed(&[2u8; 32]);
+        let mut sig = kp_a.sign_stage_id("stage-id");
+        sig.public_key = kp_b.public_hex();
+        let err = verify_stage_id("stage-id", &sig).unwrap_err();
+        assert!(matches!(err, SigningError::VerifyFailed));
+    }
+
+    #[test]
+    fn from_secret_hex_round_trips() {
+        let original = Keypair::from_seed(&[42u8; 32]);
+        let hex_secret = original.secret_hex();
+        let parsed = Keypair::from_secret_hex(&hex_secret).unwrap();
+        assert_eq!(original.public_hex(), parsed.public_hex());
+        // And signatures are bit-identical given Ed25519 determinism.
+        assert_eq!(
+            original.sign_stage_id("x"),
+            parsed.sign_stage_id("x"),
+        );
+    }
+
+    #[test]
+    fn from_secret_hex_rejects_wrong_length() {
+        let err = Keypair::from_secret_hex("deadbeef").unwrap_err();
+        assert!(matches!(err, SigningError::SecretKeyLength { .. }));
+    }
+
+    #[test]
+    fn from_secret_hex_rejects_invalid_hex() {
+        let bad = "z".repeat(64);
+        let err = Keypair::from_secret_hex(&bad).unwrap_err();
+        assert!(matches!(err, SigningError::BadHex(_)));
+    }
+
+    #[test]
+    fn verify_rejects_malformed_signature_lengths() {
+        let mut sig = fixture().sign_stage_id("x");
+        sig.signature = "deadbeef".into();
+        let err = verify_stage_id("x", &sig).unwrap_err();
+        assert!(matches!(err, SigningError::SignatureLength { .. }));
+    }
+
+    #[test]
+    fn verify_rejects_malformed_public_key_lengths() {
+        let mut sig = fixture().sign_stage_id("x");
+        sig.public_key = "deadbeef".into();
+        let err = verify_stage_id("x", &sig).unwrap_err();
+        assert!(matches!(err, SigningError::PublicKeyLength { .. }));
+    }
+}


### PR DESCRIPTION
## Summary

Closes #227. Stages can now be cryptographically tied to a producer: `lex publish` signs the StageId, `lex store get` verifies, and `--require-signed` / `--trusted-key` gate consumers.

## What gets signed

The UTF-8 bytes of the lowercase-hex StageId — the existing content hash already addresses the stage. Signing the id (not the AST) means:

* Independent of canonical-AST format changes — a future migration to CBOR for the wire format wouldn't invalidate signatures.
* Cheap to verify: 64 hex chars in, single Ed25519 verify out.
* Cross-tool reproducible: any tool that can compute the StageId can verify the signature without parsing the AST.

Matches Noether's pattern for cross-ecosystem verification.

## Library surface

* `lex_vcs::signing::Keypair` (re-exported as `lex_vcs::Keypair`). `generate()` uses the OS CSPRNG via `getrandom`. `from_secret_hex` accepts the 64-hex-char seed printed by `lex keygen`. `Debug` is implemented manually to redact the secret seed.
* `lex_vcs::verify_stage_id(stage_id, &Signature)` — strict verification that surfaces typed errors for length, hex, and cryptographic mismatches.
* `lex_store::Metadata.signature: Option<lex_vcs::Signature>` — persisted alongside the existing `published_at` / `note` fields, serde-default to `None` for backward-compat with unsigned stores.
* `Store::publish_signed(stage, Option<&Keypair>)` and `Store::publish_program_signed(..., Option<&Keypair>)` — sibling methods to existing `publish` / `publish_program` so unsigned callers keep working.

## CLI

```
lex keygen
public_key  <64 hex chars>
secret_key  <64 hex chars>

lex publish --signing-key <hex> app.lex
# ... or via env: LEX_SIGNING_KEY=<hex> lex publish app.lex

lex store get --require-signed <stage>
lex store get --trusted-key <pk-hex> <stage>
```

* `lex keygen` — print a fresh keypair as hex (text: two lines; json: `{public_key, secret_key}`). The secret is printed once and not persisted by Lex.
* `lex publish --signing-key HEX` (or `LEX_SIGNING_KEY` env var) — attaches a signature to every stage written in the publish.
* `lex store get --require-signed [--trusted-key HEX]` — refuses to return an unsigned stage; `--trusted-key` further refuses any signature that isn't from the named key. A present-but-not-required signature is still verified so tampered records surface clearly.

## Why ed25519-dalek 2.x

* Rust ecosystem default for Ed25519; deterministic per RFC 8032 so two harnesses signing the same StageId with the same key produce byte-identical evidence.
* `getrandom 0.2` for the OS CSPRNG keeps the dep tree small — no `rand` in transitive scope.
* `hex 0.4` was already a `lex-runtime` dep; promoted to workspace.

## Out of scope

* `lex run --require-signed` — needs a `--from-store STAGE_ID` flag first; today `lex run` operates on file paths and there's no signature alongside arbitrary canonical-AST files.
* HTTP API verification — `serve` doesn't gate signed stages yet.
* Signing attestations themselves (the `Signature` struct already supports it; producers don't sign yet).

## Test plan

- [x] 12 unit tests in `crates/lex-vcs/src/signing.rs`: keygen, hex encoding, sign/verify round-trip, determinism, tampered-stage detection, wrong-key detection, malformed lengths.
- [x] 12 e2e tests in `crates/lex-cli/tests/signing.rs`: `lex keygen` shape, `lex publish --signing-key` persistence, `LEX_SIGNING_KEY` env-var path, `--require-signed`, `--trusted-key`, tampered-signature detection, invalid-hex error surface.
- [x] Workspace: **1014 passing, 0 failed**.
- [x] `cargo clippy --all-targets -- -D warnings` clean.

## Closes

Closes #227.

https://claude.ai/code/session_016SGtf28wA4CgAem65XrjPt

---
_Generated by [Claude Code](https://claude.ai/code/session_016SGtf28wA4CgAem65XrjPt)_