### PR TITLE
lex-store+cli: ops-during-run Trace attestations (#257)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+### Added — agent-VCS roadmap (#257)
+
+- **Ops-during-run trace attestations** (#257). Closes the
+  follow-up #246 documented: `Trace` attestations gained an
+  `op_id` field but no producer set it. Now `Store::record_op_trace`
+  emits per-stage Trace attestations with `op_id: Some(...)`
+  linking a committed op to the run that produced it, and
+  `Store::record_run_committed_ops_since` walks the
+  `ops_since(branch_head, base)` diff and emits Trace
+  attestations for each new op.
+- **`lex run --trace`** snapshots the default branch's `head_op`
+  before the VM exits and calls `record_run_committed_ops_since`
+  after, so any ops committed during the run get linked to the
+  run automatically. Common case (no ops committed) is a single
+  no-op call returning 0.
+- **`lex trace --op <op_id>`** is now populated by this pipeline
+  — the filter the surface added in #246 finally returns hits.
+- **`StoreError::UnknownOp`** for `record_op_trace` against an
+  op_id that isn't in the log.
+
 ### Added — agent-VCS roadmap (#262)
 
 - **Multi-writer CAS branch advance** (#262). Pre-#262, two writers

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -502,6 +502,20 @@ fn cmd_run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let recorder = lex_trace::Recorder::new();
     let trace_handle = recorder.handle();
     if f.trace { vm.set_tracer(Box::new(recorder)); }
+    // #257: snapshot the default branch's head before the run so we
+    // can attribute any ops committed during the run back to the
+    // run's `run_id` via Trace attestations. `pre_run_head` is
+    // `None` for a fresh store; that's fine — `record_run_committed_ops_since`
+    // treats `None` as "every reachable op is post-run", which is
+    // the right behavior on an empty pre-run history.
+    let pre_run_head = if f.trace {
+        let store = lex_store::Store::open(default_store_root())?;
+        store.get_branch(lex_store::DEFAULT_BRANCH)
+            .map_err(|e| anyhow!("reading branch: {e}"))?
+            .and_then(|b| b.head_op)
+    } else {
+        None
+    };
 
     let vargs: Vec<Value> = f.positional[arg_positional_start..]
         .iter()
@@ -556,6 +570,28 @@ fn cmd_run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
                 .map_err(|e| anyhow!("opening attestation log: {e}"))?
                 .put(&attestation)
                 .map_err(|e| anyhow!("recording trace attestation: {e}"))?;
+        }
+        // #257: emit `Trace` attestations with `op_id` set for any
+        // op committed during the run. Walks `ops_since(post_head,
+        // pre_run_head)` on the default branch — the only branch
+        // `lex run` interacts with today. Empty for the common case
+        // where the program doesn't commit ops.
+        let att_result = match &result {
+            Ok(_) => lex_vcs::AttestationResult::Passed,
+            Err(e) => lex_vcs::AttestationResult::Failed {
+                detail: format!("{e}"),
+            },
+        };
+        let n_op_traces = store.record_run_committed_ops_since(
+            &id,
+            &func,
+            lex_store::DEFAULT_BRANCH,
+            pre_run_head.as_ref(),
+            att_result,
+            trace_producer(),
+        ).map_err(|e| anyhow!("recording op traces: {e}"))?;
+        if n_op_traces > 0 && !matches!(fmt, OutputFormat::Json) {
+            eprintln!("trace attestations: {n_op_traces} op(s) linked to run");
         }
         trace_id = Some(id.clone());
         if !matches!(fmt, OutputFormat::Json) { eprintln!("trace saved: {id}"); }
@@ -666,11 +702,12 @@ fn parse_run_flags(args: &[String]) -> Result<RunFlags> {
 
 /// `lex trace <run_id>` — load the trace tree by run id (existing).
 /// `lex trace --op <op_id>` (#246) — list every `AttestationKind::Trace`
-/// attestation whose `op_id` field matches. Today no producer
-/// emits Trace attestations *with* an op_id (the existing emitter
-/// in `cmd_run` sets it to None), so this filter typically returns
-/// empty; it's the surface the next-generation
-/// "ops-committed-during-a-run" pipeline will populate.
+/// attestation whose `op_id` field matches. Populated by the
+/// ops-during-run pipeline (#257): when `lex run --trace` finds
+/// any op committed during the run, it emits per-stage Trace
+/// attestations with `op_id: Some(...)` set, which this filter
+/// surfaces. The entry-point Trace attestation (no op_id) is not
+/// returned — it's not associated with a single committed op.
 fn cmd_trace(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     // --op flag form first.
     let mut op_filter: Option<String> = None;

--- a/crates/lex-store/src/store.rs
+++ b/crates/lex-store/src/store.rs
@@ -31,6 +31,8 @@ pub enum StoreError {
     InvalidTransition(String),
     #[error("unknown branch `{0}`")]
     UnknownBranch(String),
+    #[error("unknown op_id `{0}`")]
+    UnknownOp(lex_vcs::OpId),
     #[error(transparent)]
     Apply(#[from] lex_vcs::ApplyError),
     /// The candidate program — i.e. the source the caller is
@@ -762,6 +764,99 @@ impl Store {
             log.put(&attestation)?;
         }
         Ok(())
+    }
+
+    /// Emit `Trace` attestations linking an already-committed `op`
+    /// to the run that produced it (#257). One attestation per
+    /// produced stage (matching the `TypeCheck` emission contract
+    /// — see [`Self::apply_operation_checked`]) with
+    /// `op_id: Some(op_id)` set, so `lex trace --op <op_id>`
+    /// surfaces the run.
+    ///
+    /// Returns the number of attestations emitted (zero for ops
+    /// that produce no attestable stage, e.g. `Remove` /
+    /// `ImportOnly`).
+    ///
+    /// Idempotent: re-emitting for the same
+    /// `(run_id, root_target, op_id, stage_id, producer, result)`
+    /// tuple dedups via content addressing.
+    ///
+    /// `op_id` must already exist in the op log — an unknown op
+    /// surfaces as `StoreError::UnknownOp`.
+    pub fn record_op_trace(
+        &self,
+        run_id: &str,
+        root_target: &str,
+        op_id: &lex_vcs::OpId,
+        result: lex_vcs::AttestationResult,
+        producer: lex_vcs::ProducerDescriptor,
+    ) -> Result<usize, StoreError> {
+        let log = lex_vcs::OpLog::open(self.root())?;
+        let rec = log.get(op_id)?
+            .ok_or_else(|| StoreError::UnknownOp(op_id.clone()))?;
+        let stage_ids = attestable_stage_ids(&rec.produces);
+        if stage_ids.is_empty() {
+            return Ok(0);
+        }
+        let attlog = self.attestation_log()?;
+        let mut emitted = 0;
+        for stage_id in stage_ids {
+            let attestation = lex_vcs::Attestation::new(
+                stage_id,
+                Some(op_id.clone()),
+                None,
+                lex_vcs::AttestationKind::Trace {
+                    run_id: run_id.into(),
+                    root_target: root_target.into(),
+                },
+                result.clone(),
+                producer.clone(),
+                None,
+            );
+            attlog.put(&attestation)?;
+            emitted += 1;
+        }
+        Ok(emitted)
+    }
+
+    /// Walk `ops_since(branch_head, base)` and emit per-stage
+    /// `Trace` attestations for each new op, linking them to the
+    /// run that produced them (#257). Used by `lex run --trace`
+    /// after the VM exits: snapshot `base = branch_head` before
+    /// the run, then call this with the post-run head.
+    ///
+    /// `base = None` means "every op currently reachable from the
+    /// branch head" — generally not what you want for a single
+    /// run; pass the pre-run head.
+    ///
+    /// Returns the total number of attestations emitted across
+    /// every new op. Zero is the common case (the run committed no
+    /// ops).
+    ///
+    /// Idempotent on the per-op level via [`Self::record_op_trace`].
+    pub fn record_run_committed_ops_since(
+        &self,
+        run_id: &str,
+        root_target: &str,
+        branch: &str,
+        base: Option<&lex_vcs::OpId>,
+        result: lex_vcs::AttestationResult,
+        producer: lex_vcs::ProducerDescriptor,
+    ) -> Result<usize, StoreError> {
+        let head = match self.get_branch(branch)?.and_then(|b| b.head_op) {
+            Some(h) => h,
+            None => return Ok(0),
+        };
+        let log = lex_vcs::OpLog::open(self.root())?;
+        let new_ops = log.ops_since(&head, base)?;
+        let mut total = 0;
+        for rec in new_ops {
+            total += self.record_op_trace(
+                run_id, root_target, &rec.op_id,
+                result.clone(), producer.clone(),
+            )?;
+        }
+        Ok(total)
     }
 
     /// `set_branch_head_op` for the durability story on the branch

--- a/crates/lex-store/tests/run_op_trace.rs
+++ b/crates/lex-store/tests/run_op_trace.rs
@@ -1,0 +1,181 @@
+//! Conformance tests for #257: Trace attestations with `op_id`
+//! populated for ops committed during a traced run.
+//!
+//! Pre-#257, `AttestationKind::Trace` carried `run_id` and
+//! `root_target` but no `op_id` — `lex trace --op <op_id>` had a
+//! filter wired but no producer to surface. #257 closes that loop:
+//! `Store::record_op_trace` and
+//! `Store::record_run_committed_ops_since` emit per-stage Trace
+//! attestations with `op_id: Some(...)` set.
+
+use lex_store::{Operation, OperationKind, StageTransition, Store, DEFAULT_BRANCH};
+use std::collections::BTreeSet;
+
+fn fresh() -> (Store, tempfile::TempDir) {
+    let tmp = tempfile::tempdir().unwrap();
+    let s = Store::open(tmp.path()).unwrap();
+    (s, tmp)
+}
+
+fn producer() -> lex_vcs::ProducerDescriptor {
+    lex_vcs::ProducerDescriptor {
+        tool: "test-runner".into(),
+        version: "0.0.0".into(),
+        model: None,
+    }
+}
+
+fn make_add_op(sig: &str, stage: &str) -> (Operation, StageTransition) {
+    let op = Operation::new(
+        OperationKind::AddFunction {
+            sig_id: sig.into(),
+            stage_id: stage.into(),
+            effects: BTreeSet::new(),
+            budget_cost: None,
+        },
+        [],
+    );
+    let t = StageTransition::Create {
+        sig_id: sig.into(),
+        stage_id: stage.into(),
+    };
+    (op, t)
+}
+
+#[test]
+fn record_op_trace_emits_per_stage_attestation_with_op_id() {
+    let (s, _tmp) = fresh();
+    let (op, t) = make_add_op("fac", "stg-1");
+    let op_id = s.apply_operation(DEFAULT_BRANCH, op, t).unwrap();
+
+    let n = s.record_op_trace(
+        "run-abc",
+        "fac",
+        &op_id,
+        lex_vcs::AttestationResult::Passed,
+        producer(),
+    ).unwrap();
+    assert_eq!(n, 1, "AddFunction produces exactly one attestable stage");
+
+    let attlog = s.attestation_log().unwrap();
+    let by_run = attlog.list_for_run(&"run-abc".to_string()).unwrap();
+    assert_eq!(by_run.len(), 1);
+    let att = &by_run[0];
+    assert_eq!(att.op_id.as_deref(), Some(op_id.as_str()),
+        "Trace attestation must carry the committed op_id");
+    match &att.kind {
+        lex_vcs::AttestationKind::Trace { run_id, root_target } => {
+            assert_eq!(run_id, "run-abc");
+            assert_eq!(root_target, "fac");
+        }
+        other => panic!("expected Trace kind, got {other:?}"),
+    }
+}
+
+#[test]
+fn record_op_trace_is_idempotent() {
+    // Re-emitting for the same (run_id, op_id, stage_id, producer,
+    // result) tuple dedups via content addressing — the attestation
+    // log's `put` is a no-op on existing attestation_ids.
+    let (s, _tmp) = fresh();
+    let (op, t) = make_add_op("fac", "stg-1");
+    let op_id = s.apply_operation(DEFAULT_BRANCH, op, t).unwrap();
+
+    s.record_op_trace("run-abc", "fac", &op_id,
+        lex_vcs::AttestationResult::Passed, producer()).unwrap();
+    s.record_op_trace("run-abc", "fac", &op_id,
+        lex_vcs::AttestationResult::Passed, producer()).unwrap();
+
+    let attlog = s.attestation_log().unwrap();
+    let by_run = attlog.list_for_run(&"run-abc".to_string()).unwrap();
+    assert_eq!(by_run.len(), 1, "duplicate emit must dedup by attestation_id");
+}
+
+#[test]
+fn record_op_trace_unknown_op_errors() {
+    let (s, _tmp) = fresh();
+    let bogus = lex_vcs::OpId::from("does-not-exist".to_string());
+    let err = s.record_op_trace("run-abc", "fac", &bogus,
+        lex_vcs::AttestationResult::Passed, producer());
+    assert!(matches!(err, Err(lex_store::StoreError::UnknownOp(_))));
+}
+
+#[test]
+fn record_run_committed_ops_since_walks_diff() {
+    // Snapshot pre-run head, commit several ops, snapshot post-run
+    // head, call the snapshot-diff helper. Every committed op gets
+    // a Trace attestation linking it to the run.
+    let (s, _tmp) = fresh();
+    let pre_head = s.get_branch(DEFAULT_BRANCH).unwrap()
+        .and_then(|b| b.head_op);  // None on a fresh store
+
+    let (op_a, t_a) = make_add_op("fa", "stg-fa");
+    let id_a = s.apply_operation(DEFAULT_BRANCH, op_a, t_a).unwrap();
+    let op_b = Operation::new(
+        OperationKind::AddFunction {
+            sig_id: "fb".into(), stage_id: "stg-fb".into(),
+            effects: BTreeSet::new(), budget_cost: None,
+        },
+        [id_a.clone()],
+    );
+    let id_b = s.apply_operation(DEFAULT_BRANCH, op_b, StageTransition::Create {
+        sig_id: "fb".into(), stage_id: "stg-fb".into(),
+    }).unwrap();
+
+    let n = s.record_run_committed_ops_since(
+        "run-xyz",
+        "main",
+        DEFAULT_BRANCH,
+        pre_head.as_ref(),
+        lex_vcs::AttestationResult::Passed,
+        producer(),
+    ).unwrap();
+    assert_eq!(n, 2, "both ops should be linked to the run");
+
+    let attlog = s.attestation_log().unwrap();
+    let by_run = attlog.list_for_run(&"run-xyz".to_string()).unwrap();
+    assert_eq!(by_run.len(), 2);
+    let op_ids: BTreeSet<_> = by_run.iter()
+        .filter_map(|a| a.op_id.clone())
+        .collect();
+    assert!(op_ids.contains(&id_a));
+    assert!(op_ids.contains(&id_b));
+}
+
+#[test]
+fn record_run_committed_ops_since_empty_when_no_ops_committed() {
+    // The most common case: a traced run that doesn't commit ops.
+    let (s, _tmp) = fresh();
+    // Seed one op so head_op exists.
+    let (op, t) = make_add_op("seed", "stg-seed");
+    let seed_id = s.apply_operation(DEFAULT_BRANCH, op, t).unwrap();
+
+    // Snapshot AFTER the seed — pretend the run starts here and
+    // commits nothing.
+    let pre_run_head = Some(seed_id.clone());
+    let n = s.record_run_committed_ops_since(
+        "run-quiet",
+        "main",
+        DEFAULT_BRANCH,
+        pre_run_head.as_ref(),
+        lex_vcs::AttestationResult::Passed,
+        producer(),
+    ).unwrap();
+    assert_eq!(n, 0, "no new ops since pre_run_head");
+    let attlog = s.attestation_log().unwrap();
+    let by_run = attlog.list_for_run(&"run-quiet".to_string()).unwrap();
+    assert!(by_run.is_empty());
+}
+
+#[test]
+fn record_run_committed_ops_since_unknown_branch_returns_zero() {
+    // The branch doesn't exist (no head_op) — emit nothing rather
+    // than erroring. `lex run` may be invoked in a fresh store
+    // before any branch has been advanced.
+    let (s, _tmp) = fresh();
+    let n = s.record_run_committed_ops_since(
+        "run-empty", "main", "ghost", None,
+        lex_vcs::AttestationResult::Passed, producer(),
+    ).unwrap();
+    assert_eq!(n, 0);
+}


### PR DESCRIPTION
Closes #257.

## Summary

`AttestationKind::Trace` gained an `op_id` field in #246, but no producer set it — `lex trace --op <op_id>` returned empty by construction. This PR closes the loop:

- **`Store::record_op_trace(run_id, root_target, op_id, result, producer)`** — emits per-stage `Trace` attestations with `op_id: Some(...)` for an already-committed op. Matches the per-stage `TypeCheck` emission contract from `apply_operation_checked`.
- **`Store::record_run_committed_ops_since(run_id, ..., branch, base)`** — walks `OpLog::ops_since(branch_head, base)` and calls `record_op_trace` for each new op. The snapshot-diff approach: `lex run --trace` records `pre_run_head = branch_head` before the VM starts, then calls this with `base = pre_run_head` after.
- **`lex run --trace`** wires the snapshot/walk automatically — common case (no ops committed) is a no-op returning 0.
- **`StoreError::UnknownOp(OpId)`** surfaces unknown op_ids from `record_op_trace`.

## Test plan

- [x] `cargo test --workspace` — all groups pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] New `crates/lex-store/tests/run_op_trace.rs` — 6 conformance tests covering per-stage emission, idempotence, unknown-op error, snapshot-diff walking, empty-diff fast path, and unknown-branch graceful zero.

## Notes

The acceptance criterion in #257 mentions an end-to-end test where a Lex program publishes a fn during a traced run. There's no `publish` effect in the runtime today, so the snapshot-diff approach in `lex run --trace` is dormant in practice — but it's wired and ready for the first agent runtime that drives commits from inside a traced run. The 6-test conformance suite exercises every code path directly.

https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_