### PR TITLE
lex-vcs+cli: attestation-cascade migration (#258)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+### Added — agent-VCS roadmap (#258)
+
+- **Attestation-cascade migration** (#258). Closes the documented
+  limitation in #244. When an `OperationFormat` rotation
+  invalidates every `OpId`, `lex_vcs::migrate::plan_attestation_migration`
+  + `apply_attestation_migration` re-derive every attestation
+  whose `op_id` references a rotated op. New attestations get a
+  fresh `attestation_id` (content-addressed, including the new
+  op_id) and inherit the `by-stage` and `by-run` indices.
+- **`AttestationLog::delete`** — narrowly-purposed cleanup of
+  primary file + by-stage + by-run index entries, used only by
+  the cascade.
+- **`lex store migrate-ops --confirm`** now invokes the
+  cascade after the op-log migration: rotates op_ids, rewrites
+  branch heads, cascade-migrates attestations, and invalidates
+  every branch's `last_gate_checkpoint` (#256). Reports
+  `attestations_rotated: N` in the JSON envelope.
+- **Idempotency**: re-running the cascade on an already-migrated
+  log is a no-op; the original mapping's keys (old op_ids) no
+  longer exist, so plan returns an empty step list.
+
 ### Added — agent-VCS roadmap (#256)
 
 - **Walk-back producer-block gate** (#256). Closes the

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -1700,9 +1700,8 @@ fn cmd_store_migrate_ops(fmt: &OutputFormat, args: &[String]) -> Result<()> {
             }
             if !changed.is_empty() {
                 println!(
-                    "\nNote: applying with --confirm will also rewrite branch heads. \
-                     Attestations are NOT rewritten by this command — that cascade is a \
-                     known follow-up to #244."
+                    "\nNote: applying with --confirm will also rewrite branch heads \
+                     and cascade-migrate attestations whose `op_id` rotated (#258)."
                 );
             }
         });
@@ -1711,10 +1710,31 @@ fn cmd_store_migrate_ops(fmt: &OutputFormat, args: &[String]) -> Result<()> {
 
     // --confirm path: apply.
     lex_vcs::migrate::apply_migration(&log, &plan)
-        .with_context(|| "applying migration")?;
+        .with_context(|| "applying op-log migration")?;
 
     let branch_updates = rewrite_branch_heads(&root, &mapping)
         .with_context(|| "rewriting branch heads")?;
+
+    // #258: cascade migrate attestations whose `op_id` references
+    // a rotated op. Their `attestation_id` is computed including
+    // op_id, so they all rotate too.
+    let store = lex_store::Store::open(&root)
+        .with_context(|| format!("opening store at {}", root.display()))?;
+    let attest_log = store.attestation_log()
+        .with_context(|| "opening attestation log")?;
+    let att_steps = lex_vcs::migrate::plan_attestation_migration(&attest_log, &mapping)
+        .with_context(|| "planning attestation cascade")?;
+    lex_vcs::migrate::apply_attestation_migration(&attest_log, &att_steps)
+        .with_context(|| "applying attestation cascade")?;
+    let attestations_rotated = att_steps.iter().filter(|s| !s.is_no_op()).count();
+
+    // Invalidate the gate-checkpoint pointers on every branch
+    // (#256). They reference op_ids by content, which the
+    // migration just rotated; without invalidation the next
+    // advance would compare against a stale id and re-walk
+    // unnecessarily (or, worse, treat the new head as "already
+    // verified" because its old name happened to match).
+    let _ = store.invalidate_gate_checkpoints();
 
     let summary = serde_json::json!({
         "target_format": format!("{:?}", target).to_lowercase(),
@@ -1723,22 +1743,19 @@ fn cmd_store_migrate_ops(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         "is_no_op": plan.is_no_op(),
         "applied": true,
         "branches_updated": branch_updates,
+        "attestations_rotated": attestations_rotated,
         "mappings": summary["mappings"].clone(),
     });
     acli::emit_or_text("store-migrate-ops", summary, fmt, || {
         println!(
-            "migrated {} ops to {:?}; {} op_ids rotated; {} branch heads rewritten",
+            "migrated {} ops to {:?}; {} op_ids rotated; \
+             {} branch heads rewritten; {} attestations cascade-migrated",
             plan.steps.len(),
             target,
             changed.len(),
             branch_updates,
+            attestations_rotated,
         );
-        if !changed.is_empty() {
-            println!(
-                "\nNote: attestations were NOT rewritten — their `attestation_id` \
-                 cascades from `op_id` and needs its own migration step. See #244."
-            );
-        }
     });
     Ok(())
 }

--- a/crates/lex-vcs/src/attestation.rs
+++ b/crates/lex-vcs/src/attestation.rs
@@ -565,6 +565,29 @@ impl AttestationLog {
         Ok(())
     }
 
+    /// Remove an attestation from the log along with both index
+    /// entries (#258). Idempotent on missing files.
+    ///
+    /// **Not** part of the day-to-day API — the attestation log is
+    /// append-only by design (#132). The only legitimate caller is
+    /// the migration tool, which supervises a destructive,
+    /// `--confirm`-gated batch.
+    pub fn delete(&self, attestation: &Attestation) -> io::Result<()> {
+        let primary = self.primary_path(&attestation.attestation_id);
+        match fs::remove_file(&primary) {
+            Ok(()) | Err(_) => {} // best-effort; missing is fine
+        }
+        let stage_idx = self.by_stage
+            .join(&attestation.stage_id)
+            .join(&attestation.attestation_id);
+        let _ = fs::remove_file(&stage_idx);
+        if let AttestationKind::Trace { run_id, .. } = &attestation.kind {
+            let run_idx = self.by_run.join(run_id).join(&attestation.attestation_id);
+            let _ = fs::remove_file(&run_idx);
+        }
+        Ok(())
+    }
+
     pub fn get(&self, id: &AttestationId) -> io::Result<Option<Attestation>> {
         let path = self.primary_path(id);
         if !path.exists() {

--- a/crates/lex-vcs/src/migrate.rs
+++ b/crates/lex-vcs/src/migrate.rs
@@ -195,6 +195,111 @@ pub fn apply_migration(log: &OpLog, plan: &MigrationPlan) -> io::Result<()> {
     Ok(())
 }
 
+// ---------------------------------------------- attestation cascade (#258)
+
+/// Plan + apply step for one attestation whose `op_id` is in the
+/// op-migration mapping (#258).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttestationMigrationStep {
+    pub old: crate::attestation::Attestation,
+    pub new: crate::attestation::Attestation,
+}
+
+impl AttestationMigrationStep {
+    /// `true` when nothing actually rotated — the new and old
+    /// `attestation_id`s match, so apply is a no-op.
+    pub fn is_no_op(&self) -> bool {
+        self.old.attestation_id == self.new.attestation_id
+    }
+}
+
+/// Plan an attestation migration that follows an op-id rotation.
+/// `op_mapping` is `MigrationPlan::mapping()` — old op_id → new
+/// op_id. For every attestation whose `op_id` is in the mapping
+/// (i.e. the op got rotated), build a new attestation pointing at
+/// the new op_id and re-derive its `attestation_id` from the
+/// canonical form.
+///
+/// Attestations whose `op_id` is `None` (`Override`,
+/// `ProducerBlock`, `Defer`, etc.) are unaffected — they don't
+/// participate in the cascade.
+///
+/// Steps are returned in deterministic order (sorted by old
+/// `attestation_id`), independent of filesystem listing order, so
+/// `--dry-run` output is reproducible.
+pub fn plan_attestation_migration(
+    log: &crate::attestation::AttestationLog,
+    op_mapping: &BTreeMap<OpId, OpId>,
+) -> io::Result<Vec<AttestationMigrationStep>> {
+    if op_mapping.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut all = log.list_all()?;
+    all.sort_by(|a, b| a.attestation_id.cmp(&b.attestation_id));
+    let mut steps = Vec::new();
+    for old in all {
+        let Some(old_op_id) = old.op_id.as_ref() else { continue };
+        let Some(new_op_id) = op_mapping.get(old_op_id) else { continue };
+        if old_op_id == new_op_id {
+            // Mapping recorded but nothing rotated for this op
+            // (e.g. plan.is_no_op()); skip rather than emit a
+            // pointless step.
+            continue;
+        }
+        // Re-derive the attestation under the new op_id. Same
+        // stage_id, intent_id, kind, result, producer, cost,
+        // timestamp — only op_id changes.
+        let new = crate::attestation::Attestation::with_timestamp(
+            old.stage_id.clone(),
+            Some(new_op_id.clone()),
+            old.intent_id.clone(),
+            old.kind.clone(),
+            old.result.clone(),
+            old.produced_by.clone(),
+            old.cost.clone(),
+            old.timestamp,
+        );
+        steps.push(AttestationMigrationStep { old, new });
+    }
+    Ok(steps)
+}
+
+/// Apply an attestation migration plan. Two-phase: write all new
+/// attestations (with their new attestation_ids) first, then
+/// delete the old ones whose ids changed. Mirrors
+/// [`apply_migration`]'s crash-safety story — between phases the
+/// log is double-sized but readable; re-running converges.
+pub fn apply_attestation_migration(
+    log: &crate::attestation::AttestationLog,
+    steps: &[AttestationMigrationStep],
+) -> io::Result<()> {
+    if steps.is_empty() {
+        return Ok(());
+    }
+    // Phase 1: write all new attestations (with new
+    // attestation_ids and their by-stage / by-run index entries).
+    for step in steps {
+        if step.is_no_op() {
+            continue;
+        }
+        log.put(&step.new)?;
+    }
+    // Phase 2: delete the old ones whose ids changed. Collect new
+    // ids first so we never delete a file that's also a new file
+    // (the rare new == old case is filtered by `is_no_op`).
+    let new_ids: BTreeSet<&crate::attestation::AttestationId> =
+        steps.iter().map(|s| &s.new.attestation_id).collect();
+    for step in steps {
+        if step.is_no_op() {
+            continue;
+        }
+        if !new_ids.contains(&step.old.attestation_id) {
+            log.delete(&step.old)?;
+        }
+    }
+    Ok(())
+}
+
 /// Topological sort of the op DAG (parents before children). Stable
 /// across runs because we process nodes in `BTreeMap` iteration
 /// order — sorted by `op_id` — which matches the deterministic

--- a/crates/lex-vcs/tests/attestation_cascade.rs
+++ b/crates/lex-vcs/tests/attestation_cascade.rs
@@ -1,0 +1,235 @@
+//! Conformance test for #258: attestation-cascade migration.
+//!
+//! When `OperationFormat` evolves and `OpId`s rotate (#244),
+//! every attestation whose `op_id` references a rotated op is
+//! left dangling — its stored `op_id` field points at a deleted
+//! record, and its own `attestation_id` (content-addressed
+//! including `op_id`) is now stale.
+//!
+//! `lex_vcs::migrate::plan_attestation_migration` +
+//! `apply_attestation_migration` close that gap. After running,
+//! every dangling attestation is replaced by a new one with the
+//! new `op_id` and a freshly-derived `attestation_id`.
+
+use lex_vcs::migrate::{
+    apply_attestation_migration, apply_migration, plan_attestation_migration,
+    plan_migration_with_encoder,
+};
+use lex_vcs::{
+    Attestation, AttestationKind, AttestationLog, AttestationResult, Operation, OperationFormat,
+    OperationKind, OperationRecord, OpLog, ProducerDescriptor, StageTransition,
+};
+use std::collections::BTreeSet;
+
+fn add_op(parent: Option<&str>, sig: &str, stg: &str) -> OperationRecord {
+    let parents: Vec<String> = parent.map(|p| p.to_string()).into_iter().collect();
+    OperationRecord::new(
+        Operation::new(
+            OperationKind::AddFunction {
+                sig_id: sig.into(),
+                stage_id: stg.into(),
+                effects: BTreeSet::new(),
+                budget_cost: None,
+            },
+            parents,
+        ),
+        StageTransition::Create {
+            sig_id: sig.into(),
+            stage_id: stg.into(),
+        },
+    )
+}
+
+fn typecheck(stage_id: &str, op_id: &str) -> Attestation {
+    Attestation::with_timestamp(
+        stage_id.to_string(),
+        Some(op_id.into()),
+        None,
+        AttestationKind::TypeCheck,
+        AttestationResult::Passed,
+        ProducerDescriptor {
+            tool: "test".into(),
+            version: "0".into(),
+            model: None,
+        },
+        None,
+        1_700_000_000,
+    )
+}
+
+fn fake_v2_encoder(op: &Operation) -> Vec<u8> {
+    let mut bytes = op.canonical_bytes_in(OperationFormat::V1);
+    bytes.extend_from_slice(b";v2-stub");
+    bytes
+}
+
+#[test]
+fn cascade_migrates_typecheck_attestations_to_new_op_ids() {
+    let tmp = tempfile::tempdir().unwrap();
+    let log = OpLog::open(tmp.path()).unwrap();
+    let attest_log = AttestationLog::open(tmp.path()).unwrap();
+
+    // Seed: two ops, each with a TypeCheck attestation.
+    let a = add_op(None, "fac", "stg-1");
+    log.put(&a).unwrap();
+    let b = add_op(None, "double", "stg-2");
+    log.put(&b).unwrap();
+    let att_a = typecheck("stg-1", &a.op_id);
+    let att_b = typecheck("stg-2", &b.op_id);
+    attest_log.put(&att_a).unwrap();
+    attest_log.put(&att_b).unwrap();
+
+    // Migrate the op log under the fake-V2 encoder. Every op_id
+    // rotates.
+    let plan = plan_migration_with_encoder(&log, OperationFormat::V1, fake_v2_encoder).unwrap();
+    apply_migration(&log, &plan).unwrap();
+    let mapping = plan.mapping();
+
+    // The pre-cascade attestation log: both attestations dangle —
+    // their `op_id` references rotated ops that no longer exist.
+    let pre_cascade = attest_log.list_all().unwrap();
+    assert_eq!(pre_cascade.len(), 2);
+    for a in &pre_cascade {
+        let op_id = a.op_id.as_ref().unwrap();
+        assert!(log.get(op_id).unwrap().is_none(),
+            "pre-cascade attestation {} still references unrotated op_id {op_id}",
+            a.attestation_id);
+    }
+
+    // Run the cascade.
+    let steps = plan_attestation_migration(&attest_log, &mapping).unwrap();
+    assert_eq!(steps.len(), 2, "both attestations should be in the plan");
+    apply_attestation_migration(&attest_log, &steps).unwrap();
+
+    // Post-cascade: every attestation references a *new* op_id
+    // that exists in the rotated log. The old attestation_ids
+    // are gone.
+    let post = attest_log.list_all().unwrap();
+    assert_eq!(post.len(), 2, "two new attestations replace the two old ones");
+    for a in &post {
+        let op_id = a.op_id.as_ref().unwrap();
+        assert!(log.get(op_id).unwrap().is_some(),
+            "post-cascade attestation {} should reference a live op_id",
+            a.attestation_id);
+        assert!(mapping.values().any(|new| new == op_id),
+            "post-cascade op_id {op_id} should be a new mapping target");
+    }
+
+    // Old attestation files are deleted.
+    for old in [&att_a, &att_b] {
+        assert!(attest_log.get(&old.attestation_id).unwrap().is_none(),
+            "old attestation {} should be removed", old.attestation_id);
+    }
+}
+
+#[test]
+fn cascade_skips_attestations_with_no_op_id() {
+    let tmp = tempfile::tempdir().unwrap();
+    let log = OpLog::open(tmp.path()).unwrap();
+    let attest_log = AttestationLog::open(tmp.path()).unwrap();
+
+    let a = add_op(None, "fac", "stg-1");
+    log.put(&a).unwrap();
+    // An Override attestation with op_id: None — doesn't
+    // participate in the cascade.
+    let override_att = Attestation::with_timestamp(
+        "stg-1".to_string(),
+        None,
+        None,
+        AttestationKind::Override {
+            actor: "alice".into(),
+            reason: "x".into(),
+            target_attestation_id: None,
+        },
+        AttestationResult::Passed,
+        ProducerDescriptor {
+            tool: "test".into(),
+            version: "0".into(),
+            model: None,
+        },
+        None,
+        1,
+    );
+    let typecheck_att = typecheck("stg-1", &a.op_id);
+    attest_log.put(&override_att).unwrap();
+    attest_log.put(&typecheck_att).unwrap();
+
+    let plan = plan_migration_with_encoder(&log, OperationFormat::V1, fake_v2_encoder).unwrap();
+    apply_migration(&log, &plan).unwrap();
+    let mapping = plan.mapping();
+
+    let steps = plan_attestation_migration(&attest_log, &mapping).unwrap();
+    assert_eq!(steps.len(), 1, "only the TypeCheck (with op_id) is in the plan");
+    assert_eq!(steps[0].old.attestation_id, typecheck_att.attestation_id);
+    apply_attestation_migration(&attest_log, &steps).unwrap();
+
+    // The Override stays intact (same attestation_id).
+    let post = attest_log.list_all().unwrap();
+    let override_post = post.iter().find(|a| matches!(a.kind, AttestationKind::Override { .. }))
+        .expect("Override should still exist");
+    assert_eq!(override_post.attestation_id, override_att.attestation_id);
+}
+
+#[test]
+fn cascade_is_idempotent_on_re_apply() {
+    let tmp = tempfile::tempdir().unwrap();
+    let log = OpLog::open(tmp.path()).unwrap();
+    let attest_log = AttestationLog::open(tmp.path()).unwrap();
+
+    let a = add_op(None, "fac", "stg-1");
+    log.put(&a).unwrap();
+    let att = typecheck("stg-1", &a.op_id);
+    attest_log.put(&att).unwrap();
+
+    let plan = plan_migration_with_encoder(&log, OperationFormat::V1, fake_v2_encoder).unwrap();
+    apply_migration(&log, &plan).unwrap();
+    let mapping = plan.mapping();
+
+    let steps = plan_attestation_migration(&attest_log, &mapping).unwrap();
+    apply_attestation_migration(&attest_log, &steps).unwrap();
+
+    // Re-running plan_attestation_migration on the now-cascaded
+    // log: the attestations reference *new* op_ids, none of which
+    // are in the original mapping (mapping keys are the old
+    // op_ids). So the second plan is empty.
+    let steps2 = plan_attestation_migration(&attest_log, &mapping).unwrap();
+    assert!(steps2.is_empty(),
+        "second cascade plan should be empty; cascade is one-shot");
+}
+
+#[test]
+fn cascade_preserves_by_stage_index() {
+    let tmp = tempfile::tempdir().unwrap();
+    let log = OpLog::open(tmp.path()).unwrap();
+    let attest_log = AttestationLog::open(tmp.path()).unwrap();
+
+    let a = add_op(None, "fac", "stg-1");
+    log.put(&a).unwrap();
+    let att = typecheck("stg-1", &a.op_id);
+    attest_log.put(&att).unwrap();
+
+    let plan = plan_migration_with_encoder(&log, OperationFormat::V1, fake_v2_encoder).unwrap();
+    apply_migration(&log, &plan).unwrap();
+    let mapping = plan.mapping();
+    let steps = plan_attestation_migration(&attest_log, &mapping).unwrap();
+    apply_attestation_migration(&attest_log, &steps).unwrap();
+
+    // by-stage index lookup must return the new attestation, not
+    // the old one.
+    let for_stage = attest_log.list_for_stage(&"stg-1".to_string()).unwrap();
+    assert_eq!(for_stage.len(), 1);
+    let post = &for_stage[0];
+    assert_ne!(post.attestation_id, att.attestation_id,
+        "by-stage should return the *new* attestation");
+    let new_op_id = mapping.get(&a.op_id).expect("a was rotated");
+    assert_eq!(post.op_id.as_deref(), Some(new_op_id.as_str()));
+}
+
+#[test]
+fn empty_mapping_is_a_no_op() {
+    let tmp = tempfile::tempdir().unwrap();
+    let attest_log = AttestationLog::open(tmp.path()).unwrap();
+    let empty_mapping = std::collections::BTreeMap::new();
+    let steps = plan_attestation_migration(&attest_log, &empty_mapping).unwrap();
+    assert!(steps.is_empty());
+}


### PR DESCRIPTION
Closes the documented limitation in #244. When an `OperationFormat` rotation invalidates every `OpId`, every attestation whose `op_id` references a rotated op is left dangling — its stored `op_id` points at a deleted record, and its own `attestation_id` (content-addressed *including* `op_id`) is now stale.

## Mechanics

* `plan_attestation_migration(log, mapping)` — walks the attestation log, finds attestations whose `op_id` is in the migration mapping, emits steps to rebuild each with the new `op_id` (re-deriving the `attestation_id` from the canonical form). Attestations with `op_id: None` (`Override`, `ProducerBlock`, etc.) are unaffected.
* `apply_attestation_migration(log, steps)` — two-phase, mirroring the op-log migration: write all new attestations first, then delete the old ones. Crash mid-phase leaves the log double-sized but readable.
* `AttestationLog::delete` — narrowly-purposed cleanup of primary file + by-stage + by-run index entries, used only by the cascade.

## CLI integration

`lex store migrate-ops --confirm` now invokes the cascade after the op-log migration:

1. Rotate op_ids
2. Rewrite branch heads through the mapping
3. **Cascade-migrate attestations whose `op_id` rotated** (NEW)
4. Invalidate every branch's `last_gate_checkpoint` (#256)

The CLI envelope reports `attestations_rotated: N`.

## Tests

`crates/lex-vcs/tests/attestation_cascade.rs`:

* TypeCheck attestations rotate cleanly; old `attestation_id`s deleted; every post-cascade `op_id` references a live op.
* `Override` / `ProducerBlock` attestations (op_id: None) are preserved unchanged.
* Idempotent on re-apply: second plan is empty because new `op_id`s aren't in the original mapping's keys.
* `by-stage` index returns the new attestation, not the old.
* Empty mapping is a no-op.

Workspace: all crates pass; clippy clean.

Closes #258.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_