### PR TITLE
lex-store+api: multi-writer CAS branch advance (#262)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+### Added — agent-VCS roadmap (#262)
+
+- **Multi-writer CAS branch advance** (#262). Pre-#262, two writers
+  calling `Store::apply_operation` concurrently on the same branch
+  could lose one another's update — `Branch.head_op` was a
+  read-modify-write under no lock. Now branch advance is a
+  fs2-advisory-locked CAS on `<branches>/<name>.lock`: the
+  retry loop reads the current head, persists the op (idempotent
+  via content addressing), then CAS-advances against the
+  pre-persist parent. CAS mismatch rebuilds the op with the new
+  head and retries up to 32 times before surfacing
+  `StoreError::Contention { branch, attempts }`.
+- **`Store::set_branch_head_op_cas`** + **`CasFailed`** internal
+  primitives. Single-parent ops are rebuildable (the retry loop
+  swaps the parent and re-derives the op_id); merge ops are not
+  (their parents are meaningful), so a CAS mismatch on a merge
+  surfaces immediately as `Contention`.
+- **HTTP API**: `apply_operation`-routing endpoints (`/v1/patch`,
+  `/v1/branches/.../merge/.../commit`, `/v1/programs/publish`)
+  map `Contention` → 503 with a `Retry-After: 1` header and a
+  `{kind: "contention", branch, attempts}` detail envelope.
+- Conformance tests in `crates/lex-store/tests/concurrent_apply.rs`:
+  N-thread races land every writer's signature, the resulting
+  history is a single linear chain, and op records are never lost
+  on retry (orphaned records are intentional under the append-only
+  contract).
+
 ### Added — agent-VCS roadmap (#258)
 
 - **Attestation-cascade migration** (#258). Closes the documented

--- a/crates/lex-api/src/handlers.rs
+++ b/crates/lex-api/src/handlers.rs
@@ -85,6 +85,31 @@ fn error_with_detail(status: u16, msg: impl Into<String>, detail: serde_json::Va
     }).unwrap())
 }
 
+/// Map a `StoreError` from a write path (`apply_operation` /
+/// `apply_operation_checked`) to an HTTP response. The only special
+/// case today is `Contention` (#262 multi-writer CAS retries
+/// exhausted), which maps to 503 with a `Retry-After` header so
+/// clients back off rather than hammering the same branch tip.
+fn write_error_response(prefix: &str, err: lex_store::StoreError)
+    -> Response<std::io::Cursor<Vec<u8>>>
+{
+    if let lex_store::StoreError::Contention { branch, attempts } = &err {
+        let body = serde_json::to_vec(&ErrorEnvelope {
+            error: format!("{prefix}: branch '{branch}' is contended (attempts={attempts})"),
+            detail: Some(serde_json::json!({
+                "kind": "contention",
+                "branch": branch,
+                "attempts": attempts,
+            })),
+        }).unwrap_or_else(|_| b"{}".to_vec());
+        return Response::from_data(body)
+            .with_status_code(503)
+            .with_header(Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..]).unwrap())
+            .with_header(Header::from_bytes(&b"Retry-After"[..], &b"1"[..]).unwrap());
+    }
+    error_response(500, format!("{prefix}: {err}"))
+}
+
 pub fn handle(state: Arc<State>, mut req: Request) -> std::io::Result<()> {
     let method = req.method().clone();
     let url = req.url().to_string();
@@ -297,7 +322,7 @@ pub(crate) fn publish_handler(state: &State, body: &str) -> Response<std::io::Cu
         Err(lex_store::StoreError::TypeError(errs)) => {
             error_with_detail(422, "type errors", serde_json::to_value(&errs).unwrap())
         }
-        Err(e) => error_response(500, format!("publish_program: {e}")),
+        Err(e) => write_error_response("publish_program", e),
     }
 }
 
