### PR TITLE
chore: bump workspace to 0.5.0 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+## [0.5.0] — 2026-05-09
+
+The op-log performance roadmap and the post-0.4.0 limitation
+follow-ups. #261 ships in three slices (packfiles, predicate-driven
+GC, delta-encoded stages) so the on-disk layout scales past the
+~10k-op cap that 0.4.0's loose-file model implied. Alongside, the
+limitation issues filed against 0.4.0 are now closed (#256
+walk-back gate, #257 ops-during-run trace attestations, #258
+attestation-cascade migration), the multi-writer concurrency story
+is real (#262 CAS branch advance), and `lex op pull` (#260)
+completes the symmetric inverse of #242's push.
+
+Minor bump because every data-layer change is additive — packfiles
+and `.delta.json` are new file shapes alongside the existing loose
+forms; loose-file readers ignore them. The one breaking surface is
+the dep update: `rand 0.10` and `getrandom 0.4` rotated their
+trait imports (`OsRng` → `SysRng`, `TryRngCore` → `TryRng`,
+`getrandom::getrandom` → `getrandom::fill`), so callers of
+`lex_vcs::Keypair::generate` or the `crypto.random` runtime
+handler that took out their own RNG will need to adjust imports.
+
 ### Added — agent-VCS roadmap (#261, slice 3)
 
 - **Delta-encoded stage bytes** (#261 slice 3). When

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "EUPL-1.2"
 repository = "https://github.com/alpibrusl/lex-lang"

--- a/crates/lex-api/Cargo.toml
+++ b/crates/lex-api/Cargo.toml
@@ -16,14 +16,14 @@ serde_json.workspace = true
 anyhow.workspace = true
 indexmap.workspace = true
 tiny_http = "0.12"
-lex-syntax = { path = "../lex-syntax", version = "0.4.0" }
-lex-ast = { path = "../lex-ast", version = "0.4.0" }
-lex-types = { path = "../lex-types", version = "0.4.0" }
-lex-bytecode = { path = "../lex-bytecode", version = "0.4.0" }
-lex-runtime = { path = "../lex-runtime", version = "0.4.0" }
-lex-store = { path = "../lex-store", version = "0.4.0" }
-lex-trace = { path = "../lex-trace", version = "0.4.0" }
-lex-vcs = { path = "../lex-vcs", version = "0.4.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.5.0" }
+lex-ast = { path = "../lex-ast", version = "0.5.0" }
+lex-types = { path = "../lex-types", version = "0.5.0" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.5.0" }
+lex-runtime = { path = "../lex-runtime", version = "0.5.0" }
+lex-store = { path = "../lex-store", version = "0.5.0" }
+lex-trace = { path = "../lex-trace", version = "0.5.0" }
+lex-vcs = { path = "../lex-vcs", version = "0.5.0" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/lex-ast/Cargo.toml
+++ b/crates/lex-ast/Cargo.toml
@@ -16,4 +16,4 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-syntax = { path = "../lex-syntax", version = "0.4.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.5.0" }

--- a/crates/lex-bytecode/Cargo.toml
+++ b/crates/lex-bytecode/Cargo.toml
@@ -16,8 +16,8 @@ serde_json.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
 sha2.workspace = true
-lex-ast = { path = "../lex-ast", version = "0.4.0" }
-lex-types = { path = "../lex-types", version = "0.4.0" }
+lex-ast = { path = "../lex-ast", version = "0.5.0" }
+lex-types = { path = "../lex-types", version = "0.5.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.4.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.5.0" }

--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -35,10 +35,10 @@ toml = "1.1"
 serde_yaml = "0.9"
 csv = "1"
 rusqlite = { version = "0.39", features = ["bundled"] }
-lex-bytecode = { path = "../lex-bytecode", version = "0.4.0" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.5.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.4.0" }
-lex-ast = { path = "../lex-ast", version = "0.4.0" }
-lex-types = { path = "../lex-types", version = "0.4.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.5.0" }
+lex-ast = { path = "../lex-ast", version = "0.5.0" }
+lex-types = { path = "../lex-types", version = "0.5.0" }
 tempfile = "3"

--- a/crates/lex-search/Cargo.toml
+++ b/crates/lex-search/Cargo.toml
@@ -17,10 +17,10 @@ thiserror.workspace = true
 sha2.workspace = true
 hex.workspace = true
 ureq = { version = "3.3", default-features = false, features = ["rustls", "platform-verifier", "json"] }
-lex-ast = { path = "../lex-ast", version = "0.4.0" }
-lex-store = { path = "../lex-store", version = "0.4.0" }
+lex-ast = { path = "../lex-ast", version = "0.5.0" }
+lex-store = { path = "../lex-store", version = "0.5.0" }
 
 [dev-dependencies]
 tempfile = "3"
 tiny_http = "0.12"
-lex-syntax = { path = "../lex-syntax", version = "0.4.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.5.0" }

--- a/crates/lex-store/Cargo.toml
+++ b/crates/lex-store/Cargo.toml
@@ -21,11 +21,11 @@ hex.workspace = true
 # transitive dep via tempfile; promoting to direct so the lock
 # call sites compile.
 fs2 = "0.4"
-lex-ast = { path = "../lex-ast", version = "0.4.0" }
-lex-trace = { path = "../lex-trace", version = "0.4.0" }
-lex-types = { path = "../lex-types", version = "0.4.0" }
-lex-vcs = { path = "../lex-vcs", version = "0.4.0" }
+lex-ast = { path = "../lex-ast", version = "0.5.0" }
+lex-trace = { path = "../lex-trace", version = "0.5.0" }
+lex-types = { path = "../lex-types", version = "0.5.0" }
+lex-vcs = { path = "../lex-vcs", version = "0.5.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.4.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.5.0" }
 tempfile = "3"

--- a/crates/lex-trace/Cargo.toml
+++ b/crates/lex-trace/Cargo.toml
@@ -16,9 +16,9 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-bytecode = { path = "../lex-bytecode", version = "0.4.0" }
-lex-ast = { path = "../lex-ast", version = "0.4.0" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.5.0" }
+lex-ast = { path = "../lex-ast", version = "0.5.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.4.0" }
-lex-runtime = { path = "../lex-runtime", version = "0.4.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.5.0" }
+lex-runtime = { path = "../lex-runtime", version = "0.5.0" }

--- a/crates/lex-types/Cargo.toml
+++ b/crates/lex-types/Cargo.toml
@@ -15,7 +15,7 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-ast = { path = "../lex-ast", version = "0.4.0" }
+lex-ast = { path = "../lex-ast", version = "0.5.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.4.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.5.0" }

--- a/crates/lex-vcs/Cargo.toml
+++ b/crates/lex-vcs/Cargo.toml
@@ -11,8 +11,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-lex-ast = { path = "../lex-ast", version = "0.4.0" }
-lex-types = { path = "../lex-types", version = "0.4.0" }
+lex-ast = { path = "../lex-ast", version = "0.5.0" }
+lex-types = { path = "../lex-types", version = "0.5.0" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
@@ -24,4 +24,4 @@ hex.workspace = true
 
 [dev-dependencies]
 tempfile = "3"
-lex-syntax = { path = "../lex-syntax", version = "0.4.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.5.0" }

--- a/crates/spec-checker/Cargo.toml
+++ b/crates/spec-checker/Cargo.toml
@@ -16,11 +16,11 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-syntax = { path = "../lex-syntax", version = "0.4.0" }
-lex-ast = { path = "../lex-ast", version = "0.4.0" }
-lex-types = { path = "../lex-types", version = "0.4.0" }
-lex-bytecode = { path = "../lex-bytecode", version = "0.4.0" }
-lex-runtime = { path = "../lex-runtime", version = "0.4.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.5.0" }
+lex-ast = { path = "../lex-ast", version = "0.5.0" }
+lex-types = { path = "../lex-types", version = "0.5.0" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.5.0" }
+lex-runtime = { path = "../lex-runtime", version = "0.5.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.4.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.5.0" }


### PR DESCRIPTION
Promotes [Unreleased] → [0.5.0] — 2026-05-09.

## Summary

Cuts the op-log performance + limitation-followup release. Workspace + inter-crate version pins move from `0.4.0` to `0.5.0`.

**What's in 0.5.0**:

- **#261 — op-log performance roadmap, all three slices**: packfiles (#268), predicate-driven GC (#276), delta-encoded stages (#277).
- **Post-0.4.0 limitation follow-ups**: walk-back producer-block gate (#256/#264), ops-during-run trace attestations (#257/#267), attestation-cascade migration (#258/#265).
- **#262 multi-writer CAS branch advance** (#266) — fs2-locked retry loop maps to 503 + Retry-After at the HTTP edge.
- **#260 `lex op pull`** (#263) — symmetric inverse of #242's push.
- **#278 dep bump** — `rand 0.9→0.10`, `getrandom 0.2→0.4`, `toml 0.9→1.1`, `rusqlite 0.36→0.39`, `notify 6→8`, `softprops/action-gh-release v2→v3`.

## Why a minor bump

All data-layer changes are additive — packfiles and `.delta.json` are new file shapes alongside the existing loose forms; loose-file readers ignore them. The one breaking surface is the dep update: `rand 0.10` and `getrandom 0.4` rotated their trait imports (`OsRng` → `SysRng`, `TryRngCore` → `TryRng`, `getrandom::getrandom` → `getrandom::fill`). Callers of `lex_vcs::Keypair::generate` or the `crypto.random` runtime handler that took out their own RNG will need to adjust imports.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — passes (the documented `cloud_config_fails_without_api_key` env-var flake from 0.2.2 still applies under parallel runs; passes serially)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean

https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_