### PR TITLE
lex-vcs+store+cli: retroactive producer quarantine (#248)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+### Added — agent-VCS roadmap (#248)
+
+- **Retroactive producer quarantine** (#248). Two new
+  `AttestationKind` variants — `ProducerBlock { tool_id, reason,
+  blocked_at }` and `ProducerUnblock { tool_id, reason,
+  unblocked_at }` — let an admin declare "as of T, attestations
+  produced by tool X are no longer trusted." The branch advance
+  gate consults the latest verdict per `tool_id` (by timestamp;
+  ties go to `ProducerUnblock`) and refuses to advance over an op
+  whose stage carries an attestation produced by a quarantined
+  tool at or after the cutoff. Distinct from `policy.json`'s
+  `blocked_producers` (#181), which is a forward-going read-time
+  tag for the activity feed; this is a write-time gate.
+- **`StoreError::ProducerBlocked`** with a structured
+  `ProducerBlocked` envelope (`error: "ProducerBlocked"`,
+  `op_id`, `stage_id`, `tool_id`, `blocked_at`, `attestation_at`,
+  `attestation_id`). Distinct error code from #245's
+  `BranchAdvanceBlocked` so the HTTP API can route the security
+  failure separately from the missing-evidence failure.
+- **`lex attest retro-block --producer <tool_id> --reason "..."`**
+  and **`lex attest retro-unblock --producer <tool_id> --reason
+  "..."`** CLI commands. Emit attestations under
+  `stage_id == tool_id` so the existing by-stage index doubles as
+  a by-tool lookup — no schema break, no separate index needed.
+- **Ops are not deleted.** The attestation log carries the
+  tombstone; the op log stays append-only. Branch advance is
+  refused, but the audit trail is intact.
+
+#### Limitation (called out for follow-up)
+
+- **Walk-back gate is not implemented.** Today's gate only checks
+  the *new* op being advanced past, not its ancestors. Pre-
+  existing contamination in a branch's history is grandfathered
+  in at the moment of the retro-block. A future "walk back to the
+  last successful gate run" pass would close this gap.
+
 ### Added — agent-VCS roadmap (#245)
 
 - **Machine-checkable branch advancement gates** (#245). New

--- a/crates/lex-api/src/web.rs
+++ b/crates/lex-api/src/web.rs
@@ -843,6 +843,12 @@ fn kind_short(k: &AttestationKind) -> String {
         AttestationKind::Defer { actor, .. } => format!("Defer({actor})"),
         AttestationKind::Block { actor, .. } => format!("Block({actor})"),
         AttestationKind::Unblock { actor, .. } => format!("Unblock({actor})"),
+        AttestationKind::ProducerBlock { tool_id, .. } => {
+            format!("ProducerBlock({tool_id})")
+        }
+        AttestationKind::ProducerUnblock { tool_id, .. } => {
+            format!("ProducerUnblock({tool_id})")
+        }
     }
 }
 

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -166,6 +166,8 @@ fn print_usage() {
     println!("                                     ranked by description+signature+examples.");
     println!("  stage <stage> [--attestations]     print stage info, or list its attestations");
     println!("  attest filter [--kind K] [--result R] [--since T] [--store DIR]");
+    println!("  attest retro-block --producer TOOL_ID --reason \"...\" [--store DIR]");
+    println!("  attest retro-unblock --producer TOOL_ID --reason \"...\" [--store DIR]");
     println!("                                     cross-stage attestation queries");
     println!("  trace <run_id>                     print a saved trace tree as JSON");
     println!("  replay <run_id> <file> <fn> [args] [--override NODE=JSON]...");
@@ -1790,6 +1792,12 @@ fn cmd_stage(fmt: &OutputFormat, args: &[String]) -> Result<()> {
                     lex_vcs::AttestationKind::Unblock { actor, .. } => {
                         format!("Unblock({actor})")
                     }
+                    lex_vcs::AttestationKind::ProducerBlock { tool_id, .. } => {
+                        format!("ProducerBlock({tool_id})")
+                    }
+                    lex_vcs::AttestationKind::ProducerUnblock { tool_id, .. } => {
+                        format!("ProducerUnblock({tool_id})")
+                    }
                 };
                 let result = match &a.result {
                     lex_vcs::AttestationResult::Passed => "passed".to_string(),
@@ -2138,23 +2146,176 @@ fn cmd_attest(fmt: &OutputFormat, args: &[String]) -> Result<()> {
             });
             Ok(())
         }
+        "retro-block" => cmd_attest_retro_block(fmt, rest),
+        "retro-unblock" => cmd_attest_retro_unblock(fmt, rest),
         other => bail!("unknown `lex attest` subcommand: {other}"),
+    }
+}
+
+/// `lex attest retro-block --producer <tool_id> --reason "..."` (#248).
+/// Emits an `AttestationKind::ProducerBlock` attestation under
+/// `stage_id == tool_id`. The branch advance gate consults the
+/// resulting record on every subsequent apply and refuses to
+/// advance over an op whose stage carries an attestation produced
+/// by `tool_id` at or after this block's timestamp.
+fn cmd_attest_retro_block(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    let (root, rest, _, _) = parse_store_flag(args);
+    let mut producer: Option<String> = None;
+    let mut reason: Option<String> = None;
+    let mut i = 0;
+    while i < rest.len() {
+        match rest[i].as_str() {
+            "--producer" => {
+                producer = rest.get(i + 1).cloned();
+                i += 2;
+            }
+            "--reason" => {
+                reason = rest.get(i + 1).cloned();
+                i += 2;
+            }
+            other => bail!("unexpected arg `{other}`"),
+        }
+    }
+    let tool_id = producer.ok_or_else(|| anyhow!(
+        "usage: lex attest retro-block --producer <tool_id> --reason \"...\""
+    ))?;
+    let reason = reason.ok_or_else(|| anyhow!(
+        "lex attest retro-block: --reason required"
+    ))?;
+
+    let store = Store::open(&root)
+        .with_context(|| format!("opening store at {}", root.display()))?;
+    let log = store.attestation_log()?;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let attestation = lex_vcs::Attestation::with_timestamp(
+        tool_id.clone(),
+        None,
+        None,
+        lex_vcs::AttestationKind::ProducerBlock {
+            tool_id: tool_id.clone(),
+            reason: reason.clone(),
+            blocked_at: now,
+        },
+        // The verdict on the *block itself* is always Passed —
+        // it's a declaration, not the result of a verification.
+        // Failure to land the attestation surfaces as an io error,
+        // not as `Failed { detail }`.
+        lex_vcs::AttestationResult::Passed,
+        retro_block_producer(),
+        None,
+        now,
+    );
+    log.put(&attestation)?;
+
+    let data = serde_json::json!({
+        "tool_id": &tool_id,
+        "reason": &reason,
+        "blocked_at": now,
+        "attestation_id": &attestation.attestation_id,
+    });
+    let printable_tool = tool_id.clone();
+    acli::emit_or_text("attest", data, fmt, move || {
+        println!("→ retroactively blocked producer `{printable_tool}` at {now}");
+    });
+    Ok(())
+}
+
+/// `lex attest retro-unblock --producer <tool_id> --reason "..."` (#248).
+/// Counterpart to `retro-block`. Emits an
+/// `AttestationKind::ProducerUnblock` so the gate honors the most
+/// recent verdict per `tool_id` by timestamp.
+fn cmd_attest_retro_unblock(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    let (root, rest, _, _) = parse_store_flag(args);
+    let mut producer: Option<String> = None;
+    let mut reason: Option<String> = None;
+    let mut i = 0;
+    while i < rest.len() {
+        match rest[i].as_str() {
+            "--producer" => {
+                producer = rest.get(i + 1).cloned();
+                i += 2;
+            }
+            "--reason" => {
+                reason = rest.get(i + 1).cloned();
+                i += 2;
+            }
+            other => bail!("unexpected arg `{other}`"),
+        }
+    }
+    let tool_id = producer.ok_or_else(|| anyhow!(
+        "usage: lex attest retro-unblock --producer <tool_id> --reason \"...\""
+    ))?;
+    let reason = reason.ok_or_else(|| anyhow!(
+        "lex attest retro-unblock: --reason required"
+    ))?;
+
+    let store = Store::open(&root)
+        .with_context(|| format!("opening store at {}", root.display()))?;
+    let log = store.attestation_log()?;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let attestation = lex_vcs::Attestation::with_timestamp(
+        tool_id.clone(),
+        None,
+        None,
+        lex_vcs::AttestationKind::ProducerUnblock {
+            tool_id: tool_id.clone(),
+            reason: reason.clone(),
+            unblocked_at: now,
+        },
+        lex_vcs::AttestationResult::Passed,
+        retro_block_producer(),
+        None,
+        now,
+    );
+    log.put(&attestation)?;
+
+    let data = serde_json::json!({
+        "tool_id": &tool_id,
+        "reason": &reason,
+        "unblocked_at": now,
+        "attestation_id": &attestation.attestation_id,
+    });
+    let printable_tool = tool_id.clone();
+    acli::emit_or_text("attest", data, fmt, move || {
+        println!("→ retroactively unblocked producer `{printable_tool}` at {now}");
+    });
+    Ok(())
+}
+
+/// Producer descriptor for the synthetic `ProducerBlock` /
+/// `ProducerUnblock` attestations written by the `lex attest
+/// retro-{block,unblock}` commands. Tagged distinctly from
+/// `lex run --trace`'s `trace_producer` so the activity feed can
+/// tell the two apart.
+fn retro_block_producer() -> lex_vcs::ProducerDescriptor {
+    lex_vcs::ProducerDescriptor {
+        tool: "lex attest retro-block".into(),
+        version: env!("CARGO_PKG_VERSION").into(),
+        model: None,
     }
 }
 
 fn attestation_kind_tag(k: &lex_vcs::AttestationKind) -> &'static str {
     use lex_vcs::AttestationKind::*;
     match k {
-        Examples { .. }   => "examples",
-        Spec { .. }       => "spec",
-        DiffBody { .. }   => "diff_body",
-        TypeCheck         => "type_check",
-        EffectAudit       => "effect_audit",
-        SandboxRun { .. } => "sandbox_run",
-        Override { .. }   => "override",
-        Defer { .. }      => "defer",
-        Block { .. }      => "block",
-        Unblock { .. }    => "unblock",
+        Examples { .. }         => "examples",
+        Spec { .. }             => "spec",
+        DiffBody { .. }         => "diff_body",
+        TypeCheck               => "type_check",
+        EffectAudit             => "effect_audit",
+        SandboxRun { .. }       => "sandbox_run",
+        Override { .. }         => "override",
+        Defer { .. }            => "defer",
+        Block { .. }            => "block",
+        Unblock { .. }          => "unblock",
+        ProducerBlock { .. }    => "producer_block",
+        ProducerUnblock { .. }  => "producer_unblock",
     }
 }
 

