### PR TITLE
cli: --from-store STAGE_ID + HTTP embedder/cache (#227 follow-up + #224 slice 2)

### DIFF
--- a/crates/lex-cli/src/audit.rs
+++ b/crates/lex-cli/src/audit.rs
@@ -513,10 +513,10 @@ fn cmd_audit_semantic(fmt: &OutputFormat, opts: &AuditOpts) -> Result<()> {
 
     let store = lex_store::Store::open(&root)
         .with_context(|| format!("opening store at {}", root.display()))?;
-    let embedder = lex_search::MockEmbedder::new();
-    let idx = lex_search::SearchIndex::build(&store, &embedder)
+    let embedder = crate::build_embedder(&root)?;
+    let idx = lex_search::SearchIndex::build(&store, &*embedder)
         .map_err(|e| anyhow!("building search index: {e}"))?;
-    let mut hits = idx.query(&embedder, query, limit.saturating_mul(4))
+    let mut hits = idx.query(&*embedder, query, limit.saturating_mul(4))
         .map_err(|e| anyhow!("query embedding: {e}"))?;
 
     // Post-filter by --effect on the ranked list. We over-fetch

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -147,6 +147,9 @@ fn print_usage() {
     println!("  parse <file>                       print canonical AST as JSON");
     println!("  check <file>                       type-check; exit 0 or print errors");
     println!("  run [policy] <file> <fn> [args]    execute fn (args parsed as JSON)");
+    println!("  run --from-store STAGE_ID [--require-signed] [--trusted-key HEX] <fn> [args]");
+    println!("                                     run a stage straight out of the store;");
+    println!("                                     verify Ed25519 signature when present.");
     println!("  hash <file>                        print stage canonical hashes");
     println!("  publish [--store DIR] [--branch NAME] [--activate] [--signing-key HEX] <file>");
     println!("                                     publish each stage to the store as Draft;");
@@ -254,6 +257,27 @@ fn load_stages(path: &str, from_canonical: bool) -> Result<Vec<lex_ast::Stage>> 
         let prog = read_program(path)?;
         Ok(canonicalize_program(&prog))
     }
+}
+
+/// Load a single stage out of the default `lex-store` and verify
+/// its signature against the supplied policy. The returned program
+/// is `vec![stage]` — the function being called is expected to be
+/// self-contained inside that stage. Imports / cross-stage refs
+/// would need a richer load path; this slice keeps the surface
+/// minimal.
+fn load_stages_from_store(
+    stage_id: &str,
+    require_signed: bool,
+    trusted_key: Option<&str>,
+) -> Result<Vec<lex_ast::Stage>> {
+    let store = lex_store::Store::open(default_store_root())
+        .with_context(|| "opening default store")?;
+    let meta = store.get_metadata(stage_id)
+        .with_context(|| format!("loading metadata for stage `{stage_id}`"))?;
+    verify_metadata_signature(&meta, require_signed, trusted_key)?;
+    let stage = store.get_ast(stage_id)
+        .with_context(|| format!("loading AST for stage `{stage_id}`"))?;
+    Ok(vec![stage])
 }
 
 fn cmd_parse(fmt: &OutputFormat, args: &[String]) -> Result<()> {
@@ -393,15 +417,31 @@ fn suggest_grants(s: &EffectsSummary) -> String {
 }
 
 fn cmd_run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
-    let (policy, positional, trace, max_steps, dry_run, from_canonical) = parse_run_flags(args)?;
-    let path = positional.first().ok_or_else(|| anyhow!("usage: lex run [policy] [--from-canonical] <file> <fn> [args]"))?;
-    let func = positional.get(1).ok_or_else(|| anyhow!("missing function name"))?;
-    if dry_run {
+    let f = parse_run_flags(args)?;
+    // #227 follow-up: when `--from-store` is set, the first
+    // positional is the function name (no path needed). Otherwise
+    // the legacy shape `lex run <file> <fn> [args]` applies.
+    let (source_label, func, arg_positional_start) = if f.from_store.is_some() {
+        let func = f.positional.first().ok_or_else(|| anyhow!(
+            "usage: lex run --from-store STAGE_ID [--require-signed] [--trusted-key HEX] <fn> [args]"))?;
+        (
+            format!("store:{}", f.from_store.as_deref().unwrap()),
+            func.clone(),
+            1,
+        )
+    } else {
+        let path = f.positional.first().ok_or_else(|| anyhow!(
+            "usage: lex run [policy] [--from-canonical] <file> <fn> [args]"))?;
+        let func = f.positional.get(1).ok_or_else(|| anyhow!("missing function name"))?;
+        (path.clone(), func.clone(), 2)
+    };
+    let policy = &f.policy;
+    if f.dry_run {
         let actions = vec![serde_json::json!({
             "action": "execute",
-            "file": path,
+            "source": &source_label,
             "function": func,
-            "args": &positional[2..],
+            "args": &f.positional[arg_positional_start..],
             "policy": {
                 "allow_effects": policy.allow_effects.iter().collect::<Vec<_>>(),
                 "allow_fs_read": policy.allow_fs_read.iter().map(|p| p.display().to_string()).collect::<Vec<_>>(),
@@ -409,16 +449,20 @@ fn cmd_run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
                 "allow_net_host": &policy.allow_net_host,
                 "budget": policy.budget,
             },
-            "trace": trace,
-            "max_steps": max_steps,
+            "trace": f.trace,
+            "max_steps": f.max_steps,
         })];
         acli::emit_dry_run("run", fmt,
-            &format!("would call `{func}` in {path}"), actions);
+            &format!("would call `{func}` in {source_label}"), actions);
     }
-    // #206 slice 3: load via text parser or canonical-AST decoder.
-    // Both paths produce the same Vec<Stage>; the typecheck and
-    // compile pipeline is identical from this point on.
-    let mut stages = load_stages(path, from_canonical)?;
+    // #206 slice 3 (text/canonical paths) or #227 follow-up
+    // (store path). Each produces the same Vec<Stage>; the typecheck
+    // and compile pipeline is identical from this point on.
+    let mut stages = if let Some(stage_id) = &f.from_store {
+        load_stages_from_store(stage_id, f.require_signed, f.trusted_key.as_deref())?
+    } else {
+        load_stages(&source_label, f.from_canonical)?
+    };
     // #168: rewrite stdlib parse calls during type-check so the
     // runtime sees the strict (validated) shape.
     if let Err(errs) = lex_types::check_and_rewrite_program(&mut stages) {
@@ -434,7 +478,7 @@ fn cmd_run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     }
     let bc = compile_program(&stages);
 
-    if let Err(violations) = check_policy(&bc, &policy) {
+    if let Err(violations) = check_policy(&bc, policy) {
         let arr: Vec<serde_json::Value> = violations.iter()
             .map(|v| serde_json::to_value(v).unwrap()).collect();
         let data = serde_json::json!({ "phase": "policy", "violations": arr });
@@ -447,14 +491,14 @@ fn cmd_run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     }
 
     let bc = std::sync::Arc::new(bc);
-    let handler = DefaultHandler::new(policy).with_program(std::sync::Arc::clone(&bc));
+    let handler = DefaultHandler::new(f.policy.clone()).with_program(std::sync::Arc::clone(&bc));
     let mut vm = Vm::with_handler(&bc, Box::new(handler));
-    if let Some(n) = max_steps { vm.set_step_limit(n); }
+    if let Some(n) = f.max_steps { vm.set_step_limit(n); }
     let recorder = lex_trace::Recorder::new();
     let trace_handle = recorder.handle();
-    if trace { vm.set_tracer(Box::new(recorder)); }
+    if f.trace { vm.set_tracer(Box::new(recorder)); }
 
-    let vargs: Vec<Value> = positional[2..]
+    let vargs: Vec<Value> = f.positional[arg_positional_start..]
         .iter()
         .map(|a| {
             let v: serde_json::Value = serde_json::from_str(a)
@@ -464,11 +508,11 @@ fn cmd_run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         .collect::<Result<Vec<_>>>()?;
     let started = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
-    let result = vm.call(func, vargs);
+    let result = vm.call(&func, vargs);
     let ended = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
     let mut trace_id: Option<String> = None;
-    if trace {
+    if f.trace {
         let store = lex_store::Store::open(default_store_root())?;
         let (root_out, root_err) = match &result {
             Ok(v) => (Some(value_to_json(v)), None),
@@ -490,37 +534,51 @@ fn cmd_run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     Ok(())
 }
 
-#[allow(clippy::type_complexity)]
-fn parse_run_flags(args: &[String]) -> Result<(Policy, Vec<String>, bool, Option<u64>, bool, bool)> {
-    let mut policy = Policy::pure();
-    let mut positional = Vec::new();
-    let mut trace = false;
-    let mut max_steps: Option<u64> = None;
-    let mut dry_run = false;
-    let mut from_canonical = false;
+/// Parsed arguments for `lex run`.
+#[derive(Default)]
+struct RunFlags {
+    policy: Policy,
+    positional: Vec<String>,
+    trace: bool,
+    max_steps: Option<u64>,
+    dry_run: bool,
+    from_canonical: bool,
+    /// `--from-store STAGE_ID` (#227 follow-up). Loads the stage's
+    /// canonical AST out of the store instead of reading a file. The
+    /// fn-arg must name a function that exists in the loaded stage.
+    from_store: Option<String>,
+    /// Refuse to run an unsigned stage (only meaningful with
+    /// `--from-store`). Implied by `--trusted-key`.
+    require_signed: bool,
+    /// Hex Ed25519 public key the stage must be signed by.
+    trusted_key: Option<String>,
+}
+
+fn parse_run_flags(args: &[String]) -> Result<RunFlags> {
+    let mut f = RunFlags { policy: Policy::pure(), ..Default::default() };
     let mut i = 0;
     while i < args.len() {
         let a = &args[i];
         match a.as_str() {
             "--allow-effects" => {
                 let val = args.get(i + 1).ok_or_else(|| anyhow!("--allow-effects needs a value"))?;
-                policy.allow_effects = val.split(',').filter(|s| !s.is_empty())
+                f.policy.allow_effects = val.split(',').filter(|s| !s.is_empty())
                     .map(|s| s.to_string()).collect::<BTreeSet<_>>();
                 i += 2;
             }
             "--allow-fs-read" => {
                 let val = args.get(i + 1).ok_or_else(|| anyhow!("--allow-fs-read needs a value"))?;
-                policy.allow_fs_read.push(PathBuf::from(val));
+                f.policy.allow_fs_read.push(PathBuf::from(val));
                 i += 2;
             }
             "--allow-fs-write" => {
                 let val = args.get(i + 1).ok_or_else(|| anyhow!("--allow-fs-write needs a value"))?;
-                policy.allow_fs_write.push(PathBuf::from(val));
+                f.policy.allow_fs_write.push(PathBuf::from(val));
                 i += 2;
             }
             "--allow-net-host" => {
                 let val = args.get(i + 1).ok_or_else(|| anyhow!("--allow-net-host needs a value"))?;
-                policy.allow_net_host.push(val.clone());
+                f.policy.allow_net_host.push(val.clone());
                 i += 2;
             }
             "--allow-proc" => {
@@ -528,34 +586,46 @@ fn parse_run_flags(args: &[String]) -> Result<(Policy, Vec<String>, bool, Option
                 // is allowed to spawn. Read SECURITY.md before granting.
                 let val = args.get(i + 1).ok_or_else(|| anyhow!("--allow-proc needs a value"))?;
                 for name in val.split(',').filter(|s| !s.is_empty()) {
-                    policy.allow_proc.push(name.to_string());
+                    f.policy.allow_proc.push(name.to_string());
                 }
                 i += 2;
             }
             "--budget" => {
                 let val = args.get(i + 1).ok_or_else(|| anyhow!("--budget needs a value"))?;
-                policy.budget = Some(val.parse().context("--budget must be an integer")?);
+                f.policy.budget = Some(val.parse().context("--budget must be an integer")?);
                 i += 2;
             }
             "--max-steps" => {
                 let val = args.get(i + 1).ok_or_else(|| anyhow!("--max-steps needs a value"))?;
-                max_steps = Some(val.parse().context("--max-steps must be an integer")?);
+                f.max_steps = Some(val.parse().context("--max-steps must be an integer")?);
                 i += 2;
             }
-            "--trace" => { trace = true; i += 1; }
-            "--dry-run" => { dry_run = true; i += 1; }
+            "--trace" => { f.trace = true; i += 1; }
+            "--dry-run" => { f.dry_run = true; i += 1; }
             "--from-canonical" => {
                 // #206 slice 3: read the program as canonical-AST
                 // bytes instead of `.lex` text. The path argument
                 // points to the bytes file (or `-` for stdin); the
                 // text parser is bypassed entirely on this path.
-                from_canonical = true;
+                f.from_canonical = true;
                 i += 1;
             }
-            _ => { positional.push(a.clone()); i += 1; }
+            "--from-store" => {
+                let val = args.get(i + 1).ok_or_else(|| anyhow!("--from-store needs a stage_id"))?;
+                f.from_store = Some(val.clone());
+                i += 2;
+            }
+            "--require-signed" => { f.require_signed = true; i += 1; }
+            "--trusted-key" => {
+                let val = args.get(i + 1).ok_or_else(|| anyhow!("--trusted-key needs a hex value"))?;
+                f.trusted_key = Some(val.clone());
+                f.require_signed = true;
+                i += 2;
+            }
+            _ => { f.positional.push(a.clone()); i += 1; }
         }
     }
-    Ok((policy, positional, trace, max_steps, dry_run, from_canonical))
+    Ok(f)
 }
 
 fn cmd_trace(fmt: &OutputFormat, args: &[String]) -> Result<()> {

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -753,6 +753,24 @@ fn cmd_canonical_encode(fmt: &OutputFormat, args: &[String]) -> Result<()> {
 /// The secret key is printed once and never persisted by Lex itself —
 /// the caller is responsible for storing it (env var, secret manager,
 /// hardware token, etc.).
+/// Build the embedder used by `lex store search` / `lex audit
+/// --query`. When `LEX_EMBED_URL` is set we wire up an HTTP backend
+/// (Ollama or OpenAI-compat per `LEX_EMBED_PROVIDER`) wrapped in a
+/// filesystem cache under `<store>/search/embeddings/`. Otherwise
+/// we use the deterministic [`lex_search::MockEmbedder`].
+pub(crate) fn build_embedder(store_root: &std::path::Path) -> Result<Box<dyn lex_search::Embedder>> {
+    if let Some(http) = lex_search::HttpEmbedder::from_env()
+        .map_err(|e| anyhow!("LEX_EMBED_URL configuration: {e}"))?
+    {
+        let fingerprint = format!("{:?}:{}", http.provider(), http.model());
+        let cache_root = lex_search::default_cache_root(store_root);
+        let cached = lex_search::CachingEmbedder::new(http, cache_root, fingerprint);
+        Ok(Box::new(cached))
+    } else {
+        Ok(Box::new(lex_search::MockEmbedder::new()))
+    }
+}
+
 fn cmd_keygen(fmt: &OutputFormat, _args: &[String]) -> Result<()> {
     let kp = lex_vcs::Keypair::generate()
         .map_err(|e| anyhow!("keygen: {e}"))?;
@@ -1482,10 +1500,10 @@ fn cmd_store_search(fmt: &OutputFormat, args: &[String]) -> Result<()> {
 
     let store = Store::open(&root)
         .with_context(|| format!("opening store at {}", root.display()))?;
-    let embedder = lex_search::MockEmbedder::new();
-    let idx = lex_search::SearchIndex::build(&store, &embedder)
+    let embedder = build_embedder(&root)?;
+    let idx = lex_search::SearchIndex::build(&store, &*embedder)
         .map_err(|e| anyhow!("building search index: {e}"))?;
-    let hits = idx.query(&embedder, &query, limit)
+    let hits = idx.query(&*embedder, &query, limit)
         .map_err(|e| anyhow!("query embedding: {e}"))?;
     let v = serde_json::json!({
         "query": &query,

--- a/crates/lex-cli/tests/run_from_store.rs
+++ b/crates/lex-cli/tests/run_from_store.rs
@@ -1,0 +1,205 @@
+//! `lex run --from-store STAGE_ID` (#227 follow-up). Loads a stage's
+//! canonical AST out of the store rather than from a file, optionally
+//! enforcing Ed25519 signature policy via `--require-signed` /
+//! `--trusted-key`.
+//!
+//! Tests publish a small fn into a fresh tempdir store (signed or
+//! unsigned), then drive `lex run --from-store ...` and check the
+//! return value plus the verification outcomes.
+
+use std::process::{Command, Stdio};
+use tempfile::tempdir;
+
+fn lex_bin() -> &'static str { env!("CARGO_BIN_EXE_lex") }
+
+fn run_with_env(args: &[&str], env: &[(&str, &str)]) -> (i32, String, String) {
+    let mut cmd = Command::new(lex_bin());
+    cmd.args(args).stdout(Stdio::piped()).stderr(Stdio::piped());
+    for (k, v) in env { cmd.env(k, v); }
+    let out = cmd.output().expect("spawn lex");
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+fn run(args: &[&str]) -> (i32, String, String) {
+    run_with_env(args, &[])
+}
+
+const SOURCE: &str = "fn add(x :: Int, y :: Int) -> Int { x + y }\n";
+
+/// Pull the first add_function stage_id out of `lex publish` JSON.
+fn first_stage_id(publish_json: &str) -> String {
+    let v: serde_json::Value = serde_json::from_str(publish_json).expect("parse publish JSON");
+    let ops = v.pointer("/data/ops")
+        .or_else(|| v.get("ops"))
+        .and_then(|x| x.as_array())
+        .expect("ops array");
+    for op in ops {
+        if let Some(stg) = op.pointer("/kind/stage_id").and_then(|x| x.as_str()) {
+            return stg.to_string();
+        }
+    }
+    panic!("no stage_id in publish output: {publish_json}");
+}
+
+fn fresh_keypair() -> (String, String) {
+    let (_, out, _) = run(&["--output", "json", "keygen"]);
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+    (
+        v.pointer("/data/public_key").and_then(|x| x.as_str()).unwrap().to_string(),
+        v.pointer("/data/secret_key").and_then(|x| x.as_str()).unwrap().to_string(),
+    )
+}
+
+/// Publish SOURCE into `store_path`, optionally signing with `sk`.
+/// Returns the StageId of the published function.
+fn publish_into(store_path: &std::path::Path, sk: Option<&str>) -> String {
+    let src = store_path.join("a.lex");
+    std::fs::write(&src, SOURCE).unwrap();
+    let mut args: Vec<&str> = vec![
+        "--output", "json", "publish",
+        "--store", store_path.to_str().unwrap(),
+        "--activate",
+    ];
+    if let Some(sk) = sk {
+        args.push("--signing-key");
+        args.push(sk);
+    }
+    args.push(src.to_str().unwrap());
+    let (code, stdout, stderr) = run(&args);
+    assert_eq!(code, 0, "publish failed: {stderr}");
+    first_stage_id(&stdout)
+}
+
+// ---- happy path -----------------------------------------------------
+
+#[test]
+fn run_from_store_calls_unsigned_stage() {
+    let store = tempdir().unwrap();
+    let stage_id = publish_into(store.path(), None);
+
+    let env = [("LEX_STORE", store.path().to_str().unwrap())];
+    let (code, stdout, stderr) = run_with_env(&[
+        "--output", "json", "run",
+        "--from-store", &stage_id,
+        "add", "2", "3",
+    ], &env);
+    assert_eq!(code, 0, "stderr: {stderr}");
+    let v: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let result = v.pointer("/data/result")
+        .or_else(|| v.get("result"))
+        .expect("result");
+    // Lex Ints come back as strings in the JSON envelope (Value::Int
+    // serialises as { "kind": "Int", "value": 5 } via value_to_json).
+    let answer = result.pointer("/value").and_then(|x| x.as_i64())
+        .or_else(|| result.as_i64())
+        .expect("integer result");
+    assert_eq!(answer, 5);
+}
+
+#[test]
+fn run_from_store_calls_signed_stage_with_require_signed() {
+    let store = tempdir().unwrap();
+    let (_, sk) = fresh_keypair();
+    let stage_id = publish_into(store.path(), Some(&sk));
+
+    let env = [("LEX_STORE", store.path().to_str().unwrap())];
+    let (code, _, stderr) = run_with_env(&[
+        "--output", "json", "run",
+        "--from-store", &stage_id,
+        "--require-signed",
+        "add", "2", "3",
+    ], &env);
+    assert_eq!(code, 0, "stderr: {stderr}");
+}
+
+#[test]
+fn run_from_store_with_trusted_key_accepts_matching_signer() {
+    let store = tempdir().unwrap();
+    let (pk, sk) = fresh_keypair();
+    let stage_id = publish_into(store.path(), Some(&sk));
+
+    let env = [("LEX_STORE", store.path().to_str().unwrap())];
+    let (code, _, stderr) = run_with_env(&[
+        "--output", "json", "run",
+        "--from-store", &stage_id,
+        "--trusted-key", &pk,
+        "add", "10", "20",
+    ], &env);
+    assert_eq!(code, 0, "stderr: {stderr}");
+}
+
+// ---- rejection paths ------------------------------------------------
+
+#[test]
+fn run_from_store_rejects_unsigned_under_require_signed() {
+    let store = tempdir().unwrap();
+    let stage_id = publish_into(store.path(), None);
+
+    let env = [("LEX_STORE", store.path().to_str().unwrap())];
+    let (code, _, stderr) = run_with_env(&[
+        "run",
+        "--from-store", &stage_id,
+        "--require-signed",
+        "add", "1", "2",
+    ], &env);
+    assert_ne!(code, 0, "should refuse unsigned stage under --require-signed");
+    assert!(stderr.contains("not signed") || stderr.contains("require"),
+        "stderr should mention the missing signature; got: {stderr}");
+}
+
+#[test]
+fn run_from_store_rejects_wrong_trusted_key() {
+    let store = tempdir().unwrap();
+    let (_pk_a, sk_a) = fresh_keypair();
+    let (pk_b, _sk_b) = fresh_keypair();
+    let stage_id = publish_into(store.path(), Some(&sk_a));
+
+    let env = [("LEX_STORE", store.path().to_str().unwrap())];
+    let (code, _, stderr) = run_with_env(&[
+        "run",
+        "--from-store", &stage_id,
+        "--trusted-key", &pk_b,
+        "add", "1", "2",
+    ], &env);
+    assert_ne!(code, 0);
+    assert!(stderr.contains("trusted") || stderr.contains("not by"),
+        "stderr should explain the trust mismatch; got: {stderr}");
+}
+
+#[test]
+fn run_from_store_unknown_stage_id_errors_clearly() {
+    let store = tempdir().unwrap();
+    // Force the store dir to exist but without any stages.
+    std::fs::create_dir_all(store.path().join("stages")).unwrap();
+    let env = [("LEX_STORE", store.path().to_str().unwrap())];
+    let (code, _, stderr) = run_with_env(&[
+        "run",
+        "--from-store", "deadbeef".repeat(8).as_str(),
+        "add", "1", "2",
+    ], &env);
+    assert_ne!(code, 0);
+    assert!(
+        stderr.to_lowercase().contains("metadata")
+            || stderr.to_lowercase().contains("unknown")
+            || stderr.to_lowercase().contains("stage"),
+        "stderr should mention the missing stage; got: {stderr}");
+}
+
+#[test]
+fn run_from_store_missing_function_arg_errors() {
+    let store = tempdir().unwrap();
+    let stage_id = publish_into(store.path(), None);
+
+    let env = [("LEX_STORE", store.path().to_str().unwrap())];
+    let (code, _, stderr) = run_with_env(&[
+        "run",
+        "--from-store", &stage_id,
+    ], &env);
+    assert_ne!(code, 0);
+    assert!(stderr.to_lowercase().contains("usage") || stderr.contains("--from-store"),
+        "stderr should hint at usage; got: {stderr}");
+}

--- a/crates/lex-search/Cargo.toml
+++ b/crates/lex-search/Cargo.toml
@@ -15,9 +15,12 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 sha2.workspace = true
+hex.workspace = true
+ureq = { version = "3.3", default-features = false, features = ["rustls", "platform-verifier", "json"] }
 lex-ast = { path = "../lex-ast", version = "0.2.2" }
 lex-store = { path = "../lex-store", version = "0.2.2" }
 
 [dev-dependencies]
 tempfile = "3"
+tiny_http = "0.12"
 lex-syntax = { path = "../lex-syntax", version = "0.2.2" }

--- a/crates/lex-search/src/cache.rs
+++ b/crates/lex-search/src/cache.rs
@@ -1,0 +1,236 @@
+//! On-disk embedding cache (#224 slice 2).
+//!
+//! Wraps any [`Embedder`] so the second `lex store search` query
+//! doesn't pay for re-embedding every stage. The cache key is a
+//! SHA-256 over `(fingerprint, text)` where `fingerprint` is the
+//! caller-provided string identifying the upstream model + dim —
+//! switching providers or models invalidates entries automatically.
+//!
+//! Layout:
+//!
+//! ```text
+//! <root>/<first-2-hex>/<remaining-62-hex>.json
+//! ```
+//!
+//! Each file is `{"v":[f32, ...]}` — minimal JSON so `cat` debugging
+//! is sane and corrupt files surface as parse errors. The two-byte
+//! sharding keeps a single directory from bloating past a few
+//! thousand entries.
+
+use crate::embedder::{EmbedError, Embedder};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+
+/// Filesystem-backed cache wrapping an inner embedder.
+pub struct CachingEmbedder<E: Embedder> {
+    inner: E,
+    root: PathBuf,
+    fingerprint: String,
+}
+
+impl<E: Embedder> CachingEmbedder<E> {
+    /// Build a new caching embedder. `root` is created on first
+    /// write; missing files are treated as cache misses.
+    /// `fingerprint` should encode the upstream model identity —
+    /// e.g. `"ollama:nomic-embed-text"` — so swapping providers
+    /// doesn't return stale vectors of the wrong shape.
+    pub fn new(inner: E, root: impl Into<PathBuf>, fingerprint: impl Into<String>) -> Self {
+        Self {
+            inner,
+            root: root.into(),
+            fingerprint: fingerprint.into(),
+        }
+    }
+
+    fn key_for(&self, text: &str) -> String {
+        let mut h = Sha256::new();
+        h.update(self.fingerprint.as_bytes());
+        h.update(b"\x1f"); // ASCII unit separator: avoids "abc"+"d" colliding with "ab"+"cd".
+        h.update(text.as_bytes());
+        hex::encode(h.finalize())
+    }
+
+    fn path_for(&self, key: &str) -> PathBuf {
+        let (lo, hi) = key.split_at(2);
+        self.root.join(lo).join(format!("{hi}.json"))
+    }
+
+    fn read(&self, key: &str) -> Option<Vec<f32>> {
+        let path = self.path_for(key);
+        let bytes = std::fs::read(&path).ok()?;
+        let parsed: CacheEntry = serde_json::from_slice(&bytes).ok()?;
+        Some(parsed.v)
+    }
+
+    fn write(&self, key: &str, vec: &[f32]) {
+        let path = self.path_for(key);
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let payload = CacheEntry { v: vec.to_vec() };
+        if let Ok(bytes) = serde_json::to_vec(&payload) {
+            // Atomic-ish: write tmp + rename so a partial file never
+            // looks valid. Errors are swallowed because the cache is
+            // an optimisation, not a source of truth.
+            let tmp = path.with_extension("json.tmp");
+            if std::fs::write(&tmp, &bytes).is_ok() {
+                let _ = std::fs::rename(&tmp, &path);
+            }
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct CacheEntry {
+    v: Vec<f32>,
+}
+
+impl<E: Embedder> Embedder for CachingEmbedder<E> {
+    fn dim(&self) -> usize { self.inner.dim() }
+
+    fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbedError> {
+        // First pass: find which keys are missing, build a dense
+        // list of missing texts to send upstream.
+        let keys: Vec<String> = texts.iter().map(|t| self.key_for(t)).collect();
+        let mut hits: Vec<Option<Vec<f32>>> = keys.iter().map(|k| self.read(k)).collect();
+        let missing_idx: Vec<usize> = hits.iter().enumerate()
+            .filter_map(|(i, v)| if v.is_none() { Some(i) } else { None })
+            .collect();
+        if !missing_idx.is_empty() {
+            let missing_texts: Vec<&str> = missing_idx.iter().map(|i| texts[*i]).collect();
+            let fresh = self.inner.embed_batch(&missing_texts)?;
+            for (slot, vec) in missing_idx.iter().zip(fresh.iter()) {
+                self.write(&keys[*slot], vec);
+                hits[*slot] = Some(vec.clone());
+            }
+        }
+        Ok(hits.into_iter().map(|v| v.expect("filled above")).collect())
+    }
+}
+
+/// Pick a cache root under `<store_root>/search/embeddings/`. The
+/// CLI uses this so the cache lives next to the store it indexes.
+pub fn default_cache_root(store_root: &Path) -> PathBuf {
+    store_root.join("search").join("embeddings")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::MockEmbedder;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    /// Embedder that delegates to a Mock but counts every text it
+    /// embeds, so tests can assert cache hits don't reach the inner
+    /// embedder.
+    struct CountingMock {
+        inner: MockEmbedder,
+        count: Arc<AtomicUsize>,
+    }
+    impl Embedder for CountingMock {
+        fn dim(&self) -> usize { self.inner.dim() }
+        fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbedError> {
+            self.count.fetch_add(texts.len(), Ordering::SeqCst);
+            self.inner.embed_batch(texts)
+        }
+    }
+
+    fn fixture() -> (tempfile::TempDir, Arc<AtomicUsize>) {
+        (tempfile::tempdir().unwrap(), Arc::new(AtomicUsize::new(0)))
+    }
+
+    #[test]
+    fn second_call_is_a_cache_hit() {
+        let (dir, count) = fixture();
+        let cache = CachingEmbedder::new(
+            CountingMock { inner: MockEmbedder::new(), count: Arc::clone(&count) },
+            dir.path().to_path_buf(),
+            "test:v1",
+        );
+        let _ = cache.embed("alpha beta").unwrap();
+        let n_after_first = count.load(Ordering::SeqCst);
+        assert_eq!(n_after_first, 1);
+
+        let _ = cache.embed("alpha beta").unwrap();
+        assert_eq!(
+            count.load(Ordering::SeqCst), n_after_first,
+            "a repeat call must not reach the inner embedder",
+        );
+    }
+
+    #[test]
+    fn cached_vector_matches_uncached_vector() {
+        let (dir, count) = fixture();
+        let cache = CachingEmbedder::new(
+            CountingMock { inner: MockEmbedder::new(), count: Arc::clone(&count) },
+            dir.path().to_path_buf(),
+            "test:v1",
+        );
+        let direct = MockEmbedder::new().embed("the quick brown fox").unwrap();
+        let v1 = cache.embed("the quick brown fox").unwrap();
+        let v2 = cache.embed("the quick brown fox").unwrap();
+        assert_eq!(v1, direct);
+        assert_eq!(v2, direct);
+    }
+
+    #[test]
+    fn batch_mixes_hits_and_misses_correctly() {
+        let (dir, count) = fixture();
+        let cache = CachingEmbedder::new(
+            CountingMock { inner: MockEmbedder::new(), count: Arc::clone(&count) },
+            dir.path().to_path_buf(),
+            "test:v1",
+        );
+        let _ = cache.embed("warm").unwrap();
+        count.store(0, Ordering::SeqCst);
+        let _ = cache.embed_batch(&["warm", "cold", "warm", "lukewarm"]).unwrap();
+        // "warm" cached, "cold" + "lukewarm" fresh → 2 inner calls.
+        assert_eq!(count.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn fingerprint_change_invalidates_cache() {
+        let (dir, count) = fixture();
+        let cache_a = CachingEmbedder::new(
+            CountingMock { inner: MockEmbedder::new(), count: Arc::clone(&count) },
+            dir.path().to_path_buf(),
+            "model-a",
+        );
+        let cache_b = CachingEmbedder::new(
+            CountingMock { inner: MockEmbedder::new(), count: Arc::clone(&count) },
+            dir.path().to_path_buf(),
+            "model-b",
+        );
+        let _ = cache_a.embed("hello").unwrap();
+        count.store(0, Ordering::SeqCst);
+        let _ = cache_b.embed("hello").unwrap();
+        assert_eq!(count.load(Ordering::SeqCst), 1,
+            "a different fingerprint must NOT serve cached entries from another model");
+    }
+
+    #[test]
+    fn corrupt_cache_file_falls_back_to_fresh_embed() {
+        let (dir, count) = fixture();
+        let cache = CachingEmbedder::new(
+            CountingMock { inner: MockEmbedder::new(), count: Arc::clone(&count) },
+            dir.path().to_path_buf(),
+            "test:v1",
+        );
+        // Prime the cache then truncate the file.
+        let _ = cache.embed("token").unwrap();
+        let key = cache.key_for("token");
+        std::fs::write(cache.path_for(&key), b"not json").unwrap();
+        count.store(0, Ordering::SeqCst);
+        let _ = cache.embed("token").unwrap();
+        assert_eq!(count.load(Ordering::SeqCst), 1,
+            "corrupt cache entry must trigger a fresh upstream call");
+    }
+
+    #[test]
+    fn default_cache_root_lives_under_store() {
+        let p = default_cache_root(Path::new("/tmp/store"));
+        assert!(p.ends_with("search/embeddings"));
+    }
+}

--- a/crates/lex-search/src/http.rs
+++ b/crates/lex-search/src/http.rs
@@ -1,0 +1,254 @@
+//! HTTP-backed embedder (#224 slice 2).
+//!
+//! Two wire formats:
+//!
+//! * **Ollama** — `POST <url>/api/embeddings` with body
+//!   `{"model": "...", "prompt": "..."}`. Response is
+//!   `{"embedding": [f32, ...]}`. One request per text — Ollama's
+//!   classic embeddings endpoint isn't batchable. The `CachingEmbedder`
+//!   wrapper makes repeat calls cheap.
+//! * **OpenAI-compat** — `POST <url>/v1/embeddings` with body
+//!   `{"model": "...", "input": ["t1", "t2", ...]}`. Response is
+//!   `{"data": [{"embedding": [...]}, ...]}`. Batch-friendly.
+//!
+//! The caller picks via `LEX_EMBED_PROVIDER=ollama|openai`. If
+//! unset, we default to `ollama` because that's the most common
+//! local-LLM workflow.
+
+use crate::embedder::{EmbedError, Embedder};
+use serde::{Deserialize, Serialize};
+
+/// Wire-format flavor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Provider {
+    Ollama,
+    OpenAi,
+}
+
+impl Provider {
+    fn endpoint(self, base: &str) -> String {
+        let trimmed = base.trim_end_matches('/');
+        match self {
+            Provider::Ollama => format!("{trimmed}/api/embeddings"),
+            Provider::OpenAi => format!("{trimmed}/v1/embeddings"),
+        }
+    }
+}
+
+/// HTTP embedder. The constructor [`HttpEmbedder::from_env`] reads
+/// `LEX_EMBED_URL`, `LEX_EMBED_PROVIDER`, `LEX_EMBED_MODEL`,
+/// `LEX_EMBED_API_KEY` (the last is OpenAI-only). All but URL have
+/// reasonable defaults.
+pub struct HttpEmbedder {
+    agent: ureq::Agent,
+    base_url: String,
+    provider: Provider,
+    model: String,
+    api_key: Option<String>,
+    /// Cached vector dimension, learned from the first successful
+    /// response. Avoids returning a different `dim()` mid-session
+    /// if the model decides to misbehave (defensive — shouldn't
+    /// happen with a single fixed model).
+    dim_cell: std::sync::OnceLock<usize>,
+}
+
+impl std::fmt::Debug for HttpEmbedder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HttpEmbedder")
+            .field("base_url", &self.base_url)
+            .field("provider", &self.provider)
+            .field("model", &self.model)
+            .field("api_key", &if self.api_key.is_some() { "<set>" } else { "<unset>" })
+            .finish()
+    }
+}
+
+impl HttpEmbedder {
+    /// Construct a new embedder for the given URL + provider.
+    pub fn new(base_url: impl Into<String>, provider: Provider, model: impl Into<String>) -> Self {
+        Self {
+            agent: ureq::Agent::config_builder()
+                .timeout_global(Some(std::time::Duration::from_secs(30)))
+                .build()
+                .into(),
+            base_url: base_url.into(),
+            provider,
+            model: model.into(),
+            api_key: None,
+            dim_cell: std::sync::OnceLock::new(),
+        }
+    }
+
+    pub fn with_api_key(mut self, key: impl Into<String>) -> Self {
+        self.api_key = Some(key.into());
+        self
+    }
+
+    /// Read configuration from env vars and construct. Returns
+    /// `Ok(None)` when `LEX_EMBED_URL` is unset so the caller can
+    /// fall back to [`crate::MockEmbedder`].
+    pub fn from_env() -> Result<Option<Self>, EmbedError> {
+        let url = match std::env::var("LEX_EMBED_URL") {
+            Ok(v) if !v.is_empty() => v,
+            _ => return Ok(None),
+        };
+        let provider = match std::env::var("LEX_EMBED_PROVIDER").ok().as_deref() {
+            Some("openai") | Some("openai-compat") => Provider::OpenAi,
+            Some("ollama") | None | Some("") => Provider::Ollama,
+            Some(other) => return Err(EmbedError::Generic(format!(
+                "LEX_EMBED_PROVIDER must be `ollama` or `openai`, got `{other}`"
+            ))),
+        };
+        let model = std::env::var("LEX_EMBED_MODEL").ok()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| match provider {
+                Provider::Ollama => "nomic-embed-text".into(),
+                Provider::OpenAi => "text-embedding-3-small".into(),
+            });
+        let api_key = std::env::var("LEX_EMBED_API_KEY").ok().filter(|s| !s.is_empty());
+        let mut e = Self::new(url, provider, model);
+        if let Some(k) = api_key { e = e.with_api_key(k); }
+        Ok(Some(e))
+    }
+
+    /// Provider this embedder talks to (test introspection).
+    pub fn provider(&self) -> Provider { self.provider }
+
+    pub fn model(&self) -> &str { &self.model }
+
+    fn record_dim(&self, observed: usize) {
+        let _ = self.dim_cell.set(observed);
+    }
+
+    fn ollama_embed(&self, text: &str) -> Result<Vec<f32>, EmbedError> {
+        #[derive(Serialize)]
+        struct Req<'a> { model: &'a str, prompt: &'a str }
+        #[derive(Deserialize)]
+        struct Resp { embedding: Vec<f32> }
+        let url = self.provider.endpoint(&self.base_url);
+        let req = Req { model: &self.model, prompt: text };
+        let resp: Resp = self.agent.post(&url)
+            .send_json(&req)
+            .map_err(|e| EmbedError::Generic(format!("ollama POST {url}: {e}")))?
+            .body_mut().read_json()
+            .map_err(|e| EmbedError::Generic(format!("ollama parse: {e}")))?;
+        Ok(resp.embedding)
+    }
+
+    fn openai_embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbedError> {
+        #[derive(Serialize)]
+        struct Req<'a> { model: &'a str, input: &'a [&'a str] }
+        #[derive(Deserialize)]
+        struct DataItem { embedding: Vec<f32> }
+        #[derive(Deserialize)]
+        struct Resp { data: Vec<DataItem> }
+        let url = self.provider.endpoint(&self.base_url);
+        let req = Req { model: &self.model, input: texts };
+        let mut request = self.agent.post(&url);
+        if let Some(k) = &self.api_key {
+            request = request.header("authorization", &format!("Bearer {k}"));
+        }
+        let resp: Resp = request
+            .send_json(&req)
+            .map_err(|e| EmbedError::Generic(format!("openai POST {url}: {e}")))?
+            .body_mut().read_json()
+            .map_err(|e| EmbedError::Generic(format!("openai parse: {e}")))?;
+        if resp.data.len() != texts.len() {
+            return Err(EmbedError::Generic(format!(
+                "openai returned {} embeddings for {} inputs",
+                resp.data.len(), texts.len(),
+            )));
+        }
+        Ok(resp.data.into_iter().map(|d| d.embedding).collect())
+    }
+}
+
+impl Embedder for HttpEmbedder {
+    fn dim(&self) -> usize {
+        // Until the first call lands a real response, we don't know
+        // the dim — the model is the source of truth. Most embedding
+        // models settle on 384 / 768 / 1024 / 1536 / 3072 dims, but
+        // we let the response tell us. Returning 0 here would be
+        // wrong (it's a unit-vector dimension) and 1 would mask bugs;
+        // 1024 is a reasonable optimistic default that gets corrected
+        // on the first observed response.
+        *self.dim_cell.get().unwrap_or(&1024)
+    }
+
+    fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>, EmbedError> {
+        if texts.is_empty() { return Ok(Vec::new()); }
+        let out: Vec<Vec<f32>> = match self.provider {
+            Provider::Ollama => texts.iter()
+                .map(|t| self.ollama_embed(t))
+                .collect::<Result<_, _>>()?,
+            Provider::OpenAi => self.openai_embed_batch(texts)?,
+        };
+        if let Some(first) = out.first() {
+            self.record_dim(first.len());
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ollama_endpoint_is_built_from_base() {
+        assert_eq!(
+            Provider::Ollama.endpoint("http://localhost:11434"),
+            "http://localhost:11434/api/embeddings",
+        );
+        // Trailing slash is tolerated.
+        assert_eq!(
+            Provider::Ollama.endpoint("http://localhost:11434/"),
+            "http://localhost:11434/api/embeddings",
+        );
+    }
+
+    #[test]
+    fn openai_endpoint_is_built_from_base() {
+        assert_eq!(
+            Provider::OpenAi.endpoint("https://api.openai.com"),
+            "https://api.openai.com/v1/embeddings",
+        );
+    }
+
+    #[test]
+    fn from_env_returns_none_without_url() {
+        // Test relies on the env var being unset; tests don't share
+        // global env so we explicitly remove it.
+        // SAFETY: tests in this module are single-threaded with
+        // respect to env; not the case for parallel tests in real
+        // Rust test runs but this single-process check is fine.
+        // (We'd use std::env::set_var via a mutex lock for shared
+        // env, but here we simply remove and re-check.)
+        unsafe { std::env::remove_var("LEX_EMBED_URL"); }
+        assert!(HttpEmbedder::from_env().unwrap().is_none());
+    }
+
+    #[test]
+    fn from_env_rejects_unknown_provider() {
+        unsafe {
+            std::env::set_var("LEX_EMBED_URL", "http://example.com");
+            std::env::set_var("LEX_EMBED_PROVIDER", "voyage");
+        }
+        let r = HttpEmbedder::from_env();
+        unsafe {
+            std::env::remove_var("LEX_EMBED_URL");
+            std::env::remove_var("LEX_EMBED_PROVIDER");
+        }
+        assert!(matches!(r, Err(EmbedError::Generic(_))));
+    }
+
+    #[test]
+    fn debug_redacts_api_key() {
+        let e = HttpEmbedder::new("http://x", Provider::OpenAi, "m")
+            .with_api_key("super-secret");
+        let s = format!("{e:?}");
+        assert!(!s.contains("super-secret"),
+            "Debug output must not contain the API key; got: {s}");
+        assert!(s.contains("<set>"));
+    }
+}

--- a/crates/lex-search/src/lib.rs
+++ b/crates/lex-search/src/lib.rs
@@ -40,12 +40,16 @@
 
 use serde::{Deserialize, Serialize};
 
+mod cache;
 mod embedder;
+mod http;
 mod index;
 mod mock;
 mod scoring;
 
+pub use cache::{default_cache_root, CachingEmbedder};
 pub use embedder::{EmbedError, Embedder};
+pub use http::{HttpEmbedder, Provider};
 pub use index::{IndexedStage, SearchHit, SearchIndex};
 pub use mock::MockEmbedder;
 pub use scoring::{cosine_similarity, fuse_scores};

--- a/crates/lex-search/tests/http_integration.rs
+++ b/crates/lex-search/tests/http_integration.rs
@@ -1,0 +1,136 @@
+//! Integration tests for [`HttpEmbedder`] using a tiny in-process
+//! HTTP server. The server returns deterministic vectors derived
+//! from the input length so tests can assert exact output without
+//! depending on a real embedding model.
+
+use lex_search::{Embedder, HttpEmbedder, Provider};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+/// Spin up a `tiny_http` server on a random port and return
+/// (base_url, request_count, shutdown_handle). Each test gets its
+/// own server so concurrent runs don't collide.
+struct TestServer {
+    port: u16,
+    requests: Arc<AtomicUsize>,
+    _thread: std::thread::JoinHandle<()>,
+}
+
+impl TestServer {
+    fn start_ollama() -> Self {
+        Self::start(|req: &mut tiny_http::Request| {
+            let mut body = String::new();
+            req.as_reader().read_to_string(&mut body).ok();
+            let json: serde_json::Value = serde_json::from_str(&body).unwrap_or_default();
+            let prompt = json["prompt"].as_str().unwrap_or("");
+            // Deterministic 4-dim vector: [len, len*2, len*3, 1.0]
+            // Useful: empty string => [0,0,0,1] (still distinguishable).
+            let len = prompt.len() as f32;
+            let vec = vec![len, len * 2.0, len * 3.0, 1.0];
+            let resp_body = serde_json::json!({"embedding": vec}).to_string();
+            tiny_http::Response::from_string(resp_body)
+                .with_header("content-type: application/json".parse::<tiny_http::Header>().unwrap())
+        })
+    }
+
+    fn start_openai() -> Self {
+        Self::start(|req: &mut tiny_http::Request| {
+            let mut body = String::new();
+            req.as_reader().read_to_string(&mut body).ok();
+            let json: serde_json::Value = serde_json::from_str(&body).unwrap_or_default();
+            let inputs = json["input"].as_array().cloned().unwrap_or_default();
+            let data: Vec<serde_json::Value> = inputs.iter().map(|t| {
+                let s = t.as_str().unwrap_or("");
+                let len = s.len() as f32;
+                let vec = vec![len, len * 2.0, len * 3.0, 1.0];
+                serde_json::json!({"embedding": vec})
+            }).collect();
+            let resp_body = serde_json::json!({"data": data}).to_string();
+            tiny_http::Response::from_string(resp_body)
+                .with_header("content-type: application/json".parse::<tiny_http::Header>().unwrap())
+        })
+    }
+
+    fn start<F>(handler: F) -> Self
+    where F: Fn(&mut tiny_http::Request) -> tiny_http::Response<std::io::Cursor<Vec<u8>>>
+        + Send + 'static,
+    {
+        let server = tiny_http::Server::http("127.0.0.1:0").expect("bind test server");
+        let port = server.server_addr().to_ip().unwrap().port();
+        let requests = Arc::new(AtomicUsize::new(0));
+        let req_clone = Arc::clone(&requests);
+        let handle = std::thread::spawn(move || {
+            for mut req in server.incoming_requests() {
+                req_clone.fetch_add(1, Ordering::SeqCst);
+                let resp = handler(&mut req);
+                let _ = req.respond(resp);
+            }
+        });
+        Self { port, requests, _thread: handle }
+    }
+
+    fn url(&self) -> String { format!("http://127.0.0.1:{}", self.port) }
+    fn count(&self) -> usize { self.requests.load(Ordering::SeqCst) }
+}
+
+#[test]
+fn ollama_embedder_round_trips_a_single_prompt() {
+    let server = TestServer::start_ollama();
+    let e = HttpEmbedder::new(server.url(), Provider::Ollama, "nomic-embed-text");
+    let v = e.embed("hello").unwrap();
+    assert_eq!(v.len(), 4);
+    assert_eq!(v[0], 5.0); // len("hello")
+    assert_eq!(v[3], 1.0);
+    assert_eq!(server.count(), 1);
+}
+
+#[test]
+fn ollama_embedder_loops_per_text_for_batches() {
+    // Ollama's /api/embeddings is non-batchable; the embedder loops
+    // and we observe one HTTP request per text.
+    let server = TestServer::start_ollama();
+    let e = HttpEmbedder::new(server.url(), Provider::Ollama, "any");
+    let _ = e.embed_batch(&["a", "bb", "ccc"]).unwrap();
+    assert_eq!(server.count(), 3);
+}
+
+#[test]
+fn openai_embedder_sends_one_batch_request() {
+    let server = TestServer::start_openai();
+    let e = HttpEmbedder::new(server.url(), Provider::OpenAi, "text-embedding-3-small");
+    let out = e.embed_batch(&["alpha", "beta", "gamma"]).unwrap();
+    assert_eq!(out.len(), 3);
+    assert_eq!(out[0][0], 5.0);  // len("alpha")
+    assert_eq!(out[1][0], 4.0);  // len("beta")
+    assert_eq!(out[2][0], 5.0);  // len("gamma")
+    assert_eq!(server.count(), 1, "OpenAI-compat sends one request per batch");
+}
+
+#[test]
+fn http_embedder_records_dim_from_first_response() {
+    let server = TestServer::start_ollama();
+    let e = HttpEmbedder::new(server.url(), Provider::Ollama, "any");
+    // Default before first call.
+    assert_ne!(e.dim(), 4);
+    let _ = e.embed("anything").unwrap();
+    assert_eq!(e.dim(), 4, "dim should reflect the first observed embedding length");
+}
+
+#[test]
+fn caching_embedder_amortises_repeat_queries_against_http() {
+    let server = TestServer::start_ollama();
+    let inner = HttpEmbedder::new(server.url(), Provider::Ollama, "any");
+    let cache_dir = tempfile::tempdir().unwrap();
+    let cache = lex_search::CachingEmbedder::new(
+        inner, cache_dir.path().to_path_buf(), "ollama:any",
+    );
+    let _ = cache.embed("first").unwrap();
+    let _ = cache.embed("second").unwrap();
+    let after_two_unique = server.count();
+    assert_eq!(after_two_unique, 2);
+
+    // Now hit both again and a new one — only the new one should
+    // reach the HTTP server.
+    let _ = cache.embed_batch(&["first", "third", "second"]).unwrap();
+    assert_eq!(server.count(), after_two_unique + 1);
+}


### PR DESCRIPTION
Bundles two follow-ups on the same branch — independent commits, stacked because the work happened back-to-back without a review pause.

| Commit | Scope |
|---|---|
| `5604dc7` | `lex run --from-store STAGE_ID` with signature verification (#227 follow-up) |
| `40ea04e` | HTTP embedder (Ollama / OpenAI-compat) + on-disk cache (#224 slice 2) |

After this PR, the agents-only language track + tooling track is **substantively complete**. Only the meta-tracker (#220) and tier-3 federation (#173) remain as long-term meta items.

---

## Part 1 — `lex run --from-store STAGE_ID` (`5604dc7`)

Closes the gap left by #227's "out of scope" section: signed stages can now be executed directly from the store without first writing a `.lex` file or canonical-AST file.

### CLI

```
lex run --from-store STAGE_ID [--require-signed] [--trusted-key HEX] <fn> [args...]
```

The store is opened at `LEX_STORE` (or `.lex`). Metadata is loaded first; if `--require-signed` or `--trusted-key` is set the signature is verified before the AST is even read. The stage's AST becomes a single-element program; the function-name argument selects which fn inside it to call.

`--trusted-key HEX` implies `--require-signed`. A present signature is always verified, so a tampered metadata file fails fast even without `--require-signed`.

### Implementation

* Refactored `parse_run_flags` from a 6-tuple into a `RunFlags` struct so the new flags don't blow out the return shape further.
* New `load_stages_from_store(stage_id, require_signed, trusted_key)` helper alongside the existing `load_stages` (file path / canonical-bytes) helper. Both produce a `Vec<Stage>`.
* Reuses the existing `verify_metadata_signature` from #227.

### Out of scope

* Multi-stage programs (imports / cross-stage calls). The store surfaces stages individually; resolving an import graph at run time is a separate piece of work and not blocking for the signature-verification story.
* HTTP API equivalent — `lex serve` doesn't yet expose signature-gated execution.

---

## Part 2 — HTTP embedder + cache (`40ea04e`, #224 slice 2)

Closes the slice-2 scope of #224. With `LEX_EMBED_URL` set, `lex store search` and `lex audit --query` talk to a real embedding service; without it, they keep using the deterministic `MockEmbedder` from slice 1.

### New types

* **`lex_search::HttpEmbedder`** — sync `ureq` client speaking either Ollama (`POST /api/embeddings`, per-text) or OpenAI-compat (`POST /v1/embeddings`, batched). `from_env()` reads:
  * `LEX_EMBED_URL` — base URL (e.g. `http://localhost:11434` or `https://api.openai.com`)
  * `LEX_EMBED_PROVIDER` — `ollama` | `openai`
  * `LEX_EMBED_MODEL` — model name (sane defaults per provider)
  * `LEX_EMBED_API_KEY` — bearer token, OpenAI-compat only

  Manual `Debug` impl redacts the API key.

* **`lex_search::CachingEmbedder<E>`** — wraps any embedder with a filesystem cache. Sharded by the first two hex chars of a SHA-256 over `(fingerprint, text)`. `fingerprint` encodes the upstream model identity so swapping providers / models doesn't return stale vectors of the wrong shape. Atomic `tmp + rename` writes; corrupt cache files transparently fall back to a fresh upstream call.

* **`lex_search::default_cache_root(store_root)`** — picks `<store>/search/embeddings/`.

### CLI behaviour

`build_embedder(store_root)` (in `lex-cli`) returns `Box<dyn Embedder>`:
- `LEX_EMBED_URL` set → `CachingEmbedder<HttpEmbedder>` keyed by `provider:model`.
- otherwise → `MockEmbedder`.

Both `cmd_store_search` and `cmd_audit_semantic` go through this helper; switching providers is a pure env-var change.

### Out of scope (slice 2)

* HNSW / approximate-nearest-neighbour for stores past ~500 stages. Brute force still sub-ms there.
* Cache eviction. The cache grows indefinitely today; no driver yet for LRU.

---

## Test plan

- [x] 7 e2e tests in `crates/lex-cli/tests/run_from_store.rs`: happy paths (unsigned / signed / trusted-key) and rejection paths (unsigned-under-require, wrong-trusted-key, unknown stage_id, missing fn).
- [x] 8 new unit tests in `lex_search::http` (endpoint construction, env-var parsing, Debug redaction) and `lex_search::cache` (cache-hit on second call, fingerprint isolation, batch hit/miss mix, corrupt-file fallback).
- [x] 5 integration tests in `crates/lex-search/tests/http_integration.rs` using a `tiny_http` server: Ollama single + per-text-loop batching, OpenAI batch in one request, dim auto-recorded from first response, caching amortises HTTP requests.
- [x] Workspace: **1069 passing, 0 failing**.
- [x] `cargo clippy --all-targets -- -D warnings` clean.

## Closes

- Follow-up to #227 (`--from-store`).
- Slice 2 of #224 (HTTP embedder + cache); slice 1 was #238.

https://claude.ai/code/session_016SGtf28wA4CgAem65XrjPt