### PR TITLE
runtime: str.slice clamping + parse_strict nested + std.cli (Rubric port)

### DIFF
--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -1655,16 +1655,26 @@ fn required_field_names(arg: Option<&Value>) -> Result<Vec<String>, String> {
     Ok(out)
 }
 
-/// Verify that `value`'s top level is an object containing every
-/// name in `required`. Returns a stable, human-readable error
-/// listing the missing field(s) so the agent's verifier can
-/// surface it directly.
+/// Verify that `value` is an object containing every entry in
+/// `required`. A required entry may be a plain field name (must
+/// exist at the top level) or a dotted path (`"project.license"`)
+/// which descends through nested objects. Returns a stable,
+/// human-readable error listing every missing path so the agent's
+/// verifier can surface it directly.
 ///
-/// Tactical fix for #168 — gives users a way to make
-/// `parse[T]` errors propagate as `Result::Err` instead of as
-/// runtime `GetField` errors at access time. The full
-/// type-driven fix (deriving `required` from `T` at type-check
-/// time so plain `parse[T]` works) tracked in #168.
+/// Tactical fix for #168 — gives users a way to make `parse[T]`
+/// errors propagate as `Result::Err` instead of as runtime
+/// `GetField` errors at access time. The full type-driven fix
+/// (deriving `required` from `T` at type-check time so plain
+/// `parse[T]` works, including auto-wrapping `Option[F]` fields
+/// as not-required) is the cleaner endgame; see #168.
+///
+/// Path semantics:
+/// * `"name"` → top-level `name` must be present (any value).
+/// * `"a.b.c"` → walk `a`, then `b`, then check `c` exists. Each
+///   intermediate value must itself be an object.
+/// * `\\.` is the literal-dot escape (e.g. `"weird\\.key"` for a
+///   field that genuinely contains a dot in its name).
 fn check_required_fields(
     value: &serde_json::Value,
     required: &[String],
@@ -1672,22 +1682,68 @@ fn check_required_fields(
     if required.is_empty() {
         return Ok(());
     }
-    let obj = match value {
-        serde_json::Value::Object(o) => o,
-        _ => return Err(format!(
+    if !matches!(value, serde_json::Value::Object(_)) {
+        return Err(format!(
             "parse_strict: expected top-level object with fields {:?}, got {value}",
             required
-        )),
-    };
-    let missing: Vec<&str> = required.iter()
-        .filter(|n| !obj.contains_key(n.as_str()))
-        .map(String::as_str)
-        .collect();
+        ));
+    }
+    let mut missing: Vec<String> = Vec::new();
+    for path in required {
+        if !path_exists(value, path) {
+            missing.push(path.clone());
+        }
+    }
     if missing.is_empty() {
         Ok(())
     } else {
         Err(format!("missing required field(s): {}", missing.join(", ")))
     }
+}
+
+/// Walk `value` along the dotted `path` and report whether the
+/// terminal segment exists. Intermediate non-object stops surface
+/// as "missing" — a path can't traverse through a string, list, or
+/// scalar.
+fn path_exists(value: &serde_json::Value, path: &str) -> bool {
+    let mut cursor = value;
+    let segments = split_dotted_path(path);
+    for seg in &segments {
+        match cursor {
+            serde_json::Value::Object(o) => match o.get(seg.as_str()) {
+                Some(next) => cursor = next,
+                None => return false,
+            },
+            _ => return false,
+        }
+    }
+    true
+}
+
+/// Split `"a.b.c"` into `["a", "b", "c"]`, with `\.` recognised
+/// as a literal-dot escape so legitimate dotted field names
+/// (e.g. `"package\.json"`) don't accidentally start a descent.
+fn split_dotted_path(path: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut cur = String::new();
+    let mut iter = path.chars().peekable();
+    while let Some(c) = iter.next() {
+        if c == '\\' {
+            // Backslash at end is preserved; only `\.` is special.
+            if let Some(&'.') = iter.peek() {
+                cur.push('.');
+                iter.next();
+                continue;
+            }
+            cur.push(c);
+        } else if c == '.' {
+            out.push(std::mem::take(&mut cur));
+        } else {
+            cur.push(c);
+        }
+    }
+    out.push(cur);
+    out
 }
 
 /// Parse a `.env`-style file into key→value pairs. Accepts:

--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -115,15 +115,24 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             })
         }
         ("str", "slice") => {
-            // Half-open byte-range slice. Out-of-range or non-UTF-8
-            // boundaries error rather than panic, so caller code can
-            // recover via Result. Spec §11.1 doesn't pin a name; this
-            // matches the bytes.slice helper added earlier.
+            // Half-open byte-range slice. `hi` is clamped to `s.len()`
+            // and a negative `lo` / `hi` clamps to `0`, mirroring
+            // Python's `s[lo:hi]` semantics (and matching what
+            // production users expect when slicing fixed sizes off
+            // a possibly-shorter string — e.g. the first 64 chars
+            // of a license header). Reversed ranges (`lo > hi` after
+            // clamping) error since that's a caller logic bug. A
+            // mid-codepoint `lo` after clamping still errors so
+            // silent UTF-8 truncation never sneaks through.
             let s = expect_str(args.first())?;
-            let lo = expect_int(args.get(1))? as usize;
-            let hi = expect_int(args.get(2))? as usize;
-            if lo > hi || hi > s.len() {
-                return Err(format!("str.slice: out of range [{lo}..{hi}] of len {}", s.len()));
+            let lo_i = expect_int(args.get(1))?;
+            let hi_i = expect_int(args.get(2))?;
+            let lo = (lo_i.max(0) as usize).min(s.len());
+            let hi = (hi_i.max(0) as usize).min(s.len());
+            if lo > hi {
+                return Err(format!(
+                    "str.slice: reversed range [{lo}..{hi}] (after clamping to len {})",
+                    s.len()));
             }
             if !s.is_char_boundary(lo) || !s.is_char_boundary(hi) {
                 return Err(format!("str.slice: [{lo}..{hi}] not on char boundaries"));

--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -31,7 +31,8 @@ pub fn is_pure_module(kind: &str) -> bool {
     matches!(kind, "str" | "int" | "float" | "bool" | "list"
         | "option" | "result" | "tuple" | "json" | "bytes" | "flow" | "math"
         | "map" | "set" | "crypto" | "regex" | "deque" | "datetime" | "http"
-        | "toml" | "yaml" | "dotenv" | "csv" | "test" | "random" | "parser")
+        | "toml" | "yaml" | "dotenv" | "csv" | "test" | "random" | "parser"
+        | "cli")
 }
 
 fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
@@ -1286,9 +1287,84 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             }
         }
 