--- a/crates/lex-store/src/policy.rs
+++ b/crates/lex-store/src/policy.rs
@@ -359,6 +359,153 @@ fn passed(r: &AttestationResult) -> bool {
 #[allow(dead_code)]
 fn _force_use(_: Attestation) {} // keep unused-import warning quiet across feature flips
 
+// ----------------------------------------------- producer-block gate (#248)
+
+/// Why a branch advance was refused by the
+/// [`check_producer_block`] gate. Surfaced as
+/// `StoreError::ProducerBlocked` and as a distinct
+/// `ProducerBlocked` envelope on the HTTP API.
+///
+/// Distinct from [`BranchAdvanceBlocked`] (#245's positive
+/// attestation gate) because the response shape is different:
+/// the operator needs to know *which producer* was blocked and
+/// *which attestation* tripped the gate, not just "an
+/// attestation was missing."
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ProducerBlocked {
+    pub op_id: OpId,
+    /// Stage the offending attestation was about. Always set —
+    /// `ProducerBlock` only fires when a candidate op has at
+    /// least one stage with attestations.
+    pub stage_id: String,
+    /// Tool that's been retroactively quarantined.
+    pub tool_id: String,
+    /// Cutoff from the most recent `AttestationKind::ProducerBlock`
+    /// for this tool.
+    pub blocked_at: u64,
+    /// Wall-clock timestamp of the offending attestation. Always
+    /// `>= blocked_at`; otherwise the gate wouldn't have fired.
+    pub attestation_at: u64,
+    /// `attestation_id` of the offending attestation, so the
+    /// operator can drill in via `lex attest filter`.
+    pub attestation_id: String,
+}
+
+impl ProducerBlocked {
+    /// Render as a structured JSON envelope. Distinct `error`
+    /// discriminator (`ProducerBlocked`) so the HTTP layer can
+    /// route it to a different status code or recovery path
+    /// from `BranchAdvanceBlocked`.
+    pub fn to_envelope(&self) -> serde_json::Value {
+        serde_json::json!({
+            "error": "ProducerBlocked",
+            "op_id": self.op_id,
+            "stage_id": self.stage_id,
+            "tool_id": self.tool_id,
+            "blocked_at": self.blocked_at,
+            "attestation_at": self.attestation_at,
+            "attestation_id": self.attestation_id,
+        })
+    }
+}
+
+/// Verify that the candidate ops are not contaminated by
+/// attestations from a retroactively quarantined producer (#248).
+///
+/// Algorithm:
+///
+/// 1. Walk the entire attestation log to collect every
+///    `ProducerBlock` / `ProducerUnblock` record. Build a map
+///    `tool_id → Some(blocked_at)` reflecting the latest verdict
+///    per tool.
+/// 2. For each candidate op, list attestations on its
+///    `stage_id`. For every attestation produced by a currently-
+///    blocked tool with `attestation.timestamp >= block.blocked_at`,
+///    refuse the advance with the offending row's details.
+///
+/// Cost is `O(total attestations)` for step 1 — fine for small
+/// stores; a `by-tool` index becomes worthwhile if the producer
+/// list grows past dozens. Step 2 is `O(attestations on the
+/// candidate stage)` per op, dominated by step 1 for the common
+/// case of a single-op advance.
+pub fn check_producer_block(
+    log: &AttestationLog,
+    candidate: &[(OpId, Option<String>, BTreeSet<String>)],
+) -> Result<(), ProducerBlocked> {
+    // Step 1: build the active-block map.
+    let all = match log.list_all() {
+        Ok(v) => v,
+        // Empty log = nothing to check.
+        Err(_) => return Ok(()),
+    };
+    use std::collections::HashMap;
+    let mut active: HashMap<String, u64> = HashMap::new();
+    // Process in timestamp order so the latest verdict per tool
+    // wins. Ties go to ProducerUnblock (matches the spirit of
+    // is_stage_blocked).
+    let mut ordered: Vec<&Attestation> = all.iter().collect();
+    ordered.sort_by(|a, b| {
+        a.timestamp.cmp(&b.timestamp).then_with(|| {
+            // Same timestamp: ProducerUnblock sorts after
+            // ProducerBlock so it wins the "latest" check.
+            let a_unblock = matches!(a.kind, AttestationKind::ProducerUnblock { .. });
+            let b_unblock = matches!(b.kind, AttestationKind::ProducerUnblock { .. });
+            a_unblock.cmp(&b_unblock)
+        })
+    });
+    for a in ordered {
+        match &a.kind {
+            AttestationKind::ProducerBlock { tool_id, blocked_at, .. } => {
+                active.insert(tool_id.clone(), *blocked_at);
+            }
+            AttestationKind::ProducerUnblock { tool_id, .. } => {
+                active.remove(tool_id);
+            }
+            _ => {}
+        }
+    }
+    if active.is_empty() {
+        return Ok(());
+    }
+
+    // Step 2: per-op attestation walk.
+    for (op_id, stage_id_opt, _) in candidate {
+        let stage_id = match stage_id_opt {
+            Some(s) => s,
+            None => continue,
+        };
+        let attestations = match log.list_for_stage(stage_id) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        for a in attestations {
+            // Self-references (a producer's own ProducerBlock /
+            // Unblock attestations are stored at stage_id ==
+            // tool_id) shouldn't be flagged as contamination.
+            if matches!(
+                a.kind,
+                AttestationKind::ProducerBlock { .. }
+                    | AttestationKind::ProducerUnblock { .. }
+            ) {
+                continue;
+            }
+            if let Some(&blocked_at) = active.get(&a.produced_by.tool) {
+                if a.timestamp >= blocked_at {
+                    return Err(ProducerBlocked {
+                        op_id: op_id.clone(),
+                        stage_id: stage_id.clone(),
+                        tool_id: a.produced_by.tool.clone(),
+                        blocked_at,
+                        attestation_at: a.timestamp,
+                        attestation_id: a.attestation_id.clone(),
+                    });
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/lex-store/src/store.rs
+++ b/crates/lex-store/src/store.rs
@@ -51,6 +51,18 @@ pub enum StoreError {
         .0.op_id, .0.missing.join(", ")
     )]
     BranchAdvanceBlocked(crate::policy::BranchAdvanceBlocked),
+    /// The op was persisted but its stage carries an attestation
+    /// produced by a retroactively quarantined tool (#248). The
+    /// branch head is unchanged. The op record stays in the log
+    /// (audit trail intact); re-running with the producer
+    /// unblocked, or with un-contaminated attestations, succeeds
+    /// without re-persisting the op.
+    #[error(
+        "branch advance blocked: op {} touches stage {} with an attestation from \
+         quarantined producer `{}` (blocked at {}, attestation at {})",
+        .0.op_id, .0.stage_id, .0.tool_id, .0.blocked_at, .0.attestation_at
+    )]
+    ProducerBlocked(crate::policy::ProducerBlocked),
 }
 
 /// The outcome returned by [`Store::publish_program`].
@@ -794,31 +806,34 @@ impl Store {
         })
     }
 
