### PR TITLE
lex-ast+vcs+store: typed ReplaceMatchArm transform (#280 slice 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+### Added — agent-VCS roadmap (#280, slice 1)
+
+- **Typed `ReplaceMatchArm` transform** (#280 slice 1). First of
+  the typed refactoring operations identified as the load-bearing
+  primitive for "agents write Lex by typed delta, not by raw
+  bytes." A new `lex_ast::replace_match_arm(stage, match_node,
+  arm_index, new_body)` produces a `Stage` with one arm's body
+  replaced; pattern preserved.
+- **`OperationKind::ReplaceMatchArm { sig_id, from_stage_id,
+  to_stage_id, match_node, arm_index, from_budget, to_budget }`**
+  records the transform's intent in the op log. Semantically a
+  `ModifyBody`, but the op carries *what* changed and *where* in
+  the AST — so the log reads as a semantic edit history rather
+  than as opaque hash-to-hash bytes. Same `skip_if_none` budget
+  discipline as #247's existing variants — pre-#280 OpIds stay
+  stable.
+- **`Store::apply_replace_match_arm`** end-to-end: loads source
+  AST → runs transform → publishes the new stage → re-typechecks
+  the candidate program → emits the typed op. Failure modes:
+  `StoreError::TransformError` (transform didn't apply),
+  `StoreError::TypeError` (transform succeeded but result is
+  ill-typed, branch unchanged), or `InvalidTransition` for no-op
+  edits.
+- 6 unit tests in `lex_ast::transforms` (splice/apply primitives,
+  arm bounds, kind mismatch, error surfaces) and 6 conformance
+  tests in `crates/lex-store/tests/replace_match_arm.rs` (lands
+  typed op, reconstruction via `get_ast`, TypeCheck attestation
+  emission, ill-typed rejection with unchanged branch, transform-
+  error surfacing, no-op rejection).
+
+Slices for `RenameLocal`, `InlineLet`, `ExtractFunction` (the
+other three transforms in #280) will land separately.
+
 ## [0.5.0] — 2026-05-09
 
 The op-log performance roadmap and the post-0.4.0 limitation

--- a/crates/lex-ast/src/lib.rs
+++ b/crates/lex-ast/src/lib.rs
@@ -10,12 +10,14 @@ pub mod canonical_format;
 pub mod dead_branch;
 pub mod ids;
 pub mod patch;
+pub mod transforms;
 
 pub use canonical::*;
 pub use canonicalize::{canonicalize_program, canonicalize_item};
 pub use canon_print::print_stages;
 pub use ids::{collect_ids, expr_ids, NodeId, NodeRef};
 pub use patch::{apply_patch, Patch, PatchError};
+pub use transforms::{replace_match_arm, TransformError};
 
 /// SHA-256 over the canonical-JSON encoding of a stage. Excludes NodeIds
 /// (the canonical AST data does not carry IDs; they're derived).

--- a/crates/lex-ast/src/transforms.rs
+++ b/crates/lex-ast/src/transforms.rs
@@ -1,0 +1,311 @@
+//! Typed, valid-by-construction AST transforms (#280).
+//!
+//! The op log historically records body-shaping edits as opaque
+//! `ModifyBody { from_stage_id, to_stage_id, … }` — the bytes
+//! changed, but *what* changed is recoverable only by diffing the
+//! two stages. For agents writing Lex, that's the wrong primitive:
+//! they want to express "replace the body of arm 2 in this match"
+//! as a single typed operation, get back a valid AST, and have the
+//! op log record the transform's intent, not just its byte effect.
+//!
+//! Each transform in this module is a pure function:
+//!
+//!   `fn transform(stage: &Stage, params…) -> Result<Stage, TransformError>`
+//!
+//! No I/O, no LLM, no type checking — type checking happens *after*
+//! the transform in `lex-store`'s apply path, so a transform that
+//! produces an ill-typed AST surfaces as `StoreError::TypeError`
+//! rather than failing inside the transformer.
+//!
+//! # Slice 1 (#280)
+//!
+//! [`replace_match_arm`] — replaces the body of one arm in a match
+//! expression. Pattern is preserved; the new body must be a valid
+//! `CExpr`. This is the simplest position-targeted transform and
+//! establishes the pattern for the rest (`RenameLocal`,
+//! `InlineLet`, `ExtractFunction` — separate slices).
+
+use crate::canonical::{CExpr, Stage};
+use crate::ids::NodeId;
+
+#[derive(Debug, Clone, thiserror::Error, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TransformError {
+    #[error("unknown node id `{at}`")]
+    UnknownNode { at: String },
+    #[error("expected a Match expression at `{at}` but found `{found_kind}`")]
+    NotAMatch { at: String, found_kind: &'static str },
+    #[error("arm index {requested} out of range (arm count = {arm_count}) at `{at}`")]
+    ArmIndexOutOfRange { at: String, arm_count: usize, requested: usize },
+    #[error("malformed NodeId `{0}`")]
+    BadNodeId(String),
+    #[error("cannot transform inside `{stage_kind}` — only FnDecl bodies are transformable")]
+    NonFnTarget { stage_kind: &'static str },
+}
+
+/// Replace `match_node`'s arm at `arm_index` with a new body,
+/// preserving the arm's pattern (#280 slice 1).
+///
+/// `match_node` must address a `CExpr::Match` inside the FnDecl
+/// body of `stage`. The returned `Stage` is a clone with the one
+/// arm body replaced; everything else is untouched, so the
+/// resulting `StageId` differs from the input's only by the
+/// affected sub-tree.
+pub fn replace_match_arm(
+    stage: &Stage,
+    match_node: &NodeId,
+    arm_index: usize,
+    new_body: CExpr,
+) -> Result<Stage, TransformError> {
+    let mut out = stage.clone();
+    let (body, n_params) = match &mut out {
+        Stage::FnDecl(fd) => {
+            let n = fd.params.len();
+            (&mut fd.body, n)
+        }
+        Stage::TypeDecl(_) => return Err(TransformError::NonFnTarget { stage_kind: "TypeDecl" }),
+        Stage::Import(_) => return Err(TransformError::NonFnTarget { stage_kind: "Import" }),
+    };
+    let path = parse_node_id(match_node.as_str())?;
+    // First index identifies a child of the FnDecl: params at
+    // 0..n_params, return_type at n_params, body at n_params + 1.
+    // Only the body slot is reachable for this transform.
+    if path.is_empty() {
+        return Err(TransformError::NotAMatch {
+            at: match_node.as_str().into(),
+            found_kind: "stage_root",
+        });
+    }
+    if path[0] != n_params + 1 {
+        return Err(TransformError::UnknownNode { at: match_node.as_str().into() });
+    }
+    let inner = &path[1..];
+    let target = navigate_to_expr(body, inner, match_node.as_str())?;
+    let CExpr::Match { scrutinee: _, arms } = target else {
+        return Err(TransformError::NotAMatch {
+            at: match_node.as_str().into(),
+            found_kind: cexpr_kind(target),
+        });
+    };
+    if arm_index >= arms.len() {
+        return Err(TransformError::ArmIndexOutOfRange {
+            at: match_node.as_str().into(),
+            arm_count: arms.len(),
+            requested: arm_index,
+        });
+    }
+    arms[arm_index].body = new_body;
+    Ok(out)
+}
+
+fn parse_node_id(id: &str) -> Result<Vec<usize>, TransformError> {
+    let s = id.strip_prefix("n_").ok_or_else(|| TransformError::BadNodeId(id.into()))?;
+    let mut parts = s.split('.');
+    let head = parts.next().ok_or_else(|| TransformError::BadNodeId(id.into()))?;
+    if head != "0" {
+        return Err(TransformError::BadNodeId(id.into()));
+    }
+    let mut out = Vec::new();
+    for p in parts {
+        out.push(p.parse::<usize>().map_err(|_| TransformError::BadNodeId(id.into()))?);
+    }
+    Ok(out)
+}
+
+/// Walk into an expression tree along a path of child indices and
+/// return a `&mut` to the resolved sub-expression. The indexing
+/// matches [`crate::ids::collect_ids`]'s walk order so a
+/// `NodeId` minted from `collect_ids` resolves to the same node
+/// here.
+fn navigate_to_expr<'a>(
+    root: &'a mut CExpr,
+    path: &[usize],
+    target_id: &str,
+) -> Result<&'a mut CExpr, TransformError> {
+    let mut current = root;
+    for &idx in path {
+        current = step_expr(current, idx)
+            .ok_or_else(|| TransformError::UnknownNode { at: target_id.into() })?;
+    }
+    Ok(current)
+}
+
+/// Single step into an expression's `idx`-th child, mirroring the
+/// walk order in `ids::walk_expr`. Returns `None` when the index
+/// is out of range or when the kind has no addressable children.
+fn step_expr(e: &mut CExpr, idx: usize) -> Option<&mut CExpr> {
+    match e {
+        CExpr::Call { callee, args } => {
+            if idx == 0 { return Some(callee); }
+            args.get_mut(idx - 1)
+        }
+        CExpr::Let { value, body, .. } => {
+            match idx {
+                0 => Some(value),
+                1 => Some(body),
+                _ => None,
+            }
+        }
+        CExpr::Match { scrutinee, arms } => {
+            if idx == 0 { return Some(scrutinee); }
+            // Arms are walked as Pattern then Body; only the body
+            // is reachable as a CExpr child. ids::walk_expr emits
+            // pattern + body for each arm, so arm i's body lives
+            // at child index (1 + 2*i + 1).
+            let arm_off = idx - 1;
+            if arm_off % 2 != 1 {
+                return None;
+            }
+            let arm_index = arm_off / 2;
+            arms.get_mut(arm_index).map(|a| &mut a.body)
+        }
+        CExpr::Block { statements, result } => {
+            if idx < statements.len() {
+                statements.get_mut(idx)
+            } else if idx == statements.len() {
+                Some(result)
+            } else {
+                None
+            }
+        }
+        CExpr::Constructor { args, .. } | CExpr::TupleLit { items: args, .. }
+        | CExpr::ListLit { items: args, .. } => args.get_mut(idx),
+        CExpr::RecordLit { fields } => fields.get_mut(idx).map(|f| &mut f.value),
+        CExpr::FieldAccess { value, .. } => if idx == 0 { Some(value) } else { None },
+        CExpr::Lambda { body, .. } => if idx == 0 { Some(body) } else { None },
+        CExpr::BinOp { lhs, rhs, .. } => match idx {
+            0 => Some(lhs), 1 => Some(rhs), _ => None,
+        },
+        CExpr::UnaryOp { expr, .. } => if idx == 0 { Some(expr) } else { None },
+        CExpr::Return { value } => if idx == 0 { Some(value) } else { None },
+        _ => None,
+    }
+}
+
+fn cexpr_kind(e: &CExpr) -> &'static str {
+    match e {
+        CExpr::Literal { .. } => "Literal",
+        CExpr::Var { .. } => "Var",
+        CExpr::Call { .. } => "Call",
+        CExpr::Let { .. } => "Let",
+        CExpr::Match { .. } => "Match",
+        CExpr::Block { .. } => "Block",
+        CExpr::Constructor { .. } => "Constructor",
+        CExpr::RecordLit { .. } => "RecordLit",
+        CExpr::TupleLit { .. } => "TupleLit",
+        CExpr::ListLit { .. } => "ListLit",
+        CExpr::FieldAccess { .. } => "FieldAccess",
+        CExpr::Lambda { .. } => "Lambda",
+        CExpr::BinOp { .. } => "BinOp",
+        CExpr::UnaryOp { .. } => "UnaryOp",
+        CExpr::Return { .. } => "Return",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::canonical::{Arm, CLit, FnDecl, Param, Pattern, TypeExpr};
+
+    fn match_stage_with_two_arms() -> Stage {
+        // fn pick(n :: Int) -> Int { match n { 0 => 1, _ => 2 } }
+        // Two arms: pattern-literal-0 → 1; wildcard → 2.
+        let body = CExpr::Match {
+            scrutinee: Box::new(CExpr::Var { name: "n".into() }),
+            arms: vec![
+                Arm {
+                    pattern: Pattern::PLiteral { value: CLit::Int { value: 0 } },
+                    body: CExpr::Literal { value: CLit::Int { value: 1 } },
+                },
+                Arm {
+                    pattern: Pattern::PWild,
+                    body: CExpr::Literal { value: CLit::Int { value: 2 } },
+                },
+            ],
+        };
+        Stage::FnDecl(FnDecl {
+            name: "pick".into(),
+            type_params: Vec::new(),
+            params: vec![Param {
+                name: "n".into(),
+                ty: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
+            }],
+            effects: Vec::new(),
+            return_type: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
+            body,
+        })
+    }
+
+    fn match_node_id() -> NodeId {
+        // FnDecl with 1 param: body is at child index 2 (param 0,
+        // return_type at 1, body at 2). The body IS the Match
+        // expression — so the match node is at `n_0.2`.
+        NodeId("n_0.2".into())
+    }
+
+    #[test]
+    fn replace_first_arm_body_succeeds() {
+        let stage = match_stage_with_two_arms();
+        let new_body = CExpr::Literal { value: CLit::Int { value: 42 } };
+        let out = replace_match_arm(&stage, &match_node_id(), 0, new_body).unwrap();
+        let Stage::FnDecl(fd) = out else { panic!() };
+        let CExpr::Match { arms, .. } = fd.body else { panic!() };
+        assert_eq!(arms.len(), 2);
+        assert!(matches!(arms[0].body, CExpr::Literal { value: CLit::Int { value: 42 } }));
+        // Second arm untouched.
+        assert!(matches!(arms[1].body, CExpr::Literal { value: CLit::Int { value: 2 } }));
+        // Pattern preserved.
+        assert!(matches!(arms[0].pattern, Pattern::PLiteral { .. }));
+    }
+
+    #[test]
+    fn replace_second_arm_preserves_first() {
+        let stage = match_stage_with_two_arms();
+        let new_body = CExpr::Literal { value: CLit::Int { value: 99 } };
+        let out = replace_match_arm(&stage, &match_node_id(), 1, new_body).unwrap();
+        let Stage::FnDecl(fd) = out else { panic!() };
+        let CExpr::Match { arms, .. } = fd.body else { panic!() };
+        assert!(matches!(arms[0].body, CExpr::Literal { value: CLit::Int { value: 1 } }));
+        assert!(matches!(arms[1].body, CExpr::Literal { value: CLit::Int { value: 99 } }));
+    }
+
+    #[test]
+    fn arm_index_out_of_range_errors() {
+        let stage = match_stage_with_two_arms();
+        let new_body = CExpr::Literal { value: CLit::Unit };
+        let err = replace_match_arm(&stage, &match_node_id(), 5, new_body).unwrap_err();
+        assert!(matches!(err, TransformError::ArmIndexOutOfRange { arm_count: 2, requested: 5, .. }));
+    }
+
+    #[test]
+    fn non_match_target_errors() {
+        // The body's scrutinee at n_0.2.0 is a Var, not a Match.
+        let stage = match_stage_with_two_arms();
+        let new_body = CExpr::Literal { value: CLit::Unit };
+        let err = replace_match_arm(&stage, &NodeId("n_0.2.0".into()), 0, new_body)
+            .unwrap_err();
+        assert!(matches!(err, TransformError::NotAMatch { found_kind: "Var", .. }),
+            "got {err:?}");
+    }
+
+    #[test]
+    fn unknown_node_errors() {
+        let stage = match_stage_with_two_arms();
+        let new_body = CExpr::Literal { value: CLit::Unit };
+        let err = replace_match_arm(&stage, &NodeId("n_0.99".into()), 0, new_body)
+            .unwrap_err();
+        assert!(matches!(err, TransformError::UnknownNode { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn typedecl_target_errors() {
+        let stage = Stage::TypeDecl(crate::canonical::TypeDecl {
+            name: "T".into(),
+            params: Vec::new(),
+            definition: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
+        });
+        let err = replace_match_arm(&stage, &match_node_id(), 0,
+            CExpr::Literal { value: CLit::Unit }).unwrap_err();
+        assert!(matches!(err, TransformError::NonFnTarget { stage_kind: "TypeDecl" }));
+    }
+}

--- a/crates/lex-store/src/store.rs
+++ b/crates/lex-store/src/store.rs
@@ -33,6 +33,14 @@ pub enum StoreError {
     UnknownBranch(String),
     #[error("unknown op_id `{0}`")]
     UnknownOp(lex_vcs::OpId),
+    /// A typed AST transform (#280) — e.g. `ReplaceMatchArm` — was
+    /// asked to operate on a node it couldn't address (wrong kind,
+    /// out-of-range arm index, unknown NodeId, etc.). Distinct from
+    /// `TypeError` (which means the transform succeeded but its
+    /// output didn't typecheck) so callers can render the right
+    /// error message.
+    #[error("transform failed: {0}")]
+    TransformError(lex_ast::TransformError),
     #[error(transparent)]
     Apply(#[from] lex_vcs::ApplyError),
     /// The candidate program — i.e. the source the caller is
@@ -981,6 +989,101 @@ impl Store {
         Ok(total)
     }
 
+    /// Apply a typed `ReplaceMatchArm` transform (#280) and emit a
+    /// `OperationKind::ReplaceMatchArm` op that records the
+    /// semantic shape of the edit, not just the byte effect.
+    ///
+    /// Steps:
+    ///   1. Load the source stage's canonical bytes (delta-aware).
+    ///   2. Run [`lex_ast::replace_match_arm`] to produce the new
+    ///      `Stage`. Pure function, no I/O.
+    ///   3. Publish the new stage. Idempotent on the
+    ///      content-addressed `to_stage_id`.
+    ///   4. Assemble the candidate program (every active stage on
+    ///      the branch, with the rewritten one swapped in) and call
+    ///      [`Self::apply_operation_checked`] — re-typechecks and
+    ///      runs every existing gate (TypeCheck attestation,
+    ///      required_attestations, producer-block walk-back).
+    ///
+    /// Failure modes:
+    ///   * [`StoreError::TransformError`] — transform didn't apply.
+    ///     The branch is unchanged; no stage published.
+    ///   * [`StoreError::TypeError`] — transform produced an
+    ///     ill-typed program. The new stage is on disk (idempotent
+    ///     on its content hash) but the branch is unchanged. Same
+    ///     "publish without advance" semantics as #245.
+    ///   * Everything else from `apply_operation_checked`.
+    pub fn apply_replace_match_arm(
+        &self,
+        branch: &str,
+        from_stage_id: &str,
+        match_node: &lex_ast::NodeId,
+        arm_index: usize,
+        new_body: lex_ast::CExpr,
+    ) -> Result<lex_vcs::OpId, StoreError> {
+        let from_stage = self.get_ast(from_stage_id)?;
+        let new_stage = lex_ast::replace_match_arm(
+            &from_stage, match_node, arm_index, new_body,
+        ).map_err(StoreError::TransformError)?;
+        let sig = lex_ast::sig_id(&from_stage)
+            .ok_or(StoreError::CannotPublishImport)?;
+        let to_stage_id = self.publish(&new_stage)?;
+        if to_stage_id == from_stage_id {
+            // No-op transform — the new body was structurally
+            // identical to the old. Refuse rather than advancing
+            // the branch with an empty edit.
+            return Err(StoreError::InvalidTransition(format!(
+                "replace_match_arm produced the same stage_id `{from_stage_id}`"
+            )));
+        }
+
+        // Assemble the candidate program: every active stage on
+        // the branch, with `from_stage_id` swapped for `new_stage`.
+        let head = self.branch_head(branch)?;
+        let mut candidate: Vec<lex_ast::Stage> = Vec::with_capacity(head.len());
+        for (other_sig, other_stage_id) in &head {
+            if other_sig == &sig {
+                candidate.push(new_stage.clone());
+            } else {
+                candidate.push(self.get_ast(other_stage_id)?);
+            }
+        }
+        // If the source sig isn't on the current branch head, the
+        // transform is operating on a stage that hasn't been added
+        // yet — refuse rather than risking a candidate program
+        // that doesn't reflect the branch's actual state.
+        if !head.contains_key(&sig) {
+            return Err(StoreError::InvalidTransition(format!(
+                "sig `{sig}` not on branch `{branch}`'s head"
+            )));
+        }
+
+        // #247: budget delta captured for `lex op log --budget-drift`.
+        let from_budget = budget_of_stage(&from_stage);
+        let to_budget = budget_of_stage(&new_stage);
+
+        let head_now = self.get_branch(branch)?.and_then(|b| b.head_op);
+        let kind = lex_vcs::OperationKind::ReplaceMatchArm {
+            sig_id: sig.clone(),
+            from_stage_id: from_stage_id.to_string(),
+            to_stage_id: to_stage_id.clone(),
+            match_node: match_node.as_str().to_string(),
+            arm_index,
+            from_budget,
+            to_budget,
+        };
+        let transition = lex_vcs::StageTransition::Replace {
+            sig_id: sig.clone(),
+            from: from_stage_id.to_string(),
+            to: to_stage_id.clone(),
+        };
+        let op = lex_vcs::Operation::new(
+            kind,
+            head_now.into_iter().collect::<Vec<_>>(),
+        );
+        self.apply_operation_checked(branch, op, transition, &candidate)
+    }
+
     /// `set_branch_head_op` for the durability story on the branch
     /// file itself.
     pub fn apply_operation(
@@ -1293,7 +1396,8 @@ fn transition_for_kind(kind: &lex_vcs::OperationKind) -> lex_vcs::StageTransitio
         },
         ModifyBody { sig_id, from_stage_id, to_stage_id, .. }
         | ChangeEffectSig { sig_id, from_stage_id, to_stage_id, .. }
-        | ModifyType { sig_id, from_stage_id, to_stage_id } => StageTransition::Replace {
+        | ModifyType { sig_id, from_stage_id, to_stage_id }
+        | ReplaceMatchArm { sig_id, from_stage_id, to_stage_id, .. } => StageTransition::Replace {
             sig_id: sig_id.clone(),
             from: from_stage_id.clone(),
             to:   to_stage_id.clone(),
@@ -1370,6 +1474,26 @@ fn write_canonical_json<T: Serialize>(path: &Path, value: &T) -> Result<(), Stor
     if let Some(parent) = path.parent() { fs::create_dir_all(parent)?; }
     fs::write(path, s)?;
     Ok(())
+}
+
+/// Extract the declared `[budget(N)]` integer from a stage's
+/// effect set, if any (#280 + #247). Returns `None` for stages
+/// that aren't `FnDecl` or don't carry a budget effect — same
+/// shape as `lex_vcs::budget_from_effects`.
+fn budget_of_stage(stage: &Stage) -> Option<u64> {
+    let fd = match stage {
+        Stage::FnDecl(fd) => fd,
+        _ => return None,
+    };
+    let mut min_cost: Option<u64> = None;
+    for eff in &fd.effects {
+        if eff.name != "budget" { continue }
+        if let Some(lex_ast::EffectArg::Int { value }) = &eff.arg {
+            let n = *value as u64;
+            min_cost = Some(min_cost.map(|c| c.min(n)).unwrap_or(n));
+        }
+    }
+    min_cost
 }
 
 /// Serialize a stage to its canonical-JSON byte form. Used by

--- a/crates/lex-store/tests/replace_match_arm.rs
+++ b/crates/lex-store/tests/replace_match_arm.rs
@@ -1,0 +1,199 @@
+//! Conformance tests for #280: typed `ReplaceMatchArm` transform
+//! + matching `OperationKind::ReplaceMatchArm` op.
+
+use lex_ast::{canonicalize_program, sig_id, stage_id, CExpr, CLit, NodeId, Stage};
+use lex_store::{Store, DEFAULT_BRANCH};
+use lex_syntax::parse_source;
+use tempfile::TempDir;
+
+fn fresh() -> (Store, TempDir) {
+    let tmp = TempDir::new().unwrap();
+    let s = Store::open(tmp.path()).unwrap();
+    (s, tmp)
+}
+
+fn stage_named(src: &str, name: &str) -> Stage {
+    let prog = parse_source(src).unwrap();
+    canonicalize_program(&prog)
+        .into_iter()
+        .find(|s| match s {
+            Stage::FnDecl(fd) => fd.name == name,
+            _ => false,
+        })
+        .expect("stage not found")
+}
+
+/// `pick` matches on `n` and returns 1 for 0, else returns 2.
+const PICK_SRC: &str = "fn pick(n :: Int) -> Int { match n { 0 => 1, _ => 2 } }\n";
+
+/// Find the `NodeId` of the `Match` expression in `pick`'s body.
+/// For a 1-param FnDecl the body is at `n_0.2`, and `pick`'s body
+/// is *literally* the match — no surrounding block — so `n_0.2`
+/// addresses the Match itself.
+fn pick_match_node() -> NodeId {
+    NodeId("n_0.2".into())
+}
+
+fn publish_initial_pick(store: &Store) -> (String, String) {
+    // Publish + add to the branch via apply_operation. Returns
+    // (sig_id, stage_id).
+    let s = stage_named(PICK_SRC, "pick");
+    let sig = sig_id(&s).unwrap();
+    let stg = stage_id(&s).unwrap();
+    store.publish(&s).unwrap();
+    let op = lex_vcs::Operation::new(
+        lex_vcs::OperationKind::AddFunction {
+            sig_id: sig.clone(),
+            stage_id: stg.clone(),
+            effects: Default::default(),
+            budget_cost: None,
+        },
+        [],
+    );
+    let t = lex_vcs::StageTransition::Create {
+        sig_id: sig.clone(),
+        stage_id: stg.clone(),
+    };
+    store.apply_operation(DEFAULT_BRANCH, op, t).unwrap();
+    (sig, stg)
+}
+
+#[test]
+fn replace_match_arm_lands_a_typed_op_on_the_branch() {
+    let (store, _tmp) = fresh();
+    let (sig, from_stage_id) = publish_initial_pick(&store);
+
+    // Replace the first arm's body (0 → 1) with (0 → 42).
+    let new_body = CExpr::Literal { value: CLit::Int { value: 42 } };
+    let op_id = store
+        .apply_replace_match_arm(DEFAULT_BRANCH, &from_stage_id, &pick_match_node(), 0, new_body)
+        .expect("transform should apply cleanly on well-typed input");
+
+    // Op record exists; transition is Replace; kind is ReplaceMatchArm.
+    let log = lex_vcs::OpLog::open(store.root()).unwrap();
+    let rec = log.get(&op_id).unwrap().unwrap();
+    let lex_vcs::OperationKind::ReplaceMatchArm {
+        sig_id: rec_sig,
+        from_stage_id: rec_from,
+        arm_index,
+        match_node,
+        ..
+    } = &rec.op.kind else {
+        panic!("expected ReplaceMatchArm op kind, got {:?}", rec.op.kind);
+    };
+    assert_eq!(rec_sig, &sig);
+    assert_eq!(rec_from, &from_stage_id);
+    assert_eq!(*arm_index, 0);
+    assert_eq!(match_node, "n_0.2");
+
+    // Branch head updated.
+    let head = store.branch_head(DEFAULT_BRANCH).unwrap();
+    assert_ne!(head.get(&sig), Some(&from_stage_id));
+}
+
+#[test]
+fn replace_match_arm_get_ast_reconstructs_new_body() {
+    let (store, _tmp) = fresh();
+    let (_sig, from_stage_id) = publish_initial_pick(&store);
+
+    let new_body = CExpr::Literal { value: CLit::Int { value: 7 } };
+    let op_id = store
+        .apply_replace_match_arm(DEFAULT_BRANCH, &from_stage_id, &pick_match_node(), 0, new_body)
+        .unwrap();
+
+    let log = lex_vcs::OpLog::open(store.root()).unwrap();
+    let rec = log.get(&op_id).unwrap().unwrap();
+    let lex_vcs::OperationKind::ReplaceMatchArm { to_stage_id, .. } = &rec.op.kind else {
+        panic!();
+    };
+
+    let reloaded = store.get_ast(to_stage_id).unwrap();
+    let Stage::FnDecl(fd) = reloaded else { panic!() };
+    let CExpr::Match { arms, .. } = fd.body else { panic!() };
+    // First arm body was replaced.
+    assert!(matches!(arms[0].body, CExpr::Literal { value: CLit::Int { value: 7 } }));
+    // Second arm untouched.
+    assert!(matches!(arms[1].body, CExpr::Literal { value: CLit::Int { value: 2 } }));
+}
+
+#[test]
+fn replace_match_arm_emits_typecheck_attestation() {
+    // The transform path goes through `apply_operation_checked`,
+    // which emits a TypeCheck::Passed attestation against the new
+    // stage. Verify the attestation lands.
+    let (store, _tmp) = fresh();
+    let (_sig, from_stage_id) = publish_initial_pick(&store);
+
+    let new_body = CExpr::Literal { value: CLit::Int { value: 99 } };
+    let op_id = store
+        .apply_replace_match_arm(DEFAULT_BRANCH, &from_stage_id, &pick_match_node(), 0, new_body)
+        .unwrap();
+
+    let log = lex_vcs::OpLog::open(store.root()).unwrap();
+    let rec = log.get(&op_id).unwrap().unwrap();
+    let lex_vcs::OperationKind::ReplaceMatchArm { to_stage_id, .. } = &rec.op.kind else {
+        panic!();
+    };
+
+    let attlog = store.attestation_log().unwrap();
+    let by_stage = attlog.list_for_stage(to_stage_id).unwrap();
+    assert!(
+        by_stage.iter().any(|a| matches!(a.kind, lex_vcs::AttestationKind::TypeCheck)),
+        "expected a TypeCheck attestation against the new stage"
+    );
+}
+
+#[test]
+fn replace_match_arm_rejects_ill_typed_result() {
+    // Replace the first arm's body (an Int) with a string literal.
+    // The transform succeeds (it's a pure AST edit) but the
+    // re-typecheck in `apply_operation_checked` rejects with
+    // `StoreError::TypeError`. Branch head unchanged.
+    let (store, _tmp) = fresh();
+    let (sig, from_stage_id) = publish_initial_pick(&store);
+    let head_before = store.branch_head(DEFAULT_BRANCH).unwrap();
+
+    let ill_typed = CExpr::Literal { value: CLit::Str { value: "not an int".into() } };
+    let err = store
+        .apply_replace_match_arm(DEFAULT_BRANCH, &from_stage_id, &pick_match_node(), 0, ill_typed)
+        .unwrap_err();
+    assert!(matches!(err, lex_store::StoreError::TypeError(_)),
+        "expected TypeError, got {err:?}");
+
+    let head_after = store.branch_head(DEFAULT_BRANCH).unwrap();
+    assert_eq!(head_after.get(&sig), head_before.get(&sig),
+        "branch head must be unchanged after a rejected transform");
+}
+
+#[test]
+fn replace_match_arm_surface_transform_errors() {
+    let (store, _tmp) = fresh();
+    let (_sig, from_stage_id) = publish_initial_pick(&store);
+
+    // Arm index out of range.
+    let err = store
+        .apply_replace_match_arm(
+            DEFAULT_BRANCH, &from_stage_id, &pick_match_node(),
+            99, CExpr::Literal { value: CLit::Int { value: 0 } },
+        )
+        .unwrap_err();
+    assert!(matches!(err, lex_store::StoreError::TransformError(_)),
+        "expected TransformError, got {err:?}");
+}
+
+#[test]
+fn replace_match_arm_no_op_is_rejected() {
+    // Replace arm 0's body with the IDENTICAL body. The transform
+    // produces the same stage_id; we refuse the empty edit rather
+    // than advance the branch with a redundant op.
+    let (store, _tmp) = fresh();
+    let (_sig, from_stage_id) = publish_initial_pick(&store);
+
+    // Arm 0's original body was `1`; replace with `1`.
+    let same = CExpr::Literal { value: CLit::Int { value: 1 } };
+    let err = store
+        .apply_replace_match_arm(DEFAULT_BRANCH, &from_stage_id, &pick_match_node(), 0, same)
+        .unwrap_err();
+    assert!(matches!(err, lex_store::StoreError::InvalidTransition(_)),
+        "expected InvalidTransition for no-op transform, got {err:?}");
+}

--- a/crates/lex-vcs/src/merge.rs
+++ b/crates/lex-vcs/src/merge.rs
@@ -136,7 +136,8 @@ fn touched_sigs(k: &OperationKind) -> Vec<SigId> {
         | OperationKind::ChangeEffectSig { sig_id, .. }
         | OperationKind::AddType { sig_id, .. }
         | OperationKind::RemoveType { sig_id, .. }
-        | OperationKind::ModifyType { sig_id, .. } => vec![sig_id.clone()],
+        | OperationKind::ModifyType { sig_id, .. }
+        | OperationKind::ReplaceMatchArm { sig_id, .. } => vec![sig_id.clone()],
         // A rename touches both sides — concurrent modifies on `from`
         // must surface as a conflict, not as a disjoint set.
         OperationKind::RenameSymbol { from, to, .. } => vec![from.clone(), to.clone()],

--- a/crates/lex-vcs/src/operation.rs
+++ b/crates/lex-vcs/src/operation.rs
@@ -219,6 +219,35 @@ pub enum OperationKind {
     Merge {
         resolved: usize,
     },
+    /// Typed transform: replaced one arm's body in a `Match`
+    /// expression (#280). Semantically a `ModifyBody`, but the op
+    /// records *which* arm changed and *where* in the AST — so the
+    /// op log reads as a semantic edit history rather than as
+    /// opaque hash-to-hash bytes.
+    ///
+    /// `match_node` is the [`lex_ast::ids::NodeId`] of the Match
+    /// expression at the time of the transform. NodeIds aren't
+    /// stable across structural edits — they're audit-trail metadata,
+    /// not re-derivation keys. The authoritative record of the new
+    /// stage is `to_stage_id` (content-addressed).
+    ///
+    /// `from_budget`/`to_budget` follow the same `skip_if_none`
+    /// discipline as [`Self::ModifyBody`]: pre-#280 ops continue
+    /// hashing to their original `OpId`s.
+    ReplaceMatchArm {
+        sig_id: SigId,
+        from_stage_id: StageId,
+        to_stage_id: StageId,
+        /// Path-style NodeId of the Match expression that was
+        /// modified, captured at transform time. See
+        /// [`lex_ast::ids::NodeId`] for the format.
+        match_node: String,
+        arm_index: usize,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        from_budget: Option<u64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        to_budget: Option<u64>,
+    },
 }
 
 impl OperationKind {
@@ -242,6 +271,7 @@ impl OperationKind {
             ModifyBody { sig_id, to_stage_id, .. }
             | ChangeEffectSig { sig_id, to_stage_id, .. }
             | ModifyType { sig_id, to_stage_id, .. }
+            | ReplaceMatchArm { sig_id, to_stage_id, .. }
                 => Some((sig_id.clone(), Some(to_stage_id.clone()))),
             RemoveFunction { sig_id, .. }
             | RemoveType { sig_id, .. }
@@ -263,7 +293,8 @@ impl OperationKind {
         match self {
             AddFunction { budget_cost, .. } => (None, *budget_cost),
             ModifyBody { from_budget, to_budget, .. }
-            | ChangeEffectSig { from_budget, to_budget, .. } => (*from_budget, *to_budget),
+            | ChangeEffectSig { from_budget, to_budget, .. }
+            | ReplaceMatchArm { from_budget, to_budget, .. } => (*from_budget, *to_budget),
             _ => (None, None),
         }
     }
@@ -277,7 +308,8 @@ impl OperationKind {
         match self {
             AddFunction { sig_id, .. }
             | ModifyBody { sig_id, .. }
-            | ChangeEffectSig { sig_id, .. } => Some(sig_id),
+            | ChangeEffectSig { sig_id, .. }
+            | ReplaceMatchArm { sig_id, .. } => Some(sig_id),
             _ => None,
         }
     }

--- a/crates/lex-vcs/tests/opid_golden.rs
+++ b/crates/lex-vcs/tests/opid_golden.rs
@@ -332,5 +332,6 @@ fn variant_tag(k: &OperationKind) -> &'static str {
         OperationKind::RemoveType { .. } => "remove_type",
         OperationKind::ModifyType { .. } => "modify_type",
         OperationKind::Merge { .. } => "merge",
+        OperationKind::ReplaceMatchArm { .. } => "replace_match_arm",
     }
 }


### PR DESCRIPTION
First slice of #280 — typed refactoring operations.

## Summary

`ReplaceMatchArm` is the simplest position-targeted transform: replace one arm's body in a `Match` expression, pattern preserved. End-to-end:

1. **`lex_ast::replace_match_arm(stage, match_node, arm_index, new_body)`** — pure-function AST transform in a new `crates/lex-ast/src/transforms.rs` module. No I/O, no type-checking — type-checking happens *after* the transform in `lex-store`'s apply path, so an ill-typed result surfaces as `StoreError::TypeError` rather than failing inside the transformer.

2. **`OperationKind::ReplaceMatchArm { sig_id, from_stage_id, to_stage_id, match_node, arm_index, from_budget, to_budget }`** — records the transform's *intent* in the op log. Semantically a `ModifyBody`, but the op carries *what* changed and *where* in the AST. Same `skip_if_none` budget discipline as #247's existing variants, so pre-#280 OpIds stay stable.

3. **`Store::apply_replace_match_arm`** — bundles load → transform → publish → re-typecheck → emit op into one call. Failure modes:
   - `StoreError::TransformError` — transform didn't apply (unknown node, wrong kind, arm index out of range). Branch unchanged, no stage published.
   - `StoreError::TypeError` — transform produced an ill-typed program. New stage is on disk (idempotent on content hash) but branch is unchanged.
   - `InvalidTransition` — transform was a no-op (new body identical to old).

## Test plan

- [x] 6 unit tests in `lex_ast::transforms` (happy paths × 2, arm index out of range, kind mismatch, unknown node, non-FnDecl target).
- [x] 6 conformance tests in `crates/lex-store/tests/replace_match_arm.rs` (lands typed op on branch, `get_ast` reconstructs through the new stage, `TypeCheck` attestation emitted, ill-typed result rejected with branch unchanged, transform-error surfaces, no-op refused).
- [x] Golden-OpId test arm updated (`crates/lex-vcs/tests/opid_golden.rs`).
- [x] `cargo test --workspace` — all 167 test groups pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.

## What this PR is NOT

The remaining three transforms from #280 — `RenameLocal`, `InlineLet`, `ExtractFunction` — will land as separate PRs sharing the same pattern. `RenameLocal` requires scope-aware substitution; `InlineLet` requires capture-aware substitution; `ExtractFunction` requires free-variable analysis. Splitting keeps each PR reviewable and lets the surface stabilize before the harder transforms compound on it.

## Strategic context

From the 0.5.0 review: this is the load-bearing primitive for "agents write Lex by typed delta, not by raw bytes." #281 (closed repair loop) depends on this being a real `OperationKind` set so the suggested-transform field has somewhere to land.

https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_