@@ -407,7 +432,7 @@ fn patch_handler(state: &State, body: &str) -> Response<std::io::Cursor<Vec<u8>>
     );
     let op_id = match store.apply_operation(&branch, op, transition) {
         Ok(id) => id,
-        Err(e) => return error_response(500, format!("apply_operation: {e}")),
+        Err(e) => return write_error_response("apply_operation", e),
     };
 
     let status = format!("{:?}",
@@ -832,7 +857,7 @@ fn merge_commit_handler(
             "new_head_op": new_head_op,
             "dst_branch": dst_branch,
         })),
-        Err(e) => error_response(500, format!("apply merge op: {e}")),
+        Err(e) => write_error_response("apply merge op", e),
     }
 }
 

--- a/crates/lex-store/Cargo.toml
+++ b/crates/lex-store/Cargo.toml
@@ -16,6 +16,10 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
+# Advisory file locking for #262's CAS branch advance. Already a
+# transitive dep via tempfile; promoting to direct so the lock
+# call sites compile.
+fs2 = "0.4"
 lex-ast = { path = "../lex-ast", version = "0.4.0" }
 lex-trace = { path = "../lex-trace", version = "0.4.0" }
 lex-types = { path = "../lex-types", version = "0.4.0" }

--- a/crates/lex-store/src/branches.rs
+++ b/crates/lex-store/src/branches.rs
@@ -13,6 +13,31 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
 
+/// Why a CAS branch advance failed (#262). Surfaced through the
+/// retry loop in `Store::apply_operation` and friends; callers
+/// either retry (on `Mismatch`, after re-reading the head and
+/// rebuilding the candidate op) or propagate (on `Io` /
+/// `UnknownBranch`).
+#[derive(Debug)]
+pub enum CasFailed {
+    /// Read-time `head_op` didn't match the supplied `expected`.
+    /// Another writer advanced the branch between this caller's
+    /// read and write. `actual` is the head we found instead.
+    /// Public field so callers (e.g. an HTTP layer) can surface
+    /// the actual head in a structured error envelope; today's
+    /// retry loop just discards it and re-reads on the next
+    /// iteration.
+    #[allow(dead_code)] // populated for callers that inspect the variant
+    Mismatch { actual: Option<OpId> },
+    /// Branch doesn't exist (and isn't the default branch).
+    UnknownBranch(String),
+    /// Disk I/O failure (lock acquisition, file read, atomic
+    /// write). Stringified at the boundary because `io::Error`
+    /// isn't `Clone`/`PartialEq` and the variant is consumed by
+    /// the retry loop, not pattern-matched on.
+    Io(String),
+}
+
 pub const DEFAULT_BRANCH: &str = "main";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -307,6 +332,83 @@ impl Store {
         fs::create_dir_all(self.branches_dir())?;
         write_branch_atomic(&self.branch_path(name), &b)?;
         Ok(())
+    }
+
+    /// Atomic compare-and-swap on `branch.head_op` (#262). Holds
+    /// an advisory `flock` on a per-branch lock file across the
+    /// read-compare-write sequence so two concurrent writers can't
+    /// both see the same `head_op`, both decide to advance, and
+    /// both succeed (silently dropping one's lineage).
+    ///
+    /// Returns `Ok(())` when `expected == current head_op` and the
+    /// new value is durably written; `Err(CasFailed { actual })`
+    /// when the actual head doesn't match `expected`. Callers
+    /// should re-read the head, rebuild the candidate op against
+    /// the new parent, and retry. Op records are content-addressed
+    /// and idempotent, so re-persisting under a new parent is safe.
+    ///
+    /// Crash safety: same tempfile + rename + fsync as the
+    /// non-CAS path. The lock is the only addition; on a crashed
+    /// process the OS releases the flock and the next writer can
+    /// proceed.
+    pub(crate) fn set_branch_head_op_cas(
+        &self,
+        name: &str,
+        expected: Option<OpId>,
+        new: OpId,
+    ) -> Result<(), CasFailed> {
+        // Acquire the per-branch advisory lock. Path is
+        // `<branches_dir>/<name>.lock`; the file is created on
+        // first use and reused thereafter. We hold the lock for
+        // the entire RMW sequence.
+        fs::create_dir_all(self.branches_dir())
+            .map_err(|e| CasFailed::Io(e.to_string()))?;
+        let lock_path = self.branches_dir().join(format!("{name}.lock"));
+        let lock_file = fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&lock_path)
+            .map_err(|e| CasFailed::Io(e.to_string()))?;
+        use fs2::FileExt;
+        lock_file.lock_exclusive()
+            .map_err(|e| CasFailed::Io(e.to_string()))?;
+
+        // Critical section: read, compare, write. The lock is
+        // released when `lock_file` drops at end of scope (or on
+        // early return).
+        let result = (|| -> Result<(), CasFailed> {
+            let actual = self.get_branch(name)
+                .map_err(|e| CasFailed::Io(format!("{e}")))?
+                .and_then(|b| b.head_op);
+            if actual != expected {
+                return Err(CasFailed::Mismatch { actual });
+            }
+            let mut b = match self.get_branch(name)
+                .map_err(|e| CasFailed::Io(format!("{e}")))?
+            {
+                Some(b) => b,
+                None if name == DEFAULT_BRANCH => Branch {
+                    name: DEFAULT_BRANCH.into(),
+                    parent: None,
+                    head_op: None,
+                    predicate: None,
+                    merges: Vec::new(),
+                    created_at: now(),
+                    last_gate_checkpoint: None,
+                },
+                None => return Err(CasFailed::UnknownBranch(name.into())),
+            };
+            b.head_op = Some(new.clone());
+            b.last_gate_checkpoint = Some(new);
+            write_branch_atomic(&self.branch_path(name), &b)
+                .map_err(|e| CasFailed::Io(format!("{e}")))?;
+            Ok(())
+        })();
+        // Best-effort unlock; OS releases on file close anyway.
+        let _ = fs2::FileExt::unlock(&lock_file);
+        result
     }
 
     /// Invalidate every branch's `last_gate_checkpoint` (#256). Run