-    /// Run the `required_attestations` gate (#245) over a single op
-    /// against the store's `policy.json`. Surfaces a
-    /// `BranchAdvanceBlocked` error if any required attestation is
-    /// missing for any of the op's attestable stages. Loads the
-    /// policy and the attestation log lazily; if no policy file
-    /// exists, the gate is a no-op (default-permissive behavior
-    /// matches pre-#245 stores).
+    /// Run the `required_attestations` gate (#245) and the
+    /// retroactive producer-block gate (#248) over a single op
+    /// against the store's `policy.json` and attestation log.
+    ///
+    /// Failure modes (in order):
+    ///
+    /// 1. Producer-block first: if any attestation on the op's
+    ///    stage is from a quarantined tool, refuse with
+    ///    `ProducerBlocked` (#248). Surfaces *before* the
+    ///    required-attestations gate so a clearly-malicious record
+    ///    isn't masked by a missing-Spec error.
+    /// 2. Required-attestations next: if any required attestation
+    ///    kind is missing, refuse with `BranchAdvanceBlocked`
+    ///    (#245).
+    ///
+    /// Loads the policy / attestation log lazily; with no policy
+    /// file and no `ProducerBlock` attestations the gate is a no-op
+    /// (default-permissive — matches pre-#245 stores).
     fn run_required_attestations_gate(
         &self,
         op_id: &lex_vcs::OpId,
         stage_ids: &[String],
         op_effects: &std::collections::BTreeSet<String>,
     ) -> Result<(), StoreError> {
-        let policy = match crate::policy::load(self.root())? {
-            Some(p) if !p.required_attestations.is_empty() => p,
-            // No file or no rules — gate is a no-op, return
-            // immediately. Avoids opening the attestation log when
-            // there's nothing to check.
-            _ => return Ok(()),
-        };
-        let attest_log = self.attestation_log()?;
-        // One tuple per stage the op touches. Ops with no
-        // attestable stage (imports, empty merges) get a single
-        // `None`-stage tuple, and the gate skips those — there's
-        // nothing to attest.
+        // Build the candidate slice once and reuse it for both
+        // gates. Ops with no attestable stage (imports, empty
+        // merges) get a single `None`-stage tuple; both gates skip
+        // those — there's nothing to attest.
         let candidate: Vec<(lex_vcs::OpId, Option<String>, std::collections::BTreeSet<String>)> =
             if stage_ids.is_empty() {
                 vec![(op_id.clone(), None, op_effects.clone())]
@@ -828,6 +843,20 @@ impl Store {
                     .map(|sid| (op_id.clone(), Some(sid.clone()), op_effects.clone()))
                     .collect()
             };
+        let attest_log = self.attestation_log()?;
+
+        // #248: producer-block gate. Always evaluated regardless of
+        // policy.json contents — `ProducerBlock` attestations live
+        // in the attestation log, not policy.json.
+        crate::policy::check_producer_block(&attest_log, &candidate)
+            .map_err(StoreError::ProducerBlocked)?;
+
+        // #245: required-attestations gate. Only fires when the
+        // policy declares rules.
+        let policy = match crate::policy::load(self.root())? {
+            Some(p) if !p.required_attestations.is_empty() => p,
+            _ => return Ok(()),
+        };
         crate::policy::check_required_attestations(&attest_log, &candidate, &policy)
             .map_err(StoreError::BranchAdvanceBlocked)
     }

--- a/crates/lex-store/tests/producer_block_gate.rs
+++ b/crates/lex-store/tests/producer_block_gate.rs
@@ -1,0 +1,258 @@
+//! Conformance tests for #248: retroactive producer quarantine via
+//! `AttestationKind::ProducerBlock` + the `check_producer_block`
+//! gate.
+//!
+//! Coverage:
+//!
+//! 1. Default-permissive: no `ProducerBlock` attestations → gate
+//!    passes.
+//! 2. ProducerBlock attestation → gate refuses to advance over an
+//!    op whose stage carries an attestation produced by the
+//!    quarantined tool *at or after* `blocked_at`. Pre-block
+//!    attestations are grandfathered.
+//! 3. `ProducerUnblock` reverses the block by timestamp; the gate
+//!    honors the latest verdict.
+//! 4. The structured `ProducerBlocked` envelope shape matches the
+//!    issue's HTTP API expectation.
+//! 5. Self-references (a tool's own ProducerBlock attestations,
+//!    stored at `stage_id == tool_id`) don't trip the gate.
+
+use lex_store::policy::{check_producer_block, ProducerBlocked};
+use lex_vcs::{
+    Attestation, AttestationKind, AttestationLog, AttestationResult, ProducerDescriptor,
+};
+use std::collections::BTreeSet;
+
+fn producer(tool: &str) -> ProducerDescriptor {
+    ProducerDescriptor {
+        tool: tool.into(),
+        version: "test".into(),
+        model: None,
+    }
+}
+
+fn typecheck_attestation(stage_id: &str, op_id: &str, by_tool: &str, at: u64) -> Attestation {
+    Attestation::with_timestamp(
+        stage_id.to_string(),
+        Some(op_id.into()),
+        None,
+        AttestationKind::TypeCheck,
+        AttestationResult::Passed,
+        producer(by_tool),
+        None,
+        at,
+    )
+}
+
+fn producer_block_attestation(tool_id: &str, reason: &str, at: u64) -> Attestation {
+    Attestation::with_timestamp(
+        // Stored under stage_id == tool_id so the by-stage index
+        // doubles as a by-tool lookup.
+        tool_id.to_string(),
+        None,
+        None,
+        AttestationKind::ProducerBlock {
+            tool_id: tool_id.into(),
+            reason: reason.into(),
+            blocked_at: at,
+        },
+        AttestationResult::Passed,
+        producer("lex attest retro-block"),
+        None,
+        at,
+    )
+}
+
+fn producer_unblock_attestation(tool_id: &str, reason: &str, at: u64) -> Attestation {
+    Attestation::with_timestamp(
+        tool_id.to_string(),
+        None,
+        None,
+        AttestationKind::ProducerUnblock {
+            tool_id: tool_id.into(),
+            reason: reason.into(),
+            unblocked_at: at,
+        },
+        AttestationResult::Passed,
+        producer("lex attest retro-block"),
+        None,
+        at,
+    )
+}
+
+fn candidate(op_id: &str, stage_id: &str) -> Vec<(String, Option<String>, BTreeSet<String>)> {
+    vec![(
+        op_id.to_string(),
+        Some(stage_id.to_string()),
+        BTreeSet::new(),
+    )]
+}
+
+#[test]
+fn no_producer_blocks_means_gate_passes() {
+    let tmp = tempfile::tempdir().unwrap();
+    let log = AttestationLog::open(tmp.path()).unwrap();
+    log.put(&typecheck_attestation("stage-1", "op-1", "lex-store", 100))
+        .unwrap();
+    let res = check_producer_block(&log, &candidate("op-1", "stage-1"));
+    assert!(res.is_ok());
+}
+
+#[test]
+fn block_after_attestation_does_not_fence_grandfathered_evidence() {
+    // Tool X produced an attestation at t=100. Admin retro-blocks
+    // X at t=200. The block's `blocked_at` is 200, so the t=100
+    // attestation is *before* the cutoff and is not contaminated.
+    // The gate passes — retro-blocks are forward-going from the
+    // cutoff timestamp, not retroactive to the start of time.
+    let tmp = tempfile::tempdir().unwrap();
+    let log = AttestationLog::open(tmp.path()).unwrap();
+    log.put(&typecheck_attestation("stage-1", "op-1", "tool-X", 100))
+        .unwrap();
+    log.put(&producer_block_attestation(
+        "tool-X",
+        "compromised at 200",
+        200,
+    ))
+    .unwrap();
+    let res = check_producer_block(&log, &candidate("op-1", "stage-1"));
+    assert!(
+        res.is_ok(),
+        "attestation at 100 with block at 200 must not fire: {res:?}",
+    );
+}
+
+#[test]
+fn block_with_attestation_at_or_after_cutoff_refuses_advance() {
+    // Tool X produces an attestation at t=200; admin retro-blocks
+    // X at t=200 (the simultaneous case). The gate refuses because
+    // `attestation.timestamp >= blocked_at`.
+    let tmp = tempfile::tempdir().unwrap();
+    let log = AttestationLog::open(tmp.path()).unwrap();
+    let bad = typecheck_attestation("stage-1", "op-1", "tool-X", 250);
+    log.put(&bad).unwrap();
+    log.put(&producer_block_attestation(
+        "tool-X",
+        "key leaked at 200",
+        200,
+    ))
+    .unwrap();
+
+    let err = check_producer_block(&log, &candidate("op-1", "stage-1"))
+        .expect_err("attestation at 250 with block at 200 must refuse");
+    let blocked: ProducerBlocked = err;
+    assert_eq!(blocked.op_id, "op-1");
+    assert_eq!(blocked.stage_id, "stage-1");
+    assert_eq!(blocked.tool_id, "tool-X");
+    assert_eq!(blocked.blocked_at, 200);
+    assert_eq!(blocked.attestation_at, 250);
+    assert_eq!(blocked.attestation_id, bad.attestation_id);
+}
+
+#[test]
+fn unblock_after_block_clears_the_quarantine() {
+    // Block at t=200, unblock at t=300, attestation at t=400.
+    // Latest verdict is "unblocked", so the gate passes.
+    let tmp = tempfile::tempdir().unwrap();
+    let log = AttestationLog::open(tmp.path()).unwrap();
+    log.put(&typecheck_attestation("stage-1", "op-1", "tool-X", 400))
+        .unwrap();
+    log.put(&producer_block_attestation("tool-X", "compromised", 200))
+        .unwrap();
+    log.put(&producer_unblock_attestation(
+        "tool-X",
+        "vendor patched and rotated keys",
+        300,
+    ))
+    .unwrap();
+
+    let res = check_producer_block(&log, &candidate("op-1", "stage-1"));
+    assert!(res.is_ok(), "unblock should clear the quarantine: {res:?}");
+}
+
+#[test]
+fn block_after_unblock_re_quarantines() {
+    // unblock at t=200, then a fresh block at t=400. attestation
+    // at t=500. Latest verdict is "blocked", so the gate refuses.
+    let tmp = tempfile::tempdir().unwrap();
+    let log = AttestationLog::open(tmp.path()).unwrap();
+    log.put(&typecheck_attestation("stage-1", "op-1", "tool-X", 500))
+        .unwrap();
+    log.put(&producer_unblock_attestation("tool-X", "ok at 200", 200))
+        .unwrap();
+    log.put(&producer_block_attestation("tool-X", "re-flagged", 400))
+        .unwrap();
+
+    let err = check_producer_block(&log, &candidate("op-1", "stage-1"))
+        .expect_err("re-block must fire");
+    assert_eq!(err.tool_id, "tool-X");
+    assert_eq!(err.blocked_at, 400);
+}
+
+#[test]
+fn envelope_shape_matches_issue_spec() {
+    let blocked = ProducerBlocked {
+        op_id: "op-deadbeef".into(),
+        stage_id: "stage-1".into(),
+        tool_id: "claude-code-mcp@v0.3.1".into(),
+        blocked_at: 1_700_000_200,
+        attestation_at: 1_700_000_400,
+        attestation_id: "attestation-feedface".into(),
+    };
+    let env = blocked.to_envelope();
+    assert_eq!(env["error"], "ProducerBlocked");
+    assert_eq!(env["op_id"], "op-deadbeef");
+    assert_eq!(env["stage_id"], "stage-1");
+    assert_eq!(env["tool_id"], "claude-code-mcp@v0.3.1");
+    assert_eq!(env["blocked_at"], 1_700_000_200);
+    assert_eq!(env["attestation_at"], 1_700_000_400);
+    assert_eq!(env["attestation_id"], "attestation-feedface");
+}
+
+#[test]
+fn producer_block_self_references_dont_trip_the_gate() {
+    // ProducerBlock attestations are stored at `stage_id ==
+    // tool_id`. If the candidate stage_id happens to match a
+    // tool_id (rare but possible in tests), the gate must skip
+    // ProducerBlock / ProducerUnblock attestations themselves —
+    // otherwise blocking a tool would also block any op whose
+    // stage_id collides with the tool name.
+    let tmp = tempfile::tempdir().unwrap();
+    let log = AttestationLog::open(tmp.path()).unwrap();
+    // ProducerBlock for "tool-X" — produced by "lex attest retro-block".
+    log.put(&producer_block_attestation("tool-X", "x", 200))
+        .unwrap();
+    // Now also retro-block the *retro-block tool itself*: a
+    // pathological self-reference. The gate must not fire on the
+    // existing ProducerBlock attestation, even though that
+    // attestation's producer (`lex attest retro-block`) is now in
+    // the active block set.
+    log.put(&producer_block_attestation(
+        "lex attest retro-block",
+        "ironic",
+        300,
+    ))
+    .unwrap();
+
+    // Candidate is the tool-X stage itself. The only attestations
+    // there are ProducerBlock/Unblock records for tool-X — those
+    // are skipped by the gate so the advance succeeds.
+    let res = check_producer_block(&log, &candidate("op-1", "tool-X"));
+    assert!(
+        res.is_ok(),
+        "self-referenced producer-block records must not contaminate themselves: {res:?}",
+    );
+}
+
+#[test]
+fn pre_245_records_without_producer_block_field_are_unaffected() {
+    // Backward-compat: an attestation log from before #248 has no
+    // ProducerBlock / ProducerUnblock records. The gate is a no-op
+    // — same behavior as a fresh store.
+    let tmp = tempfile::tempdir().unwrap();
+    let log = AttestationLog::open(tmp.path()).unwrap();
+    log.put(&typecheck_attestation("stage-1", "op-1", "lex-store", 100))
+        .unwrap();
+    let res = check_producer_block(&log, &candidate("op-1", "stage-1"));
+    assert!(res.is_ok());
+}

--- a/crates/lex-vcs/src/attestation.rs
+++ b/crates/lex-vcs/src/attestation.rs
@@ -167,6 +167,84 @@ pub enum AttestationKind {
         actor: String,
         reason: String,
     },
+    /// Retroactive producer quarantine (#248). Declares "as of
+    /// `blocked_at`, attestations produced by `tool_id` are no
+    /// longer trusted; the branch advance gate must refuse to move
+    /// past any op whose attestations were produced by this tool
+    /// at or after `blocked_at`."
+    ///
+    /// Distinct from `policy.json`'s `blocked_producers` (#181):
+    /// that is a *forward-going* read-time tag for the activity
+    /// feed; this is a write-time gate on branch advance, retro-
+    /// active to a specific timestamp. The two compose cleanly —
+    /// `blocked_producers` filters what reviewers see; `ProducerBlock`
+    /// stops a compromised tool's history from being promoted past
+    /// a known-bad point.
+    ///
+    /// Stored at the attestation log under `stage_id == tool_id`
+    /// so the by-stage index doubles as a by-tool lookup for these
+    /// records — no schema break, no separate index needed.
+    /// `Attestation::stage_id` carries the `tool_id` for these
+    /// records; the variant payload duplicates it for clarity in
+    /// the JSON.
+    ProducerBlock {
+        tool_id: String,
+        reason: String,
+        blocked_at: u64,
+    },
+    /// Counterpart to [`AttestationKind::ProducerBlock`] (#248). The
+    /// attestation log is append-only, so revoking a producer block
+    /// is a separate, later fact rather than a delete. The branch
+    /// advance gate honors the most recent verdict for each
+    /// `tool_id` by timestamp.
+    ProducerUnblock {
+        tool_id: String,
+        reason: String,
+        unblocked_at: u64,
+    },
+}
+
+/// Walk a tool's `ProducerBlock` / `ProducerUnblock` attestations
+/// and return the active block timestamp, if any (#248). The
+/// attestation log is append-only, so a tool's state is whichever
+/// `ProducerBlock` / `ProducerUnblock` record has the latest
+/// `timestamp`. Returns `Some(blocked_at)` when the latest verdict
+/// is a `ProducerBlock` and `None` when the latest is an unblock or
+/// no verdict exists.
+///
+/// Ties: a `ProducerUnblock` at the same wall-clock second as a
+/// `ProducerBlock` wins, so re-running an unblock immediately after
+/// a block leaves the tool unblocked. Mirrors the tie-breaking in
+/// [`is_stage_blocked`].
+pub fn active_producer_block(
+    attestations: &[Attestation],
+    tool_id: &str,
+) -> Option<u64> {
+    let mut latest: Option<&Attestation> = None;
+    for a in attestations {
+        let matches = match &a.kind {
+            AttestationKind::ProducerBlock { tool_id: tid, .. }
+            | AttestationKind::ProducerUnblock { tool_id: tid, .. } => tid == tool_id,
+            _ => false,
+        };
+        if !matches {
+            continue;
+        }
+        match latest {
+            None => latest = Some(a),
+            Some(prev) if a.timestamp > prev.timestamp => latest = Some(a),
+            Some(prev) if a.timestamp == prev.timestamp
+                && matches!(a.kind, AttestationKind::ProducerUnblock { .. }) =>
+            {
+                latest = Some(a);
+            }
+            _ => {}
+        }
+    }
+    match latest.map(|a| &a.kind) {
+        Some(AttestationKind::ProducerBlock { blocked_at, .. }) => Some(*blocked_at),
+        _ => None,
+    }
 }
 
 /// Walk a stage's attestations and return whether the latest

