### PR TITLE
chore: bump workspace to 0.4.0 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to lex-lang. The format follows
 versioning follows [SemVer](https://semver.org/) (pre-1.0; minor
 bumps may carry breaking changes when justified).
 
-## [Unreleased]
+## [0.4.0] — 2026-05-08
+
+The agent-VCS roadmap. Closes the seven gaps from the lex-vcs
+review: a positive attestation-gate on branch advance, retroactive
+producer quarantine, an op-log ↔ trace link, cost accounting on
+ops, append-only sync over HTTP, plus the foundational OpId
+stability spec and operation format versioning that already
+shipped in 0.3.0's tail. Minor bump because every change is
+additive at the data layer (Option fields with
+`skip_serializing_if`, new enum variants, new endpoints) — no
+existing OpId rotates and no on-disk record changes shape.
 
 ### Added — agent-VCS roadmap (#248)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "EUPL-1.2"
 repository = "https://github.com/alpibrusl/lex-lang"

--- a/crates/lex-api/Cargo.toml
+++ b/crates/lex-api/Cargo.toml
@@ -16,14 +16,14 @@ serde_json.workspace = true
 anyhow.workspace = true
 indexmap.workspace = true
 tiny_http = "0.12"
-lex-syntax = { path = "../lex-syntax", version = "0.3.0" }
-lex-ast = { path = "../lex-ast", version = "0.3.0" }
-lex-types = { path = "../lex-types", version = "0.3.0" }
-lex-bytecode = { path = "../lex-bytecode", version = "0.3.0" }
-lex-runtime = { path = "../lex-runtime", version = "0.3.0" }
-lex-store = { path = "../lex-store", version = "0.3.0" }
-lex-trace = { path = "../lex-trace", version = "0.3.0" }
-lex-vcs = { path = "../lex-vcs", version = "0.3.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.4.0" }
+lex-ast = { path = "../lex-ast", version = "0.4.0" }
+lex-types = { path = "../lex-types", version = "0.4.0" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.4.0" }
+lex-runtime = { path = "../lex-runtime", version = "0.4.0" }
+lex-store = { path = "../lex-store", version = "0.4.0" }
+lex-trace = { path = "../lex-trace", version = "0.4.0" }
+lex-vcs = { path = "../lex-vcs", version = "0.4.0" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/lex-ast/Cargo.toml
+++ b/crates/lex-ast/Cargo.toml
@@ -16,4 +16,4 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-syntax = { path = "../lex-syntax", version = "0.3.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.4.0" }

--- a/crates/lex-bytecode/Cargo.toml
+++ b/crates/lex-bytecode/Cargo.toml
@@ -16,8 +16,8 @@ serde_json.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
 sha2.workspace = true
-lex-ast = { path = "../lex-ast", version = "0.3.0" }
-lex-types = { path = "../lex-types", version = "0.3.0" }
+lex-ast = { path = "../lex-ast", version = "0.4.0" }
+lex-types = { path = "../lex-types", version = "0.4.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.3.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.4.0" }

--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -35,10 +35,10 @@ toml = "0.9"
 serde_yaml = "0.9"
 csv = "1"
 rusqlite = { version = "0.36", features = ["bundled"] }
-lex-bytecode = { path = "../lex-bytecode", version = "0.3.0" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.4.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.3.0" }
-lex-ast = { path = "../lex-ast", version = "0.3.0" }
-lex-types = { path = "../lex-types", version = "0.3.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.4.0" }
+lex-ast = { path = "../lex-ast", version = "0.4.0" }
+lex-types = { path = "../lex-types", version = "0.4.0" }
 tempfile = "3"

--- a/crates/lex-search/Cargo.toml
+++ b/crates/lex-search/Cargo.toml
@@ -17,10 +17,10 @@ thiserror.workspace = true
 sha2.workspace = true
 hex.workspace = true
 ureq = { version = "3.3", default-features = false, features = ["rustls", "platform-verifier", "json"] }
-lex-ast = { path = "../lex-ast", version = "0.3.0" }
-lex-store = { path = "../lex-store", version = "0.3.0" }
+lex-ast = { path = "../lex-ast", version = "0.4.0" }
+lex-store = { path = "../lex-store", version = "0.4.0" }
 
 [dev-dependencies]
 tempfile = "3"
 tiny_http = "0.12"
-lex-syntax = { path = "../lex-syntax", version = "0.3.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.4.0" }

--- a/crates/lex-store/Cargo.toml
+++ b/crates/lex-store/Cargo.toml
@@ -16,11 +16,11 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-ast = { path = "../lex-ast", version = "0.3.0" }
-lex-trace = { path = "../lex-trace", version = "0.3.0" }
-lex-types = { path = "../lex-types", version = "0.3.0" }
-lex-vcs = { path = "../lex-vcs", version = "0.3.0" }
+lex-ast = { path = "../lex-ast", version = "0.4.0" }
+lex-trace = { path = "../lex-trace", version = "0.4.0" }
+lex-types = { path = "../lex-types", version = "0.4.0" }
+lex-vcs = { path = "../lex-vcs", version = "0.4.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.3.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.4.0" }
 tempfile = "3"

--- a/crates/lex-trace/Cargo.toml
+++ b/crates/lex-trace/Cargo.toml
@@ -16,9 +16,9 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-bytecode = { path = "../lex-bytecode", version = "0.3.0" }
-lex-ast = { path = "../lex-ast", version = "0.3.0" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.4.0" }
+lex-ast = { path = "../lex-ast", version = "0.4.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.3.0" }
-lex-runtime = { path = "../lex-runtime", version = "0.3.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.4.0" }
+lex-runtime = { path = "../lex-runtime", version = "0.4.0" }

--- a/crates/lex-types/Cargo.toml
+++ b/crates/lex-types/Cargo.toml
@@ -15,7 +15,7 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-ast = { path = "../lex-ast", version = "0.3.0" }
+lex-ast = { path = "../lex-ast", version = "0.4.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.3.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.4.0" }

--- a/crates/lex-vcs/Cargo.toml
+++ b/crates/lex-vcs/Cargo.toml
@@ -11,8 +11,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-lex-ast = { path = "../lex-ast", version = "0.3.0" }
-lex-types = { path = "../lex-types", version = "0.3.0" }
+lex-ast = { path = "../lex-ast", version = "0.4.0" }
+lex-types = { path = "../lex-types", version = "0.4.0" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
@@ -24,4 +24,4 @@ hex.workspace = true
 
 [dev-dependencies]
 tempfile = "3"
-lex-syntax = { path = "../lex-syntax", version = "0.3.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.4.0" }

--- a/crates/spec-checker/Cargo.toml
+++ b/crates/spec-checker/Cargo.toml
@@ -16,11 +16,11 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-syntax = { path = "../lex-syntax", version = "0.3.0" }
-lex-ast = { path = "../lex-ast", version = "0.3.0" }
-lex-types = { path = "../lex-types", version = "0.3.0" }
-lex-bytecode = { path = "../lex-bytecode", version = "0.3.0" }
-lex-runtime = { path = "../lex-runtime", version = "0.3.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.4.0" }
+lex-ast = { path = "../lex-ast", version = "0.4.0" }
+lex-types = { path = "../lex-types", version = "0.4.0" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.4.0" }
+lex-runtime = { path = "../lex-runtime", version = "0.4.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.3.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.4.0" }


### PR DESCRIPTION
Promotes the agent-VCS roadmap from `[Unreleased]` to `[0.4.0] — 2026-05-08`.

## What's in this release

* **#243** OpId stability spec — golden tests + canonical-form invariants
* **#244** Operation format versioning + `lex store migrate-ops`
* **#245** Machine-checkable branch advancement gates via attestations
* **#246** `AttestationKind::Trace { run_id, root_target }` + by-run index
* **#247** Cost accounting on ops (`[budget]` deltas in op payloads)
* **#248** Retroactive producer quarantine via `ProducerBlock` attestation
* **#242** Append-only sync — `lex op push` / `lex attest push` over HTTP

## Why a minor bump

Every change is additive at the data layer:

* **Option fields with `skip_serializing_if`** (budget cost on `OperationKind` variants in #247; `format_version` on `OperationRecord` in #244) — empty fields are omitted from canonical bytes, so existing `OpId`s don't rotate and existing on-disk records don't change shape. The golden hash from #243 still pins the same value.
* **New `AttestationKind` variants** (`Trace` from #246; `ProducerBlock` / `ProducerUnblock` from #248) — additive enum extensions.
* **New HTTP endpoints** (`POST /v1/ops/batch`, `POST /v1/attestations/batch`, `GET /v1/branches/<name>/head` from #242) — additive URL surface.

The only API-visible change worth calling out for downstream consumers: `StoreError` gains `BranchAdvanceBlocked` (#245) and `ProducerBlocked` (#248) variants. Pattern-matchers that don't use a wildcard arm will need a new arm; everyone else is unaffected.

## Mechanical

* `Cargo.toml` workspace `version = "0.3.0"` → `"0.4.0"` (1 site)
* 39 `crates/*/Cargo.toml` inter-crate `version = "0.3.0"` → `"0.4.0"` specifiers
* `CHANGELOG.md`: `## [Unreleased]` → `## [0.4.0] — 2026-05-08` with a brief preamble; existing 5 sub-sections (#248, #245, #246, #247, #242) preserved verbatim

## Test plan

- [x] `cargo build --workspace` clean at 0.4.0
- [x] `cargo test --workspace` green (4 m8 test parallelism flakes pass standalone, same behavior as 0.3.0)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

Same shape as the 0.3.0 bump (commit `1f9e18f`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_