--- a/crates/lex-store/src/store.rs
+++ b/crates/lex-store/src/store.rs
@@ -51,6 +51,14 @@ pub enum StoreError {
         .0.op_id, .0.missing.join(", ")
     )]
     BranchAdvanceBlocked(crate::policy::BranchAdvanceBlocked),
+    /// All retry attempts of the CAS branch-head advance failed
+    /// because another writer kept advancing the same branch
+    /// (#262). The op record itself is durable in the op log
+    /// (orphaned), so re-running with backoff would eventually
+    /// land — return `503 Contention { retry_after }` from the
+    /// HTTP API and let the client back off.
+    #[error("branch advance contention on `{branch}`: {attempts} retries exhausted")]
+    Contention { branch: String, attempts: u32 },
     /// The op was persisted but its stage carries an attestation
     /// produced by a retroactively quarantined tool (#248). The
     /// branch head is unchanged. The op record stays in the log
@@ -694,17 +702,20 @@ impl Store {
         if let Err(errors) = lex_types::check_program(candidate) {
             return Err(StoreError::TypeError(errors));
         }
-        // Persist the op without advancing the branch head — we want
-        // the TypeCheck attestation visible *before* the gate runs,
-        // so policies that require TypeCheck pass for newly-typed
-        // ops. Then gate, then advance.
         let attestable = attestable_stage_ids(&transition);
         let op_effects = op_declared_effects(&op.kind);
-        let new_head = self.persist_op_only(branch, op, transition)?;
-        self.record_typecheck_passed(&attestable, &new_head.op_id)?;
-        self.run_required_attestations_gate(branch, &new_head.op_id, &attestable, &op_effects)?;
-        self.set_branch_head_op(branch, new_head.op_id.clone())?;
-        Ok(new_head.op_id)
+        // #262: CAS retry loop. Single-parent ops can be safely
+        // re-persisted under a new parent on contention (the kind
+        // is invariant; only `parents` changes). Merge ops (already
+        // 2-parent) come through the merge engine which has its own
+        // coordination; we don't retry them here — we'll see the
+        // first attempt's CAS fail and surface Contention.
+        self.cas_retry_advance(branch, op, transition, |new_head| {
+            self.record_typecheck_passed(&attestable, &new_head.op_id)?;
+            self.run_required_attestations_gate(
+                branch, &new_head.op_id, &attestable, &op_effects,
+            )
+        })
     }
 
     /// Open the attestation log rooted at this store. The log lives