+        // -- std.cli (Rubric port): argparse-equivalent for end-user
+        // programs. Specs are tagged Json values; the parser walks
+        // argv against the spec and returns a CliParsed Json record.
+        ("cli", "flag") => {
+            let name = expect_str(args.first())?;
+            let short = opt_str(args.get(1));
+            let help = expect_str(args.get(2))?;
+            Ok(value_from_json(crate::cli::flag_spec(&name, short.as_deref(), &help)))
+        }
+        ("cli", "option") => {
+            let name = expect_str(args.first())?;
+            let short = opt_str(args.get(1));
+            let help = expect_str(args.get(2))?;
+            let default = opt_str(args.get(3));
+            Ok(value_from_json(crate::cli::option_spec(&name, short.as_deref(), &help, default.as_deref())))
+        }
+        ("cli", "positional") => {
+            let name = expect_str(args.first())?;
+            let help = expect_str(args.get(1))?;
+            let required = expect_bool(args.get(2))?;
+            Ok(value_from_json(crate::cli::positional_spec(&name, &help, required)))
+        }
+        ("cli", "spec") => {
+            let name = expect_str(args.first())?;
+            let help = expect_str(args.get(1))?;
+            let arg_specs: Vec<serde_json::Value> = expect_list(args.get(2))?
+                .iter().map(value_to_json).collect();
+            let subs: Vec<serde_json::Value> = expect_list(args.get(3))?
+                .iter().map(value_to_json).collect();
+            Ok(value_from_json(crate::cli::build_spec(&name, &help, arg_specs, subs)))
+        }
+        ("cli", "parse") => {
+            let spec = value_to_json(args.first().unwrap_or(&Value::Unit));
+            let argv: Vec<String> = expect_list(args.get(1))?
+                .iter().map(|v| match v {
+                    Value::Str(s) => Ok(s.clone()),
+                    other => Err(format!("cli.parse: argv must be List[Str], got {other:?}")),
+                }).collect::<Result<_, _>>()?;
+            match crate::cli::parse(&spec, &argv) {
+                Ok(parsed) => Ok(ok_v(value_from_json(parsed))),
+                Err(msg) => Ok(err_v(Value::Str(msg))),
+            }
+        }
+        ("cli", "envelope") => {
+            let ok = expect_bool(args.first())?;
+            let cmd = expect_str(args.get(1))?;
+            let data = value_to_json(args.get(2).unwrap_or(&Value::Unit));
+            Ok(value_from_json(crate::cli::envelope(ok, &cmd, data)))
+        }
+        ("cli", "describe") => {
+            let spec = value_to_json(args.first().unwrap_or(&Value::Unit));
+            Ok(value_from_json(crate::cli::describe(&spec)))
+        }
+        ("cli", "help") => {
+            let spec = value_to_json(args.first().unwrap_or(&Value::Unit));
+            Ok(Value::Str(crate::cli::help_text(&spec)))
+        }
+
         _ => Err(format!("unknown pure builtin: {kind}.{op}")),
     }
 }
+
+/// Extract `Option[Str]` arg as `Option<String>`. None and missing
+/// arg both map to `None`. Used by the `cli` builders so callers can
+/// pass `option.none()` or `Some("v")` interchangeably.
+fn opt_str(arg: Option<&Value>) -> Option<String> {
+    match arg {
+        Some(Value::Variant { name, args }) if name == "Some" => {
+            args.first().and_then(|v| match v {
+                Value::Str(s) => Some(s.clone()),
+                _ => None,
+            })
+        }
+        _ => None,
+    }
+}
+
+fn value_from_json(v: serde_json::Value) -> Value { Value::from_json(&v) }
 
 /// Process-wide cache of compiled regexes, keyed by the pattern
 /// string. Compilation is the only cost we want to amortize; matching
@@ -1436,6 +1512,14 @@ fn expect_list(v: Option<&Value>) -> Result<&Vec<Value>, String> {
     match v {
         Some(Value::List(xs)) => Ok(xs),
         Some(other) => Err(format!("expected List, got {other:?}")),
+        None => Err("missing argument".into()),
+    }
+}
+
+fn expect_bool(v: Option<&Value>) -> Result<bool, String> {
+    match v {
+        Some(Value::Bool(b)) => Ok(*b),
+        Some(other) => Err(format!("expected Bool, got {other:?}")),
         None => Err("missing argument".into()),
     }
 }

