### PR TITLE
lex-api+cli: append-only fetch of ops + attestations (#260)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to lex-lang. The format follows
 versioning follows [SemVer](https://semver.org/) (pre-1.0; minor
 bumps may carry breaking changes when justified).
 
+## [Unreleased]
+
+### Added — agent-VCS roadmap (#260)
+
+The symmetric inverse of #242. With both push and pull, content-
+addressed sync is bidirectional: any agent on any machine can
+both publish and consume ops + attestations from a remote.
+
+- **`GET /v1/ops/since?after=<op_id>&branch=<name>&limit=<n>`** —
+  server endpoint accepting a since-cutoff and returning a JSON
+  array of `OperationRecord`s reachable from `branch.head_op` but
+  not from `<after>`, sorted **oldest-first** so the client can
+  apply with the existing idempotent `OpLog::put`. Empty array
+  when caller is at the remote's head, when the branch doesn't
+  exist, or when the remote is behind. `--limit` chunks large
+  gaps.
+- **`GET /v1/attestations/since?after-op=<op_id>&limit=<n>`** —
+  mirror for the attestation log. Excludes attestations whose
+  `op_id` is in the cutoff's ancestry; always ships
+  attestations with `op_id: None` (e.g. `Override`,
+  `ProducerBlock`).
+- **`lex op pull <remote_url> [--branch NAME] [--since OP_ID]
+  [--limit N] [--dry-run]`** CLI command. Probes the remote head,
+  fetches the delta, validates each record (content-addressing +
+  DAG integrity), persists via `OpLog::put`. On clean
+  fast-forward (local head is an ancestor of the new tip) the
+  branch advances; on divergent histories the pull refuses with
+  a `DivergentHistory { local_head, remote_head }` envelope and
+  the local branch is unchanged.
+- **`lex attest pull <remote_url> [--since-op OP_ID] [--limit N]
+  [--dry-run]`** mirrors the same shape for attestations.
+  Attestations whose `op_id` references an op the local doesn't
+  yet have are skipped (with a `rejected_unknown_op` count) so
+  the caller can re-issue after pulling the missing ops.
+
+### Out of scope (called out for follow-up)
+
+- **Bidirectional `lex sync`** that wraps `pull && push` — a CLI
+  veneer, not a new protocol primitive.
+- **`--force-fast-forward`** that overwrites local divergent
+  history. Route through the merge engine (#134) instead.
+- **Capability-scoped pull** (only fetch ops matching effect set
+  X). Symmetric to the same gap on the push side.
+
 ## [0.4.0] — 2026-05-08
 
 The agent-VCS roadmap. Closes the seven gaps from the lex-vcs

--- a/crates/lex-api/src/handlers.rs
+++ b/crates/lex-api/src/handlers.rs
@@ -191,6 +191,11 @@ fn route(
             let name = &p["/v1/branches/".len()..p.len() - "/head".len()];
             branch_head_handler(state, name)
         }
+        // ---- #260: append-only fetch (inverse of #242 push)
+        // Body is a JSON array of OperationRecords reachable from
+        // `branch.head_op` but not from `after`, oldest-first.
+        (Method::Get, "/v1/ops/since") => ops_since_handler(state, query),
+        (Method::Get, "/v1/attestations/since") => attestations_since_handler(state, query),
         _ => error_response(404, format!("unknown route: {method:?} {path}")),
     }
 }
@@ -1104,5 +1109,168 @@ pub(crate) fn branch_head_handler(state: &State, name: &str)
         "branch": name,
         "head_op": head,
     }))
