### PR TITLE
deps: bump getrandom 0.2→0.4, rand 0.9→0.10, toml, rusqlite, notify, action-gh-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
         run: ls -la dist/
 
       - name: Create / update Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name || github.event.inputs.tag }}
           generate_release_notes: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,5 +42,5 @@ anyhow = "1"
 logos = "0.16"
 indexmap = { version = "2", features = ["serde"] }
 ed25519-dalek = { version = "2", default-features = false, features = ["std", "fast"] }
-getrandom = "0.2"
+getrandom = "0.4"
 hex = "0.4"

--- a/crates/lex-cli/Cargo.toml
+++ b/crates/lex-cli/Cargo.toml
@@ -30,7 +30,7 @@ lex-api = { path = "../lex-api" }
 conformance = { path = "../conformance" }
 spec-checker = { path = "../spec-checker" }
 acli = "0.5"
-notify = { version = "6", default-features = false, features = ["macos_kqueue"] }
+notify = { version = "8", default-features = false, features = ["macos_kqueue"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -27,14 +27,14 @@ md-5 = "0.11"
 base64 = "0.22"
 hex = "0.4"
 subtle = "2.6"
-rand = { version = "0.9", features = ["os_rng"] }
+rand = { version = "0.10", features = ["sys_rng"] }
 tiny_http = { version = "0.12", features = ["ssl-rustls"] }
 tungstenite = "0.29"
 ureq = { version = "3.3", default-features = false, features = ["rustls", "platform-verifier"] }
-toml = "0.9"
+toml = "1.1"
 serde_yaml = "0.9"
 csv = "1"
-rusqlite = { version = "0.36", features = ["bundled"] }
+rusqlite = { version = "0.39", features = ["bundled"] }
 lex-bytecode = { path = "../lex-bytecode", version = "0.4.0" }
 
 [dev-dependencies]

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -686,9 +686,9 @@ impl EffectHandler for DefaultHandler {
             if !(0..=1_048_576).contains(&n) {
                 return Err("crypto.random: n must be in 0..=1048576".into());
             }
-            use rand::{rngs::OsRng, TryRngCore};
+            use rand::{rngs::SysRng, TryRng};
             let mut buf = vec![0u8; n as usize];
-            OsRng.try_fill_bytes(&mut buf)
+            SysRng.try_fill_bytes(&mut buf)
                 .map_err(|e| format!("crypto.random: OS RNG: {e}"))?;
             return Ok(Value::Bytes(buf));
         }

--- a/crates/lex-vcs/src/signing.rs
+++ b/crates/lex-vcs/src/signing.rs
@@ -74,7 +74,7 @@ impl Keypair {
     /// (test vectors, KAT) should use [`Keypair::from_secret_hex`].
     pub fn generate() -> Result<Self, SigningError> {
         let mut seed = [0u8; SECRET_KEY_LENGTH];
-        getrandom::getrandom(&mut seed)
+        getrandom::fill(&mut seed)
             .map_err(|e| SigningError::Entropy(e.to_string()))?;
         Ok(Self::from_seed(&seed))
     }


### PR DESCRIPTION
Combines dependabot PRs #269, #271, #272, #273, #274, #275 into a single update.

## Summary

Bumps in one shot to avoid the rebase chain that would result from merging dependabot's PRs serially:

| Crate | From | To | Breaking? |
|-------|------|----|-----------|
| `getrandom` | 0.2 | 0.4 | yes — `getrandom()` → `fill()` |
| `rand` | 0.9 | 0.10 | yes — `OsRng` → `SysRng`; `TryRngCore` → `TryRng` |
| `toml` | 0.9 | 1.1 | no |
| `rusqlite` | 0.36 | 0.39 | no |
| `notify` | 6 | 8 | no |
| `softprops/action-gh-release` | v2 | v3 | no |

## Fixed call sites

- `crates/lex-vcs/src/signing.rs` — `Keypair::generate` uses `getrandom::fill` for the seed.
- `crates/lex-runtime/src/handler.rs` — `crypto.random` handler uses `rand::rngs::SysRng` + `rand::TryRng` (the `os_rng` feature is renamed `sys_rng` in rand 0.10; `OsRng` no longer exists in `rngs`).

`toml`, `rusqlite`, and `notify` compiled clean — call sites already used the stable surface.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — 166 test groups pass, 0 failures
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean

## Out of scope

#270 (`getrandom` in `/fuzz`) — fuzz crate doesn't declare `getrandom` directly, only transitively. Closing as superseded; dependabot will re-open against the new lockfile if needed.

https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_