### PR TITLE
lex-store+cli: walk-back producer-block gate (#256)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+### Added — agent-VCS roadmap (#256)
+
+- **Walk-back producer-block gate** (#256). Closes the
+  grandfathering window in #248. Previously, a retro-block of a
+  compromised tool only fenced off *new* ops; pre-existing
+  contamination in branch history was grandfathered in. Now the
+  gate walks back from `head_op` to the per-branch
+  `last_gate_checkpoint`, runs `check_producer_block` on every
+  ancestor's attestable stages, and refuses if any contamination
+  is found.
+- **`Branch.last_gate_checkpoint: Option<OpId>`** persisted on
+  disk. Every successful advance moves the checkpoint to the new
+  head; subsequent advances are `O(new ops)` because the walk
+  stops at the checkpoint. Pre-#256 branch files default to
+  `None` (serde default) and trigger a one-time full walk on
+  next advance — same backward-compat trick `intent_id` (#131)
+  used.
+- **`Store::invalidate_gate_checkpoints()`** clears every
+  branch's checkpoint. `lex attest retro-block` and
+  `lex attest retro-unblock` call it after writing the
+  attestation, so the next advance re-walks and surfaces (or
+  clears) any newly contaminated ancestors. Reported as
+  `branches_invalidated: N` in the CLI's JSON envelope.
+
 ### Added — agent-VCS roadmap (#260)
 
 The symmetric inverse of #242. With both push and pull, content-

--- a/crates/lex-cli/src/branch.rs
+++ b/crates/lex-cli/src/branch.rs
@@ -230,6 +230,7 @@ fn peek(fmt: &OutputFormat, store: &Store, args: &[String]) -> Result<()> {
             predicate: None,
             merges: Vec::new(),
             created_at: 0,
+            last_gate_checkpoint: None,
         },
         None => bail!("unknown branch `{name}`"),
     };

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -2358,12 +2358,18 @@ fn cmd_attest_retro_block(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         now,
     );
     log.put(&attestation)?;
+    // #256: a fresh ProducerBlock invalidates every branch's
+    // walk-back gate checkpoint, forcing the next advance to
+    // re-walk the chain and discover any contamination.
+    let invalidated = store.invalidate_gate_checkpoints()
+        .with_context(|| "invalidating gate checkpoints after retro-block")?;
 
     let data = serde_json::json!({
         "tool_id": &tool_id,
         "reason": &reason,
         "blocked_at": now,
         "attestation_id": &attestation.attestation_id,
+        "branches_invalidated": invalidated,
     });
     let printable_tool = tool_id.clone();
     acli::emit_or_text("attest", data, fmt, move || {
@@ -2423,12 +2429,18 @@ fn cmd_attest_retro_unblock(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         now,
     );
     log.put(&attestation)?;
+    // #256: an unblock can also unblock previously-refused branch
+    // advances. Invalidate so the next advance re-walks and lets
+    // through anything the unblock cleared.
+    let invalidated = store.invalidate_gate_checkpoints()
+        .with_context(|| "invalidating gate checkpoints after retro-unblock")?;
 
     let data = serde_json::json!({
         "tool_id": &tool_id,
         "reason": &reason,
         "unblocked_at": now,
         "attestation_id": &attestation.attestation_id,
+        "branches_invalidated": invalidated,
     });
     let printable_tool = tool_id.clone();
     acli::emit_or_text("attest", data, fmt, move || {

--- a/crates/lex-store/src/branches.rs
+++ b/crates/lex-store/src/branches.rs
@@ -34,6 +34,26 @@ pub struct Branch {
     #[serde(default)]
     pub merges: Vec<MergeRecord>,
     pub created_at: u64,
+    /// Last op_id through which the producer-block gate (#248) has
+    /// verified the branch's history (#256). When advancing from
+    /// `head_op` to a new tip, the gate walks ops in
+    /// `(last_gate_checkpoint .. head_op]` and runs the
+    /// producer-block check on each ancestor's attestable stages —
+    /// not just the new op. Once that walk passes, the checkpoint
+    /// advances.
+    ///
+    /// Invalidated (set to `None`) when `lex attest retro-block`
+    /// lands a new `ProducerBlock` attestation, forcing the next
+    /// advance to re-walk from genesis once. Steady-state advances
+    /// are `O(new ops)` because the previous advance already
+    /// covered everything up through `last_gate_checkpoint`.
+    ///
+    /// Pre-#256 branch files have no `last_gate_checkpoint` field;
+    /// serde defaults to `None`, which forces a one-time full walk
+    /// on next advance. Same backward-compat trick `intent_id`
+    /// (#131) used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_gate_checkpoint: Option<OpId>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -183,6 +203,7 @@ impl Store {
             predicate: None,
             merges: Vec::new(),
             created_at: now(),
+            last_gate_checkpoint: None,
         };
         fs::write(self.branch_path(name), serde_json::to_string_pretty(&b)?)?;
         Ok(())
@@ -214,6 +235,7 @@ impl Store {
             predicate: Some(predicate),
             merges: Vec::new(),
             created_at: now(),
+            last_gate_checkpoint: None,
         };
         fs::write(self.branch_path(name), serde_json::to_string_pretty(&b)?)?;
         Ok(())
@@ -271,13 +293,52 @@ impl Store {
                 predicate: None,
                 merges: Vec::new(),
                 created_at: now(),
+                last_gate_checkpoint: None,
             },
             None => return Err(StoreError::UnknownBranch(name.into())),
         };
-        b.head_op = Some(head_op);
+        // #256: every successful advance also moves the gate
+        // checkpoint to the new head. The gate that ran before this
+        // call has already verified everything in
+        // `(last_gate_checkpoint .. new_head]`, so the new head is
+        // now the verified frontier.
+        b.head_op = Some(head_op.clone());
+        b.last_gate_checkpoint = Some(head_op);
         fs::create_dir_all(self.branches_dir())?;
         write_branch_atomic(&self.branch_path(name), &b)?;
         Ok(())
+    }
+
+    /// Invalidate every branch's `last_gate_checkpoint` (#256). Run
+    /// when a new `ProducerBlock` attestation lands so the next
+    /// branch advance walks back from genesis once and re-verifies
+    /// the full chain. Returns the number of branches whose
+    /// checkpoint changed.
+    pub fn invalidate_gate_checkpoints(&self) -> Result<usize, StoreError> {
+        let dir = self.branches_dir();
+        if !dir.exists() {
+            return Ok(0);
+        }
+        let mut updated = 0usize;
+        for entry in fs::read_dir(&dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().is_none_or(|e| e != "json") { continue; }
+            let bytes = fs::read(&path)?;
+            let mut b: Branch = match serde_json::from_slice(&bytes) {
+                Ok(b) => b,
+                // Corrupt branch file shouldn't take down the
+                // invalidation pass; the next gate run will surface
+                // the parse error on a real call path.
+                Err(_) => continue,
+            };
+            if b.last_gate_checkpoint.is_some() {
+                b.last_gate_checkpoint = None;
+                write_branch_atomic(&path, &b)?;
+                updated += 1;
+            }
+        }
+        Ok(updated)
     }
 }
 

--- a/crates/lex-store/src/store.rs
+++ b/crates/lex-store/src/store.rs
@@ -702,7 +702,7 @@ impl Store {
         let op_effects = op_declared_effects(&op.kind);
         let new_head = self.persist_op_only(branch, op, transition)?;
         self.record_typecheck_passed(&attestable, &new_head.op_id)?;
-        self.run_required_attestations_gate(&new_head.op_id, &attestable, &op_effects)?;
+        self.run_required_attestations_gate(branch, &new_head.op_id, &attestable, &op_effects)?;
         self.set_branch_head_op(branch, new_head.op_id.clone())?;
         Ok(new_head.op_id)
     }
@@ -771,7 +771,7 @@ impl Store {
         // separately first. This is the intended behavior — the
         // unchecked path opts out of the safety net the gate
         // depends on.
-        self.run_required_attestations_gate(&new_head.op_id, &attestable, &op_effects)?;
+        self.run_required_attestations_gate(branch, &new_head.op_id, &attestable, &op_effects)?;
         self.set_branch_head_op(branch, new_head.op_id.clone())?;
         Ok(new_head.op_id)
     }
@@ -826,15 +826,15 @@ impl Store {
     /// (default-permissive — matches pre-#245 stores).
     fn run_required_attestations_gate(
         &self,
+        branch: &str,
         op_id: &lex_vcs::OpId,
         stage_ids: &[String],
         op_effects: &std::collections::BTreeSet<String>,
     ) -> Result<(), StoreError> {
-        // Build the candidate slice once and reuse it for both
-        // gates. Ops with no attestable stage (imports, empty
-        // merges) get a single `None`-stage tuple; both gates skip
-        // those — there's nothing to attest.
-        let candidate: Vec<(lex_vcs::OpId, Option<String>, std::collections::BTreeSet<String>)> =
+        // Build the candidate slice for the new op. Ops with no
+        // attestable stage (imports, empty merges) get a single
+        // `None`-stage tuple; both gates skip those.
+        let new_op_candidate: Vec<(lex_vcs::OpId, Option<String>, std::collections::BTreeSet<String>)> =
             if stage_ids.is_empty() {
                 vec![(op_id.clone(), None, op_effects.clone())]
             } else {
@@ -845,20 +845,78 @@ impl Store {
             };
         let attest_log = self.attestation_log()?;
 
-        // #248: producer-block gate. Always evaluated regardless of
-        // policy.json contents — `ProducerBlock` attestations live
-        // in the attestation log, not policy.json.
-        crate::policy::check_producer_block(&attest_log, &candidate)
+        // #248 + #256: producer-block gate, walk-back style.
+        //
+        // The naive #248 gate only checked the new op's stage. That
+        // missed contamination on ancestors — once `lex attest
+        // retro-block` lands, every previously-gated op stays in
+        // the chain even though its attestations are now from a
+        // quarantined producer.
+        //
+        // #256 fixes this by walking the chain from `head_op` back
+        // to `last_gate_checkpoint` (or genesis when the checkpoint
+        // is invalidated), collecting each ancestor's attestable
+        // stages, and running `check_producer_block` on the
+        // combined set. After a successful advance,
+        // `set_branch_head_op` moves the checkpoint to the new
+        // head (steady-state O(new ops) per advance).
+        let walk_back_candidate = self.collect_ancestor_candidates(branch)?;
+        let mut producer_block_candidate = walk_back_candidate;
+        producer_block_candidate.extend(new_op_candidate.iter().cloned());
+        crate::policy::check_producer_block(&attest_log, &producer_block_candidate)
             .map_err(StoreError::ProducerBlocked)?;
 
-        // #245: required-attestations gate. Only fires when the
-        // policy declares rules.
+        // #245: required-attestations gate. Forward-going only —
+        // only the new op is checked. Walking back makes no sense
+        // here: the policy is "this advance must carry these
+        // attestations," not "every prior op must have."
         let policy = match crate::policy::load(self.root())? {
             Some(p) if !p.required_attestations.is_empty() => p,
             _ => return Ok(()),
         };
-        crate::policy::check_required_attestations(&attest_log, &candidate, &policy)
+        crate::policy::check_required_attestations(&attest_log, &new_op_candidate, &policy)
             .map_err(StoreError::BranchAdvanceBlocked)
+    }
+
+    /// Walk the branch from `head_op` back to `last_gate_checkpoint`
+    /// (exclusive) and return the `(op_id, stage_id, op_effects)`
+    /// tuples for every attestable stage touched by an ancestor
+    /// (#256). Empty when the branch is fresh, when the checkpoint
+    /// equals the head, or when the head is None.
+    fn collect_ancestor_candidates(
+        &self,
+        branch: &str,
+    ) -> Result<Vec<GateCandidate>, StoreError> {
+        let b = match self.get_branch(branch)? {
+            Some(b) => b,
+            None => return Ok(Vec::new()),
+        };
+        let Some(head) = b.head_op else { return Ok(Vec::new()); };
+        if Some(&head) == b.last_gate_checkpoint.as_ref() {
+            // Steady-state common case: previous advance left the
+            // checkpoint at head. Nothing to re-walk.
+            return Ok(Vec::new());
+        }
+
+        let log = lex_vcs::OpLog::open(self.root())?;
+        let walk = log.walk_back(&head, None)?;
+        let stop_at = b.last_gate_checkpoint.clone();
+        let mut out = Vec::new();
+        for rec in walk {
+            if Some(&rec.op_id) == stop_at.as_ref() {
+                break;
+            }
+            let stages = attestable_stage_ids(&rec.produces);
+            let effects = op_declared_effects(&rec.op.kind);
+            if stages.is_empty() {
+                out.push((rec.op_id.clone(), None, effects));
+            } else {
+                for sid in stages {
+                    out.push((rec.op_id.clone(), Some(sid), effects.clone()));
+                }
+            }
+        }
+        Ok(out)
     }
 }
 
@@ -932,6 +990,12 @@ fn typecheck_producer() -> lex_vcs::ProducerDescriptor {
 /// sig resolution of a Merge. Removes and ImportOnly produce no
 /// attestable stage; the program typechecks but no specific stage
 /// is the subject of the claim.
+/// One row of input to the producer-block / required-attestations
+/// gates: `(op_id, stage_id, op_effects)`. The `stage_id` is
+/// `None` for ops that don't touch a stage (imports, empty
+/// merges) — the gate skips those.
+type GateCandidate = (lex_vcs::OpId, Option<String>, std::collections::BTreeSet<String>);
+
 /// Effect set declared *by the operation itself* (#245). Used by
 /// the `required_attestations` gate's `EffectsIntersect` clause.
 ///

--- a/crates/lex-store/tests/walk_back_gate.rs
+++ b/crates/lex-store/tests/walk_back_gate.rs
@@ -1,0 +1,311 @@
+//! Conformance test for #256: the walk-back producer-block gate.
+//!
+//! The scenario from #256's issue body:
+//!
+//! 1. Tool X publishes op A1 (attests stage S1 with a Spec
+//!    attestation at t=100). Branch advances to A1.
+//! 2. Time passes. Branch advances to A2, A3, etc.
+//! 3. Admin retro-blocks tool X at t=2000.
+//! 4. Some agent now publishes op A_new. The naive #248 gate
+//!    checks A_new's stage attestations (just the auto-emitted
+//!    TypeCheck from `lex-store`); lex-store isn't blocked, so
+//!    the gate passes — even though A1 in the chain is
+//!    contaminated.
+//!
+//! With #256, the gate walks back from `head_op` toward
+//! `last_gate_checkpoint` and runs `check_producer_block` on
+//! every ancestor's attestable stages. The retro-block
+//! invalidates the checkpoint, so the next advance re-walks the
+//! whole chain and refuses.
+
+use lex_ast::canonicalize_program;
+use lex_store::{Operation, OperationKind, StageTransition, Store, StoreError, DEFAULT_BRANCH};
+use lex_syntax::parse_source;
+use lex_vcs::{
+    Attestation, AttestationKind, AttestationResult, ProducerDescriptor,
+};
+use std::collections::BTreeSet;
+
+fn fresh() -> (Store, tempfile::TempDir) {
+    let tmp = tempfile::tempdir().unwrap();
+    let s = Store::open(tmp.path()).unwrap();
+    (s, tmp)
+}
+
+fn parse(src: &str) -> Vec<lex_ast::Stage> {
+    let prog = parse_source(src).expect("parse");
+    canonicalize_program(&prog)
+}
+
+fn pure_op(sig: &str, stg: &str) -> (Operation, StageTransition) {
+    (
+        Operation::new(
+            OperationKind::AddFunction {
+                sig_id: sig.into(),
+                stage_id: stg.into(),
+                effects: BTreeSet::new(),
+                budget_cost: None,
+            },
+            [],
+        ),
+        StageTransition::Create {
+            sig_id: sig.into(),
+            stage_id: stg.into(),
+        },
+    )
+}
+
+fn modify_op(sig: &str, parent: &lex_vcs::OpId, from: &str, to: &str)
+    -> (Operation, StageTransition)
+{
+    (
+        Operation::new(
+            OperationKind::ModifyBody {
+                sig_id: sig.into(),
+                from_stage_id: from.into(),
+                to_stage_id: to.into(),
+                from_budget: None,
+                to_budget: None,
+            },
+            [parent.clone()],
+        ),
+        StageTransition::Replace {
+            sig_id: sig.into(),
+            from: from.into(),
+            to: to.into(),
+        },
+    )
+}
+
+fn pure_candidate(name: &str) -> Vec<lex_ast::Stage> {
+    parse(&format!("fn {name}(n :: Int) -> Int {{ n }}\n"))
+}
+
+#[test]
+fn walk_back_gate_refuses_advance_when_ancestor_is_contaminated() {
+    let (s, _tmp) = fresh();
+
+    // 1. Publish op A1 with stage stg-1. Branch advances clean.
+    let (op_a, t_a) = pure_op("fac", "stg-1");
+    s.apply_operation_checked(DEFAULT_BRANCH, op_a, t_a, &pure_candidate("fac"))
+        .expect("clean publish of A1");
+
+    // Manually emit a Spec attestation on stg-1 produced by tool-X.
+    // This represents an external producer (#186 spec checker)
+    // that ran after A1 landed.
+    let log = s.attestation_log().unwrap();
+    let head_after_a = s.get_branch(DEFAULT_BRANCH).unwrap().unwrap().head_op.clone();
+    let spec_att = Attestation::with_timestamp(
+        "stg-1".to_string(),
+        head_after_a.clone(),
+        None,
+        AttestationKind::Spec {
+            spec_id: "fac-spec".into(),
+            method: lex_vcs::SpecMethod::Random,
+            trials: Some(100),
+        },
+        AttestationResult::Passed,
+        ProducerDescriptor {
+            tool: "tool-X".into(),
+            version: "1.0".into(),
+            model: None,
+        },
+        None,
+        100,
+    );
+    log.put(&spec_att).unwrap();
+
+    // 2. Advance the branch a couple more times. Each advance
+    //    runs the gate; since tool-X isn't blocked yet, all pass.
+    let head_a = head_after_a.clone().unwrap();
+    let (op_b, t_b) = modify_op("fac", &head_a, "stg-1", "stg-2");
+    s.apply_operation_checked(DEFAULT_BRANCH, op_b, t_b, &pure_candidate("fac"))
+        .expect("clean publish of B");
+
+    // 3. Retro-block tool-X. This invalidates last_gate_checkpoint
+    //    on every branch.
+    let block_att = Attestation::with_timestamp(
+        "tool-X".to_string(),
+        None,
+        None,
+        AttestationKind::ProducerBlock {
+            tool_id: "tool-X".into(),
+            reason: "compromised".into(),
+            blocked_at: 50, // before t=100, so the spec att at t=100 IS contaminated
+        },
+        AttestationResult::Passed,
+        ProducerDescriptor {
+            tool: "lex attest retro-block".into(),
+            version: "0".into(),
+            model: None,
+        },
+        None,
+        2000,
+    );
+    log.put(&block_att).unwrap();
+    let invalidated = s.invalidate_gate_checkpoints().unwrap();
+    assert_eq!(invalidated, 1, "main's checkpoint should have been cleared");
+
+    // 4. Try to advance again. With #256, the gate now walks back
+    //    over A1 and discovers stg-1 has a contaminated Spec
+    //    attestation. The advance refuses.
+    let head_b = s.get_branch(DEFAULT_BRANCH).unwrap().unwrap().head_op.clone().unwrap();
+    let (op_c, t_c) = modify_op("fac", &head_b, "stg-2", "stg-3");
+    let err = s.apply_operation_checked(DEFAULT_BRANCH, op_c, t_c, &pure_candidate("fac"))
+        .expect_err("post-retro-block advance must refuse");
+    let blocked = match err {
+        StoreError::ProducerBlocked(b) => b,
+        other => panic!("expected ProducerBlocked, got {other:?}"),
+    };
+    assert_eq!(blocked.tool_id, "tool-X");
+    assert_eq!(blocked.stage_id, "stg-1",
+        "the contamination is on stg-1 (an ancestor), not the new op's stage");
+}
+
+#[test]
+fn walk_back_skipped_when_checkpoint_equals_head() {
+    // Steady-state: every successful advance moves the checkpoint
+    // to the new head, so the next advance has nothing to walk back
+    // over (only the new op's candidate is checked). This test
+    // verifies the optimization works — that we don't redundantly
+    // re-walk on every advance.
+    let (s, _tmp) = fresh();
+    let (op_a, t_a) = pure_op("fac", "stg-1");
+    s.apply_operation_checked(DEFAULT_BRANCH, op_a, t_a, &pure_candidate("fac"))
+        .expect("clean publish");
+
+    let b = s.get_branch(DEFAULT_BRANCH).unwrap().unwrap();
+    assert_eq!(
+        b.head_op, b.last_gate_checkpoint,
+        "after successful advance, checkpoint must equal head",
+    );
+}
+
+#[test]
+fn unblock_clears_contamination_and_allows_advance() {
+    // Scenario: contamination exists, retro-block fires, advance
+    // refuses. Then admin retro-unblocks tool-X. The next advance
+    // re-walks and (because the most-recent verdict is unblock)
+    // accepts the chain.
+    let (s, _tmp) = fresh();
+
+    let (op_a, t_a) = pure_op("fac", "stg-1");
+    s.apply_operation_checked(DEFAULT_BRANCH, op_a, t_a, &pure_candidate("fac"))
+        .expect("clean publish of A1");
+
+    let log = s.attestation_log().unwrap();
+    let head_a = s.get_branch(DEFAULT_BRANCH).unwrap().unwrap().head_op.clone().unwrap();
+    let spec_att = Attestation::with_timestamp(
+        "stg-1".to_string(),
+        Some(head_a.clone()),
+        None,
+        AttestationKind::Spec {
+            spec_id: "fac-spec".into(),
+            method: lex_vcs::SpecMethod::Random,
+            trials: Some(100),
+        },
+        AttestationResult::Passed,
+        ProducerDescriptor {
+            tool: "tool-X".into(),
+            version: "1.0".into(),
+            model: None,
+        },
+        None,
+        100,
+    );
+    log.put(&spec_att).unwrap();
+
+    // Block at t=50 (before the spec att at t=100).
+    let block_att = Attestation::with_timestamp(
+        "tool-X".to_string(),
+        None,
+        None,
+        AttestationKind::ProducerBlock {
+            tool_id: "tool-X".into(),
+            reason: "compromised".into(),
+            blocked_at: 50,
+        },
+        AttestationResult::Passed,
+        ProducerDescriptor {
+            tool: "lex attest retro-block".into(),
+            version: "0".into(),
+            model: None,
+        },
+        None,
+        2000,
+    );
+    log.put(&block_att).unwrap();
+    s.invalidate_gate_checkpoints().unwrap();
+
+    // Verify advance refuses.
+    let (op_b, t_b) = modify_op("fac", &head_a, "stg-1", "stg-2");
+    let err = s.apply_operation_checked(DEFAULT_BRANCH, op_b, t_b, &pure_candidate("fac"));
+    assert!(matches!(err, Err(StoreError::ProducerBlocked(_))),
+        "expected ProducerBlocked, got {err:?}");
+
+    // Now unblock at t=3000 (latest verdict).
+    let unblock_att = Attestation::with_timestamp(
+        "tool-X".to_string(),
+        None,
+        None,
+        AttestationKind::ProducerUnblock {
+            tool_id: "tool-X".into(),
+            reason: "vendor patched".into(),
+            unblocked_at: 3000,
+        },
+        AttestationResult::Passed,
+        ProducerDescriptor {
+            tool: "lex attest retro-block".into(),
+            version: "0".into(),
+            model: None,
+        },
+        None,
+        3000,
+    );
+    log.put(&unblock_att).unwrap();
+    s.invalidate_gate_checkpoints().unwrap();
+
+    // Same advance attempt now succeeds — the active block map is
+    // empty after the unblock.
+    let (op_b2, t_b2) = modify_op("fac", &head_a, "stg-1", "stg-2");
+    s.apply_operation_checked(DEFAULT_BRANCH, op_b2, t_b2, &pure_candidate("fac"))
+        .expect("post-unblock advance should succeed");
+}
+
+#[test]
+fn pre_256_branch_files_without_checkpoint_walk_from_genesis() {
+    // Backward-compat: a branch.json from before #256 has no
+    // last_gate_checkpoint field. Default deserializes to None,
+    // which forces a one-time walk from genesis. This test seeds
+    // a chain, manually clears the checkpoint to simulate an
+    // upgraded store, and verifies the next advance still works
+    // (no contamination → walk passes → advance succeeds).
+    let (s, _tmp) = fresh();
+    let (op_a, t_a) = pure_op("fac", "stg-1");
+    s.apply_operation_checked(DEFAULT_BRANCH, op_a, t_a, &pure_candidate("fac"))
+        .expect("clean publish of A");
+
+    // Simulate an upgraded store: rewrite branch.json with
+    // last_gate_checkpoint missing.
+    let path = s.root().join("branches/main.json");
+    let bytes = std::fs::read(&path).unwrap();
+    let mut value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    value.as_object_mut().unwrap().remove("last_gate_checkpoint");
+    std::fs::write(&path, serde_json::to_vec_pretty(&value).unwrap()).unwrap();
+
+    // Reload + verify the field is None.
+    let b = s.get_branch(DEFAULT_BRANCH).unwrap().unwrap();
+    assert!(b.last_gate_checkpoint.is_none(), "checkpoint should default to None");
+
+    // Advance. With no contamination in the log, the walk-back
+    // from head to genesis passes; the advance succeeds.
+    let head = b.head_op.clone().unwrap();
+    let (op_b, t_b) = modify_op("fac", &head, "stg-1", "stg-2");
+    s.apply_operation_checked(DEFAULT_BRANCH, op_b, t_b, &pure_candidate("fac"))
+        .expect("upgraded-store advance should succeed");
+
+    // After the advance, checkpoint should now equal the new head.
+    let b2 = s.get_branch(DEFAULT_BRANCH).unwrap().unwrap();
+    assert!(b2.last_gate_checkpoint.is_some());
+    assert_eq!(b2.last_gate_checkpoint, b2.head_op);
+}


### PR DESCRIPTION
Closes the grandfathering window in #248. Previously, a retro-block of a compromised tool only fenced off *new* ops; pre-existing contamination in branch history was grandfathered in.

Now the gate walks from `head_op` back to a per-branch `last_gate_checkpoint`, runs `check_producer_block` on every ancestor's attestable stages, and refuses the advance if any contamination is found. After a successful advance, the checkpoint moves to the new head — steady-state advances are O(new ops) because the walk stops at the checkpoint.

## Mechanics

* `Branch.last_gate_checkpoint: Option<OpId>` persisted to disk with `serde(default, skip_if = none)`. Pre-#256 branch files default to None and trigger a one-time full walk on next advance.
* `Store::set_branch_head_op` now advances both `head_op` and `last_gate_checkpoint` atomically to the new head.
* `Store::invalidate_gate_checkpoints()` clears every branch's checkpoint. `lex attest retro-block` and `lex attest retro-unblock` call it after writing the attestation, so the next advance re-walks and surfaces any newly-contaminated ancestors (or clears them, in the unblock case). The CLI envelope reports `branches_invalidated: N`.
* `Store::run_required_attestations_gate` now takes the branch name. The producer-block check runs on the new op's candidates plus the ancestor walk-back; the required-attestations check stays forward-only — #248's grandfathering issue didn't affect #245's gate semantics.

## Tests

`crates/lex-store/tests/walk_back_gate.rs`:

* **The issue's scenario verbatim**: contamination on stg-1 (an ancestor), retro-block lands, next advance refuses with `ProducerBlocked` pointing at the *ancestor's* stage.
* **Steady-state**: after a successful advance, `last_gate_checkpoint == head_op`.
* **Unblock recovery**: retro-unblock invalidates and re-walks; if the latest verdict clears the contamination, the same advance attempt now succeeds.
* **Backward-compat**: a `branch.json` without `last_gate_checkpoint` deserializes to None; the next advance walks from genesis once.

Workspace: all crates pass; clippy clean.

Closes #256.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_