+}
+
+/// `GET /v1/ops/since?after=<op_id>&branch=<name>&limit=<n>` (#260).
+/// Server endpoint for `lex op pull`.
+///
+/// Returns a JSON array of `OperationRecord`s reachable from
+/// `branch.head_op` but not from `<after>`, sorted **oldest-first**
+/// so the client can apply them in topological order without
+/// re-sorting. Empty array when:
+///
+/// * The branch doesn't exist on the remote.
+/// * The branch's `head_op` is `None`.
+/// * `after == branch.head_op` (caller is already at the remote's head).
+/// * `after` is *ahead of* the remote's head (caller is past the
+///   remote — the symmetric "remote behind" case from #260).
+///
+/// `branch` defaults to `main`. `limit` caps the response — useful
+/// for chunked pulls of large gaps; clients re-issue with the next
+/// `after` once the prefix has landed.
+///
+/// Failure modes:
+///
+/// * `400` if the query string is malformed.
+/// * `200` with `[]` for any of the empty-result cases above. "Caller
+///   is already up to date" is a normal answer, not an error.
+pub(crate) fn ops_since_handler(state: &State, query: &str)
+    -> Response<std::io::Cursor<Vec<u8>>>
+{
+    let mut after: Option<String> = None;
+    let mut branch = String::from("main");
+    let mut limit: Option<usize> = None;
+    for kv in query.split('&') {
+        let Some((k, v)) = kv.split_once('=') else { continue };
+        match k {
+            "after" => after = Some(v.to_string()),
+            "branch" => branch = v.to_string(),
+            "limit" => {
+                limit = Some(match v.parse::<usize>() {
+                    Ok(n) => n,
+                    Err(_) => return error_response(400,
+                        format!("limit must be a positive integer, got `{v}`")),
+                });
+            }
+            _ => {}
+        }
+    }
+
+    let store = state.store.lock().unwrap();
+    let log = match lex_vcs::OpLog::open(store.root()) {
+        Ok(l) => l,
+        Err(e) => return error_response(500, format!("opening op log: {e}")),
+    };
+    let head = match store.get_branch(&branch) {
+        Ok(Some(b)) => b.head_op,
+        Ok(None) => None,
+        Err(e) => return error_response(500, format!("get_branch: {e}")),
+    };
+    let Some(head) = head else {
+        return json_response(200, &serde_json::json!([]));
+    };
+
+    let ops_since = match log.ops_since(&head, after.as_ref()) {
+        Ok(o) => o,
+        Err(e) => return error_response(500, format!("ops_since: {e}")),
+    };
+    // ops_since walks newest-first; reverse so the client receives
+    // oldest-first and can apply them in topological order with
+    // `OpLog::put` straight through.
+    let mut ops = ops_since;
+    ops.reverse();
+    if let Some(n) = limit {
+        ops.truncate(n);
+    }
+
+    json_response(200, &serde_json::to_value(&ops).unwrap_or_default())
+}
+
+/// `GET /v1/attestations/since?after-op=<op_id>&limit=<n>` (#260).
+/// Mirror of `ops_since_handler` for the attestation log.
+///
+/// Returns attestations whose `op_id` field is reachable from
+/// **any** branch's head — not just one — and not in `after_op`'s
+/// ancestry. The cross-branch fan-out matches the push side:
+/// attestations are stage-keyed, not branch-keyed, so a single
+/// "since this op" filter is the right shape.
+///
+/// Attestations with `op_id: None` (e.g. `Override`,
+/// `ProducerBlock`) are always included — the cutoff doesn't apply.
+/// `--limit` caps the response.
+pub(crate) fn attestations_since_handler(state: &State, query: &str)
+    -> Response<std::io::Cursor<Vec<u8>>>
+{
+    let mut after_op: Option<String> = None;
+    let mut limit: Option<usize> = None;
+    for kv in query.split('&') {
+        let Some((k, v)) = kv.split_once('=') else { continue };
+        match k {
+            "after-op" => after_op = Some(v.to_string()),
+            "limit" => {
+                limit = Some(match v.parse::<usize>() {
+                    Ok(n) => n,
+                    Err(_) => return error_response(400,
+                        format!("limit must be a positive integer, got `{v}`")),
+                });
+            }
+            _ => {}
+        }
+    }
+
+    let store = state.store.lock().unwrap();
+    let log = match store.attestation_log() {
+        Ok(l) => l,
+        Err(e) => return error_response(500, format!("opening attestation log: {e}")),
+    };
+
+    // Build the exclude set: every op_id reachable from `after_op`,
+    // inclusive. Attestations whose op_id is in this set were
+    // already known to the caller.
+    let exclude: std::collections::BTreeSet<String> = match &after_op {
+        None => std::collections::BTreeSet::new(),
+        Some(cutoff) => {
+            let op_log = match lex_vcs::OpLog::open(store.root()) {
+                Ok(l) => l,
+                Err(e) => return error_response(500, format!("opening op log: {e}")),
+            };
+            match op_log.walk_back(cutoff, None) {
+                Ok(records) => records.into_iter().map(|r| r.op_id).collect(),
+                Err(_) => {
+                    // Cutoff op doesn't exist on this remote. Treat
+                    // as "no exclude" — caller will get every
+                    // attestation. They may dedup client-side.
+                    std::collections::BTreeSet::new()
+                }
+            }
+        }
+    };
+
+    let all = match log.list_all() {
+        Ok(v) => v,
+        Err(e) => return error_response(500, format!("listing attestations: {e}")),
+    };
+    let mut filtered: Vec<lex_vcs::Attestation> = all
+        .into_iter()
+        .filter(|a| match &a.op_id {
+            Some(op_id) => !exclude.contains(op_id),
+            // No op_id = doesn't participate in the cutoff; always
+            // ship it on the first pull, server-side idempotency
+            // dedupes on the client.
+            None => true,
+        })
+        .collect();
+    // Stable order: oldest-first by `timestamp`, then by
+    // `attestation_id` for ties. Lets the client land them
+    // deterministically.
+    filtered.sort_by(|a, b| {
+        a.timestamp.cmp(&b.timestamp)
+            .then_with(|| a.attestation_id.cmp(&b.attestation_id))
+    });
+    if let Some(n) = limit {
+        filtered.truncate(n);
+    }
+
+    json_response(200, &serde_json::to_value(&filtered).unwrap_or_default())
 }
 

