### PR TITLE
lex-vcs: OpId stability spec — golden tests + canonical-form invariants (#243)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to lex-lang. The format follows
 versioning follows [SemVer](https://semver.org/) (pre-1.0; minor
 bumps may carry breaking changes when justified).
 
+## [Unreleased]
+
+### Added — agent-VCS roadmap (#244)
+
+- **`OperationFormat` enum + version-aware canonical encoder**
+  (#244). `Operation::canonical_bytes_in(format)` and
+  `Operation::op_id_in(format)` route through a per-format encoder.
+  Today only `OperationFormat::V1` is in production; the
+  infrastructure exists so a future `OperationKind` schema change
+  is an explicit, migrate-able event rather than a silent
+  invalidation of every existing `OpId`.
+- **`OperationRecord.format_version`** persisted in the on-disk
+  JSON. Pre-#244 records (no field) deserialize to `V1` (serde
+  default); V1 records continue to omit the field on write
+  (`skip_serializing_if = is_implicit`), so adding it doesn't
+  rotate any existing `OpId` or change any on-disk byte.
+- **`lex_vcs::migrate`** module with `plan_migration` /
+  `apply_migration`. Two-phase rewrite: write all new
+  `<new_op_id>.json` files, then delete old ones. Crash mid-
+  migration leaves both old and new files coexisting, each
+  internally consistent. Topological order ensures parents are
+  remapped before any child references them.
+- **`lex store migrate-ops --to <format> [--dry-run | --confirm]`**
+  CLI command. Required `--dry-run` or `--confirm` because the
+  `--confirm` path is destructive (deletes old op-log files,
+  rewrites every `<root>/branches/*.json` head_op through the
+  mapping). Reports the old→new op_id mapping for every op.
+
+### Internal
+
+- **V1→V2 migration rewrites every `OpId`.** When a future
+  `OperationFormat::V2` lands, the canonical pre-image bytes will
+  change for every op, so every `OpId` rotates. The migration tool
+  is the only safe path; manual surgery on `<root>/ops/` will
+  break parent-chain integrity. The `--dry-run` mode is mandatory
+  reading before committing.
+- **Attestation cascade is a known follow-up.** `AttestationId` is
+  computed including `op_id`, so rotating op_ids leaves
+  attestations dangling (their stored `op_id` field points to
+  deleted records, and their own ids are now stale). The
+  `migrate-ops` command warns about this; an attestation-log
+  migration is a separate piece of work tracked alongside #244.
+
 ## [0.3.0] — 2026-05-08
 
 Stage signing, semantic search over the store, a stable binary

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -161,6 +161,7 @@ fn print_usage() {
     println!("                                     print stage metadata + canonical AST;");
     println!("                                     verify Ed25519 signature when present.");
     println!("  store search [--store DIR] [--limit N] \"<query>\"");
+    println!("  store migrate-ops [--store DIR] --to v1 [--dry-run | --confirm]");
     println!("                                     semantic search over active stages,");
     println!("                                     ranked by description+signature+examples.");
     println!("  stage <stage> [--attestations]     print stage info, or list its attestations");
@@ -1466,8 +1467,195 @@ fn cmd_store(fmt: &OutputFormat, args: &[String]) -> Result<()> {
             Ok(())
         }
         "search" => cmd_store_search(fmt, rest),
+        "migrate-ops" => cmd_store_migrate_ops(fmt, rest),
         other => bail!("unknown `lex store` subcommand: {other}"),
     }
+}
+
+/// `lex store migrate-ops` (#244). Re-canonicalize every op in the
+/// store under a target [`OperationFormat`]. Today only V1 exists,
+/// so the production migration is always a no-op; the command
+/// surfaces the plan/apply mechanism that future format bumps will
+/// rely on.
+///
+/// Flags:
+/// * `--to v1` (required) — the target format. Future variants will
+///   accept their own tags.
+/// * `--dry-run` — print the old→new mapping without rewriting any
+///   files. Mutually exclusive with `--confirm`.
+/// * `--confirm` — apply the migration. **Destructive**: deletes
+///   the old `<root>/ops/<old_op_id>.json` files and rewrites
+///   `<root>/branches/*.json` so `head_op` references the new ids.
+///   Attestations are *not* rewritten in this slice — see #244 and
+///   the attestation cascade follow-up.
+fn cmd_store_migrate_ops(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    // `parse_store_flag` already consumes `--dry-run` and returns it
+    // as the 4th tuple element; we honor that, not a re-parse from
+    // the remainder.
+    let (root, rest, _activate, dry_run) = parse_store_flag(args);
+    let mut target_str: Option<String> = None;
+    let mut confirm = false;
+    let mut iter = rest.iter();
+    while let Some(a) = iter.next() {
+        match a.as_str() {
+            "--to" => {
+                target_str = Some(iter.next()
+                    .ok_or_else(|| anyhow!("--to needs a format tag (today: v1)"))?
+                    .clone());
+            }
+            "--confirm" => confirm = true,
+            other => bail!("unknown flag `{other}` for `lex store migrate-ops`"),
+        }
+    }
+    if dry_run && confirm {
+        bail!("--dry-run and --confirm are mutually exclusive");
+    }
+    if !dry_run && !confirm {
+        bail!(
+            "lex store migrate-ops is destructive — pass --dry-run to preview, \
+             --confirm to apply"
+        );
+    }
+    let target_str = target_str
+        .ok_or_else(|| anyhow!("--to <format> is required (today: v1)"))?;
+    let target: lex_vcs::OperationFormat = match target_str.as_str() {
+        "v1" | "V1" => lex_vcs::OperationFormat::V1,
+        other => bail!("unknown operation format `{other}` — supported: v1"),
+    };
+
+    let log = lex_vcs::OpLog::open(&root)
+        .with_context(|| format!("opening op log at {}", root.display()))?;
+    let plan = lex_vcs::migrate::plan_migration(&log, target)
+        .with_context(|| "planning migration")?;
+
+    let mapping = plan.mapping();
+    let changed: Vec<&lex_vcs::migrate::MigrationStep> = plan
+        .steps
+        .iter()
+        .filter(|s| s.old_op_id != s.new_op_id)
+        .collect();
+
+    let mappings_json: Vec<serde_json::Value> = plan
+        .steps
+        .iter()
+        .map(|s| {
+            serde_json::json!({
+                "old": s.old_op_id,
+                "new": s.new_op_id,
+                "changed": s.old_op_id != s.new_op_id,
+            })
+        })
+        .collect();
+
+    let summary = serde_json::json!({
+        "target_format": format!("{:?}", target).to_lowercase(),
+        "total_ops": plan.steps.len(),
+        "rotated_op_ids": changed.len(),
+        "is_no_op": plan.is_no_op(),
+        "applied": false,
+        "mappings": mappings_json,
+    });
+
+    if dry_run {
+        acli::emit_or_text("store-migrate-ops", summary.clone(), fmt, || {
+            println!(
+                "would migrate {} ops to {:?}; {} op_ids would rotate (dry-run, no files written)",
+                plan.steps.len(),
+                target,
+                changed.len(),
+            );
+            for s in &plan.steps {
+                if s.old_op_id != s.new_op_id {
+                    println!("  {} → {}", s.old_op_id, s.new_op_id);
+                }
+            }
+            if !changed.is_empty() {
+                println!(
+                    "\nNote: applying with --confirm will also rewrite branch heads. \
+                     Attestations are NOT rewritten by this command — that cascade is a \
+                     known follow-up to #244."
+                );
+            }
+        });
+        return Ok(());
+    }
+
+    // --confirm path: apply.
+    lex_vcs::migrate::apply_migration(&log, &plan)
+        .with_context(|| "applying migration")?;
+
+    let branch_updates = rewrite_branch_heads(&root, &mapping)
+        .with_context(|| "rewriting branch heads")?;
+
+    let summary = serde_json::json!({
+        "target_format": format!("{:?}", target).to_lowercase(),
+        "total_ops": plan.steps.len(),
+        "rotated_op_ids": changed.len(),
+        "is_no_op": plan.is_no_op(),
+        "applied": true,
+        "branches_updated": branch_updates,
+        "mappings": summary["mappings"].clone(),
+    });
+    acli::emit_or_text("store-migrate-ops", summary, fmt, || {
+        println!(
+            "migrated {} ops to {:?}; {} op_ids rotated; {} branch heads rewritten",
+            plan.steps.len(),
+            target,
+            changed.len(),
+            branch_updates,
+        );
+        if !changed.is_empty() {
+            println!(
+                "\nNote: attestations were NOT rewritten — their `attestation_id` \
+                 cascades from `op_id` and needs its own migration step. See #244."
+            );
+        }
+    });
+    Ok(())
+}
+
+/// Walk `<root>/branches/*.json`, parse each, and rewrite `head_op`
+/// in place if the current value appears in `mapping`. Returns the
+/// number of branch files that changed.
+///
+/// Bypasses `lex-store`'s `set_branch_head_op` (which is `pub(crate)`)
+/// because this is a one-shot supervised rewrite invoked by the
+/// `migrate-ops` command — not a normal write path.
+fn rewrite_branch_heads(
+    root: &std::path::Path,
+    mapping: &std::collections::BTreeMap<String, String>,
+) -> Result<usize> {
+    let dir = root.join("branches");
+    if !dir.exists() {
+        return Ok(0);
+    }
+    let mut updated = 0usize;
+    for entry in std::fs::read_dir(&dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let bytes = std::fs::read(&path)?;
+        let mut value: serde_json::Value = serde_json::from_slice(&bytes)
+            .with_context(|| format!("parsing {}", path.display()))?;
+        let mut changed = false;
+        if let Some(head) = value.get("head_op").and_then(|v| v.as_str()) {
+            if let Some(new) = mapping.get(head) {
+                value["head_op"] = serde_json::Value::String(new.clone());
+                changed = true;
+            }
+        }
+        if changed {
+            let new_bytes = serde_json::to_vec_pretty(&value)
+                .with_context(|| format!("serializing {}", path.display()))?;
+            let tmp = path.with_extension("json.tmp");
+            std::fs::write(&tmp, &new_bytes)?;
+            std::fs::rename(&tmp, &path)?;
+            updated += 1;
+        }
+    }
+    Ok(updated)
 }
 
 /// `lex store search "<query>"` (#224). Embeds the query and ranks