@@ -763,48 +774,155 @@ impl Store {
     ) -> Result<lex_vcs::OpId, StoreError> {
         let attestable = attestable_stage_ids(&transition);
         let op_effects = op_declared_effects(&op.kind);
-        let new_head = self.persist_op_only(branch, op, transition)?;
-        // The unchecked path doesn't auto-emit TypeCheck, so a
-        // policy requiring TypeCheck (or any other attestation) on
-        // ops with attestable stages will refuse to advance the
-        // branch unless the caller emitted the attestation
-        // separately first. This is the intended behavior — the
-        // unchecked path opts out of the safety net the gate
-        // depends on.
-        self.run_required_attestations_gate(branch, &new_head.op_id, &attestable, &op_effects)?;
-        self.set_branch_head_op(branch, new_head.op_id.clone())?;
-        Ok(new_head.op_id)
+        self.cas_retry_advance(branch, op, transition, |new_head| {
+            self.run_required_attestations_gate(
+                branch, &new_head.op_id, &attestable, &op_effects,
+            )
+        })
     }
 
-    /// Persist an op via [`lex_vcs::apply`] but do NOT advance the
-    /// branch head. Internal to the apply pipeline so
-    /// `apply_operation` and `apply_operation_checked` share the
-    /// pre-check + persist sequence without duplicating the
-    /// validation code. The TypeCheck attestation and the
-    /// `required_attestations` gate slot in between this and the
-    /// final `set_branch_head_op` call.
-    fn persist_op_only(
+    /// CAS retry loop for #262. Single-parent ops are rebuilt on
+    /// each iteration with the current branch head as parent;
+    /// the per-iteration callback runs the gate (and TypeCheck
+    /// emission, for the checked path) between persist and CAS.
+    /// Merge ops (with 2 parents already set) skip the rebuild —
+    /// their parents are caller-supplied and meaningful — and get
+    /// a single attempt; on CAS failure they surface `Contention`.
+    fn cas_retry_advance<F>(
         &self,
         branch: &str,
         op: lex_vcs::Operation,
         transition: lex_vcs::StageTransition,
+        mut between_persist_and_cas: F,
+    ) -> Result<lex_vcs::OpId, StoreError>
+    where
+        F: FnMut(&lex_vcs::NewHead) -> Result<(), StoreError>,
+    {
+        // 32 retries handles up to ~32 concurrent writers racing on
+        // the same branch tip. Beyond that, surfacing `Contention`
+        // is the right signal — clients should back off or batch.
+        const MAX_ATTEMPTS: u32 = 32;
+        // Single-parent ops can be rebuilt on retry; merge ops
+        // can't (their two parents are meaningful, supplied by the
+        // merge engine). For merges, single attempt: if CAS
+        // fails, surface Contention.
+        let is_rebuildable = op.parents.len() <= 1;
+        let kind = op.kind.clone();
+        let intent_id = op.intent_id.clone();
+
+        let mut last_io_err: Option<StoreError> = None;
+        let mut current_op = op;
+        let current_transition = transition;
+        // Only rebuild on retries — attempt 1 honors the caller's
+        // exact op so a user-supplied bogus parent surfaces as
+        // `StaleParent` instead of being silently corrected.
+        let mut rebuilt_already = false;
+        for attempt in 1..=MAX_ATTEMPTS {
+            // Read the current head BEFORE we persist — this is
+            // the value we'll compare against in the CAS.
+            let parent = self
+                .get_branch(branch)?
+                .and_then(|b| b.head_op);
+
+            // Rebuild the op against the current head, but only
+            // on retries (not the caller's first attempt) and
+            // only for single-parent operations. Multi-parent
+            // (merge) ops are passed through unchanged.
+            if is_rebuildable && rebuilt_already {
+                current_op = lex_vcs::Operation {
+                    kind: kind.clone(),
+                    parents: parent.iter().cloned().collect(),
+                    intent_id: intent_id.clone(),
+                };
+            }
+
+            // Persist (idempotent). On `StaleParent` from a retry
+            // attempt (where we already rebuilt), the head changed
+            // between our `get_branch` and this `lex_vcs::apply`
+            // — race; rebuild and continue. On `StaleParent` from
+            // attempt 1 (caller's input), propagate.
+            let new_head = match self.persist_op_only_with_parent(
+                branch,
+                parent.as_ref(),
+                current_op.clone(),
+                current_transition.clone(),
+            ) {
+                Ok(nh) => nh,
+                Err(StoreError::Apply(lex_vcs::ApplyError::StaleParent { .. }))
+                    if is_rebuildable && rebuilt_already =>
+                {
+                    rebuilt_already = true;
+                    continue;
+                }
+                Err(e) => return Err(e),
+            };
+
+            // Run the caller's between-persist-and-cas hook
+            // (TypeCheck emission + gate). If this fails, the op
+            // record is durable but orphaned — same semantics as
+            // pre-#262.
+            between_persist_and_cas(&new_head)?;
+
+            // CAS the branch head. On success: done. On mismatch:
+            // someone advanced in parallel; retry.
+            match self.set_branch_head_op_cas(branch, parent, new_head.op_id.clone()) {
+                Ok(()) => return Ok(new_head.op_id),
+                Err(crate::branches::CasFailed::Mismatch { .. }) if is_rebuildable => {
+                    // Try again with the new head as parent.
+                    rebuilt_already = true;
+                    continue;
+                }
+                Err(crate::branches::CasFailed::Mismatch { .. }) => {
+                    // Merge op: surface immediately — we can't
+                    // rebuild without rerunning the merge engine.
+                    let _ = attempt;
+                    return Err(StoreError::Contention {
+                        branch: branch.into(),
+                        attempts: 1,
+                    });
+                }
+                Err(crate::branches::CasFailed::UnknownBranch(b)) => {
+                    return Err(StoreError::UnknownBranch(b));
+                }
+                Err(crate::branches::CasFailed::Io(e)) => {
+                    last_io_err = Some(StoreError::Io(std::io::Error::other(e)));
+                    continue;
+                }
+            }
+        }
+        // Retries exhausted. Prefer surfacing the most recent IO
+        // error if we hit one; otherwise it's pure CAS contention.
+        match last_io_err {
+            Some(e) => Err(e),
+            None => Err(StoreError::Contention {
+                branch: branch.into(),
+                attempts: MAX_ATTEMPTS,
+            }),
+        }
+    }
+
+    /// Persist an op against an explicitly-supplied parent. Used
+    /// by the CAS retry loop in `cas_retry_advance` so the
+    /// `lex_vcs::apply` parent check matches what we read at the
+    /// top of the loop iteration (avoids a TOCTOU race against
+    /// `persist_op_only`'s second read).
+    fn persist_op_only_with_parent(
+        &self,
+        branch: &str,
+        parent: Option<&lex_vcs::OpId>,
+        op: lex_vcs::Operation,
+        transition: lex_vcs::StageTransition,
     ) -> Result<lex_vcs::NewHead, StoreError> {
-        // Pre-check: refuse to persist any op against a branch that
-        // doesn't exist. Without this, applying against a non-default
-        // ghost branch would write the op record (succeeding via
-        // lex_vcs::apply on a None head) and only fail at
-        // set_branch_head_op below — leaving an orphan op in the log
-        // with no branch pointing at it.
         if branch != DEFAULT_BRANCH && self.get_branch(branch)?.is_none() {
             return Err(StoreError::UnknownBranch(branch.into()));
         }
         let log = lex_vcs::OpLog::open(self.root())?;
-        let head_op = self.get_branch(branch)?.and_then(|b| b.head_op);
-        lex_vcs::apply(&log, head_op.as_ref(), op, transition).map_err(|e| match e {
+        lex_vcs::apply(&log, parent, op, transition).map_err(|e| match e {
             lex_vcs::ApplyError::Persist(io) => StoreError::Io(io),
             other => StoreError::Apply(other),
         })
     }
+
 
     /// Run the `required_attestations` gate (#245) and the
     /// retroactive producer-block gate (#248) over a single op

--- a/crates/lex-store/tests/concurrent_apply.rs
+++ b/crates/lex-store/tests/concurrent_apply.rs
@@ -1,0 +1,174 @@
+//! Conformance tests for #262 multi-writer CAS on branch advance.
+//!
+//! Pre-#262, two writers calling `apply_operation` against the same
+//! branch concurrently could either lose one another's update (last
+//! write wins on the branch file) or land in an inconsistent state.
+//! With #262, branch advance is a CAS guarded by `fs2` advisory
+//! locking on a per-branch lockfile, and `apply_operation` retries
+//! up to 8 times on contention before surfacing
+//! `StoreError::Contention`.
+
+use lex_store::{Operation, OperationKind, StageTransition, Store, DEFAULT_BRANCH};
+use std::collections::BTreeSet;
+use std::sync::Arc;
+use std::thread;
+
+fn fresh() -> (Arc<Store>, tempfile::TempDir) {
+    let tmp = tempfile::tempdir().unwrap();
+    let s = Store::open(tmp.path()).unwrap();
+    (Arc::new(s), tmp)
+}
+
+#[test]
+fn n_concurrent_writers_all_land() {
+    // Spawn N threads, each calling `apply_operation` with a unique
+    // signature. After all threads finish, the head_state must
+    // contain every signature — none lost to races.
+    const N: usize = 12;
+    let (s, _tmp) = fresh();
+
+    let handles: Vec<_> = (0..N)
+        .map(|i| {
+            let s = Arc::clone(&s);
+            thread::spawn(move || {
+                let sig = format!("sig-{}", i);
+                let stage = format!("stg-{}", i);
+                let op = Operation::new(
+                    OperationKind::AddFunction {
+                        sig_id: sig.clone(),
+                        stage_id: stage.clone(),
+                        effects: BTreeSet::new(),
+                        budget_cost: None,
+                    },
+                    [],
+                );
+                let t = StageTransition::Create {
+                    sig_id: sig.clone(),
+                    stage_id: stage.clone(),
+                };
+                s.apply_operation(DEFAULT_BRANCH, op, t)
+                    .expect("apply should succeed under contention")
+            })
+        })
+        .collect();
+
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    let head = s.branch_head(DEFAULT_BRANCH).unwrap();
+    assert_eq!(head.len(), N, "every writer's signature must be present");
+    for i in 0..N {
+        assert_eq!(head.get(&format!("sig-{}", i)), Some(&format!("stg-{}", i)));
+    }
+}
+
+#[test]
+fn n_concurrent_writers_chain_into_a_single_history() {
+    // After N concurrent writers, the op-log must form a single
+    // chain of length N rooted at the genesis op (parents=[]).
+    // Each non-root op has exactly one parent, and the chain
+    // terminates at the branch head.
+    const N: usize = 8;
+    let (s, _tmp) = fresh();
+
+    let handles: Vec<_> = (0..N)
+        .map(|i| {
+            let s = Arc::clone(&s);
+            thread::spawn(move || {
+                let sig = format!("sig-{}", i);
+                let stage = format!("stg-{}", i);
+                let op = Operation::new(
+                    OperationKind::AddFunction {
+                        sig_id: sig.clone(),
+                        stage_id: stage.clone(),
+                        effects: BTreeSet::new(),
+                        budget_cost: None,
+                    },
+                    [],
+                );
+                let t = StageTransition::Create {
+                    sig_id: sig.clone(),
+                    stage_id: stage.clone(),
+                };
+                s.apply_operation(DEFAULT_BRANCH, op, t).unwrap()
+            })
+        })
+        .collect();
+
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    // Walk back from head and count nodes; verify single linear chain.
+    let log = lex_vcs::OpLog::open(s.root()).unwrap();
+    let head_op = s.get_branch(DEFAULT_BRANCH).unwrap().unwrap().head_op.unwrap();
+    let mut cursor = Some(head_op);
+    let mut count = 0;
+    while let Some(id) = cursor {
+        let rec = log.get(&id).unwrap().unwrap();
+        count += 1;
+        cursor = match rec.op.parents.len() {
+            0 => None,
+            1 => Some(rec.op.parents[0].clone()),
+            n => panic!("unexpected fan-in of {} at op {}", n, id),
+        };
+    }
+    assert_eq!(count, N, "history should be a linear chain of N ops");
+}
+
+#[test]
+fn concurrent_writers_do_not_lose_op_records() {
+    // Even on contention paths where the final op_id changes after
+    // a CAS-mismatch retry (because the rebuilt op has a new
+    // parent), the *intermediate* persisted op record is still on
+    // disk. This test ensures we don't silently drop op records on
+    // retry — we just don't reference them from the branch head.
+    const N: usize = 6;
+    let (s, tmp) = fresh();
+
+    let handles: Vec<_> = (0..N)
+        .map(|i| {
+            let s = Arc::clone(&s);
+            thread::spawn(move || {
+                let sig = format!("sig-{}", i);
+                let stage = format!("stg-{}", i);
+                let op = Operation::new(
+                    OperationKind::AddFunction {
+                        sig_id: sig.clone(),
+                        stage_id: stage.clone(),
+                        effects: BTreeSet::new(),
+                        budget_cost: None,
+                    },
+                    [],
+                );
+                let t = StageTransition::Create {
+                    sig_id: sig.clone(),
+                    stage_id: stage.clone(),
+                };
+                s.apply_operation(DEFAULT_BRANCH, op, t).unwrap()
+            })
+        })
+        .collect();
+
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    // The ops/ directory should contain at least N op records (one
+    // per logical write). It may contain *more* if any writer was
+    // forced to retry — those orphan records are intentional under
+    // the append-only contract.
+    let ops_dir = tmp.path().join("ops");
+    let n_ops = std::fs::read_dir(&ops_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|x| x == "json"))
+        .count();
+    assert!(
+        n_ops >= N,
+        "ops/ should hold at least {} records (got {})",
+        N,
+        n_ops
+    );
+}


### PR DESCRIPTION
Closes #262.

## Summary

- **Multi-writer safety**: Pre-#262, two writers calling `Store::apply_operation` concurrently on the same branch could lose one another's update — `Branch.head_op` was a read-modify-write under no lock. Now branch advance is an `fs2`-advisory-locked CAS on `<branches>/<name>.lock` with up to 32 retries.
- **CAS retry loop**: Read parent → persist op (idempotent via content addressing) → CAS-advance under lock. On mismatch, rebuild single-parent ops with the new head and retry; merge ops surface `Contention` immediately (their parents are meaningful, supplied by the merge engine).
- **Error contract**: Exhausted retries surface `StoreError::Contention { branch, attempts }`. The HTTP API maps this to 503 with `Retry-After: 1` and a `{kind: "contention", branch, attempts}` detail envelope, so clients back off rather than hammering the same branch tip.

## Test plan

- [x] `cargo test --workspace` — all 162 test groups pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] New `crates/lex-store/tests/concurrent_apply.rs` — 3 conformance tests
  - N concurrent writers all land their signatures
  - Resulting history is a single linear chain (no fan-in, no lost ops)
  - Orphan op records preserved on retry (append-only contract)
- [x] Existing `apply_operation_with_stale_parent_errors` — still rejects user-supplied bogus parents on attempt 1 (the retry loop only rebuilds after a CAS mismatch, never on the caller's first try)

https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_