--- a/crates/lex-api/tests/op_pull.rs
+++ b/crates/lex-api/tests/op_pull.rs
@@ -1,0 +1,334 @@
+//! Conformance tests for #260 — HTTP pull of ops + attestations
+//! (the inverse of #242's push).
+//!
+//! Coverage:
+//!
+//! 1. Pull from empty remote returns `[]`.
+//! 2. Pull from a remote that's strictly ahead returns the delta
+//!    in oldest-first order.
+//! 3. Pull when caller is already at the remote's head returns `[]`.
+//! 4. `--limit` chunks the response.
+//! 5. Attestation pull respects the `after-op` filter.
+//! 6. Attestations with `op_id: None` (Override etc.) ship on
+//!    every pull (no cutoff applies).
+
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpStream};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use lex_api::handlers::State;
+use lex_vcs::{
+    Attestation, AttestationKind, AttestationResult, Operation, OperationKind, OperationRecord,
+    ProducerDescriptor, StageTransition,
+};
+use std::collections::BTreeSet;
+use tempfile::TempDir;
+
+struct Server {
+    addr: SocketAddr,
+    tmp: TempDir,
+    _join: Option<thread::JoinHandle<()>>,
+}
+
+fn start_server() -> Server {
+    let tmp = TempDir::new().unwrap();
+    let server = tiny_http::Server::http(("127.0.0.1", 0)).unwrap();
+    let addr: SocketAddr = match server.server_addr() {
+        tiny_http::ListenAddr::IP(addr) => addr,
+        _ => panic!("expected IP listener"),
+    };
+    let state = Arc::new(State::open(tmp.path().to_path_buf()).unwrap());
+    let join = thread::spawn(move || lex_api::serve_on(server, state));
+    thread::sleep(Duration::from_millis(20));
+    Server { addr, tmp, _join: Some(join) }
+}
+
+fn http(addr: &SocketAddr, method: &str, path: &str, body: &str) -> (u16, String) {
+    let mut s = TcpStream::connect(addr).unwrap();
+    s.set_read_timeout(Some(Duration::from_secs(10))).unwrap();
+    let req = format!(
+        "{method} {path} HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(), body
+    );
+    s.write_all(req.as_bytes()).unwrap();
+    let mut buf = String::new();
+    s.read_to_string(&mut buf).unwrap();
+    let (head, body) = buf.split_once("\r\n\r\n").unwrap_or((&buf, ""));
+    let status = head.split_whitespace().nth(1).unwrap_or("0").parse().unwrap_or(0);
+    (status, body.to_string())
+}
+
+fn add_op(parent: Option<&str>, sig: &str, stg: &str) -> OperationRecord {
+    let parents: Vec<String> = parent.map(|p| p.to_string()).into_iter().collect();
+    OperationRecord::new(
+        Operation::new(
+            OperationKind::AddFunction {
+                sig_id: sig.into(),
+                stage_id: stg.into(),
+                effects: BTreeSet::new(),
+                budget_cost: None,
+            },
+            parents,
+        ),
+        StageTransition::Create {
+            sig_id: sig.into(),
+            stage_id: stg.into(),
+        },
+    )
+}
+
+fn modify_op(parent: &str, sig: &str, from: &str, to: &str) -> OperationRecord {
+    OperationRecord::new(
+        Operation::new(
+            OperationKind::ModifyBody {
+                sig_id: sig.into(),
+                from_stage_id: from.into(),
+                to_stage_id: to.into(),
+                from_budget: None,
+                to_budget: None,
+            },
+            [parent.to_string()],
+        ),
+        StageTransition::Replace {
+            sig_id: sig.into(),
+            from: from.into(),
+            to: to.into(),
+        },
+    )
+}
+
+fn typecheck(stage_id: &str, op_id: &str) -> Attestation {
+    Attestation::with_timestamp(
+        stage_id.to_string(),
+        Some(op_id.into()),
+        None,
+        AttestationKind::TypeCheck,
+        AttestationResult::Passed,
+        ProducerDescriptor {
+            tool: "test".into(),
+            version: "0".into(),
+            model: None,
+        },
+        None,
+        1_700_000_000,
+    )
+}
+
+/// Seed the remote by pushing a chain of ops via /v1/ops/batch and
+/// then advancing `main`'s head_op via the file directly. (We
+/// can't use Store::apply_operation_checked here without a real
+/// candidate program; the server-side push endpoint is the
+/// supported way to populate a test fixture.)
+fn seed_remote_chain(srv: &Server, length: usize) -> Vec<OperationRecord> {
+    assert!(length >= 1);
+    let mut chain: Vec<OperationRecord> = Vec::new();
+    let root = add_op(None, "fac", "stg-0");
+    chain.push(root.clone());
+    let mut last_id = root.op_id.clone();
+    let mut last_stage = "stg-0".to_string();
+    for i in 1..length {
+        let to_stg = format!("stg-{i}");
+        let m = modify_op(&last_id, "fac", &last_stage, &to_stg);
+        last_id = m.op_id.clone();
+        last_stage.clone_from(&to_stg);
+        chain.push(m);
+    }
+    let body = serde_json::to_string(&chain).unwrap();
+    let (status, _) = http(&srv.addr, "POST", "/v1/ops/batch", &body);
+    assert_eq!(status, 200);
+
+    // Manually advance main's head_op to the last record. Mirrors
+    // the lex op pull's `fast_forward_branch_head` helper.
+    let path = srv.tmp.path().join("branches/main.json");
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    let value = serde_json::json!({
+        "name": "main",
+        "parent": serde_json::Value::Null,
+        "head_op": chain.last().unwrap().op_id,
+        "merges": [],
+        "created_at": 0,
+    });
+    std::fs::write(&path, serde_json::to_vec_pretty(&value).unwrap()).unwrap();
+    chain
+}
+
+#[test]
+fn pull_from_empty_remote_returns_empty_array() {
+    let srv = start_server();
+    let (status, body) = http(&srv.addr, "GET", "/v1/ops/since?branch=main", "");
+    assert_eq!(status, 200, "{body}");
+    let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(v.as_array().map(|a| a.len()), Some(0));
+}
+
+#[test]
+fn pull_returns_ops_oldest_first() {
+    let srv = start_server();
+    let chain = seed_remote_chain(&srv, 5);
+
+    let (status, body) = http(&srv.addr, "GET", "/v1/ops/since?branch=main", "");
+    assert_eq!(status, 200, "{body}");
+    let received: Vec<OperationRecord> = serde_json::from_str(&body).unwrap();
+    assert_eq!(received.len(), 5);
+    // Oldest-first: first record has no parents, then each subsequent
+    // record has the previous one as parent.
+    assert!(received[0].op.parents.is_empty(), "first record should be the genesis");
+    for i in 1..5 {
+        assert_eq!(
+            received[i].op.parents, vec![received[i - 1].op_id.clone()],
+            "record {i} must reference record {} as parent", i - 1,
+        );
+    }
+    // Match the seeded chain.
+    for (got, expected) in received.iter().zip(chain.iter()) {
+        assert_eq!(got.op_id, expected.op_id);
+    }
+}
+
+#[test]
+fn pull_with_after_returns_only_new_records() {
+    let srv = start_server();
+    let chain = seed_remote_chain(&srv, 5);
+    let cutoff = &chain[2].op_id;
+
+    let path = format!("/v1/ops/since?branch=main&after={cutoff}");
+    let (status, body) = http(&srv.addr, "GET", &path, "");
+    assert_eq!(status, 200, "{body}");
+    let received: Vec<OperationRecord> = serde_json::from_str(&body).unwrap();
+    // Records 3 and 4 are after the cutoff (cutoff itself excluded).
+    assert_eq!(received.len(), 2);
+    assert_eq!(received[0].op_id, chain[3].op_id);
+    assert_eq!(received[1].op_id, chain[4].op_id);
+}
+
+#[test]
+fn pull_at_remote_head_returns_empty() {
+    let srv = start_server();
+    let chain = seed_remote_chain(&srv, 3);
+    let head = &chain.last().unwrap().op_id;
+
+    let path = format!("/v1/ops/since?branch=main&after={head}");
+    let (status, body) = http(&srv.addr, "GET", &path, "");
+    assert_eq!(status, 200, "{body}");
+    let received: Vec<OperationRecord> = serde_json::from_str(&body).unwrap();
+    assert!(received.is_empty(), "caller is at remote head; pull should be a no-op");
+}
+
+#[test]
+fn pull_with_limit_chunks_the_response() {
+    let srv = start_server();
+    let chain = seed_remote_chain(&srv, 10);
+
+    let (status, body) = http(&srv.addr, "GET", "/v1/ops/since?branch=main&limit=3", "");
+    assert_eq!(status, 200, "{body}");
+    let received: Vec<OperationRecord> = serde_json::from_str(&body).unwrap();
+    assert_eq!(received.len(), 3);
+    // First chunk is the oldest 3 records.
+    for i in 0..3 {
+        assert_eq!(received[i].op_id, chain[i].op_id);
+    }
+
+    // Next chunk via `after`.
+    let after = &chain[2].op_id;
+    let path = format!("/v1/ops/since?branch=main&after={after}&limit=3");
+    let (_, body) = http(&srv.addr, "GET", &path, "");
+    let next: Vec<OperationRecord> = serde_json::from_str(&body).unwrap();
+    assert_eq!(next.len(), 3);
+    assert_eq!(next[0].op_id, chain[3].op_id);
+}
+
+#[test]
+fn pull_unknown_branch_returns_empty() {
+    let srv = start_server();
+    let _ = seed_remote_chain(&srv, 2);
+
+    let (status, body) = http(&srv.addr, "GET", "/v1/ops/since?branch=does_not_exist", "");
+    assert_eq!(status, 200, "{body}");
+    let received: Vec<OperationRecord> = serde_json::from_str(&body).unwrap();
+    assert!(received.is_empty());
+}
+
+#[test]
+fn attestations_pull_respects_after_op_filter() {
+    let srv = start_server();
+    let chain = seed_remote_chain(&srv, 3);
+
+    // Push one TypeCheck per op.
+    let attestations: Vec<Attestation> = chain.iter()
+        .map(|r| {
+            let stage = match &r.op.kind {
+                OperationKind::AddFunction { stage_id, .. } => stage_id.clone(),
+                OperationKind::ModifyBody { to_stage_id, .. } => to_stage_id.clone(),
+                _ => unreachable!(),
+            };
+            typecheck(&stage, &r.op_id)
+        })
+        .collect();
+    let body = serde_json::to_string(&attestations).unwrap();
+    let (status, _) = http(&srv.addr, "POST", "/v1/attestations/batch", &body);
+    assert_eq!(status, 200);
+
+    // Pull with no cutoff: get every attestation.
+    let (status, body) = http(&srv.addr, "GET", "/v1/attestations/since", "");
+    assert_eq!(status, 200, "{body}");
+    let all: Vec<Attestation> = serde_json::from_str(&body).unwrap();
+    assert_eq!(all.len(), 3);
+
+    // Pull with after-op = chain[1]: get only attestations whose
+    // op_id is *not* in chain[1]'s ancestry. That's just the
+    // attestation on chain[2] (chain[0] and chain[1] are
+    // ancestors of chain[1]).
+    let cutoff = &chain[1].op_id;
+    let path = format!("/v1/attestations/since?after-op={cutoff}");
+    let (_, body) = http(&srv.addr, "GET", &path, "");
+    let after: Vec<Attestation> = serde_json::from_str(&body).unwrap();
+    assert_eq!(after.len(), 1, "only the attestation on chain[2] should remain");
+    assert_eq!(after[0].op_id.as_deref(), Some(chain[2].op_id.as_str()));
+}
+
+#[test]
+fn attestations_with_no_op_id_ship_regardless_of_cutoff() {
+    let srv = start_server();
+    let chain = seed_remote_chain(&srv, 2);
+
+    // An Override attestation has op_id: None — doesn't participate
+    // in the cutoff.
+    let stage_id = match &chain[0].op.kind {
+        OperationKind::AddFunction { stage_id, .. } => stage_id.clone(),
+        _ => unreachable!(),
+    };
+    let override_att = Attestation::with_timestamp(
+        stage_id,
+        None, // no op_id
+        None,
+        AttestationKind::Override {
+            actor: "alice".into(),
+            reason: "manual".into(),
+            target_attestation_id: None,
+        },
+        AttestationResult::Passed,
+        ProducerDescriptor {
+            tool: "test".into(),
+            version: "0".into(),
+            model: None,
+        },
+        None,
+        1_700_000_001,
+    );
+    let body = serde_json::to_string(&vec![override_att.clone()]).unwrap();
+    let (status, _) = http(&srv.addr, "POST", "/v1/attestations/batch", &body);
+    assert_eq!(status, 200);
+
+    // Pull with after-op = remote head: cutoff would normally
+    // include chain[0]'s ancestry. The Override's op_id is None,
+    // so it always ships.
+    let cutoff = &chain.last().unwrap().op_id;
+    let path = format!("/v1/attestations/since?after-op={cutoff}");
+    let (_, body) = http(&srv.addr, "GET", &path, "");
+    let received: Vec<Attestation> = serde_json::from_str(&body).unwrap();
+    let has_override = received.iter()
+        .any(|a| matches!(a.kind, AttestationKind::Override { .. }));
+    assert!(has_override, "Override attestation must ship regardless of after-op cutoff");
+}

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -2201,6 +2201,9 @@ fn cmd_attest(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     if sub == "push" {
         return cmd_attest_push(fmt, rest);
     }
+    if sub == "pull" {
+        return cmd_attest_pull(fmt, rest);
+    }
     match sub.as_str() {
         "filter" => {
             let mut kind_filter: Option<String> = None;
@@ -2571,6 +2574,146 @@ fn cmd_attest_push(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         println!(
             "pushed {received} attestations to {remote_text}: \
              {added} added, {skipped} skipped (already present)"
+        );
+    });
+    Ok(())
+}
+
+/// `lex attest pull <remote_url> [--since-op OP_ID] [--limit N]
+/// [--dry-run] [--store DIR]` (#260).
+///
+/// Append-only fetch of attestations — the inverse of `lex attest
+/// push`. Asks the remote for attestations whose `op_id` is not in
+/// the ancestry of `--since-op` (or, without the flag, whose
+/// `op_id` we don't already know about), validates each, and
+/// persists.
+///
+/// Idempotency: re-running converges to `added: 0`. Network failure
+/// mid-pull leaves the local with the prefix that landed; the next
+/// run picks up where the failure occurred.
+fn cmd_attest_pull(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    let (root, rest, _, _) = parse_store_flag(args);
+    let mut remote: Option<String> = None;
+    let mut since_op: Option<String> = None;
+    let mut limit: Option<usize> = None;
+    let mut dry_run = false;
+    let mut it = rest.iter();
+    while let Some(a) = it.next() {
+        match a.as_str() {
+            "--since-op" => {
+                since_op = Some(it.next().ok_or_else(|| anyhow!("--since-op needs an op_id"))?.clone());
+            }
+            "--limit" => {
+                limit = Some(it.next().ok_or_else(|| anyhow!("--limit needs N"))?
+                    .parse().map_err(|e| anyhow!("--limit: {e}"))?);
+            }
+            "--dry-run" => dry_run = true,
+            other if !other.starts_with("--") && remote.is_none() => {
+                remote = Some(other.to_string());
+            }
+            other => bail!("unexpected arg `{other}`"),
+        }
+    }
+    let remote = remote.ok_or_else(|| anyhow!(
+        "usage: lex attest pull <remote_url> [--since-op OP_ID] [--limit N] [--dry-run] [--store DIR]"
+    ))?;
+
+    let mut url = format!(
+        "{}/v1/attestations/since",
+        remote.trim_end_matches('/'),
+    );
+    let mut sep = '?';
+    if let Some(op) = &since_op {
+        url.push_str(&format!("{sep}after-op={op}"));
+        sep = '&';
+    }
+    if let Some(n) = limit {
+        url.push_str(&format!("{sep}limit={n}"));
+    }
+    let resp = ureq::get(&url)
+        .call()
+        .map_err(|e| anyhow!("GET {url}: {e}"))?;
+    let status = resp.status().as_u16();
+    if status >= 400 {
+        let body = resp.into_body().read_to_string()
+            .unwrap_or_else(|_| "(unreadable body)".into());
+        bail!("server returned HTTP {status}: {body}");
+    }
+    let received: Vec<lex_vcs::Attestation> = resp.into_body().read_json()
+        .map_err(|e| anyhow!("decoding response from {url}: {e}"))?;
+
+    if dry_run {
+        let ids: Vec<&String> = received.iter().map(|a| &a.attestation_id).collect();
+        let data = serde_json::json!({
+            "remote": remote,
+            "since_op": since_op,
+            "would_receive": received.len(),
+            "attestation_ids": ids,
+        });
+        let count = received.len();
+        let remote_text = remote.clone();
+        acli::emit_or_text("attest-pull", data, fmt, move || {
+            println!("would pull {count} attestations from {remote_text} (dry-run)");
+        });
+        return Ok(());
+    }
+
+    let store = lex_store::Store::open(&root)
+        .with_context(|| format!("opening store at {}", root.display()))?;
+    let log = store.attestation_log()?;
+    let op_log = lex_vcs::OpLog::open(&root)?;
+
+    let mut added = 0usize;
+    let mut rejected_unknown_op = 0usize;
+    for att in &received {
+        // Validate content-addressing.
+        let expected = lex_vcs::Attestation::with_timestamp(
+            att.stage_id.clone(),
+            att.op_id.clone(),
+            att.intent_id.clone(),
+            att.kind.clone(),
+            att.result.clone(),
+            att.produced_by.clone(),
+            att.cost.clone(),
+            att.timestamp,
+        ).attestation_id;
+        if expected != att.attestation_id {
+            bail!(
+                "remote returned attestation with mismatched id: supplied={}, expected={}",
+                att.attestation_id, expected,
+            );
+        }
+        // If the attestation references an op_id, that op must
+        // already exist locally — otherwise the attestation is
+        // dangling. Skip rather than fail the whole pull; the
+        // caller can re-issue after pulling the missing ops.
+        if let Some(op_id) = &att.op_id {
+            if op_log.get(op_id)?.is_none() {
+                rejected_unknown_op += 1;
+                continue;
+            }
+        }
+        let was_present = log.get(&att.attestation_id)?.is_some();
+        log.put(att)?;
+        if !was_present {
+            added += 1;
+        }
+    }
+
+    let data = serde_json::json!({
+        "remote": remote,
+        "received": received.len(),
+        "added": added,
+        "skipped": received.len() - added - rejected_unknown_op,
+        "rejected_unknown_op": rejected_unknown_op,
+    });
+    let total = received.len();
+    let skipped = received.len() - added - rejected_unknown_op;
+    let remote_text = remote.clone();
+    acli::emit_or_text("attest-pull", data, fmt, move || {
+        println!(
+            "pulled {total} attestations from {remote_text}: \
+             {added} new, {skipped} already present, {rejected_unknown_op} skipped (unknown op_id)"
         );
     });
     Ok(())

--- a/crates/lex-cli/src/op.rs
+++ b/crates/lex-cli/src/op.rs
@@ -2,7 +2,7 @@
 
 use crate::acli;
 use ::acli::OutputFormat;
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use lex_store::Store;
 use lex_vcs::{OpLog, OperationRecord};
 use std::path::PathBuf;
@@ -28,12 +28,13 @@ fn parse_store(args: &[String]) -> (PathBuf, Vec<String>) {
 
 pub fn cmd_op(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let sub = args.first().ok_or_else(|| anyhow!(
-        "usage: lex op {{show|log|push}} [--store DIR] ..."))?;
+        "usage: lex op {{show|log|push|pull}} [--store DIR] ..."))?;
     let rest = &args[1..];
     match sub.as_str() {
         "show" => cmd_op_show(fmt, rest),
         "log"  => cmd_op_log(fmt, rest),
         "push" => cmd_op_push(fmt, rest),
+        "pull" => cmd_op_pull(fmt, rest),
         other  => bail!("unknown `lex op` subcommand: {other}"),
     }
 }
@@ -345,4 +346,257 @@ pub(crate) fn probe_remote_head(remote: &str, branch: &str) -> Result<Option<Str
     Ok(body.get("head_op")
         .and_then(|v| v.as_str())
         .map(|s| s.to_string()))
+}
+
+/// `lex op pull <remote_url> [--branch NAME] [--since OP_ID]
+/// [--limit N] [--dry-run] [--store DIR]` (#260).
+///
+/// Append-only fetch — the inverse of `lex op push`. Asks the
+/// remote for ops reachable from its `branch.head_op` but not from
+/// the local branch's head, validates each, and persists. On
+/// fast-forward (local head is an ancestor of the new remote head)
+/// the local branch's `head_op` advances; on divergent histories
+/// the pull refuses with a structured envelope and the local
+/// branch is unchanged.
+///
+/// `--since` overrides the cutoff explicitly (useful for partial
+/// pulls). `--limit` chunks the response so very large gaps don't
+/// require a single huge round-trip; the client re-issues until
+/// the remote reports an empty response.
+fn cmd_op_pull(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    let (root, rest) = parse_store(args);
+    let mut remote: Option<String> = None;
+    let mut branch: Option<String> = None;
+    let mut since: Option<String> = None;
+    let mut limit: Option<usize> = None;
+    let mut dry_run = false;
+    let mut it = rest.iter();
+    while let Some(a) = it.next() {
+        match a.as_str() {
+            "--branch" => {
+                branch = Some(it.next().ok_or_else(|| anyhow!("--branch needs a value"))?.clone());
+            }
+            "--since" => {
+                since = Some(it.next().ok_or_else(|| anyhow!("--since needs an op_id"))?.clone());
+            }
+            "--limit" => {
+                limit = Some(it.next().ok_or_else(|| anyhow!("--limit needs N"))?
+                    .parse().map_err(|e| anyhow!("--limit: {e}"))?);
+            }
+            "--dry-run" => dry_run = true,
+            other if !other.starts_with("--") && remote.is_none() => {
+                remote = Some(other.to_string());
+            }
+            other => bail!("unexpected arg `{other}`"),
+        }
+    }
+    let remote = remote.ok_or_else(|| anyhow!(
+        "usage: lex op pull <remote_url> [--branch NAME] [--since OP_ID] [--limit N] [--dry-run] [--store DIR]"
+    ))?;
+    let store = Store::open(&root)?;
+    let branch = branch.unwrap_or_else(|| store.current_branch());
+
+    let local_head = store.get_branch(&branch)?.and_then(|b| b.head_op);
+    let cutoff: Option<String> = since.or_else(|| local_head.clone());
+
+    // Fetch the delta from the remote. Returns oldest-first so we
+    // can apply in topological order with the existing idempotent
+    // OpLog::put.
+    let received = fetch_ops_since(&remote, &branch, cutoff.as_deref(), limit)?;
+
+    if dry_run {
+        let ids: Vec<&String> = received.iter().map(|r| &r.op_id).collect();
+        let data = serde_json::json!({
+            "remote": remote,
+            "branch": branch,
+            "since": cutoff,
+            "would_receive": received.len(),
+            "op_ids": ids,
+        });
+        let count = received.len();
+        let remote_text = remote.clone();
+        let branch_text = branch.clone();
+        acli::emit_or_text("op-pull", data, fmt, move || {
+            println!(
+                "would pull {count} ops from {remote_text} on branch `{branch_text}` (dry-run)"
+            );
+        });
+        return Ok(());
+    }
+
+    if received.is_empty() {
+        let data = serde_json::json!({
+            "remote": remote,
+            "branch": branch,
+            "received": 0,
+            "added": 0,
+            "fast_forwarded_to": serde_json::Value::Null,
+        });
+        acli::emit_or_text("op-pull", data, fmt, || {
+            println!("nothing to pull (local is at or ahead of remote)");
+        });
+        return Ok(());
+    }
+
+    // Validate + persist. The local op log is idempotent, so we
+    // can safely re-apply ops that may already be present.
+    let log = OpLog::open(&root)?;
+    let mut added = 0usize;
+    let mut batch_ids: std::collections::BTreeSet<String> =
+        std::collections::BTreeSet::new();
+    for rec in &received {
+        // Content-addressing: the supplied op_id must equal the
+        // canonical hash of the payload. Otherwise the remote is
+        // serving forged or corrupted records.
+        let expected = rec.op.op_id();
+        if expected != rec.op_id {
+            bail!(
+                "remote returned op with mismatched op_id: supplied={}, expected={}",
+                rec.op_id, expected,
+            );
+        }
+        // DAG integrity: every parent must already be in the local
+        // log OR appear earlier in this batch (which is sorted
+        // oldest-first by the server).
+        for parent in &rec.op.parents {
+            let known = log.get(parent)?.is_some() || batch_ids.contains(parent);
+            if !known {
+                bail!(
+                    "remote returned op {} with unreachable parent {parent}; \
+                     pull aborted to preserve DAG integrity",
+                    rec.op_id,
+                );
+            }
+        }
+        let was_present = log.get(&rec.op_id)?.is_some();
+        log.put(rec)?;
+        if !was_present {
+            added += 1;
+        }
+        batch_ids.insert(rec.op_id.clone());
+    }
+
+    // Divergent-history detection: a clean fast-forward requires
+    // that the local head, if present, is reachable from the
+    // remote tip. Walk the new tip's ancestry; if local_head doesn't
+    // appear, the histories diverged.
+    let new_tip = received.last().expect("checked is_empty above").op_id.clone();
+    let fast_forward_ok = match &local_head {
+        None => true, // empty branch can absorb anything
+        Some(lh) => log.walk_back(&new_tip, None)?
+            .iter()
+            .any(|r| &r.op_id == lh),
+    };
+
+    if !fast_forward_ok {
+        let envelope = serde_json::json!({
+            "error": "DivergentHistory",
+            "local_head": local_head,
+            "remote_head": new_tip,
+            "remark": "local branch head is not an ancestor of the pulled tip; \
+                      use `lex merge` to integrate the divergent histories",
+        });
+        // Print structured envelope; exit non-zero so scripts can
+        // tell the difference from a successful no-op pull.
+        let env_clone = envelope.clone();
+        acli::emit_or_text("op-pull", envelope, fmt, move || {
+            eprintln!("{}", serde_json::to_string_pretty(&env_clone).unwrap());
+        });
+        bail!("divergent histories — branch unchanged");
+    }
+
+    // Fast-forward: advance the branch head to the new tip.
+    // `Store::set_branch_head_op` is `pub(crate)`, so we go through
+    // the JSON file directly. (#262 will replace this with a CAS
+    // path; for now we rely on the single-writer invariant.)
+    fast_forward_branch_head(&root, &branch, &new_tip)
+        .with_context(|| format!("advancing branch head to {new_tip}"))?;
+
+    let data = serde_json::json!({
+        "remote": remote,
+        "branch": branch,
+        "received": received.len(),
+        "added": added,
+        "fast_forwarded_to": new_tip,
+    });
+    let total = received.len();
+    let remote_text = remote.clone();
+    let branch_text = branch.clone();
+    let new_tip_text = new_tip.clone();
+    acli::emit_or_text("op-pull", data, fmt, move || {
+        println!(
+            "pulled {total} ops from {remote_text} on branch `{branch_text}`: \
+             {added} new, branch advanced to {new_tip_text}"
+        );
+    });
+    Ok(())
+}
+
+/// Fetch a delta from `<remote>/v1/ops/since`. Returns the records
+/// in the order the server sent them (oldest-first by contract).
+fn fetch_ops_since(
+    remote: &str,
+    branch: &str,
+    after: Option<&str>,
+    limit: Option<usize>,
+) -> Result<Vec<OperationRecord>> {
+    let mut url = format!(
+        "{}/v1/ops/since?branch={branch}",
+        remote.trim_end_matches('/'),
+    );
+    if let Some(a) = after { url.push_str(&format!("&after={a}")); }
+    if let Some(n) = limit { url.push_str(&format!("&limit={n}")); }
+    let resp = ureq::get(&url)
+        .call()
+        .map_err(|e| anyhow!("GET {url}: {e}"))?;
+    let status = resp.status().as_u16();
+    if status >= 400 {
+        let body = resp.into_body().read_to_string()
+            .unwrap_or_else(|_| "(unreadable body)".into());
+        bail!("server returned HTTP {status}: {body}");
+    }
+    resp.into_body().read_json::<Vec<OperationRecord>>()
+        .map_err(|e| anyhow!("decoding response from {url}: {e}"))
+}
+
+/// Advance `<root>/branches/<name>.json`'s `head_op` to `new`. The
+/// store's `set_branch_head_op` is `pub(crate)`, so we operate on
+/// the JSON file directly. Same temp-file + rename pattern as the
+/// `lex store migrate-ops` branch-head rewriter.
+fn fast_forward_branch_head(
+    root: &std::path::Path,
+    branch: &str,
+    new: &str,
+) -> Result<()> {
+    let path = root.join("branches").join(format!("{branch}.json"));
+    if !path.exists() {
+        // First-time pull on a branch the local doesn't have yet.
+        // Bootstrap a minimal branch file pointing at the new head.
+        std::fs::create_dir_all(path.parent().unwrap())?;
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let value = serde_json::json!({
+            "name": branch,
+            "parent": serde_json::Value::Null,
+            "head_op": new,
+            "merges": [],
+            "created_at": now,
+        });
+        let bytes = serde_json::to_vec_pretty(&value)?;
+        let tmp = path.with_extension("json.tmp");
+        std::fs::write(&tmp, &bytes)?;
+        std::fs::rename(&tmp, &path)?;
+        return Ok(());
+    }
+    let bytes = std::fs::read(&path)?;
+    let mut value: serde_json::Value = serde_json::from_slice(&bytes)
+        .with_context(|| format!("parsing {}", path.display()))?;
+    value["head_op"] = serde_json::Value::String(new.to_string());
+    let new_bytes = serde_json::to_vec_pretty(&value)?;
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, &new_bytes)?;
+    std::fs::rename(&tmp, &path)?;
+    Ok(())
 }