--- a/crates/lex-vcs/src/lib.rs
+++ b/crates/lex-vcs/src/lib.rs
@@ -46,8 +46,9 @@ pub mod signing;
 
 pub use apply::{apply, ApplyError, NewHead};
 pub use attestation::{
-    is_stage_blocked, Attestation, AttestationId, AttestationKind, AttestationLog,
-    AttestationResult, ContentHash, Cost, ProducerDescriptor, Signature, SpecId, SpecMethod,
+    active_producer_block, is_stage_blocked, Attestation, AttestationId, AttestationKind,
+    AttestationLog, AttestationResult, ContentHash, Cost, ProducerDescriptor, Signature, SpecId,
+    SpecMethod,
 };
 pub use compute_diff::{compute_diff, effect_label, render_signature};
 pub use diff_report::DiffReport;


### PR DESCRIPTION
Lets an admin declare "as of T, attestations produced by tool X are no longer trusted." The branch advance gate consults the declaration and refuses to advance over an op whose stage carries an attestation produced by a quarantined tool at or after the cutoff. Composes with #245's `required_attestations` gate (both fire from `Store::apply_operation`); distinct from #181's forward-going `blocked_producers` (read-time tag for the activity feed).

## Mechanics

* `AttestationKind::ProducerBlock { tool_id, reason, blocked_at }` and `ProducerUnblock { tool_id, reason, unblocked_at }` — two new variants. Stored at `stage_id == tool_id` so the existing by-stage index doubles as a by-tool lookup; no schema break, no new index.
* `lex_vcs::active_producer_block(attestations, tool_id)` walks Block/Unblock pairs and returns the active block timestamp if the latest verdict is a block. Ties go to Unblock (mirrors `is_stage_blocked`).
* `lex_store::policy::check_producer_block(log, candidate)` — the gate. Builds a `tool_id → blocked_at` map from the attestation log, then per-op checks if any non-self-reference attestation on the op's stage is from a currently-blocked tool with `attestation.timestamp >= blocked_at`.
* `Store::run_required_attestations_gate` now runs `check_producer_block` *before* `check_required_attestations`, so a security failure isn't masked by a missing-evidence error.
* `StoreError::ProducerBlocked(ProducerBlocked)` — distinct variant, distinct envelope (`error: "ProducerBlocked"`, `op_id`, `stage_id`, `tool_id`, `blocked_at`, `attestation_at`, `attestation_id`).

## CLI

* `lex attest retro-block --producer <tool_id> --reason "..."`
* `lex attest retro-unblock --producer <tool_id> --reason "..."`

## Tests

`crates/lex-store/tests/producer_block_gate.rs` — 8 conformance tests:

* No blocks → gate passes.
* Block at T2 with attestation at T1 < T2 → grandfathered, gate passes. Issue's "blocked from this point forward" semantics.
* Block at T2 with attestation at T2+ → gate refuses; envelope carries the right op_id, stage_id, tool_id, attestation_id.
* Unblock at T3 after Block at T2 → latest verdict wins, gate passes for attestations at T3+.
* Re-block at T4 after Unblock at T3 → gate refuses again.
* Self-reference: a ProducerBlock attestation about its own producer doesn't fire the gate on itself.
* Backward-compat: pre-#248 logs without the new variants behave exactly like a fresh store.

## Limitation called out in CHANGELOG

The gate only checks the *new* op being added, not its ancestors. Pre-existing contamination in a branch's history is grandfathered in at the moment of the retro-block. A walk-back gate is the documented follow-up.

Workspace: lex-vcs + lex-store + lex-cli + lex-api all pass; clippy clean. CLI smoke-tested end-to-end.

Closes #248.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_