--- a/crates/lex-runtime/src/cli.rs
+++ b/crates/lex-runtime/src/cli.rs
@@ -1,0 +1,534 @@
+//! `std.cli` — argparse-equivalent for end-user Lex programs
+//! (Rubric port follow-up).
+//!
+//! The Rubric CLI has six subcommands with a mixed bag of positional
+//! / option / flag arguments, JSON-envelope output, and ACLI
+//! introspection. Hand-rolling each subcommand's parser is days of
+//! clipped-wing work; this module provides the equivalent Lex builder
+//! surface.
+//!
+//! The wire format for spec values is JSON (opaque to user code,
+//! constructed via `cli.flag` / `cli.option` / `cli.positional` /
+//! `cli.spec`). Internal records carry a `kind` discriminator so
+//! `parse` can identify what each entry is without relying on field
+//! shape.
+
+use serde_json::{json, Value};
+
+// ---- Spec construction --------------------------------------------
+
+pub fn flag_spec(name: &str, short: Option<&str>, help: &str) -> Value {
+    json!({
+        "kind": "flag",
+        "name": name,
+        "short": short,
+        "help": help,
+    })
+}
+
+pub fn option_spec(name: &str, short: Option<&str>, help: &str, default: Option<&str>) -> Value {
+    json!({
+        "kind": "option",
+        "name": name,
+        "short": short,
+        "help": help,
+        "default": default,
+    })
+}
+
+pub fn positional_spec(name: &str, help: &str, required: bool) -> Value {
+    json!({
+        "kind": "positional",
+        "name": name,
+        "help": help,
+        "required": required,
+    })
+}
+
+pub fn build_spec(name: &str, help: &str, args: Vec<Value>, subcommands: Vec<Value>) -> Value {
+    json!({
+        "kind": "spec",
+        "name": name,
+        "help": help,
+        "args": args,
+        "subcommands": subcommands,
+    })
+}
+
+// ---- Parsing ------------------------------------------------------
+
+/// Parse `argv` against `spec`. Returns a `CliParsed`-shaped JSON
+/// value on success, an error message on failure.
+///
+/// `CliParsed` shape:
+/// ```json
+/// {
+///   "command":     ["rubric", "scan"],   // path of subcommand names
+///   "flags":       { "verbose": true },
+///   "options":     { "output": "report.json" },
+///   "positionals": { "path": "./src" },
+///   "remaining":   []                    // args after `--` separator
+/// }
+/// ```
+pub fn parse(spec: &Value, argv: &[String]) -> Result<Value, String> {
+    let mut state = ParseState::default();
+    parse_into(spec, argv, 0, &mut state)?;
+    Ok(json!({
+        "command": state.command,
+        "flags": state.flags,
+        "options": state.options,
+        "positionals": state.positionals,
+        "remaining": state.remaining,
+    }))
+}
+
+#[derive(Default)]
+struct ParseState {
+    command: Vec<String>,
+    flags: serde_json::Map<String, Value>,
+    options: serde_json::Map<String, Value>,
+    positionals: serde_json::Map<String, Value>,
+    remaining: Vec<String>,
+}
+
+fn parse_into(spec: &Value, argv: &[String], start: usize, state: &mut ParseState) -> Result<(), String> {
+    let name = spec_name(spec);
+    state.command.push(name.to_string());
+
+    // Index this spec's args by long/short for cheap lookup.
+    let args = spec_args(spec);
+    let mut by_long: std::collections::HashMap<&str, &Value> = std::collections::HashMap::new();
+    let mut by_short: std::collections::HashMap<&str, &Value> = std::collections::HashMap::new();
+    let mut positionals: Vec<&Value> = Vec::new();
+    for a in args {
+        let kind = a.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+        match kind {
+            "flag" | "option" => {
+                if let Some(n) = a.get("name").and_then(|v| v.as_str()) {
+                    by_long.insert(n, a);
+                }
+                if let Some(s) = a.get("short").and_then(|v| v.as_str()) {
+                    by_short.insert(s, a);
+                }
+            }
+            "positional" => positionals.push(a),
+            _ => {}
+        }
+    }
+
+    // Apply defaults for any options that have one — overwritten if
+    // the option is later seen on the command line.
+    for a in args {
+        if a.get("kind").and_then(|v| v.as_str()) == Some("option") {
+            if let (Some(n), Some(d)) = (
+                a.get("name").and_then(|v| v.as_str()),
+                a.get("default").and_then(|v| v.as_str()),
+            ) {
+                state.options.insert(n.to_string(), Value::String(d.to_string()));
+            }
+        }
+    }
+    // All flags default to `false` so consumers don't have to handle
+    // the missing-key case.
+    for a in args {
+        if a.get("kind").and_then(|v| v.as_str()) == Some("flag") {
+            if let Some(n) = a.get("name").and_then(|v| v.as_str()) {
+                state.flags.insert(n.to_string(), Value::Bool(false));
+            }
+        }
+    }
+
+    let subcommands = spec_subcommands(spec);
+    let sub_by_name: std::collections::HashMap<&str, &Value> = subcommands.iter()
+        .filter_map(|s| spec_name_opt(s).map(|n| (n, s)))
+        .collect();
+
+    let mut i = start;
+    let mut positional_idx = 0usize;
+    while i < argv.len() {
+        let tok = &argv[i];
+
+        // `--` ends flag/option parsing; everything after is remainder.
+        if tok == "--" {
+            state.remaining.extend(argv[i + 1..].iter().cloned());
+            return Ok(());
+        }
+
+        // Long flag / option: --name or --name=value.
+        if let Some(rest) = tok.strip_prefix("--") {
+            let (lname, inline_val) = match rest.split_once('=') {
+                Some((n, v)) => (n, Some(v.to_string())),
+                None => (rest, None),
+            };
+            let entry = by_long.get(lname).ok_or_else(|| format!(
+                "unknown flag `--{lname}` for `{name}`"))?;
+            apply_flag_or_option(entry, inline_val, &mut i, argv, state)?;
+            i += 1;
+            continue;
+        }
+
+        // Short flag: `-x` (single char) or `-x=value`.
+        if let Some(rest) = tok.strip_prefix('-') {
+            // Reject negative-number-as-positional collision: a token
+            // like "-5" with no matching short flag is treated as a
+            // positional value rather than an unknown flag.
+            let (sname, inline_val) = match rest.split_once('=') {
+                Some((n, v)) => (n, Some(v.to_string())),
+                None => (rest, None),
+            };
+            if let Some(entry) = by_short.get(sname) {
+                apply_flag_or_option(entry, inline_val, &mut i, argv, state)?;
+                i += 1;
+                continue;
+            }
+            // Fall through: treat as positional.
+        }
+
+        // Subcommand match (only at the first non-flag positional
+        // *before* any explicit positional has been consumed).
+        if positional_idx == 0 && !sub_by_name.is_empty() {
+            if let Some(sub) = sub_by_name.get(tok.as_str()) {
+                return parse_into(sub, argv, i + 1, state);
+            }
+        }
+
+        // Positional.
+        if let Some(p) = positionals.get(positional_idx) {
+            let pname = p.get("name").and_then(|v| v.as_str()).unwrap_or("");
+            state.positionals.insert(pname.to_string(), Value::String(tok.clone()));
+            positional_idx += 1;
+        } else {
+            return Err(format!(
+                "unexpected positional argument `{tok}` for `{name}`"));
+        }
+        i += 1;
+    }
+
+    // Validate required positionals.
+    for (idx, p) in positionals.iter().enumerate() {
+        if idx >= positional_idx
+            && p.get("required").and_then(|v| v.as_bool()).unwrap_or(false)
+        {
+            let pname = p.get("name").and_then(|v| v.as_str()).unwrap_or("?");
+            return Err(format!(
+                "missing required positional `{pname}` for `{name}`"));
+        }
+    }
+
+    Ok(())
+}
+
+fn apply_flag_or_option(
+    entry: &Value,
+    inline_val: Option<String>,
+    i: &mut usize,
+    argv: &[String],
+    state: &mut ParseState,
+) -> Result<(), String> {
+    let kind = entry.get("kind").and_then(|v| v.as_str()).unwrap_or("");
+    let name = entry.get("name").and_then(|v| v.as_str()).unwrap_or("?");
+    match kind {
+        "flag" => {
+            if let Some(v) = inline_val {
+                return Err(format!(
+                    "flag `--{name}` does not take a value (got `={v}`)"));
+            }
+            state.flags.insert(name.to_string(), Value::Bool(true));
+        }
+        "option" => {
+            let val = match inline_val {
+                Some(v) => v,
+                None => {
+                    let next = argv.get(*i + 1).ok_or_else(|| format!(
+                        "option `--{name}` requires a value"))?;
+                    *i += 1;
+                    next.clone()
+                }
+            };
+            state.options.insert(name.to_string(), Value::String(val));
+        }
+        _ => return Err(format!("internal: unexpected entry kind `{kind}`")),
+    }
+    Ok(())
+}
+
+// ---- Spec helpers -------------------------------------------------
+
+fn spec_name(spec: &Value) -> &str {
+    spec.get("name").and_then(|v| v.as_str()).unwrap_or("")
+}
+
+fn spec_name_opt(spec: &Value) -> Option<&str> {
+    spec.get("name").and_then(|v| v.as_str())
+}
+
+fn spec_args(spec: &Value) -> &[Value] {
+    spec.get("args").and_then(|v| v.as_array()).map(|a| a.as_slice()).unwrap_or(&[])
+}
+
+fn spec_subcommands(spec: &Value) -> &[Value] {
+    spec.get("subcommands").and_then(|v| v.as_array()).map(|a| a.as_slice()).unwrap_or(&[])
+}
+
+// ---- ACLI envelope + introspection + help -------------------------
+
+/// `{ "ok": true|false, "command": "<name>", "data": <data> }`. The
+/// shape mirrors `acli`'s output envelope so user programs can match
+/// `lex`'s own `--output json` shape without each command rolling
+/// their own.
+pub fn envelope(ok: bool, command: &str, data: Value) -> Value {
+    json!({
+        "ok": ok,
+        "command": command,
+        "data": data,
+    })
+}
+
+/// Machine-readable description of a spec — recurses through
+/// subcommands. Useful for tools that want to discover a CLI's
+/// surface without invoking `--help`.
+pub fn describe(spec: &Value) -> Value {
+    json!({
+        "name": spec_name(spec),
+        "help": spec.get("help").cloned().unwrap_or(Value::String(String::new())),
+        "args": spec_args(spec).to_vec(),
+        "subcommands": spec_subcommands(spec).iter().map(describe).collect::<Vec<_>>(),
+    })
+}
+
+/// Human-readable help text. Layout matches `argparse`/`clap` for
+/// familiarity. Subcommands are listed below the args.
+pub fn help_text(spec: &Value) -> String {
+    let mut out = String::new();
+    out.push_str(spec_name(spec));
+    if let Some(h) = spec.get("help").and_then(|v| v.as_str()) {
+        if !h.is_empty() {
+            out.push_str(" — ");
+            out.push_str(h);
+        }
+    }
+    out.push('\n');
+
+    let args = spec_args(spec);
+    let positionals: Vec<&Value> = args.iter()
+        .filter(|a| a.get("kind").and_then(|v| v.as_str()) == Some("positional"))
+        .collect();
+    let flags: Vec<&Value> = args.iter()
+        .filter(|a| matches!(a.get("kind").and_then(|v| v.as_str()), Some("flag") | Some("option")))
+        .collect();
+
+    if !positionals.is_empty() {
+        out.push_str("\nUSAGE:\n  ");
+        out.push_str(spec_name(spec));
+        for p in &positionals {
+            let n = p.get("name").and_then(|v| v.as_str()).unwrap_or("?");
+            let required = p.get("required").and_then(|v| v.as_bool()).unwrap_or(false);
+            if required {
+                out.push_str(&format!(" <{n}>"));
+            } else {
+                out.push_str(&format!(" [{n}]"));
+            }
+        }
+        out.push('\n');
+    }
+
+    if !flags.is_empty() {
+        out.push_str("\nFLAGS:\n");
+        for f in flags {
+            let n = f.get("name").and_then(|v| v.as_str()).unwrap_or("?");
+            let s = f.get("short").and_then(|v| v.as_str()).unwrap_or("");
+            let h = f.get("help").and_then(|v| v.as_str()).unwrap_or("");
+            let prefix = if s.is_empty() {
+                format!("      --{n}")
+            } else {
+                format!("  -{s}, --{n}")
+            };
+            out.push_str(&format!("{prefix:<24}  {h}\n"));
+        }
+    }
+
+    let subs = spec_subcommands(spec);
+    if !subs.is_empty() {
+        out.push_str("\nSUBCOMMANDS:\n");
+        for sub in subs {
+            let n = spec_name(sub);
+            let h = sub.get("help").and_then(|v| v.as_str()).unwrap_or("");
+            out.push_str(&format!("  {n:<16}  {h}\n"));
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec_simple() -> Value {
+        build_spec(
+            "rubric", "Rubric CLI",
+            vec![
+                flag_spec("verbose", Some("v"), "show debug output"),
+                option_spec("output", Some("o"), "write report", None),
+                positional_spec("path", "directory to scan", true),
+            ],
+            vec![],
+        )
+    }
+
+    #[test]
+    fn parse_simple_positional_and_flag() {
+        let s = spec_simple();
+        let parsed = parse(&s, &["./src".into(), "--verbose".into()]).unwrap();
+        assert_eq!(parsed["positionals"]["path"], "./src");
+        assert_eq!(parsed["flags"]["verbose"], true);
+    }
+
+    #[test]
+    fn parse_short_flag() {
+        let s = spec_simple();
+        let parsed = parse(&s, &["./src".into(), "-v".into()]).unwrap();
+        assert_eq!(parsed["flags"]["verbose"], true);
+    }
+
+    #[test]
+    fn parse_option_with_separate_value() {
+        let s = spec_simple();
+        let parsed = parse(&s, &[
+            "--output".into(), "report.json".into(), "./src".into(),
+        ]).unwrap();
+        assert_eq!(parsed["options"]["output"], "report.json");
+        assert_eq!(parsed["positionals"]["path"], "./src");
+    }
+
+    #[test]
+    fn parse_option_with_inline_equals() {
+        let s = spec_simple();
+        let parsed = parse(&s, &["--output=report.json".into(), "./src".into()]).unwrap();
+        assert_eq!(parsed["options"]["output"], "report.json");
+    }
+
+    #[test]
+    fn parse_default_option_value_is_present() {
+        let s = build_spec("x", "", vec![
+            option_spec("level", None, "verbosity", Some("info")),
+        ], vec![]);
+        let parsed = parse(&s, &[]).unwrap();
+        assert_eq!(parsed["options"]["level"], "info");
+    }
+
+    #[test]
+    fn parse_missing_required_positional_errors() {
+        let s = spec_simple();
+        let err = parse(&s, &[]).unwrap_err();
+        assert!(err.contains("missing required") && err.contains("path"),
+            "expected missing-positional error, got: {err}");
+    }
+
+    #[test]
+    fn parse_unknown_flag_errors() {
+        let s = spec_simple();
+        let err = parse(&s, &["./src".into(), "--bogus".into()]).unwrap_err();
+        assert!(err.contains("unknown") && err.contains("--bogus"),
+            "expected unknown-flag error, got: {err}");
+    }
+
+    #[test]
+    fn parse_flag_with_inline_value_errors() {
+        let s = spec_simple();
+        let err = parse(&s, &["--verbose=yes".into(), "./src".into()]).unwrap_err();
+        assert!(err.contains("does not take a value"),
+            "expected flag-no-value error, got: {err}");
+    }
+
+    #[test]
+    fn parse_double_dash_collects_remaining() {
+        let s = spec_simple();
+        let parsed = parse(&s, &[
+            "./src".into(), "--".into(),
+            "--would-be-flag".into(), "extra".into(),
+        ]).unwrap();
+        assert_eq!(
+            parsed["remaining"].as_array().unwrap(),
+            &[Value::String("--would-be-flag".into()), Value::String("extra".into())],
+        );
+    }
+
+    #[test]
+    fn parse_subcommand_descends() {
+        let s = build_spec(
+            "rubric", "",
+            vec![flag_spec("verbose", Some("v"), "")],
+            vec![
+                build_spec("scan", "scan a directory",
+                    vec![positional_spec("path", "", true)],
+                    vec![]),
+                build_spec("init", "initialise", vec![], vec![]),
+            ],
+        );
+        let parsed = parse(&s, &["scan".into(), "./src".into()]).unwrap();
+        assert_eq!(parsed["command"], json!(["rubric", "scan"]));
+        assert_eq!(parsed["positionals"]["path"], "./src");
+    }
+
+    #[test]
+    fn unknown_flag_in_subcommand_errors() {
+        // Subcommands have their own flag namespace. A flag declared
+        // on the parent doesn't propagate to children — they must be
+        // re-declared on the subcommand if needed.
+        let s = build_spec(
+            "rubric", "",
+            vec![flag_spec("verbose", Some("v"), "")],
+            vec![build_spec("scan", "", vec![], vec![])],
+        );
+        let err = parse(&s, &["scan".into(), "-v".into()]).unwrap_err();
+        assert!(err.contains("unknown") || err.contains("unexpected"),
+            "subcommand should reject parent's flag; got: {err}");
+    }
+
+    #[test]
+    fn envelope_shape_is_acli_compatible() {
+        let env = envelope(true, "rubric", json!({"hits": 3}));
+        assert_eq!(env["ok"], true);
+        assert_eq!(env["command"], "rubric");
+        assert_eq!(env["data"]["hits"], 3);
+    }
+
+    #[test]
+    fn describe_recurses_into_subcommands() {
+        let s = build_spec(
+            "rubric", "outer",
+            vec![flag_spec("verbose", Some("v"), "")],
+            vec![build_spec("scan", "scan dir", vec![], vec![])],
+        );
+        let d = describe(&s);
+        assert_eq!(d["name"], "rubric");
+        assert_eq!(d["help"], "outer");
+        let subs = d["subcommands"].as_array().unwrap();
+        assert_eq!(subs.len(), 1);
+        assert_eq!(subs[0]["name"], "scan");
+        assert_eq!(subs[0]["help"], "scan dir");
+    }
+
+    #[test]
+    fn help_text_lists_args_and_subs() {
+        let s = build_spec(
+            "rubric", "Rubric CLI",
+            vec![
+                flag_spec("verbose", Some("v"), "noisy"),
+                option_spec("output", Some("o"), "write to FILE", None),
+                positional_spec("path", "directory", true),
+            ],
+            vec![build_spec("scan", "scan a directory", vec![], vec![])],
+        );
+        let h = help_text(&s);
+        assert!(h.contains("rubric"));
+        assert!(h.contains("Rubric CLI"));
+        assert!(h.contains("--verbose"));
+        assert!(h.contains("-v"));
+        assert!(h.contains("--output"));
+        assert!(h.contains("<path>"));
+        assert!(h.contains("scan"));
+        assert!(h.contains("scan a directory"));
+    }
+}

--- a/crates/lex-runtime/src/lib.rs
+++ b/crates/lex-runtime/src/lib.rs
@@ -14,6 +14,7 @@
 //!   half of §7.4 and what the §7.6 acceptance tests exercise.
 
 pub mod builtins;
+pub mod cli;
 pub mod policy;
 pub mod handler;
 pub mod ws;

--- a/crates/lex-runtime/tests/parse_strict_nested.rs
+++ b/crates/lex-runtime/tests/parse_strict_nested.rs
@@ -1,0 +1,183 @@
+//! Nested `parse_strict` (Rubric port follow-up to #168).
+//!
+//! `parse_strict` originally only validated top-level required
+//! fields. The Rubric port hit two real cases this didn't cover:
+//!
+//! * **`pyproject.toml`** — `[project].license` is a nested
+//!   required field. Workaround was regex extraction.
+//! * **GitHub Actions workflows** — most steps require either
+//!   `run` xor `uses`, which itself sits under `jobs.<job>.steps[]`.
+//!
+//! This slice extends the required-fields list to accept dotted
+//! paths so callers can write `["project.license"]` and have the
+//! validator descend into nested objects. List indexing and `xor`
+//! are out of scope for now.
+//!
+//! Type-driven derivation from `T` (the cleaner endgame called out
+//! in the parse_strict comment) is still future work.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+
+fn run(src: &str, func: &str, args: Vec<Value>) -> Result<Value, String> {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        return Err(format!("type errors: {errs:#?}"));
+    }
+    let bc = compile_program(&stages);
+    let handler = DefaultHandler::new(Policy::permissive());
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(func, args).map_err(|e| format!("{e}"))
+}
+
+const TOML_SRC: &str = r#"
+import "std.toml" as toml
+fn parse_proj(s :: Str) -> Result[Map[Str, Json], Str] {
+  toml.parse_strict(s, ["project.name", "project.license"])
+}
+"#;
+
+#[test]
+fn nested_dotted_path_passes_when_all_present() {
+    let toml_src = r#"
+[project]
+name = "foo"
+license = "MIT"
+"#;
+    let v = run(TOML_SRC, "parse_proj", vec![Value::Str(toml_src.into())]).unwrap();
+    // Result::Ok wrapper; we only need to check it's not Err.
+    assert!(matches!(&v, Value::Variant { name, .. } if name == "Ok"),
+        "expected Ok, got: {v:?}");
+}
+
+#[test]
+fn nested_dotted_path_reports_missing_inner_field() {
+    let toml_src = r#"
+[project]
+name = "foo"
+"#;
+    let v = run(TOML_SRC, "parse_proj", vec![Value::Str(toml_src.into())]).unwrap();
+    let err = match v {
+        Value::Variant { name, args } if name == "Err" => args.into_iter().next().unwrap(),
+        other => panic!("expected Err, got: {other:?}"),
+    };
+    let msg = format!("{err:?}");
+    assert!(msg.contains("project.license"),
+        "error should name the missing dotted path; got: {msg}");
+    assert!(!msg.contains("project.name"),
+        "present dotted path should not appear in error; got: {msg}");
+}
+
+#[test]
+fn missing_intermediate_object_reports_full_path() {
+    // No `[project]` section at all → both inner fields missing.
+    let v = run(TOML_SRC, "parse_proj", vec![Value::Str("name = \"top\"\n".into())]).unwrap();
+    let err = match v {
+        Value::Variant { name, args } if name == "Err" => args.into_iter().next().unwrap(),
+        other => panic!("expected Err, got: {other:?}"),
+    };
+    let msg = format!("{err:?}");
+    assert!(msg.contains("project.name") && msg.contains("project.license"),
+        "both missing dotted paths should be listed; got: {msg}");
+}
+
+#[test]
+fn intermediate_non_object_is_treated_as_missing() {
+    // `project = "MIT"` makes the intermediate a string, not an
+    // object. Walking through it should fail cleanly rather than
+    // panic or accept the descent.
+    let toml_src = r#"
+project = "MIT"
+"#;
+    let v = run(TOML_SRC, "parse_proj", vec![Value::Str(toml_src.into())]).unwrap();
+    let err = match v {
+        Value::Variant { name, args } if name == "Err" => args.into_iter().next().unwrap(),
+        other => panic!("expected Err on string-where-object, got: {other:?}"),
+    };
+    let msg = format!("{err:?}");
+    assert!(msg.contains("project.name") || msg.contains("project.license"),
+        "should report a dotted-path miss; got: {msg}");
+}
+
+#[test]
+fn deep_three_level_path_works() {
+    let src = r#"
+import "std.json" as json
+fn parse_deep(s :: Str) -> Result[Map[Str, Json], Str] {
+  json.parse_strict(s, ["a.b.c"])
+}
+"#;
+    // Present case.
+    let json = r#"{ "a": { "b": { "c": 1 } } }"#;
+    let v = run(src, "parse_deep", vec![Value::Str(json.into())]).unwrap();
+    assert!(matches!(&v, Value::Variant { name, .. } if name == "Ok"));
+
+    // Missing innermost.
+    let json = r#"{ "a": { "b": {} } }"#;
+    let v = run(src, "parse_deep", vec![Value::Str(json.into())]).unwrap();
+    let err = match v {
+        Value::Variant { name, args } if name == "Err" => args.into_iter().next().unwrap(),
+        other => panic!("expected Err, got: {other:?}"),
+    };
+    assert!(format!("{err:?}").contains("a.b.c"));
+}
+
+#[test]
+fn top_level_field_still_works() {
+    // Backward-compat: a path with no dot still works exactly as
+    // before — that's the daily-driver case from #168.
+    let src = r#"
+import "std.json" as json
+fn check_name(s :: Str) -> Result[Map[Str, Json], Str] {
+  json.parse_strict(s, ["name"])
+}
+"#;
+    let v = run(src, "check_name", vec![Value::Str(r#"{"name": "x"}"#.into())]).unwrap();
+    assert!(matches!(&v, Value::Variant { name, .. } if name == "Ok"));
+
+    let v = run(src, "check_name", vec![Value::Str(r#"{"version": "1"}"#.into())]).unwrap();
+    let err = match v {
+        Value::Variant { name, args } if name == "Err" => args.into_iter().next().unwrap(),
+        _ => panic!("expected Err"),
+    };
+    assert!(format!("{err:?}").contains("name"));
+}
+
+#[test]
+fn literal_dot_in_field_name_via_escape() {
+    // `"package\\.json"` in a Lex source becomes `package\.json`
+    // at runtime; the parse_strict path handler treats `\.` as a
+    // literal dot, so the descent doesn't split. Field names
+    // containing dots are rare but legitimate (e.g. domains).
+    let src = r#"
+import "std.json" as json
+fn check(s :: Str) -> Result[Map[Str, Json], Str] {
+  json.parse_strict(s, ["package\\.json"])
+}
+"#;
+    // `package.json` is a top-level key (with a literal dot).
+    let v = run(src, "check", vec![
+        Value::Str(r#"{ "package.json": "{}" }"#.into()),
+    ]).unwrap();
+    let is_ok = matches!(&v, Value::Variant { name, .. } if name == "Ok");
+    assert!(is_ok, "literal-dot key with `\\.` escape should pass; got: {v:?}");
+}
+
+#[test]
+fn yaml_nested_required_works_too() {
+    // YAML support uses the same `check_required_fields` plumbing,
+    // so dotted paths just work — pin it explicitly so a future
+    // refactor that splits the implementations doesn't regress.
+    let src = r#"
+import "std.yaml" as yaml
+fn check(s :: Str) -> Result[Map[Str, Json], Str] {
+  yaml.parse_strict(s, ["jobs.test"])
+}
+"#;
+    let yaml = "jobs:\n  test:\n    runs-on: ubuntu-latest\n";
+    let v = run(src, "check", vec![Value::Str(yaml.into())]).unwrap();
+    assert!(matches!(&v, Value::Variant { name, .. } if name == "Ok"));
+}

--- a/crates/lex-runtime/tests/std_cli.rs
+++ b/crates/lex-runtime/tests/std_cli.rs
@@ -1,0 +1,228 @@
+//! End-to-end tests for `std.cli` (Rubric port).
+//!
+//! Exercises the language-level surface — building a CliSpec with
+//! `cli.flag` / `cli.option` / `cli.positional` / `cli.spec`, then
+//! parsing argv with `cli.parse` and consuming the result. Covers
+//! the cases the Rubric CLI uses (six subcommands, mixed flags +
+//! options, JSON envelope, ACLI introspection).
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+
+fn run(src: &str, func: &str, args: Vec<Value>) -> Result<Value, String> {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        return Err(format!("type errors: {errs:#?}"));
+    }
+    let bc = compile_program(&stages);
+    let handler = DefaultHandler::new(Policy::permissive());
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(func, args).map_err(|e| format!("{e}"))
+}
+
+fn list_str(items: &[&str]) -> Value {
+    Value::List(items.iter().map(|s| Value::Str((*s).into())).collect())
+}
+
+#[test]
+fn build_and_parse_simple_cli() {
+    let src = r#"
+import "std.cli" as cli
+
+fn build_spec() -> Json {
+  cli.spec("rubric", "Rubric CLI", [
+    cli.flag("verbose", Some("v"), "show debug output"),
+    cli.option("output", Some("o"), "write report", None),
+    cli.positional("path", "directory to scan", true),
+  ], [])
+}
+
+fn parse_argv(argv :: List[Str]) -> Result[Json, Str] {
+  cli.parse(build_spec(), argv)
+}
+"#;
+    let v = run(src, "parse_argv", vec![list_str(&["./src", "--verbose"])]).unwrap();
+    let parsed = match v {
+        Value::Variant { name, mut args } if name == "Ok" => args.remove(0),
+        other => panic!("expected Ok, got: {other:?}"),
+    };
+    let json = parsed.to_json();
+    assert_eq!(json["positionals"]["path"], "./src");
+    assert_eq!(json["flags"]["verbose"], true);
+}
+
+#[test]
+fn six_subcommands_dispatch() {
+    // Mirror Rubric's shape: top-level + 6 subcommands. The path of
+    // the resolved command should be ["rubric", "<sub>"].
+    let src = r#"
+import "std.cli" as cli
+
+fn build_spec() -> Json {
+  cli.spec("rubric", "audit your repo", [], [
+    cli.spec("scan",   "scan a directory", [
+      cli.positional("path", "dir", true),
+    ], []),
+    cli.spec("init",   "initialise",      [], []),
+    cli.spec("report", "emit report",     [], []),
+    cli.spec("score",  "score a project", [], []),
+    cli.spec("badge",  "render a badge",  [], []),
+    cli.spec("ci",     "ci helpers",      [], []),
+  ])
+}
+
+fn parse_argv(argv :: List[Str]) -> Result[Json, Str] {
+  cli.parse(build_spec(), argv)
+}
+"#;
+    for sub in ["scan", "init", "report", "score", "badge", "ci"] {
+        // `scan` needs a path positional; everything else takes none.
+        let argv = if sub == "scan" {
+            list_str(&[sub, "./somewhere"])
+        } else {
+            list_str(&[sub])
+        };
+        let v = run(src, "parse_argv", vec![argv]).unwrap();
+        let parsed = match v {
+            Value::Variant { name, mut args } if name == "Ok" => args.remove(0).to_json(),
+            other => panic!("expected Ok for `{sub}`, got: {other:?}"),
+        };
+        let cmd = parsed["command"].as_array().unwrap();
+        assert_eq!(cmd[0], "rubric");
+        assert_eq!(cmd[1], sub, "wrong subcommand for input `{sub}`");
+    }
+}
+
+#[test]
+fn missing_required_positional_returns_err() {
+    let src = r#"
+import "std.cli" as cli
+
+fn parse_argv(argv :: List[Str]) -> Result[Json, Str] {
+  let s := cli.spec("p", "prog", [
+    cli.positional("input", "input file", true),
+  ], [])
+  cli.parse(s, argv)
+}
+"#;
+    let v = run(src, "parse_argv", vec![Value::List(vec![])]).unwrap();
+    let err = match v {
+        Value::Variant { name, mut args } if name == "Err" => args.remove(0),
+        other => panic!("expected Err, got: {other:?}"),
+    };
+    let msg = match err { Value::Str(s) => s, _ => panic!() };
+    assert!(msg.contains("missing required") && msg.contains("input"),
+        "expected missing-positional error; got: {msg}");
+}
+
+#[test]
+fn json_envelope_wraps_command_data() {
+    let src = r#"
+import "std.cli" as cli
+fn make_envelope(ok :: Bool, name :: Str) -> Json {
+  cli.envelope(ok, name, [1, 2, 3])
+}
+"#;
+    let v = run(src, "make_envelope", vec![
+        Value::Bool(true), Value::Str("rubric".into()),
+    ]).unwrap();
+    let env = v.to_json();
+    assert_eq!(env["ok"], true);
+    assert_eq!(env["command"], "rubric");
+    assert_eq!(env["data"], serde_json::json!([1, 2, 3]));
+}
+
+#[test]
+fn describe_returns_machine_readable_spec() {
+    let src = r#"
+import "std.cli" as cli
+
+fn describe_self() -> Json {
+  let s := cli.spec("rubric", "outer", [
+    cli.flag("verbose", Some("v"), ""),
+  ], [
+    cli.spec("scan", "scan dir", [], []),
+  ])
+  cli.describe(s)
+}
+"#;
+    let v = run(src, "describe_self", vec![]).unwrap();
+    let d = v.to_json();
+    assert_eq!(d["name"], "rubric");
+    assert_eq!(d["help"], "outer");
+    let subs = d["subcommands"].as_array().unwrap();
+    assert_eq!(subs.len(), 1);
+    assert_eq!(subs[0]["name"], "scan");
+}
+
+#[test]
+fn help_text_includes_args_and_subs() {
+    let src = r#"
+import "std.cli" as cli
+
+fn render_help() -> Str {
+  let s := cli.spec("rubric", "audit a project", [
+    cli.flag("verbose", Some("v"), "noisy"),
+    cli.positional("path", "directory", true),
+  ], [
+    cli.spec("scan", "scan a directory", [], []),
+  ])
+  cli.help(s)
+}
+"#;
+    let v = run(src, "render_help", vec![]).unwrap();
+    let s = match v { Value::Str(x) => x, _ => panic!() };
+    assert!(s.contains("rubric"));
+    assert!(s.contains("audit a project"));
+    assert!(s.contains("--verbose") && s.contains("-v"));
+    assert!(s.contains("<path>"));
+    assert!(s.contains("scan"));
+}
+
+#[test]
+fn double_dash_separator_collects_remaining() {
+    let src = r#"
+import "std.cli" as cli
+
+fn parse_argv(argv :: List[Str]) -> Result[Json, Str] {
+  let s := cli.spec("p", "", [
+    cli.positional("path", "", true),
+  ], [])
+  cli.parse(s, argv)
+}
+"#;
+    let v = run(src, "parse_argv", vec![
+        list_str(&["src", "--", "--would-be-flag", "rest"]),
+    ]).unwrap();
+    let parsed = match v {
+        Value::Variant { name, mut args } if name == "Ok" => args.remove(0).to_json(),
+        other => panic!("expected Ok, got: {other:?}"),
+    };
+    let remaining = parsed["remaining"].as_array().unwrap();
+    assert_eq!(remaining.len(), 2);
+    assert_eq!(remaining[0], "--would-be-flag");
+    assert_eq!(remaining[1], "rest");
+}
+
+#[test]
+fn option_with_default_when_absent_is_present_in_parsed() {
+    let src = r#"
+import "std.cli" as cli
+
+fn parse_argv(argv :: List[Str]) -> Result[Json, Str] {
+  let s := cli.spec("p", "", [
+    cli.option("level", None, "verbosity", Some("info")),
+  ], [])
+  cli.parse(s, argv)
+}
+"#;
+    let v = run(src, "parse_argv", vec![Value::List(vec![])]).unwrap();
+    let parsed = match v {
+        Value::Variant { name, mut args } if name == "Ok" => args.remove(0).to_json(),
+        other => panic!("expected Ok, got: {other:?}"),
+    };
+    assert_eq!(parsed["options"]["level"], "info");
+}

--- a/crates/lex-runtime/tests/str_slice_clamp.rs
+++ b/crates/lex-runtime/tests/str_slice_clamp.rs
@@ -1,0 +1,122 @@
+//! Tests for `str.slice` clamping behaviour.
+//!
+//! Until 2026-05-08 `str.slice` errored on any out-of-range
+//! `hi` (or any negative `lo`). That's correct as a type-system
+//! guarantee but inconvenient when slicing fixed-size prefixes off
+//! data of unknown length — e.g. taking the first 64 chars of a
+//! license header that may itself be only 32 chars. A real Rubric
+//! port tripped on this against a 32-char LICENSE file.
+//!
+//! New behaviour: `hi` is clamped to `s.len()`, `lo` is clamped to
+//! `[0, s.len()]`. `lo > hi` after clamping still errors (caller
+//! logic bug). A mid-codepoint `lo` after clamping still errors so
+//! silent UTF-8 truncation never sneaks through.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+
+fn run(src: &str, func: &str, args: Vec<Value>) -> Result<Value, String> {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        return Err(format!("type errors: {errs:#?}"));
+    }
+    let bc = compile_program(&stages);
+    let handler = DefaultHandler::new(Policy::permissive());
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(func, args).map_err(|e| format!("{e}"))
+}
+
+const SRC: &str = r#"
+import "std.str" as str
+fn slice(s :: Str, lo :: Int, hi :: Int) -> Str { str.slice(s, lo, hi) }
+"#;
+
+#[test]
+fn in_range_slice_returns_substring() {
+    let v = run(SRC, "slice", vec![
+        Value::Str("hello".into()), Value::Int(1), Value::Int(4),
+    ]).unwrap();
+    assert_eq!(v, Value::Str("ell".into()));
+}
+
+#[test]
+fn hi_past_end_clamps_to_len() {
+    // The 32-char-LICENSE case — agent code did `slice(text, 0, 64)`
+    // and was rejected. Now `hi` clamps to `len`.
+    let v = run(SRC, "slice", vec![
+        Value::Str("MIT License (32 char-ish here)".into()),
+        Value::Int(0), Value::Int(64),
+    ]).unwrap();
+    assert_eq!(v, Value::Str("MIT License (32 char-ish here)".into()));
+}
+
+#[test]
+fn lo_past_end_yields_empty_string() {
+    // `slice(s, 100, 200)` on a 5-char string clamps both ends to 5
+    // and returns "". Cleaner than erroring — a downstream
+    // length-check still works.
+    let v = run(SRC, "slice", vec![
+        Value::Str("hello".into()),
+        Value::Int(100), Value::Int(200),
+    ]).unwrap();
+    assert_eq!(v, Value::Str("".into()));
+}
+
+#[test]
+fn negative_lo_clamps_to_zero() {
+    // Casual `slice(s, -5, 3)` (e.g. agent emitting "the last N
+    // characters" before realising slices are absolute) clamps
+    // `lo` to 0 instead of erroring.
+    let v = run(SRC, "slice", vec![
+        Value::Str("hello".into()),
+        Value::Int(-5), Value::Int(3),
+    ]).unwrap();
+    assert_eq!(v, Value::Str("hel".into()));
+}
+
+#[test]
+fn negative_hi_clamps_to_zero_yielding_empty() {
+    let v = run(SRC, "slice", vec![
+        Value::Str("hello".into()),
+        Value::Int(0), Value::Int(-1),
+    ]).unwrap();
+    assert_eq!(v, Value::Str("".into()));
+}
+
+#[test]
+fn lo_greater_than_hi_after_clamping_errors() {
+    // Caller logic bug: still surfaces an error so it's not silently
+    // ignored. The error mentions "reversed" so messages don't get
+    // confused with the old "out of range" wording.
+    let err = run(SRC, "slice", vec![
+        Value::Str("hello".into()),
+        Value::Int(4), Value::Int(2),
+    ]).unwrap_err();
+    assert!(err.to_lowercase().contains("reversed"),
+        "expected reversed-range error, got: {err}");
+}
+
+#[test]
+fn mid_codepoint_lo_still_errors() {
+    // "héllo" is 6 bytes (h-é(0xc3 0xa9)-l-l-o). lo=2 lands inside
+    // 'é'. Clamping is purely length-based; UTF-8 boundary errors
+    // remain so callers don't accidentally produce ill-formed
+    // strings.
+    let err = run(SRC, "slice", vec![
+        Value::Str("héllo".into()),
+        Value::Int(2), Value::Int(5),
+    ]).unwrap_err();
+    assert!(err.contains("char boundaries"),
+        "expected char-boundary error, got: {err}");
+}
+
+#[test]
+fn empty_string_with_any_range_is_empty() {
+    let v = run(SRC, "slice", vec![
+        Value::Str("".into()), Value::Int(0), Value::Int(10),
+    ]).unwrap();
+    assert_eq!(v, Value::Str("".into()));
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -1259,6 +1259,67 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 Ty::Con("Result".into(), vec![Ty::Var(0), parse_err()])));
             Some(Ty::Record(fields))
         }
+        "cli" => {
+            // #224 Rubric port: argparse-equivalent for end-user
+            // programs. Spec values are tagged `Json` records (opaque
+            // to the language but inspectable). Construction via the
+            // `flag` / `option` / `positional` / `spec` builders;
+            // parse + introspection / help via the remaining ops.
+            let json = || Ty::Con("Json".into(), vec![]);
+            let opt_str = || Ty::Con("Option".into(), vec![Ty::str()]);
+            let mut fields = IndexMap::new();
+            // flag :: Str -> Option[Str] -> Str -> Json
+            //   long_name -> short -> help -> CliArg
+            fields.insert("flag".into(), Ty::function(
+                vec![Ty::str(), opt_str(), Ty::str()],
+                EffectSet::empty(),
+                json()));
+            // option :: Str -> Option[Str] -> Str -> Option[Str] -> Json
+            //   long_name -> short -> help -> default -> CliArg
+            fields.insert("option".into(), Ty::function(
+                vec![Ty::str(), opt_str(), Ty::str(), opt_str()],
+                EffectSet::empty(),
+                json()));
+            // positional :: Str -> Str -> Bool -> Json
+            //   name -> help -> required -> CliArg
+            fields.insert("positional".into(), Ty::function(
+                vec![Ty::str(), Ty::str(), Ty::bool()],
+                EffectSet::empty(),
+                json()));
+            // spec :: Str -> Str -> List[Json] -> List[Json] -> Json
+            //   name -> help -> args -> subcommands -> CliSpec
+            fields.insert("spec".into(), Ty::function(
+                vec![Ty::str(), Ty::str(),
+                     Ty::List(Box::new(json())),
+                     Ty::List(Box::new(json()))],
+                EffectSet::empty(),
+                json()));
+            // parse :: Json -> List[Str] -> Result[Json, Str]
+            //   spec -> argv -> Result[CliParsed, error]
+            fields.insert("parse".into(), Ty::function(
+                vec![json(), Ty::List(Box::new(Ty::str()))],
+                EffectSet::empty(),
+                Ty::Con("Result".into(), vec![json(), Ty::str()])));
+            // envelope :: Bool -> Str -> T -> Json
+            //   ok -> command -> data -> ACLI-shaped envelope.
+            // `data` is polymorphic so callers don't have to round-
+            // trip through `json.parse` for trivial payloads.
+            fields.insert("envelope".into(), Ty::function(
+                vec![Ty::bool(), Ty::str(), Ty::Var(0)],
+                EffectSet::empty(),
+                json()));
+            // describe :: Json -> Json — machine-readable spec dump
+            fields.insert("describe".into(), Ty::function(
+                vec![json()],
+                EffectSet::empty(),
+                json()));
+            // help :: Json -> Str — human-readable help text
+            fields.insert("help".into(), Ty::function(
+                vec![json()],
+                EffectSet::empty(),
+                Ty::str()));
+            Some(Ty::Record(fields))
+        }
         "regex" => {
             // The compiled `Regex` is stored as a `Str` at runtime
             // (the pattern source) plus a process-wide cache of the
@@ -1589,6 +1650,7 @@ pub fn module_for_import(reference: &str) -> Option<&'static str> {
         "csv" => "csv",
         "test" => "test",
         "agent" => "agent",
+        "cli" => "cli",
         _ => return None,
     })
 }


### PR DESCRIPTION
All three Rubric-port follow-ups from the v0.8 brief, on the same branch.

| Commit | Scope |
|---|---|
| `c31568b` | `str.slice` clamps out-of-range bounds |
| `2f07a61` | `parse_strict` accepts dotted paths for nested required fields |
| `3830d38` | `std.cli` — argparse-equivalent for end-user programs |

---

## Part 1 — `str.slice` clamping (`c31568b`)

`str.slice(s, lo, hi)` was rejecting any `hi > s.len()` (or any negative `lo`) with a typed error. Real Rubric port tripped on a 32-char `LICENSE` file — agent code did `slice(text, 0, 64)` and got an error.

| Input | Before | After |
|---|---|---|
| `slice("hello", 1, 4)` | `"ell"` | `"ell"` |
| `slice("MIT", 0, 64)` | error | `"MIT"` (clamps `hi`) |
| `slice("hello", 100, 200)` | error | `""` (clamps both ends) |
| `slice("hello", -5, 3)` | huge `usize` → error | `"hel"` (clamps `lo` to 0) |
| `slice("hello", 4, 2)` | error | error (still — caller logic bug) |
| `slice("héllo", 2, 5)` | error (mid-codepoint) | error (mid-codepoint, unchanged) |

Matches Python's `s[lo:hi]` semantics for the common case without losing UTF-8 safety. The mid-codepoint check stays so silent UTF-8 truncation can't sneak through.

8 tests in `crates/lex-runtime/tests/str_slice_clamp.rs`.

---

## Part 2 — Nested `parse_strict` via dotted paths (`2f07a61`)

`parse_strict` originally only validated top-level required fields. The Rubric port hit two real cases:

* **`pyproject.toml`** — `[project].license` is a nested required field. Workaround was regex extraction.
* **GitHub Actions workflows** — most steps require `run` xor `uses`, itself under `jobs.<job>.steps[]`.

Now each entry in the required-fields list may be a plain field name (top-level, as before) **or** a dotted path that descends through nested objects:

```lex
toml.parse_strict(text, ["project.name", "project.license"])
```

### Path semantics

* `"name"` — top-level `name` must exist (any value).
* `"a.b.c"` — walk `a`, then `b`, then check `c`. Each intermediate must itself be an object.
* `"package\.json"` — literal-dot escape, for field names that genuinely contain a dot.

### Why dotted paths and not `Option[F]` auto-wrap

The user-stated "cleanest fix" is `Option[F]` auto-wrap on `parse[T]`, deriving the required-fields set from `T` at type-check time. That requires plumbing the type system into the runtime. Deferred to its own slice. The dotted-path approach lands the agent-usable behaviour today without that lift.

8 tests in `crates/lex-runtime/tests/parse_strict_nested.rs`.

---

## Part 3 — `std.cli` (`3830d38`)

The Rubric CLI has six subcommands with mixed positional / option / flag args, JSON envelope output, and ACLI introspection. Hand-rolling each was ~3 days of clipped-wing work; this module makes them one-liners.

### API

```
cli.flag(name, short, help)            -> Json    # boolean flag
cli.option(name, short, help, default) -> Json    # name=value option
cli.positional(name, help, required)   -> Json    # positional arg
cli.spec(name, help, args, subs)       -> Json    # CliSpec
cli.parse(spec, argv)  -> Result[Json, Str]       # top-level parser
cli.envelope(ok, cmd, data)            -> Json    # ACLI envelope
cli.describe(spec)                     -> Json    # introspection
cli.help(spec)                         -> Str     # human help text
```

### Parsed shape

```json
{
  "command":     ["rubric", "scan"],
  "flags":       { "verbose": true },
  "options":     { "output": "report.json" },
  "positionals": { "path": "./src" },
  "remaining":   []
}
```

### Behaviour highlights

* `--name=value` and `--name value` both supported for options.
* Long form `--name` and short form `-x` for both flags and options.
* `--` ends flag/option parsing; everything after lands in `remaining`.
* Subcommands have their own flag namespace (parent flags don't inherit). Re-declare on the child if you need them.
* Options with a `default` are present in the parsed `options` even when absent from argv — consumers don't need missing-key handling.
* Boolean flags default to `false` for the same reason.
* `cli.envelope` shape mirrors `acli`'s output envelope so user programs match `lex`'s own `--output json` shape.

14 unit tests + 8 e2e tests covering positional/flag/option mixtures, defaults, missing-required, unknown-flag, double-dash separator, subcommand descent, JSON envelope, introspection, and help-text rendering.

---

## Test plan

- [x] 30 new tests across the three slices.
- [x] Workspace: **1107 passing, 0 failing**.
- [x] `cargo clippy --all-targets -- -D warnings` clean.

## Follow-ups (separate PRs, not blocking the Rubric port)

* **`Option[F]` auto-wrap** for `parse[T]` (the cleaner long-term fix). Type-system + runtime plumbing.
* **`xor` / `one-of`** constraints in `parse_strict` (workflow-step `run` vs `uses`).
* **`std.cli` ACLI introspection wiring** so `lex` itself surfaces user-program specs via the standard `--introspect` envelope.

https://claude.ai/code/session_016SGtf28wA4CgAem65XrjPt