### PR DESCRIPTION
Symmetric inverse of #242. With both push and pull, content-addressed sync is bidirectional: any agent on any machine can both publish and consume ops + attestations from a remote.

## Server endpoints (lex-api)

* `GET /v1/ops/since?after=<op_id>&branch=<name>&limit=<n>` — returns `OperationRecord`s reachable from `branch.head_op` but not from `<after>`, sorted **oldest-first** so the client applies with the existing idempotent `OpLog::put`. Empty when caller is already at or past the remote head, or when the branch doesn't exist. `--limit` chunks large gaps.
* `GET /v1/attestations/since?after-op=<op_id>&limit=<n>` — mirror for the attestation log. Always ships attestations with `op_id: None` (e.g. `Override`, `ProducerBlock`) regardless of cutoff.

## Client commands (lex-cli)

* `lex op pull <remote> [--branch NAME] [--since OP_ID] [--limit N] [--dry-run]` — probes remote head via the existing `/v1/branches/<name>/head`, fetches the delta, validates each record (content-addressing + DAG integrity), persists via `OpLog::put`. On clean fast-forward the branch advances; on divergent histories refuses with a `DivergentHistory { local_head, remote_head }` envelope and the branch is unchanged.
* `lex attest pull <remote> [--since-op OP_ID] [--limit N] [--dry-run]` — mirrors the same shape. Attestations referencing unknown ops are skipped (with a `rejected_unknown_op` count) so callers can re-issue after pulling the missing ops.

## Tests

`crates/lex-api/tests/op_pull.rs` — 8 conformance tests:

* Empty remote → empty response.
* Strictly-ahead remote → delta in oldest-first order.
* Caller already at remote head → empty.
* `--limit` chunking; subsequent pulls with `after` continue from where the previous chunk ended.
* Unknown branch → empty (no error).
* Attestation `after-op` filter excludes the cutoff's ancestry.
* `Override` / `ProducerBlock` attestations (`op_id: None`) ship regardless of cutoff.

## Out of scope

* Bidirectional `lex sync` (would be `pull && push` — a CLI veneer, not a new protocol primitive).
* `--force-fast-forward` that overwrites local divergent history. Route through the merge engine (#134) instead.
* Capability-scoped pull (symmetric to the same gap on the push side).

Workspace: all crates pass; clippy clean.

Closes #260.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_