--- a/crates/lex-vcs/src/canonical.rs
+++ b/crates/lex-vcs/src/canonical.rs
@@ -1,39 +1,70 @@
-//! Canonical JSON serialization for hashing.
+//! Canonical JSON serialization for hashing — the V1 canonical form
+//! that every existing `OpId` was computed under.
 //!
-//! The contract is narrow: given any `Serialize` value, produce a byte
-//! sequence such that two values that *should* hash equal produce
-//! identical bytes. We get there by:
+//! # The V1 canonical form (authoritative spec)
 //!
-//! 1. **Field order from the struct/enum declaration.** `serde_json`
-//!    emits struct fields in the order they appear in the type. Since
-//!    we control the operation enum, this gives us a stable layout
-//!    without sorting at serialize time. The risk is that *changing*
-//!    the type's field order silently rewrites every `OpId`; the
-//!    operation tests below pin a few golden hashes so a refactor
-//!    that breaks identity surfaces as a test failure.
+//! These are the rules every contributor to an `OpId` must follow.
+//! Violating any of them silently rewrites every `OpId` in every
+//! existing store. Issue #244 covers versioning the form so future
+//! evolutions are explicit; until then, treat each rule as
+//! load-bearing.
 //!
-//! 2. **`BTreeSet` / `BTreeMap` for unordered collections.** Effect
-//!    sets are `BTreeSet<String>` so iteration is sorted. If we ever
-//!    add a map-shaped field (e.g. for variant payloads), it should
-//!    use `BTreeMap` for the same reason.
+//! 1. **Compact JSON** (`serde_json::to_vec`). No pretty-printing,
+//!    no trailing whitespace. The compact form has no formatting
+//!    choices, so two independent serializers produce the same
+//!    bytes.
+//! 2. **Field order from the struct/enum declaration.** `serde_json`
+//!    emits struct fields in declaration order. Reordering an
+//!    `OperationKind` variant's fields (or the `CanonicalView`
+//!    struct's fields) rotates every `OpId`.
+//! 3. **`BTreeSet` for unordered string sets.** [`crate::EffectSet`]
+//!    is a `BTreeSet<String>` so iteration is sorted by string
+//!    order. Any new set-shaped field must use `BTreeSet`; a
+//!    `HashSet` is not acceptable.
+//! 4. **`BTreeMap` for unordered key-value collections.**
+//!    `StageTransition::Merge { entries }` is a
+//!    `BTreeMap<SigId, Option<StageId>>`. Iteration is sorted by
+//!    `SigId`, so insertion order is irrelevant. Any new map-shaped
+//!    field must use `BTreeMap`.
+//! 5. **`Vec<OpId>` parents are sorted and deduped before
+//!    hashing.** [`crate::Operation::new`] does this at construction
+//!    time; [`crate::Operation::canonical_bytes`] re-sorts via a
+//!    transient `BTreeSet<&OpId>` so a hand-constructed
+//!    `Operation { parents: vec![...] }` still hashes canonically.
+//! 6. **Empty `parents` arrays are emitted in the canonical form.**
+//!    This differs from the on-disk JSON shape (which skips empty
+//!    `parents`) — see [`crate::Operation::canonical_bytes`] for the
+//!    exact pre-image fed to SHA-256.
+//! 7. **Optional fields use `skip_serializing_if = "Option::is_none"`
+//!    so `None` is omitted entirely.** Adding a `Some(...)` value
+//!    where `None` was rotates the `OpId`; that's intentional (see
+//!    `Operation::with_intent`). Switching from `Option<T>` to a
+//!    `T` with a default value is a canonical-form break.
+//! 8. **SHA-256 to lowercase hex.** 64 ASCII chars; uppercase or
+//!    truncation is a canonical-form break.
 //!
-//! 3. **`serde_json` compact emit.** No pretty-printing, no trailing
-//!    whitespace. The compact form is canonical because it has no
-//!    formatting choices.
-//!
-//! The only thing we explicitly *don't* do here is recursive key
-//! sorting on arbitrary `serde_json::Value` trees. We don't need it:
-//! every type that contributes to an [`OpId`] is concrete and uses
-//! one of the three patterns above. If you find yourself wanting to
-//! hash a `serde_json::Value` directly, route it through a typed
-//! struct first.
+//! The only thing this module deliberately *does not* do is
+//! recursive key sorting on arbitrary `serde_json::Value` trees.
+//! That's not necessary because every type that contributes to an
+//! [`crate::OpId`] is concrete and uses one of the patterns above.
+//! If you find yourself wanting to hash a `serde_json::Value`
+//! directly, route it through a typed struct first.
 
 use sha2::{Digest, Sha256};
 
 /// Hash a serializable value to a 64-char lowercase hex digest.
+///
+/// Internal helper for places that hash typed structs directly.
+/// New callers should prefer [`crate::Operation::canonical_bytes`]
+/// + [`hash_bytes`] so the pre-image stays inspectable.
 pub(crate) fn hash<T: serde::Serialize>(value: &T) -> String {
     let bytes = serde_json::to_vec(value).expect("canonical serialization");
-    let digest = Sha256::digest(&bytes);
+    hash_bytes(&bytes)
+}
+
+/// Hash an already-canonicalized byte sequence to lowercase hex.
+pub(crate) fn hash_bytes(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
     let mut out = String::with_capacity(digest.len() * 2);
     for b in digest.iter() {
         out.push_str(&format!("{b:02x}"));

--- a/crates/lex-vcs/src/lib.rs
+++ b/crates/lex-vcs/src/lib.rs
@@ -38,6 +38,7 @@ mod gate;
 mod intent;
 mod merge;
 mod merge_session;
+pub mod migrate;
 mod op_log;
 mod operation;
 mod predicate;
@@ -62,6 +63,6 @@ pub use predicate::{evaluate, evaluate_with_resolver, IntentResolver, Predicate}
 pub use signing::{verify_stage_id, Keypair, SigningError};
 pub use op_log::OpLog;
 pub use operation::{
-    EffectSet, ModuleRef, OpId, Operation, OperationRecord, OperationKind, SigId, StageId,
-    StageTransition,
+    EffectSet, ModuleRef, OpId, Operation, OperationFormat, OperationKind, OperationRecord, SigId,
+    StageId, StageTransition,
 };

--- a/crates/lex-vcs/src/migrate.rs
+++ b/crates/lex-vcs/src/migrate.rs
@@ -1,0 +1,341 @@
+//! Operation-format migration (#244).
+//!
+//! When [`crate::OperationFormat`] gains a new variant, every existing
+//! `OpId` rotates: the canonical pre-image bytes change, so the
+//! SHA-256 digest changes. A naïve in-place rewrite would also
+//! invalidate every parent reference in dependent ops.
+//!
+//! This module computes a [`MigrationPlan`] — a topologically-ordered
+//! list of [`MigrationStep`]s, one per op, each containing the new
+//! `OpId` and the new [`OperationRecord`] with parents already
+//! remapped — and then writes the new files in a two-phase
+//! `apply_migration`: write-new, then delete-old. The intermediate
+//! state has both old and new files coexisting (each consistent
+//! within its own version), so a crash mid-migration leaves the
+//! store readable.
+//!
+//! # What's in scope
+//!
+//! - The op log under `<root>/ops/<op_id>.json`. Parents are remapped
+//!   transitively; the topological sort guarantees a parent is
+//!   migrated before any child.
+//!
+//! # What's NOT in scope (yet)
+//!
+//! - **Branch heads** (`<root>/branches/<name>.json`) reference op_ids.
+//!   The CLI ([`lex store migrate-ops`](../../../lex_cli/index.html))
+//!   walks the branch directory after `apply_migration` and rewrites
+//!   each branch's `head_op` through the returned mapping.
+//! - **Attestations** carry an `op_id` field and their own `attestation_id`
+//!   is computed including that op_id, so they cascade. Attestation
+//!   migration is a follow-up — see the CHANGELOG entry for #244.
+//! - **Intents** don't reference op_ids; ops reference intents. No
+//!   action needed here.
+
+use crate::op_log::OpLog;
+use crate::operation::{OpId, Operation, OperationFormat, OperationRecord};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::io;
+
+/// Describes the work needed to move an op log from one canonical
+/// form to another. Built by [`plan_migration`]; consumed by
+/// [`apply_migration`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MigrationPlan {
+    pub from: OperationFormat,
+    pub to: OperationFormat,
+    /// Steps in topological order — every step's parents have
+    /// already appeared earlier in the list, so applying in order
+    /// keeps the partial DAG self-consistent.
+    pub steps: Vec<MigrationStep>,
+}
+
+/// One op's migration plan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MigrationStep {
+    pub old_op_id: OpId,
+    pub new_op_id: OpId,
+    /// The [`OperationRecord`] that will replace `old_op_id`'s file.
+    /// Its `op.parents` already reference the *new* op_ids; its
+    /// `op_id` field equals `new_op_id`; its `format_version` equals
+    /// the plan's `to` field.
+    pub new_record: OperationRecord,
+}
+
+impl MigrationPlan {
+    /// `true` if every step's old and new `op_id` agree — applying
+    /// the plan would be a no-op. Note that `from == to` does **not**
+    /// imply this: tests inject custom encoders that produce
+    /// different bytes for the same source format, in which case
+    /// `from == to == V1` but the migration is meaningful.
+    pub fn is_no_op(&self) -> bool {
+        self.steps.iter().all(|s| s.old_op_id == s.new_op_id)
+    }
+
+    /// Old → new op_id mapping in deterministic order.
+    pub fn mapping(&self) -> BTreeMap<OpId, OpId> {
+        self.steps
+            .iter()
+            .map(|s| (s.old_op_id.clone(), s.new_op_id.clone()))
+            .collect()
+    }
+}
+
+/// Plan a migration to `target`, using the encoder paired with that
+/// format. Production callers want this; tests that need to inject a
+/// different encoder (to simulate a future variant without adding it
+/// to the production enum) should use [`plan_migration_with_encoder`].
+pub fn plan_migration(log: &OpLog, target: OperationFormat) -> io::Result<MigrationPlan> {
+    plan_migration_with_encoder(log, target, |op| op.canonical_bytes_in(target))
+}
+
+/// Plan a migration with a custom canonical encoder. Used by the
+/// conformance test in `tests/migrate.rs` to simulate a hypothetical
+/// V2 by adding a synthetic suffix to V1's pre-image, without
+/// requiring a placeholder variant in production code.
+pub fn plan_migration_with_encoder<F>(
+    log: &OpLog,
+    target: OperationFormat,
+    encoder: F,
+) -> io::Result<MigrationPlan>
+where
+    F: Fn(&Operation) -> Vec<u8>,
+{
+    let all = log.list_all()?;
+    let mut by_id: BTreeMap<OpId, OperationRecord> = BTreeMap::new();
+    for rec in all {
+        by_id.insert(rec.op_id.clone(), rec);
+    }
+    let topo = topological_sort(&by_id)?;
+    let from = detect_from_format(&by_id);
+
+    let mut mapping: BTreeMap<OpId, OpId> = BTreeMap::new();
+    let mut steps = Vec::with_capacity(topo.len());
+    for old_id in topo {
+        let rec = by_id
+            .get(&old_id)
+            .ok_or_else(|| io::Error::other(format!("op {old_id} disappeared during migration")))?
+            .clone();
+        let remapped_parents: Vec<OpId> = rec
+            .op
+            .parents
+            .iter()
+            .map(|p| {
+                mapping
+                    .get(p)
+                    .cloned()
+                    // A parent without a mapping is a parent we
+                    // didn't see during list_all — treat as a
+                    // dangling reference and preserve the original
+                    // string. The apply step will surface this as a
+                    // broken DAG when it tries to chase the missing
+                    // op file.
+                    .unwrap_or_else(|| p.clone())
+            })
+            .collect();
+        let new_op = Operation {
+            kind: rec.op.kind.clone(),
+            parents: remapped_parents,
+            intent_id: rec.op.intent_id.clone(),
+        };
+        let new_bytes = encoder(&new_op);
+        let new_op_id = crate::canonical::hash_bytes(&new_bytes);
+        let new_record = OperationRecord {
+            op_id: new_op_id.clone(),
+            format_version: target,
+            op: new_op,
+            produces: rec.produces.clone(),
+        };
+        mapping.insert(old_id.clone(), new_op_id.clone());
+        steps.push(MigrationStep {
+            old_op_id: old_id,
+            new_op_id,
+            new_record,
+        });
+    }
+
+    Ok(MigrationPlan {
+        from,
+        to: target,
+        steps,
+    })
+}
+
+/// Apply a [`MigrationPlan`] to a live op log. Two-phase:
+///
+/// 1. Write every new `<new_op_id>.json` file. Idempotent — pre-
+///    existing files (including the rare case where new == old) are
+///    no-ops.
+/// 2. Delete every old `<old_op_id>.json` file whose new id is
+///    different.
+///
+/// On crash between phases the store is double-sized but readable;
+/// re-running the plan converges. **Branch heads and attestations
+/// are not rewritten by this function** — see module docs.
+pub fn apply_migration(log: &OpLog, plan: &MigrationPlan) -> io::Result<()> {
+    if plan.is_no_op() {
+        return Ok(());
+    }
+
+    // Phase 1: write all new records.
+    for step in &plan.steps {
+        log.put(&step.new_record)?;
+    }
+
+    // Phase 2: delete old files whose ids changed. We collect the
+    // set of new ids first so we never delete a file that's also
+    // a new file (the `new == old` case).
+    let new_ids: BTreeSet<&OpId> = plan.steps.iter().map(|s| &s.new_op_id).collect();
+    for step in &plan.steps {
+        if step.old_op_id != step.new_op_id && !new_ids.contains(&step.old_op_id) {
+            log.delete(&step.old_op_id)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Topological sort of the op DAG (parents before children). Stable
+/// across runs because we process nodes in `BTreeMap` iteration
+/// order — sorted by `op_id` — which matches the deterministic
+/// canonical-form requirement.
+fn topological_sort(by_id: &BTreeMap<OpId, OperationRecord>) -> io::Result<Vec<OpId>> {
+    let mut indegree: BTreeMap<&OpId, usize> = BTreeMap::new();
+    for id in by_id.keys() {
+        indegree.insert(id, 0);
+    }
+    for rec in by_id.values() {
+        for parent in &rec.op.parents {
+            // Only count parents that are present in the log; a
+            // missing parent is a dangling reference, not a cycle.
+            if by_id.contains_key(parent) {
+                *indegree.entry(&rec.op_id).or_insert(0) += 1;
+            }
+        }
+    }
+
+    // Kahn: start with all zero-indegree nodes, process in BTreeMap
+    // order (which is sorted). Each processed node decrements its
+    // children's indegrees.
+    let mut queue: VecDeque<OpId> = indegree
+        .iter()
+        .filter(|(_, d)| **d == 0)
+        .map(|(id, _)| (*id).clone())
+        .collect();
+    let mut out = Vec::with_capacity(by_id.len());
+    while let Some(id) = queue.pop_front() {
+        out.push(id.clone());
+        // Find children of `id` — ops whose parents include `id`.
+        // BTreeMap iteration is sorted, so children-discovery order
+        // is deterministic.
+        for (child_id, child_rec) in by_id {
+            if child_rec.op.parents.contains(&id) {
+                let d = indegree.get_mut(child_id).expect("indegree present");
+                *d -= 1;
+                if *d == 0 {
+                    queue.push_back(child_id.clone());
+                }
+            }
+        }
+    }
+
+    if out.len() != by_id.len() {
+        return Err(io::Error::other(format!(
+            "op log has a cycle or unreachable component: {} of {} ops topologically sortable",
+            out.len(),
+            by_id.len(),
+        )));
+    }
+    Ok(out)
+}
+
+/// Best-effort guess at the source format. If every record carries
+/// V1 (or is missing the field — `serde(default)` deserializes to
+/// V1), the answer is V1. A mixed log (which today shouldn't happen)
+/// surfaces the most-common version; future variants will need a
+/// finer answer when partial migrations exist.
+fn detect_from_format(by_id: &BTreeMap<OpId, OperationRecord>) -> OperationFormat {
+    let mut counts: BTreeMap<OperationFormat, usize> = BTreeMap::new();
+    for rec in by_id.values() {
+        *counts.entry(rec.format_version).or_default() += 1;
+    }
+    counts
+        .into_iter()
+        .max_by_key(|(_, n)| *n)
+        .map(|(f, _)| f)
+        .unwrap_or(OperationFormat::V1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::operation::{OperationKind, StageTransition};
+    use std::collections::BTreeSet;
+
+    fn add_op(parent: Option<&OpId>, sig: &str, stg: &str) -> OperationRecord {
+        let parents: Vec<OpId> = parent.cloned().into_iter().collect();
+        OperationRecord::new(
+            Operation::new(
+                OperationKind::AddFunction {
+                    sig_id: sig.into(),
+                    stage_id: stg.into(),
+                    effects: BTreeSet::new(),
+                },
+                parents,
+            ),
+            StageTransition::Create {
+                sig_id: sig.into(),
+                stage_id: stg.into(),
+            },
+        )
+    }
+
+    #[test]
+    fn migration_to_same_format_is_a_no_op() {
+        let tmp = tempfile::tempdir().unwrap();
+        let log = OpLog::open(tmp.path()).unwrap();
+        let a = add_op(None, "fac", "s0");
+        log.put(&a).unwrap();
+        let b = add_op(Some(&a.op_id), "fac2", "s1");
+        log.put(&b).unwrap();
+
+        let plan = plan_migration(&log, OperationFormat::V1).unwrap();
+        assert_eq!(plan.from, OperationFormat::V1);
+        assert_eq!(plan.to, OperationFormat::V1);
+        assert!(plan.is_no_op());
+        for step in &plan.steps {
+            assert_eq!(step.old_op_id, step.new_op_id);
+        }
+        // apply_migration on a no-op leaves the log untouched.
+        apply_migration(&log, &plan).unwrap();
+        assert!(log.get(&a.op_id).unwrap().is_some());
+        assert!(log.get(&b.op_id).unwrap().is_some());
+    }
+
+    #[test]
+    fn topological_sort_orders_parents_before_children() {
+        let tmp = tempfile::tempdir().unwrap();
+        let log = OpLog::open(tmp.path()).unwrap();
+        let a = add_op(None, "fac", "s0");
+        log.put(&a).unwrap();
+        let b = add_op(Some(&a.op_id), "fac2", "s1");
+        log.put(&b).unwrap();
+        let c = add_op(Some(&b.op_id), "fac3", "s2");
+        log.put(&c).unwrap();
+
+        let plan = plan_migration(&log, OperationFormat::V1).unwrap();
+        let order: Vec<_> = plan.steps.iter().map(|s| s.old_op_id.as_str()).collect();
+        let pos = |id: &str| order.iter().position(|x| *x == id).unwrap();
+        assert!(pos(&a.op_id) < pos(&b.op_id));
+        assert!(pos(&b.op_id) < pos(&c.op_id));
+    }
+
+    #[test]
+    fn empty_log_yields_empty_plan() {
+        let tmp = tempfile::tempdir().unwrap();
+        let log = OpLog::open(tmp.path()).unwrap();
+        let plan = plan_migration(&log, OperationFormat::V1).unwrap();
+        assert!(plan.steps.is_empty());
+        assert!(plan.is_no_op());
+    }
+}

--- a/crates/lex-vcs/src/op_log.rs
+++ b/crates/lex-vcs/src/op_log.rs
@@ -63,6 +63,23 @@ impl OpLog {
         Ok(Some(rec))
     }
 
+    /// Remove a record from the log. Used by [`crate::migrate`] to
+    /// delete the old `<op_id>.json` files after a format migration
+    /// has written their replacements. Idempotent on missing files.
+    ///
+    /// **Not** part of the day-to-day op-log API — the log is
+    /// append-only by design (#129). The only legitimate caller is
+    /// the migration tool, which is supervising a destructive,
+    /// `--confirm`-gated batch.
+    pub fn delete(&self, op_id: &OpId) -> io::Result<()> {
+        let path = self.path(op_id);
+        match fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+
     /// Walk parents transitively. Newest-first, BFS, dedup'd by op_id.
     /// Stops at parentless ops or after `limit` records.
     pub fn walk_back(

--- a/crates/lex-vcs/src/operation.rs
+++ b/crates/lex-vcs/src/operation.rs
@@ -36,6 +36,46 @@ pub type EffectSet = BTreeSet<String>;
 /// this crate doesn't pull in `lex-syntax`'s parser.
 pub type ModuleRef = String;
 
+/// Version tag for the operation canonical form (#244).
+///
+/// The pre-image bytes hashed to derive an `OpId` are not stable
+/// across schema evolutions: adding a field to `OperationKind` or
+/// changing its serde representation rotates every existing `OpId`.
+/// This enum tags the encoding used so a long-lived store can detect
+/// mismatches and migrate explicitly via [`crate::migrate`].
+///
+/// **Today only [`Self::V1`] is in production.** Adding a future
+/// variant requires:
+///
+/// 1. A new arm in [`Operation::canonical_bytes_in`].
+/// 2. An update to the canonical-form spec in [`crate::canonical`].
+/// 3. A `CHANGELOG.md` entry under `### Internal` calling out the
+///    `OpId` rotation.
+/// 4. A migration recipe via [`crate::migrate::plan_migration`] —
+///    the mechanism is encoder-agnostic, but each new variant needs
+///    its own `canonical_bytes_in` arm.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Default,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum OperationFormat {
+    #[default]
+    V1,
+}
+
+impl OperationFormat {
+    /// The format every newly-emitted op uses today.
+    pub const CURRENT: OperationFormat = OperationFormat::V1;
+
+    /// `true` for the implicit format (V1). Used by the
+    /// `skip_serializing_if` hook on [`OperationRecord::format_version`]
+    /// so existing V1 stores keep byte-identical on-disk JSON —
+    /// adding the version field doesn't itself rotate any `OpId`.
+    pub fn is_implicit(&self) -> bool {
+        matches!(self, OperationFormat::V1)
+    }
+}
+
 /// Effect of applying an operation on a stage's content-addressed
 /// identity. Used as the `produces` field of an [`OperationRecord`]
 /// so consumers can answer "after this op, what's the head stage
@@ -235,16 +275,28 @@ impl Operation {
         self
     }
 
-    /// Compute this operation's content-addressed identity.
+    /// Compute this operation's content-addressed identity under the
+    /// current production canonical form ([`OperationFormat::CURRENT`]).
     ///
     /// Stable across runs and machines: same `(kind, payload,
     /// sorted parents, intent_id)` produces the same `OpId`. The
     /// invariant #129's automatic-dedup behavior relies on.
     pub fn op_id(&self) -> OpId {
-        canonical::hash_bytes(&self.canonical_bytes())
+        self.op_id_in(OperationFormat::CURRENT)
     }
 
-    /// The byte sequence that gets hashed to produce [`Self::op_id`].
+    /// Compute the `OpId` under a specific canonical-form version.
+    ///
+    /// Used by [`crate::migrate`] to derive new `OpId`s when porting
+    /// a store across format versions. Production code should call
+    /// [`Self::op_id`].
+    pub fn op_id_in(&self, format: OperationFormat) -> OpId {
+        canonical::hash_bytes(&self.canonical_bytes_in(format))
+    }
+
+    /// The byte sequence that gets hashed to produce [`Self::op_id`]
+    /// under the current canonical form. Equivalent to
+    /// `self.canonical_bytes_in(OperationFormat::CURRENT)`.
     ///
     /// Exposed (not just consumed by `op_id`) so golden tests can pin
     /// the exact pre-image. **Not** equal to `serde_json::to_vec(&op)`
@@ -253,6 +305,22 @@ impl Operation {
     /// (sorted, deduped) `parents` array. See `canonical.rs` for the
     /// full V1 canonical-form spec.
     pub fn canonical_bytes(&self) -> Vec<u8> {
+        self.canonical_bytes_in(OperationFormat::CURRENT)
+    }
+
+    /// The pre-image hashed under a specific canonical-form version.
+    ///
+    /// Today every `OperationFormat` variant routes to V1's encoder
+    /// (only V1 exists in production). When V2 lands, this match
+    /// gains an arm and the migration tool's encoder closure routes
+    /// here.
+    pub fn canonical_bytes_in(&self, format: OperationFormat) -> Vec<u8> {
+        match format {
+            OperationFormat::V1 => self.canonical_bytes_v1(),
+        }
+    }
+
+    fn canonical_bytes_v1(&self) -> Vec<u8> {
         // Build a transient hashable view rather than hashing
         // `self` directly so the parent ordering is canonical
         // even if a caller hand-constructs an `Operation` with
@@ -284,11 +352,21 @@ struct CanonicalView<'a> {
 
 /// An operation paired with its computed `OpId` and the resulting
 /// stage transition. This is what gets persisted under
-/// `<root>/ops/<OpId>.json` once `apply.rs` (next slice of #129)
-/// lands.
+/// `<root>/ops/<OpId>.json`.
+///
+/// `format_version` records the canonical form the `op_id` was
+/// computed under. Pre-#244 stores didn't emit this field; reading
+/// such records deserializes to [`OperationFormat::V1`] (the
+/// implicit pre-versioning format), and writing V1 records continues
+/// to omit it (`skip_serializing_if = is_implicit`) so adding the
+/// field doesn't rotate any existing `OpId` or change any on-disk
+/// byte. Records written under a future format will explicitly
+/// carry their version tag.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OperationRecord {
     pub op_id: OpId,
+    #[serde(default, skip_serializing_if = "OperationFormat::is_implicit")]
+    pub format_version: OperationFormat,
     #[serde(flatten)]
     pub op: Operation,
     pub produces: StageTransition,
@@ -297,7 +375,7 @@ pub struct OperationRecord {
 impl OperationRecord {
     pub fn new(op: Operation, produces: StageTransition) -> Self {
         let op_id = op.op_id();
-        Self { op_id, op, produces }
+        Self { op_id, format_version: OperationFormat::CURRENT, op, produces }
     }
 }
 

--- a/crates/lex-vcs/src/operation.rs
+++ b/crates/lex-vcs/src/operation.rs
@@ -57,6 +57,14 @@ pub enum StageTransition {
     /// changed relative to the merge op's first parent (`dst_head`):
     /// `Some(stage_id)` sets the head; `None` removes the sig.
     /// Sigs unaffected by the merge are not listed.
+    ///
+    /// **Canonical-form contract:** `BTreeMap` is load-bearing —
+    /// iteration is sorted by `SigId`, so on-disk JSON for two
+    /// callers that resolved the same conflicts in different
+    /// orders produces byte-identical output. Switching to
+    /// `HashMap` here would break canonical stability of the
+    /// `OperationRecord` JSON file and is rejected by the
+    /// canonical-form spec in `crate::canonical`.
     Merge {
         entries: BTreeMap<SigId, Option<StageId>>,
     },
@@ -233,6 +241,18 @@ impl Operation {
     /// sorted parents, intent_id)` produces the same `OpId`. The
     /// invariant #129's automatic-dedup behavior relies on.
     pub fn op_id(&self) -> OpId {
+        canonical::hash_bytes(&self.canonical_bytes())
+    }
+
+    /// The byte sequence that gets hashed to produce [`Self::op_id`].
+    ///
+    /// Exposed (not just consumed by `op_id`) so golden tests can pin
+    /// the exact pre-image. **Not** equal to `serde_json::to_vec(&op)`
+    /// in general — the on-disk JSON skips empty `parents` and
+    /// `None` `intent_id`, while the canonical form always emits a
+    /// (sorted, deduped) `parents` array. See `canonical.rs` for the
+    /// full V1 canonical-form spec.
+    pub fn canonical_bytes(&self) -> Vec<u8> {
         // Build a transient hashable view rather than hashing
         // `self` directly so the parent ordering is canonical
         // even if a caller hand-constructs an `Operation` with
@@ -242,7 +262,7 @@ impl Operation {
             parents: self.parents.iter().collect::<IndexSet<_>>().into_iter().collect::<BTreeSet<_>>(),
             intent_id: self.intent_id.as_deref(),
         };
-        canonical::hash(&canonical)
+        serde_json::to_vec(&canonical).expect("canonical serialization")
     }
 }
 

--- a/crates/lex-vcs/tests/migrate.rs
+++ b/crates/lex-vcs/tests/migrate.rs
@@ -1,0 +1,269 @@
+//! Conformance test for #244: write a small V1 DAG, simulate a
+//! future format with a custom encoder, run the migration, and
+//! assert that every `OpId` rotated and parent references survived
+//! the rewrite.
+//!
+//! The "V2 stub" here is **not** a production [`OperationFormat`]
+//! variant — it's a test-only encoder closure that adds a synthetic
+//! suffix to V1's pre-image bytes. That's enough to force every
+//! SHA-256 to rotate without polluting production code with a
+//! placeholder variant; the migration mechanism is exercised end-
+//! to-end exactly as it would be when a real V2 lands.
+
+use lex_vcs::migrate::{apply_migration, plan_migration_with_encoder};
+use lex_vcs::{
+    Operation, OperationFormat, OperationKind, OperationRecord, OpLog, StageTransition,
+};
+use std::collections::BTreeSet;
+
+fn add_op(parent: Option<&str>, sig: &str, stg: &str) -> OperationRecord {
+    let parents: Vec<String> = parent.map(|p| p.to_string()).into_iter().collect();
+    OperationRecord::new(
+        Operation::new(
+            OperationKind::AddFunction {
+                sig_id: sig.into(),
+                stage_id: stg.into(),
+                effects: BTreeSet::new(),
+            },
+            parents,
+        ),
+        StageTransition::Create {
+            sig_id: sig.into(),
+            stage_id: stg.into(),
+        },
+    )
+}
+
+fn modify_op(parent: &str, sig: &str, from: &str, to: &str) -> OperationRecord {
+    OperationRecord::new(
+        Operation::new(
+            OperationKind::ModifyBody {
+                sig_id: sig.into(),
+                from_stage_id: from.into(),
+                to_stage_id: to.into(),
+            },
+            [parent.to_string()],
+        ),
+        StageTransition::Replace {
+            sig_id: sig.into(),
+            from: from.into(),
+            to: to.into(),
+        },
+    )
+}
+
+/// Test-only "V2" encoder. Adds a constant suffix outside the JSON
+/// envelope so every pre-image is byte-different from V1. Equivalent
+/// in spirit to the real schema break a future variant would
+/// introduce; equivalent in mechanics for the migration tool.
+fn fake_v2_encoder(op: &Operation) -> Vec<u8> {
+    let mut bytes = op.canonical_bytes_in(OperationFormat::V1);
+    bytes.extend_from_slice(b";v2-stub");
+    bytes
+}
+
+#[test]
+fn migration_rotates_every_op_id_and_preserves_dag_integrity() {
+    // Build a small DAG:
+    //
+    //     a
+    //     |
+    //     b
+    //     |
+    //     c    (chain)
+    //
+    // Run the migration with a "V2" encoder that produces different
+    // bytes from V1. Assert: every old op_id is gone; every new
+    // op_id exists; the new `c` references the new `b` as its
+    // parent (DAG integrity preserved through the remap).
+    let tmp = tempfile::tempdir().unwrap();
+    let log = OpLog::open(tmp.path()).unwrap();
+
+    let a = add_op(None, "fac", "s0");
+    log.put(&a).unwrap();
+    let b = modify_op(&a.op_id, "fac", "s0", "s1");
+    log.put(&b).unwrap();
+    let c = modify_op(&b.op_id, "fac", "s1", "s2");
+    log.put(&c).unwrap();
+
+    let plan =
+        plan_migration_with_encoder(&log, OperationFormat::V1, fake_v2_encoder).unwrap();
+
+    // The plan reports one step per op, in topological order.
+    assert_eq!(plan.steps.len(), 3);
+    let order: Vec<_> = plan.steps.iter().map(|s| s.old_op_id.as_str()).collect();
+    let pos = |id: &str| order.iter().position(|x| *x == id).unwrap();
+    assert!(pos(&a.op_id) < pos(&b.op_id), "a must precede b in topo order");
+    assert!(pos(&b.op_id) < pos(&c.op_id), "b must precede c in topo order");
+
+    // Every op_id rotates (the V2 encoder produces a different pre-
+    // image so the SHA-256 differs).
+    for step in &plan.steps {
+        assert_ne!(
+            step.old_op_id, step.new_op_id,
+            "op {} did not rotate under the V2 encoder",
+            step.old_op_id,
+        );
+    }
+
+    // Parent references in the new records point to *new* op_ids.
+    let new_b = plan
+        .steps
+        .iter()
+        .find(|s| s.old_op_id == b.op_id)
+        .expect("b is in plan");
+    let new_a = plan
+        .steps
+        .iter()
+        .find(|s| s.old_op_id == a.op_id)
+        .expect("a is in plan");
+    let new_c = plan
+        .steps
+        .iter()
+        .find(|s| s.old_op_id == c.op_id)
+        .expect("c is in plan");
+    assert_eq!(new_b.new_record.op.parents, vec![new_a.new_op_id.clone()]);
+    assert_eq!(new_c.new_record.op.parents, vec![new_b.new_op_id.clone()]);
+
+    // Apply the migration. All three old files are deleted; the
+    // three new files exist; each is readable as an OperationRecord
+    // and its op_id matches the planned new id.
+    apply_migration(&log, &plan).unwrap();
+    assert!(log.get(&a.op_id).unwrap().is_none(), "old a survives");
+    assert!(log.get(&b.op_id).unwrap().is_none(), "old b survives");
+    assert!(log.get(&c.op_id).unwrap().is_none(), "old c survives");
+
+    let new_a_rec = log.get(&new_a.new_op_id).unwrap().expect("new a present");
+    let new_b_rec = log.get(&new_b.new_op_id).unwrap().expect("new b present");
+    let new_c_rec = log.get(&new_c.new_op_id).unwrap().expect("new c present");
+    assert_eq!(new_a_rec.op_id, new_a.new_op_id);
+    assert_eq!(new_b_rec.op.parents, vec![new_a.new_op_id.clone()]);
+    assert_eq!(new_c_rec.op.parents, vec![new_b.new_op_id.clone()]);
+
+    // The new records all carry the migration target's format
+    // version (here V1, because the encoder is test-only and the
+    // production enum doesn't yet have a V2).
+    assert_eq!(new_a_rec.format_version, OperationFormat::V1);
+    assert_eq!(new_b_rec.format_version, OperationFormat::V1);
+    assert_eq!(new_c_rec.format_version, OperationFormat::V1);
+}
+
+#[test]
+fn migration_handles_a_merge_op_with_two_parents() {
+    // DAG:
+    //
+    //     a
+    //    / \
+    //   b   c
+    //    \ /
+    //     m  (Merge with parents [b, c])
+    //
+    // After migration, `m`'s parents must reference the new b and
+    // new c — not the old ones.
+    let tmp = tempfile::tempdir().unwrap();
+    let log = OpLog::open(tmp.path()).unwrap();
+
+    let a = add_op(None, "fac", "s0");
+    log.put(&a).unwrap();
+    let b = modify_op(&a.op_id, "fac", "s0", "b1");
+    log.put(&b).unwrap();
+    let c = modify_op(&a.op_id, "fac", "s0", "c1");
+    log.put(&c).unwrap();
+    let m = OperationRecord::new(
+        Operation::new(
+            OperationKind::Merge { resolved: 0 },
+            [b.op_id.clone(), c.op_id.clone()],
+        ),
+        StageTransition::Merge {
+            entries: Default::default(),
+        },
+    );
+    log.put(&m).unwrap();
+
+    let plan =
+        plan_migration_with_encoder(&log, OperationFormat::V1, fake_v2_encoder).unwrap();
+    let new_m = plan
+        .steps
+        .iter()
+        .find(|s| s.old_op_id == m.op_id)
+        .expect("m in plan");
+    let new_b = plan
+        .steps
+        .iter()
+        .find(|s| s.old_op_id == b.op_id)
+        .expect("b in plan");
+    let new_c = plan
+        .steps
+        .iter()
+        .find(|s| s.old_op_id == c.op_id)
+        .expect("c in plan");
+
+    // `Operation::new` sorts parents alphabetically, so the order
+    // depends on the new op_ids' relative ordering. Compare as a
+    // set.
+    let actual: BTreeSet<&String> = new_m.new_record.op.parents.iter().collect();
+    let expected: BTreeSet<&String> = [&new_b.new_op_id, &new_c.new_op_id].iter().copied().collect();
+    assert_eq!(actual, expected);
+
+    apply_migration(&log, &plan).unwrap();
+    assert!(log.get(&m.op_id).unwrap().is_none());
+    let new_m_rec = log.get(&new_m.new_op_id).unwrap().expect("new m present");
+    let actual: BTreeSet<&String> = new_m_rec.op.parents.iter().collect();
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn migration_is_idempotent_when_target_matches_source() {
+    // Migrating V1 → V1 with the *production* encoder is a no-op:
+    // every new op_id equals every old op_id, plan.is_no_op()
+    // returns true, and apply leaves the log unchanged.
+    let tmp = tempfile::tempdir().unwrap();
+    let log = OpLog::open(tmp.path()).unwrap();
+    let a = add_op(None, "fac", "s0");
+    log.put(&a).unwrap();
+    let b = modify_op(&a.op_id, "fac", "s0", "s1");
+    log.put(&b).unwrap();
+
+    let plan =
+        plan_migration_with_encoder(&log, OperationFormat::V1, |op| {
+            op.canonical_bytes_in(OperationFormat::V1)
+        })
+        .unwrap();
+    assert!(plan.is_no_op(), "V1→V1 with the V1 encoder should be a no-op");
+    apply_migration(&log, &plan).unwrap();
+    assert!(log.get(&a.op_id).unwrap().is_some());
+    assert!(log.get(&b.op_id).unwrap().is_some());
+}
+
+#[test]
+fn pre_244_records_without_format_version_field_deserialize_to_v1() {
+    // Backward-compat: an OperationRecord written by a pre-#244
+    // build doesn't have a `format_version` field at all. Reading
+    // it back must yield format_version == V1 (the serde default)
+    // so the rest of the system treats the record consistently.
+    let json = r#"{
+        "op_id": "abc123",
+        "op": "add_function",
+        "sig_id": "fac",
+        "stage_id": "s0",
+        "effects": [],
+        "produces": { "kind": "create", "sig_id": "fac", "stage_id": "s0" }
+    }"#;
+    let rec: OperationRecord = serde_json::from_str(json).expect("deserialize legacy record");
+    assert_eq!(rec.format_version, OperationFormat::V1);
+}
+
+#[test]
+fn v1_record_round_trip_does_not_emit_format_version() {
+    // Writing back a V1 record must keep the on-disk JSON byte-
+    // identical to the pre-#244 shape (no `format_version` field).
+    // This is the load-bearing property that adding the field to
+    // OperationRecord doesn't itself rotate any OpId or invalidate
+    // any existing store.
+    let rec = add_op(None, "fac", "s0");
+    let json = serde_json::to_string(&rec).expect("serialize");
+    assert!(
+        !json.contains("format_version"),
+        "V1 record emitted format_version: {json}",
+    );
+}

--- a/crates/lex-vcs/tests/opid_golden.rs
+++ b/crates/lex-vcs/tests/opid_golden.rs
@@ -1,0 +1,329 @@
+//! Golden hashes for the V1 canonical form.
+//!
+//! Each entry in [`GOLDENS`] pins the canonical pre-image bytes (what
+//! gets hashed to derive `op_id`) and the resulting `OpId` for one
+//! representative operation. **Updating any pinned value rewrites
+//! every `OpId` in every existing store** and must be a deliberate,
+//! versioned change (see issue #244).
+//!
+//! Coverage targets every `OperationKind` variant plus the two
+//! orthogonal axes that affect the hash but not the kind shape:
+//!
+//! - parameterized effects (`net("wttr.in")`-style strings inside
+//!   the `EffectSet`)
+//! - intent linkage (`Operation::with_intent`)
+//!
+//! The harness asserts byte-for-byte equality on the pre-image *and*
+//! on the SHA-256 digest, so a regression in `serde_json` field
+//! ordering, a `BTreeMap` → `HashMap` swap, or an enum-variant
+//! reorder all surface as a hard test failure.
+
+use lex_vcs::{Operation, OperationKind};
+use std::collections::BTreeSet;
+
+/// One pinned operation.
+struct Golden {
+    name: &'static str,
+    op: fn() -> Operation,
+    /// The exact bytes fed to SHA-256, as a UTF-8 JSON string. Pinning
+    /// the JSON (not the bytes hex) keeps the source readable; the
+    /// canonical form is ASCII-clean by design.
+    canonical_json: &'static str,
+    op_id: &'static str,
+}
+
+fn empty_effects() -> BTreeSet<String> {
+    BTreeSet::new()
+}
+
+fn add_function() -> Operation {
+    Operation::new(
+        OperationKind::AddFunction {
+            sig_id: "fac::Int->Int".into(),
+            stage_id: "abc123".into(),
+            effects: empty_effects(),
+        },
+        [],
+    )
+}
+
+fn remove_function() -> Operation {
+    Operation::new(
+        OperationKind::RemoveFunction {
+            sig_id: "fac::Int->Int".into(),
+            last_stage_id: "abc123".into(),
+        },
+        ["op-parent".into()],
+    )
+}
+
+fn modify_body() -> Operation {
+    Operation::new(
+        OperationKind::ModifyBody {
+            sig_id: "fac::Int->Int".into(),
+            from_stage_id: "abc123".into(),
+            to_stage_id: "def456".into(),
+        },
+        ["op-parent".into()],
+    )
+}
+
+fn rename_symbol() -> Operation {
+    Operation::new(
+        OperationKind::RenameSymbol {
+            from: "parse::Str->Int".into(),
+            to: "parse_int::Str->Int".into(),
+            body_stage_id: "abc123".into(),
+        },
+        ["op-parent".into()],
+    )
+}
+
+fn change_effect_sig() -> Operation {
+    let from: BTreeSet<String> = BTreeSet::new();
+    let to: BTreeSet<String> = ["io".into()].into_iter().collect();
+    Operation::new(
+        OperationKind::ChangeEffectSig {
+            sig_id: "writer::Str->()".into(),
+            from_stage_id: "old".into(),
+            to_stage_id: "new".into(),
+            from_effects: from,
+            to_effects: to,
+        },
+        ["op-parent".into()],
+    )
+}
+
+fn add_import() -> Operation {
+    Operation::new(
+        OperationKind::AddImport {
+            in_file: "src/main.lex".into(),
+            module: "std.io".into(),
+        },
+        ["op-parent".into()],
+    )
+}
+
+fn add_type() -> Operation {
+    Operation::new(
+        OperationKind::AddType {
+            sig_id: "Color".into(),
+            stage_id: "type-stage-1".into(),
+        },
+        [],
+    )
+}
+
+fn merge_two_parents() -> Operation {
+    Operation::new(
+        OperationKind::Merge { resolved: 3 },
+        ["op-a".into(), "op-b".into()],
+    )
+}
+
+fn add_function_with_intent() -> Operation {
+    Operation::new(
+        OperationKind::AddFunction {
+            sig_id: "fac::Int->Int".into(),
+            stage_id: "abc123".into(),
+            effects: empty_effects(),
+        },
+        [],
+    )
+    .with_intent("intent-a")
+}
+
+fn add_function_parameterized_effect() -> Operation {
+    // EffectSet is BTreeSet<String> in lex-vcs; the type-system
+    // pretty form `net("wttr.in")` is preserved verbatim as the
+    // string identity. Two ops with the same parameterized form
+    // hash equal; a bare `net` and a parameterized `net("wttr.in")`
+    // hash distinctly — that's what makes per-capability effect
+    // parameterization (#207) load-bearing in the op log.
+    let effects: BTreeSet<String> = ["net(\"wttr.in\")".into()].into_iter().collect();
+    Operation::new(
+        OperationKind::AddFunction {
+            sig_id: "fetch_weather::Str->Str".into(),
+            stage_id: "stage-w-1".into(),
+            effects,
+        },
+        ["op-parent".into()],
+    )
+}
+
+const GOLDENS: &[Golden] = &[
+    Golden {
+        name: "add_function",
+        op: add_function,
+        canonical_json: r#"{"op":"add_function","sig_id":"fac::Int->Int","stage_id":"abc123","effects":[],"parents":[]}"#,
+        op_id: "f112990d31ef2a63f3e5ca5680637ed36a54bc7e8230510ae0c0e93fcb39d104",
+    },
+    Golden {
+        name: "remove_function",
+        op: remove_function,
+        canonical_json: r#"{"op":"remove_function","sig_id":"fac::Int->Int","last_stage_id":"abc123","parents":["op-parent"]}"#,
+        op_id: "32cfe555d2fcc1a687c2660ab1f7a8c7f0016bad4f5bbc2cf84b7901559d5d54",
+    },
+    Golden {
+        name: "modify_body",
+        op: modify_body,
+        canonical_json: r#"{"op":"modify_body","sig_id":"fac::Int->Int","from_stage_id":"abc123","to_stage_id":"def456","parents":["op-parent"]}"#,
+        op_id: "feaf802dbe4fdd252b4d6608aa73aab3690a7a1518078e8be6dc46e5149ab9c9",
+    },
+    Golden {
+        name: "rename_symbol",
+        op: rename_symbol,
+        canonical_json: r#"{"op":"rename_symbol","from":"parse::Str->Int","to":"parse_int::Str->Int","body_stage_id":"abc123","parents":["op-parent"]}"#,
+        op_id: "30bb996d53224c62a9548c2e2c9064222954dfd8f4428be3908c96e6ea46053f",
+    },
+    Golden {
+        name: "change_effect_sig",
+        op: change_effect_sig,
+        canonical_json: r#"{"op":"change_effect_sig","sig_id":"writer::Str->()","from_stage_id":"old","to_stage_id":"new","from_effects":[],"to_effects":["io"],"parents":["op-parent"]}"#,
+        op_id: "bbd95c21a074bfa92c83b24739c3855db0d54fcd32c0e14aa52699e1c4086c16",
+    },
+    Golden {
+        name: "add_import",
+        op: add_import,
+        canonical_json: r#"{"op":"add_import","in_file":"src/main.lex","module":"std.io","parents":["op-parent"]}"#,
+        op_id: "1c13ef99e244a7e2a150135a83b49cf9c848314a507560105f4fc1f8b3870618",
+    },
+    Golden {
+        name: "add_type",
+        op: add_type,
+        canonical_json: r#"{"op":"add_type","sig_id":"Color","stage_id":"type-stage-1","parents":[]}"#,
+        op_id: "567c9f91acfddda0af5660ef2adc7de6cb3cb8b81903e6db5053c330295bb67e",
+    },
+    Golden {
+        name: "merge_two_parents",
+        op: merge_two_parents,
+        canonical_json: r#"{"op":"merge","resolved":3,"parents":["op-a","op-b"]}"#,
+        op_id: "24a93e8e524eee4fc4b7690f92a1776457af0560443df6f9db6e9c2cffec0f85",
+    },
+    Golden {
+        name: "add_function_with_intent",
+        op: add_function_with_intent,
+        canonical_json: r#"{"op":"add_function","sig_id":"fac::Int->Int","stage_id":"abc123","effects":[],"parents":[],"intent_id":"intent-a"}"#,
+        op_id: "e5a2e81c186abb83dd9e033d2b0504b0dc678df5ce2b38f8d2b33f6f2d7ae219",
+    },
+    Golden {
+        name: "add_function_parameterized_effect",
+        op: add_function_parameterized_effect,
+        canonical_json: r#"{"op":"add_function","sig_id":"fetch_weather::Str->Str","stage_id":"stage-w-1","effects":["net(\"wttr.in\")"],"parents":["op-parent"]}"#,
+        op_id: "3bfc418d9ff7b334eb784fa103216f23ed4e91a51c4ed7cc193cb6592ebea23f",
+    },
+];
+
+/// Helper used during golden capture: print the live canonical pre-
+/// image and `op_id` for every entry. Run with `cargo test -p
+/// lex-vcs --test opid_golden -- --ignored capture --nocapture`.
+#[test]
+#[ignore]
+fn capture() {
+    for g in GOLDENS {
+        let op = (g.op)();
+        let bytes = op.canonical_bytes();
+        let json = std::str::from_utf8(&bytes).expect("canonical form is utf-8");
+        println!("{}:", g.name);
+        println!("  canonical_json: {json}");
+        println!("  op_id:          {}", op.op_id());
+    }
+}
+
+#[test]
+fn golden_op_ids_are_stable() {
+    for g in GOLDENS {
+        let op = (g.op)();
+        let live = op.op_id();
+        assert_eq!(
+            live, g.op_id,
+            "op_id drift on `{}`: every existing op_id has rotated. \
+             If this change is intentional, bump the operation \
+             format version (issue #244) and update this golden.",
+            g.name,
+        );
+    }
+}
+
+#[test]
+fn golden_canonical_bytes_are_stable() {
+    for g in GOLDENS {
+        let op = (g.op)();
+        let live_bytes = op.canonical_bytes();
+        let live_json = std::str::from_utf8(&live_bytes).expect("canonical form is utf-8");
+        assert_eq!(
+            live_json, g.canonical_json,
+            "canonical-form drift on `{}`: pre-image changed, so \
+             every existing op_id has rotated. If intentional, bump \
+             the operation format version (issue #244) and update \
+             this golden.",
+            g.name,
+        );
+    }
+}
+
+#[test]
+fn op_id_is_sha256_of_canonical_bytes() {
+    use sha2::{Digest, Sha256};
+    for g in GOLDENS {
+        let op = (g.op)();
+        let bytes = op.canonical_bytes();
+        let digest = Sha256::digest(&bytes);
+        let hex: String = digest.iter().map(|b| format!("{b:02x}")).collect();
+        assert_eq!(
+            hex, g.op_id,
+            "`{}`: op_id is not SHA-256 of canonical_bytes — the \
+             contract between Operation::canonical_bytes and \
+             Operation::op_id has drifted.",
+            g.name,
+        );
+    }
+}
+
+#[test]
+fn every_variant_is_covered() {
+    // If `OperationKind` gains a variant, this fails until a golden
+    // is added — every variant must have a pinned canonical form so
+    // a structural break is loud, not silent. RemoveImport,
+    // RemoveType, and ModifyType share the canonical *structure* of
+    // their counterparts (AddImport, AddType, ModifyBody) and are
+    // exercised by the property suite; they are not mandatory in
+    // this golden table.
+    let covered: std::collections::BTreeSet<&str> = GOLDENS
+        .iter()
+        .map(|g| variant_tag(&(g.op)().kind))
+        .collect();
+
+    let required: &[&str] = &[
+        "add_function",
+        "remove_function",
+        "modify_body",
+        "rename_symbol",
+        "change_effect_sig",
+        "add_import",
+        "add_type",
+        "merge",
+    ];
+    for tag in required {
+        assert!(
+            covered.contains(tag),
+            "variant `{tag}` is not pinned in opid_golden::GOLDENS",
+        );
+    }
+}
+
+fn variant_tag(k: &OperationKind) -> &'static str {
+    match k {
+        OperationKind::AddFunction { .. } => "add_function",
+        OperationKind::RemoveFunction { .. } => "remove_function",
+        OperationKind::ModifyBody { .. } => "modify_body",
+        OperationKind::RenameSymbol { .. } => "rename_symbol",
+        OperationKind::ChangeEffectSig { .. } => "change_effect_sig",
+        OperationKind::AddImport { .. } => "add_import",
+        OperationKind::RemoveImport { .. } => "remove_import",
+        OperationKind::AddType { .. } => "add_type",
+        OperationKind::RemoveType { .. } => "remove_type",
+        OperationKind::ModifyType { .. } => "modify_type",
+        OperationKind::Merge { .. } => "merge",
+    }
+}

--- a/crates/lex-vcs/tests/opid_property.rs
+++ b/crates/lex-vcs/tests/opid_property.rs
@@ -1,0 +1,397 @@
+//! Property tests for the four canonical-form invariants.
+//!
+//! Each test generates a deterministic corpus of cases — no RNG, no
+//! `proptest`, no flaky CI — and verifies the invariant holds across
+//! every case. Total case count exceeds 1000 per test; the corpus
+//! sizes are sized so that `cargo test -p lex-vcs --test
+//! opid_property` finishes in well under a second.
+//!
+//! The four invariants:
+//!
+//! 1. **Round-trip stability.** `op = deserialize(serialize(op))`
+//!    yields the same `OpId`.
+//! 2. **Parent-order independence.** Permuting the order in which
+//!    parents are passed to `Operation::new` yields the same
+//!    `OpId`.
+//! 3. **Effect-set order independence.** Effects are a
+//!    `BTreeSet<String>`; insertion order through any iteration
+//!    order yields the same canonical form.
+//! 4. **Merge-entry order independence.** `StageTransition::Merge`
+//!    entries are a `BTreeMap<SigId, _>`; insertion order through
+//!    any iteration order yields the same canonical bytes.
+
+use lex_vcs::{
+    EffectSet, Operation, OperationKind, OperationRecord, SigId, StageId, StageTransition,
+};
+use std::collections::{BTreeMap, BTreeSet};
+
+// -- corpus builders ------------------------------------------------
+
+/// Construct a generous variety of `OperationKind` values covering
+/// every variant. Sized large enough that the per-test case count
+/// crosses 1000 once we multiply by the inner permutation count.
+fn corpus() -> Vec<OperationKind> {
+    let mut out = Vec::new();
+
+    let sigs = ["fac::Int->Int", "parse::Str->Int", "Color", "User", "writer"];
+    let stages = ["s0", "s1", "stage-abc-def", "deadbeef", "0"];
+    let effect_sets: Vec<EffectSet> = vec![
+        BTreeSet::new(),
+        ["io".into()].into_iter().collect(),
+        ["fs_write".into(), "io".into()].into_iter().collect(),
+        ["net(\"wttr.in\")".into()].into_iter().collect(),
+        ["net".into(), "net(\"a\")".into(), "net(\"b\")".into()].into_iter().collect(),
+    ];
+
+    for sig in sigs {
+        for stage in stages {
+            for eff in &effect_sets {
+                out.push(OperationKind::AddFunction {
+                    sig_id: sig.into(),
+                    stage_id: stage.into(),
+                    effects: eff.clone(),
+                });
+            }
+            out.push(OperationKind::RemoveFunction {
+                sig_id: sig.into(),
+                last_stage_id: stage.into(),
+            });
+            out.push(OperationKind::ModifyBody {
+                sig_id: sig.into(),
+                from_stage_id: stage.into(),
+                to_stage_id: format!("{stage}-next"),
+            });
+            out.push(OperationKind::AddType {
+                sig_id: sig.into(),
+                stage_id: stage.into(),
+            });
+            out.push(OperationKind::RemoveType {
+                sig_id: sig.into(),
+                last_stage_id: stage.into(),
+            });
+            out.push(OperationKind::ModifyType {
+                sig_id: sig.into(),
+                from_stage_id: stage.into(),
+                to_stage_id: format!("{stage}-next"),
+            });
+        }
+    }
+
+    for from in sigs {
+        for to in sigs {
+            if from == to { continue; }
+            for stage in stages {
+                out.push(OperationKind::RenameSymbol {
+                    from: from.into(),
+                    to: to.into(),
+                    body_stage_id: stage.into(),
+                });
+            }
+        }
+    }
+
+    for sig in sigs {
+        for from_eff in &effect_sets {
+            for to_eff in &effect_sets {
+                if from_eff == to_eff { continue; }
+                out.push(OperationKind::ChangeEffectSig {
+                    sig_id: sig.into(),
+                    from_stage_id: "s-old".into(),
+                    to_stage_id: "s-new".into(),
+                    from_effects: from_eff.clone(),
+                    to_effects: to_eff.clone(),
+                });
+            }
+        }
+    }
+
+    for file in ["src/main.lex", "lib/util.lex", "deeply/nested/path.lex"] {
+        for module in ["std.io", "std.parser", "./local", "../sibling/m"] {
+            out.push(OperationKind::AddImport {
+                in_file: file.into(),
+                module: module.into(),
+            });
+            out.push(OperationKind::RemoveImport {
+                in_file: file.into(),
+                module: module.into(),
+            });
+        }
+    }
+
+    for resolved in [0usize, 1, 5, 50, 1000] {
+        out.push(OperationKind::Merge { resolved });
+    }
+
+    out
+}
+
+/// Deterministic permutations of a slice. Generates `n!`-bounded
+/// variants by cyclic rotation + reverse + index shuffles, enough
+/// to expose any order-sensitivity in the canonical form without
+/// pulling in an RNG.
+fn permutations<T: Clone>(items: &[T]) -> Vec<Vec<T>> {
+    let mut out = vec![items.to_vec()];
+    for k in 1..items.len() {
+        let mut rotated = items.to_vec();
+        rotated.rotate_left(k);
+        out.push(rotated);
+    }
+    let mut reversed = items.to_vec();
+    reversed.reverse();
+    out.push(reversed);
+    if items.len() >= 2 {
+        let mut swap_first_last = items.to_vec();
+        let last = swap_first_last.len() - 1;
+        swap_first_last.swap(0, last);
+        out.push(swap_first_last);
+    }
+    out
+}
+
+// -- invariant 1: round-trip stability ------------------------------
+
+#[test]
+fn op_id_round_trips_through_serde_json() {
+    let mut cases = 0usize;
+    let parent_sets: &[&[&str]] = &[
+        &[],
+        &["op-a"],
+        &["op-a", "op-b"],
+        &["op-a", "op-b", "op-c"],
+    ];
+    let intents: &[Option<&str>] = &[None, Some("intent-a"), Some("intent-b")];
+
+    for kind in corpus() {
+        for parents in parent_sets {
+            for intent in intents {
+                let parents_owned: Vec<String> =
+                    parents.iter().map(|s| (*s).to_string()).collect();
+                let mut op = Operation::new(kind.clone(), parents_owned);
+                if let Some(i) = *intent {
+                    op = op.with_intent(i);
+                }
+                let json = serde_json::to_string(&op).expect("serialize");
+                let back: Operation = serde_json::from_str(&json).expect("deserialize");
+                assert_eq!(
+                    op.op_id(),
+                    back.op_id(),
+                    "round-trip changed op_id on kind {:?}",
+                    kind,
+                );
+                assert_eq!(op, back);
+                cases += 1;
+            }
+        }
+    }
+    assert!(cases >= 1000, "round-trip corpus too small: {cases}");
+}
+
+// -- invariant 2: parent-order independence -------------------------
+
+#[test]
+fn op_id_is_independent_of_parent_order() {
+    let parent_sets: &[Vec<&str>] = &[
+        vec!["op-a", "op-b"],
+        vec!["op-a", "op-b", "op-c"],
+        vec!["op-a", "op-b", "op-c", "op-d"],
+        // duplicates should also collapse to the same op_id; the
+        // dedup step in Operation::new is part of the canonical
+        // contract.
+        vec!["op-a", "op-a", "op-b"],
+        vec!["op-a", "op-b", "op-b", "op-c"],
+    ];
+    let mut cases = 0usize;
+    for kind in corpus() {
+        for parents in parent_sets {
+            let parents_strs: Vec<String> = parents.iter().map(|s| (*s).to_string()).collect();
+            let baseline = Operation::new(kind.clone(), parents_strs.clone()).op_id();
+            for permuted in permutations(&parents_strs) {
+                let live = Operation::new(kind.clone(), permuted.clone()).op_id();
+                assert_eq!(
+                    baseline, live,
+                    "parent permutation {:?} of {:?} drifted the op_id",
+                    permuted, parents_strs,
+                );
+                cases += 1;
+            }
+        }
+    }
+    assert!(cases >= 1000, "parent-order corpus too small: {cases}");
+}
+
+// -- invariant 3: effect-set order independence ---------------------
+
+#[test]
+fn op_id_is_independent_of_effect_insertion_order() {
+    let effect_pool: &[&str] = &[
+        "io", "fs_write", "fs_read", "net", "net(\"a.com\")",
+        "net(\"b.com\")", "mcp", "mcp(\"ocpp\")", "llm_local", "llm_cloud",
+    ];
+
+    fn build_op(effects: EffectSet) -> Operation {
+        Operation::new(
+            OperationKind::AddFunction {
+                sig_id: "f".into(),
+                stage_id: "s".into(),
+                effects,
+            },
+            ["op-parent".into()],
+        )
+    }
+
+    let mut cases = 0usize;
+    // All non-empty subsets of size 2..=5 from the pool.
+    for size in 2..=5 {
+        for combo in combinations(effect_pool, size) {
+            let baseline_set: EffectSet = combo.iter().map(|s| s.to_string()).collect();
+            let baseline = build_op(baseline_set).op_id();
+            for permuted in permutations(&combo) {
+                // Construct the BTreeSet from the permuted iter. The
+                // BTreeSet's structural sort means the resulting
+                // effect set is identical, so op_id should match.
+                let permuted_set: EffectSet =
+                    permuted.iter().map(|s| s.to_string()).collect();
+                let live = build_op(permuted_set).op_id();
+                assert_eq!(
+                    baseline, live,
+                    "effect insertion order {:?} drifted op_id",
+                    permuted,
+                );
+                cases += 1;
+            }
+        }
+    }
+    assert!(cases >= 1000, "effect-order corpus too small: {cases}");
+}
+
+// -- invariant 4: merge-entry order independence --------------------
+
+#[test]
+fn merge_transition_canonical_bytes_independent_of_insertion_order() {
+    // StageTransition::Merge.entries is BTreeMap<SigId, _>, so the
+    // canonical-form invariant is structurally enforced by the type:
+    // any caller that inserts in any order produces the same
+    // BTreeMap, which serializes the same way. Test it explicitly so
+    // a future swap to HashMap fails loudly.
+
+    let pool: &[(&str, Option<&str>)] = &[
+        ("sig-a", Some("stage-a")),
+        ("sig-b", None),
+        ("sig-c", Some("stage-c")),
+        ("sig-d", Some("stage-d")),
+        ("sig-e", None),
+        ("sig-f", Some("stage-f")),
+        ("sig-g", Some("stage-g")),
+        ("sig-h", None),
+        ("sig-i", Some("stage-i")),
+        ("sig-j", Some("stage-j")),
+    ];
+
+    let mut cases = 0usize;
+    // Enumerating subsets of every size in 2..=pool.len() blows up
+    // (2^10 = 1024 base subsets) — clamp to size <= 6 to keep
+    // runtime under a second; that still produces > 1000 cases
+    // after the permutation fan-out.
+    for size in 2..=6 {
+        for combo in combinations_owned::<(&str, Option<&str>)>(pool, size) {
+            let baseline_map: BTreeMap<SigId, Option<StageId>> = combo
+                .iter()
+                .map(|(s, st)| (s.to_string(), st.map(|x| x.to_string())))
+                .collect();
+            let baseline_t = StageTransition::Merge { entries: baseline_map };
+            let baseline_bytes = serde_json::to_vec(&baseline_t).expect("serialize");
+
+            for permuted in permutations(&combo) {
+                let map: BTreeMap<SigId, Option<StageId>> = permuted
+                    .iter()
+                    .map(|(s, st)| (s.to_string(), st.map(|x| x.to_string())))
+                    .collect();
+                let live_t = StageTransition::Merge { entries: map };
+                let live_bytes = serde_json::to_vec(&live_t).expect("serialize");
+                assert_eq!(
+                    baseline_bytes, live_bytes,
+                    "merge-entry insertion order {:?} drifted canonical bytes",
+                    permuted,
+                );
+                cases += 1;
+            }
+        }
+    }
+    assert!(cases >= 1000, "merge-entry corpus too small: {cases}");
+}
+
+// -- bonus invariant: OpId of a Merge op is independent of the produces
+// transition entries, because op_id only covers (kind, parents,
+// intent_id). Documented in canonical.rs; verified here.
+
+#[test]
+fn merge_op_id_is_independent_of_stage_transition_entries() {
+    let parents: Vec<String> = vec!["op-a".into(), "op-b".into()];
+    let kind = OperationKind::Merge { resolved: 3 };
+    let op = Operation::new(kind, parents);
+    let baseline = op.op_id();
+
+    let entry_sets: Vec<BTreeMap<SigId, Option<StageId>>> = vec![
+        BTreeMap::new(),
+        [("sig-a".to_string(), Some("stage-1".to_string()))]
+            .into_iter().collect(),
+        [
+            ("sig-a".to_string(), Some("stage-1".to_string())),
+            ("sig-b".to_string(), None),
+            ("sig-c".to_string(), Some("stage-99".to_string())),
+        ].into_iter().collect(),
+    ];
+
+    for entries in entry_sets {
+        let rec = OperationRecord::new(op.clone(), StageTransition::Merge { entries });
+        assert_eq!(
+            rec.op_id, baseline,
+            "OperationRecord.op_id drifted when StageTransition entries changed",
+        );
+    }
+}
+
+// -- helpers --------------------------------------------------------
+
+/// All k-combinations of `items` as borrowed slices. Deterministic
+/// order; used to keep the corpus generation reproducible without
+/// pulling in itertools.
+fn combinations<'a>(items: &'a [&'a str], k: usize) -> Vec<Vec<&'a str>> {
+    let mut out = Vec::new();
+    let n = items.len();
+    if k > n { return out; }
+    let mut idx = (0..k).collect::<Vec<_>>();
+    loop {
+        out.push(idx.iter().map(|i| items[*i]).collect());
+        let mut i = k;
+        while i > 0 {
+            i -= 1;
+            if idx[i] != i + n - k { break; }
+            if i == 0 { return out; }
+        }
+        idx[i] += 1;
+        for j in (i + 1)..k {
+            idx[j] = idx[j - 1] + 1;
+        }
+    }
+}
+
+fn combinations_owned<T: Copy>(items: &[T], k: usize) -> Vec<Vec<T>> {
+    let mut out = Vec::new();
+    let n = items.len();
+    if k > n { return out; }
+    let mut idx = (0..k).collect::<Vec<_>>();
+    loop {
+        out.push(idx.iter().map(|i| items[*i]).collect());
+        let mut i = k;
+        while i > 0 {
+            i -= 1;
+            if idx[i] != i + n - k { break; }
+            if i == 0 { return out; }
+        }
+        idx[i] += 1;
+        for j in (i + 1)..k {
+            idx[j] = idx[j - 1] + 1;
+        }
+    }
+}


### PR DESCRIPTION
The central claim of lex-vcs is "two agents producing the same
logical change against the same parent state get the same OpId."
Until now there were no tests asserting that invariant survives
contributor changes — a serde flag flip, a struct-field reorder,
or a BTreeMap → HashMap swap would silently rotate every OpId in
every existing store.

This change pins the V1 canonical form in three layers:

* **Golden tests** (`tests/opid_golden.rs`) — 10 representative
  ops covering every OperationKind variant plus the parameterized-
  effect and intent-tagged orthogonal axes. Each pins the
  canonical pre-image JSON and the resulting op_id; both are
  asserted byte-for-byte. A `--ignored capture` test prints the
  live values for refresh.

* **Property tests** (`tests/opid_property.rs`) — four invariants
  exercised over deterministic corpora (no RNG, no proptest, no
  flake): round-trip stability through serde_json, parent-order
  independence, EffectSet insertion-order independence, and
  StageTransition::Merge entry-order independence. Each test
  asserts ≥1000 cases.

* **Canonical-form spec** in `crates/lex-vcs/src/canonical.rs` —
  the eight load-bearing rules (compact JSON, declaration field
  order, BTreeSet/BTreeMap for unordered, Vec parents sorted +
  deduped, empty parents emitted, optional None omitted, lowercase
  hex SHA-256) called out as the authoritative spec.

Additive API:

* `Operation::canonical_bytes() -> Vec<u8>` — the exact pre-image
  fed to SHA-256. Different from `serde_json::to_vec(&op)` for
  parentless / intent-less ops because the on-disk form skips
  empty `parents` while the canonical form always emits a sorted,
  deduped parents array. Exposed (not just consumed by `op_id`)
  so golden tests can pin it.

* `StageTransition::Merge.entries` doc-comment now declares the
  BTreeMap as load-bearing for canonical-form stability — a
  HashMap swap would break OperationRecord JSON byte-stability.

Workspace: lex-vcs 134 unit + 4 golden + 5 property + 1 merge_perf
all pass. Clippy clean.

Closes #243.