### PR TITLE
lex-cli: `lex docs --for-agent` structured workspace context (#282)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+### Added — agent-onboarding (#282)
+
+- **`lex docs --for-agent`** emits a single structured JSON
+  envelope with the six sections an agent needs to make sensible
+  writes against a Lex repo: `workspace` (lex version, branches,
+  current/default), `stdlib` (every active sig on the branch with
+  rendered type signature, effects, optional budget),
+  `recent_activity` (last N ops with op_id, kind tag, sig_id,
+  intent_id), `open_intents` (intents referenced by recent ops,
+  resolved against `IntentLog`), `policy` (required_attestations,
+  blocked_producers, gc_retention from `policy.json`), and
+  `attention` (stages with active `Block` attestations).
+- `--branch B`, `--limit-recent N` (default 50), `--store DIR`
+  flags. Schema versioned via `lex_docs_version` so future agents
+  can detect breakage.
+- Pure derivation from existing on-disk state — no new
+  persistence, no LLM calls, no costs beyond the per-section
+  walks.
+- 7 conformance tests in `crates/lex-cli/tests/docs_for_agent.rs`
+  driving the CLI as a subprocess.
+
 ### Added — agent-VCS roadmap (#280, slice 1)
 
 - **Typed `ReplaceMatchArm` transform** (#280 slice 1). First of

--- a/crates/lex-cli/src/docs.rs
+++ b/crates/lex-cli/src/docs.rs
@@ -1,0 +1,399 @@
+//! `lex docs --for-agent` — structured machine-readable workspace
+//! context (#282).
+//!
+//! When an agent loads into a Lex repository, it has no single
+//! place to read "what's in this workspace right now." It has to
+//! grep `stages/`, parse `policy.json`, list branches, walk
+//! intents — every agent reinvents the discovery glue and burns
+//! tokens re-learning the same shape every session.
+//!
+//! `lex docs --for-agent` emits one JSON object structured for
+//! prompt consumption. All sections are derivable from existing
+//! on-disk state; no new persistence.
+
+use crate::acli;
+use ::acli::OutputFormat;
+use anyhow::{anyhow, Result};
+use lex_store::{Store, DEFAULT_BRANCH};
+use std::path::PathBuf;
+
+/// Schema version of the emitted JSON. Bump when fields are
+/// removed or semantically reshaped; adding optional fields is
+/// schema-additive and doesn't require a bump.
+const LEX_DOCS_VERSION: u32 = 1;
+
+pub fn cmd_docs(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    let sub = args.first().ok_or_else(|| anyhow!(
+        "usage: lex docs --for-agent [--branch B] [--limit-recent N] [--store DIR]"))?;
+    if sub != "--for-agent" {
+        // Future subcommands (`lex docs serve`, `lex docs sig X`, …)
+        // can land here. For 0.5.0's slice, only `--for-agent`.
+        anyhow::bail!(
+            "unknown `lex docs` subcommand `{sub}`. only `--for-agent` is supported today"
+        );
+    }
+    let mut branch: Option<String> = None;
+    let mut limit_recent: usize = 50;
+    let mut root: Option<PathBuf> = None;
+    let mut it = args[1..].iter();
+    while let Some(a) = it.next() {
+        match a.as_str() {
+            "--branch" => {
+                branch = Some(it.next()
+                    .ok_or_else(|| anyhow!("--branch needs a value"))?.clone());
+            }
+            "--limit-recent" => {
+                limit_recent = it.next()
+                    .ok_or_else(|| anyhow!("--limit-recent needs N"))?
+                    .parse()
+                    .map_err(|e| anyhow!("--limit-recent: {e}"))?;
+            }
+            "--store" => {
+                root = Some(PathBuf::from(it.next()
+                    .ok_or_else(|| anyhow!("--store needs a path"))?));
+            }
+            other => anyhow::bail!("unexpected arg `{other}`"),
+        }
+    }
+    let root = root.unwrap_or_else(|| {
+        let home = std::env::var("HOME").map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from("."));
+        home.join(".lex/store")
+    });
+    let store = Store::open(&root)?;
+    let current_branch = branch.unwrap_or_else(|| store.current_branch());
+
+    let envelope = build_envelope(&store, &current_branch, limit_recent)?;
+    let data = serde_json::to_value(&envelope)?;
+    acli::emit_or_text("docs", data, fmt, || render_text(&envelope));
+    Ok(())
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct DocsEnvelope {
+    pub lex_docs_version: u32,
+    pub workspace: Workspace,
+    pub stdlib: StdlibSummary,
+    pub recent_activity: Vec<RecentOp>,
+    pub open_intents: Vec<OpenIntent>,
+    pub policy: PolicySummary,
+    pub attention: Vec<AttentionItem>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct Workspace {
+    pub lex_version: String,
+    pub current_branch: String,
+    pub default_branch: String,
+    pub branches: Vec<String>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct StdlibSummary {
+    /// Every active sig on `current_branch`. The name is the
+    /// function name (stable across body edits); `type_signature`
+    /// is a human-readable render of `(params) -> ret [effects]`.
+    pub sigs: Vec<SigInfo>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct SigInfo {
+    pub sig_id: String,
+    pub stage_id: String,
+    pub name: String,
+    pub type_signature: String,
+    pub effects: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub budget: Option<u64>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct RecentOp {
+    pub op_id: String,
+    pub kind_tag: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sig_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stage_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub intent_id: Option<String>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct OpenIntent {
+    pub intent_id: String,
+    pub prompt: String,
+    pub session_id: String,
+    pub model: serde_json::Value,
+    /// Op ids on `current_branch` that reference this intent.
+    pub produced_ops: Vec<String>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct PolicySummary {
+    pub required_attestations: serde_json::Value,
+    pub blocked_producers: serde_json::Value,
+    pub gc_retention: serde_json::Value,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct AttentionItem {
+    pub stage_id: String,
+    pub sig_id: String,
+    pub reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+fn build_envelope(
+    store: &Store,
+    branch: &str,
+    limit_recent: usize,
+) -> Result<DocsEnvelope> {
+    let branches = store.list_branches()?;
+    let workspace = Workspace {
+        lex_version: env!("CARGO_PKG_VERSION").into(),
+        current_branch: branch.into(),
+        default_branch: DEFAULT_BRANCH.into(),
+        branches,
+    };
+
+    let head = store.branch_head(branch).unwrap_or_default();
+    let mut sigs: Vec<SigInfo> = Vec::with_capacity(head.len());
+    for (sig_id, stage_id) in &head {
+        let Ok(ast) = store.get_ast(stage_id) else { continue };
+        let lex_ast::Stage::FnDecl(fd) = ast else { continue };
+        let effects: Vec<String> = fd.effects.iter()
+            .map(|e| match &e.arg {
+                Some(lex_ast::EffectArg::Int { value }) => format!("{}({})", e.name, value),
+                Some(lex_ast::EffectArg::Str { value }) => format!("{}({:?})", e.name, value),
+                Some(lex_ast::EffectArg::Ident { value }) => format!("{}({})", e.name, value),
+                None => e.name.clone(),
+            })
+            .collect();
+        let budget = fd.effects.iter()
+            .filter_map(|e| if e.name == "budget" {
+                match &e.arg {
+                    Some(lex_ast::EffectArg::Int { value }) => Some(*value as u64),
+                    _ => None,
+                }
+            } else {
+                None
+            })
+            .min();
+        sigs.push(SigInfo {
+            sig_id: sig_id.clone(),
+            stage_id: stage_id.clone(),
+            name: fd.name.clone(),
+            type_signature: render_signature(&fd),
+            effects,
+            budget,
+        });
+    }
+    sigs.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let recent_activity = collect_recent_activity(store, branch, limit_recent)?;
+    let open_intents = collect_open_intents(store, &recent_activity)?;
+    let policy = load_policy_summary(store)?;
+    let attention = collect_attention(store, &head)?;
+
+    Ok(DocsEnvelope {
+        lex_docs_version: LEX_DOCS_VERSION,
+        workspace,
+        stdlib: StdlibSummary { sigs },
+        recent_activity,
+        open_intents,
+        policy,
+        attention,
+    })
+}
+
+fn collect_recent_activity(
+    store: &Store,
+    branch: &str,
+    limit: usize,
+) -> Result<Vec<RecentOp>> {
+    let head_op = match store.get_branch(branch)? {
+        Some(b) => b.head_op,
+        None => return Ok(Vec::new()),
+    };
+    let Some(head) = head_op else { return Ok(Vec::new()); };
+    let log = lex_vcs::OpLog::open(store.root())?;
+    // `walk_back(_, Some(0))` still returns one record (the limit
+    // check fires after the push). Pass `None` and truncate
+    // explicitly so `--limit-recent 0` actually yields zero.
+    let mut walked = log.walk_back(&head, None)?;
+    walked.truncate(limit);
+    let mut out: Vec<RecentOp> = Vec::with_capacity(walked.len());
+    for rec in walked {
+        let kind_tag = op_kind_tag(&rec.op.kind);
+        let (sig_id, stage_id) = match rec.op.kind.merge_target() {
+            Some((s, st)) => (Some(s), st),
+            None => (None, None),
+        };
+        out.push(RecentOp {
+            op_id: rec.op_id,
+            kind_tag: kind_tag.into(),
+            sig_id,
+            stage_id,
+            intent_id: rec.op.intent_id,
+        });
+    }
+    Ok(out)
+}
+
+fn op_kind_tag(k: &lex_vcs::OperationKind) -> &'static str {
+    use lex_vcs::OperationKind::*;
+    match k {
+        AddFunction { .. }     => "add_function",
+        RemoveFunction { .. }  => "remove_function",
+        ModifyBody { .. }      => "modify_body",
+        RenameSymbol { .. }    => "rename_symbol",
+        ChangeEffectSig { .. } => "change_effect_sig",
+        AddImport { .. }       => "add_import",
+        RemoveImport { .. }    => "remove_import",
+        AddType { .. }         => "add_type",
+        RemoveType { .. }      => "remove_type",
+        ModifyType { .. }      => "modify_type",
+        Merge { .. }           => "merge",
+        ReplaceMatchArm { .. } => "replace_match_arm",
+    }
+}
+
+fn collect_open_intents(
+    store: &Store,
+    recent: &[RecentOp],
+) -> Result<Vec<OpenIntent>> {
+    use std::collections::BTreeMap;
+    let log = lex_vcs::IntentLog::open(store.root())?;
+    let mut buckets: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for op in recent {
+        if let Some(id) = &op.intent_id {
+            buckets.entry(id.clone()).or_default().push(op.op_id.clone());
+        }
+    }
+    let mut out: Vec<OpenIntent> = Vec::with_capacity(buckets.len());
+    for (intent_id, ops) in buckets {
+        let Some(intent) = log.get(&intent_id)? else { continue };
+        out.push(OpenIntent {
+            intent_id,
+            prompt: intent.prompt,
+            session_id: intent.session_id,
+            model: serde_json::to_value(&intent.model)
+                .unwrap_or(serde_json::Value::Null),
+            produced_ops: ops,
+        });
+    }
+    Ok(out)
+}
+
+fn load_policy_summary(store: &Store) -> Result<PolicySummary> {
+    let policy = lex_store::policy::load(store.root())?.unwrap_or_default();
+    Ok(PolicySummary {
+        required_attestations: serde_json::to_value(&policy.required_attestations)?,
+        blocked_producers: serde_json::to_value(&policy.blocked_producers)?,
+        gc_retention: serde_json::to_value(&policy.gc_retention)?,
+    })
+}
+
+fn collect_attention(
+    store: &Store,
+    head: &std::collections::BTreeMap<String, String>,
+) -> Result<Vec<AttentionItem>> {
+    // A stage warrants attention when it's currently active *and*
+    // it carries an attestation that blocks it: a `Block { … }`
+    // not subsequently `Unblock`'d, or a `ProducerBlock { tool }`
+    // whose attestation is referenced from this stage's TypeCheck
+    // chain. The negative path is what reviewers / agents should
+    // see first.
+    let attlog = store.attestation_log()?;
+    let mut out: Vec<AttentionItem> = Vec::new();
+    for (sig_id, stage_id) in head {
+        let atts = match attlog.list_for_stage(stage_id) {
+            Ok(a) => a,
+            Err(_) => continue,
+        };
+        if lex_vcs::is_stage_blocked(&atts) {
+            out.push(AttentionItem {
+                stage_id: stage_id.clone(),
+                sig_id: sig_id.clone(),
+                reason: "blocked_by_attestation".into(),
+                detail: Some("a `Block` attestation has not been subsequently `Unblock`'d".into()),
+            });
+        }
+    }
+    Ok(out)
+}
+
+fn render_signature(fd: &lex_ast::FnDecl) -> String {
+    let params: Vec<String> = fd.params.iter()
+        .map(|p| format!("{} :: {}", p.name, render_type(&p.ty))).collect();
+    let effects = if fd.effects.is_empty() {
+        String::new()
+    } else {
+        let s: Vec<String> = fd.effects.iter().map(|e| e.name.clone()).collect();
+        format!(" [{}]", s.join(", "))
+    };
+    format!("({}) -> {}{}", params.join(", "), render_type(&fd.return_type), effects)
+}
+
+fn render_type(t: &lex_ast::TypeExpr) -> String {
+    use lex_ast::TypeExpr::*;
+    match t {
+        Named { name, args } if args.is_empty() => name.clone(),
+        Named { name, args } => {
+            let inner: Vec<String> = args.iter().map(render_type).collect();
+            format!("{}<{}>", name, inner.join(", "))
+        }
+        Tuple { items } => {
+            let inner: Vec<String> = items.iter().map(render_type).collect();
+            format!("({})", inner.join(", "))
+        }
+        Record { fields } => {
+            let inner: Vec<String> = fields.iter()
+                .map(|f| format!("{}: {}", f.name, render_type(&f.ty))).collect();
+            format!("{{{}}}", inner.join(", "))
+        }
+        Function { params, ret, .. } => {
+            let inner: Vec<String> = params.iter().map(render_type).collect();
+            format!("({}) -> {}", inner.join(", "), render_type(ret))
+        }
+        Union { variants } => {
+            let inner: Vec<String> = variants.iter().map(|v| v.name.clone()).collect();
+            inner.join(" | ")
+        }
+        Refined { base, .. } => format!("{}{{…}}", render_type(base)),
+    }
+}
+
+fn render_text(env: &DocsEnvelope) {
+    println!("Lex workspace docs (v{})", env.lex_docs_version);
+    println!("  lex {} on branch `{}` (default: `{}`)",
+        env.workspace.lex_version, env.workspace.current_branch,
+        env.workspace.default_branch);
+    println!("  branches: {}", env.workspace.branches.join(", "));
+    println!();
+    println!("Stdlib ({} sigs):", env.stdlib.sigs.len());
+    for s in &env.stdlib.sigs {
+        println!("  {}{}", s.name, s.type_signature);
+    }
+    println!();
+    println!("Recent activity ({} ops):", env.recent_activity.len());
+    for op in &env.recent_activity {
+        let sig = op.sig_id.as_deref().unwrap_or("-");
+        println!("  {} [{}] {}", &op.op_id[..12.min(op.op_id.len())], op.kind_tag, sig);
+    }
+    println!();
+    println!("Open intents: {}", env.open_intents.len());
+    for i in &env.open_intents {
+        println!("  {} \"{}\" ({} ops)",
+            &i.intent_id[..12.min(i.intent_id.len())], i.prompt, i.produced_ops.len());
+    }
+    println!();
+    if !env.attention.is_empty() {
+        println!("Attention queue: {} item(s)", env.attention.len());
+        for a in &env.attention {
+            println!("  {} {} — {}", a.sig_id, a.stage_id, a.reason);
+        }
+    }
+}

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -17,6 +17,7 @@ mod ast_merge;
 mod branch;
 mod merge;
 mod acli;
+mod docs;
 mod op;
 mod repl;
 mod watch;
@@ -104,6 +105,7 @@ fn run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         "policy" => cmd_policy(fmt, &args[1..]),
         "log" => branch::cmd_log(fmt, &args[1..]),
         "op" => op::cmd_op(fmt, &args[1..]),
+        "docs" => docs::cmd_docs(fmt, &args[1..]),
         "canonical" => cmd_canonical(fmt, &args[1..]),
         "keygen" => cmd_keygen(fmt, &args[1..]),
         "repl" => repl::cmd_repl(&args[1..]),

--- a/crates/lex-cli/tests/docs_for_agent.rs
+++ b/crates/lex-cli/tests/docs_for_agent.rs
@@ -1,0 +1,150 @@
+//! Conformance tests for #282 — `lex docs --for-agent`.
+//!
+//! These tests drive the `lex` binary as a subprocess to check the
+//! end-to-end JSON envelope. They use `--store` to point at a
+//! freshly-prepared temp directory so no global state is touched.
+
+use std::process::Command;
+
+fn lex_bin() -> std::path::PathBuf {
+    // `cargo test --workspace` builds the lex binary at
+    // target/debug/lex; CARGO_BIN_EXE_lex resolves to it
+    // automatically when the bin is named `lex` in lex-cli.
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_lex"))
+}
+
+fn seed_store(tmp: &std::path::Path) {
+    // Use the CLI's `publish` command to seed a tiny stage,
+    // exercising the full pipeline. Simpler than constructing
+    // Store manually because the test crate is a `lex-cli` integ
+    // test (no direct dependency on `lex-store`).
+    let src = tmp.join("hello.lex");
+    std::fs::write(&src,
+        "fn hello(n :: Int) -> Int { match n { 0 => 1, _ => n } }\n",
+    ).unwrap();
+    let out = Command::new(lex_bin())
+        .args(["publish", src.to_str().unwrap(), "--store", tmp.to_str().unwrap()])
+        .output()
+        .expect("lex publish should run");
+    if !out.status.success() {
+        panic!(
+            "publish failed:\nstdout={}\nstderr={}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        );
+    }
+}
+
+fn run_docs(tmp: &std::path::Path) -> serde_json::Value {
+    let out = Command::new(lex_bin())
+        .args(["--output", "json", "docs", "--for-agent",
+            "--store", tmp.to_str().unwrap()])
+        .output()
+        .expect("lex docs should run");
+    assert!(out.status.success(),
+        "lex docs --for-agent failed: stderr={}",
+        String::from_utf8_lossy(&out.stderr));
+    let envelope: serde_json::Value = serde_json::from_slice(&out.stdout)
+        .unwrap_or_else(|e| panic!("invalid JSON: {e}\nbody={}",
+            String::from_utf8_lossy(&out.stdout)));
+    // The acli wrapper nests our envelope under `data`. Unwrap so
+    // tests can address sections directly.
+    envelope["data"].clone()
+}
+
+#[test]
+fn emits_versioned_envelope_with_all_required_sections() {
+    let tmp = tempfile::tempdir().unwrap();
+    seed_store(tmp.path());
+
+    let v = run_docs(tmp.path());
+    assert_eq!(v["lex_docs_version"], 1);
+    assert!(v["workspace"].is_object(), "workspace section present");
+    assert!(v["stdlib"]["sigs"].is_array(), "stdlib.sigs present");
+    assert!(v["recent_activity"].is_array(), "recent_activity present");
+    assert!(v["open_intents"].is_array(), "open_intents present");
+    assert!(v["policy"].is_object(), "policy section present");
+    assert!(v["attention"].is_array(), "attention queue present");
+}
+
+#[test]
+fn workspace_section_reports_branch_and_version() {
+    let tmp = tempfile::tempdir().unwrap();
+    seed_store(tmp.path());
+
+    let v = run_docs(tmp.path());
+    let ws = &v["workspace"];
+    assert!(ws["lex_version"].is_string());
+    assert_eq!(ws["current_branch"], "main");
+    assert_eq!(ws["default_branch"], "main");
+    let branches = ws["branches"].as_array().expect("branches array");
+    assert!(branches.iter().any(|b| b == "main"));
+}
+
+#[test]
+fn stdlib_sigs_include_published_fn_with_signature() {
+    let tmp = tempfile::tempdir().unwrap();
+    seed_store(tmp.path());
+
+    let v = run_docs(tmp.path());
+    let sigs = v["stdlib"]["sigs"].as_array().expect("sigs is an array");
+    let hello = sigs.iter().find(|s| s["name"] == "hello")
+        .expect("published `hello` should appear in stdlib summary");
+    assert!(hello["sig_id"].is_string());
+    assert!(hello["stage_id"].is_string());
+    assert!(hello["type_signature"].as_str().unwrap().contains("Int"),
+        "type signature should mention Int, got {}",
+        hello["type_signature"]);
+}
+
+#[test]
+fn recent_activity_lists_publish_ops() {
+    let tmp = tempfile::tempdir().unwrap();
+    seed_store(tmp.path());
+
+    let v = run_docs(tmp.path());
+    let recent = v["recent_activity"].as_array().unwrap();
+    assert!(!recent.is_empty(), "publish should land at least one op");
+    // First op is the most recent — should reference a fn add.
+    let first = &recent[0];
+    assert!(first["op_id"].is_string());
+    assert!(first["kind_tag"].is_string());
+}
+
+#[test]
+fn limit_recent_bounds_the_history() {
+    let tmp = tempfile::tempdir().unwrap();
+    seed_store(tmp.path());
+
+    let out = Command::new(lex_bin())
+        .args(["--output", "json", "docs", "--for-agent",
+            "--limit-recent", "0",
+            "--store", tmp.path().to_str().unwrap()])
+        .output().unwrap();
+    let envelope: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let v = &envelope["data"];
+    assert_eq!(v["recent_activity"].as_array().unwrap().len(), 0,
+        "--limit-recent 0 should yield empty activity");
+}
+
+#[test]
+fn unknown_subcommand_errors() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = Command::new(lex_bin())
+        .args(["docs", "--no-such-flag", "--store", tmp.path().to_str().unwrap()])
+        .output().unwrap();
+    assert!(!out.status.success(), "unknown flag should fail the command");
+}
+
+#[test]
+fn fresh_store_emits_empty_recent_activity() {
+    let tmp = tempfile::tempdir().unwrap();
+    // Don't publish anything — fresh store. The command must still
+    // succeed and emit an envelope with empty `recent_activity` /
+    // `open_intents` / `attention` lists.
+    let v = run_docs(tmp.path());
+    assert_eq!(v["lex_docs_version"], 1);
+    assert!(v["recent_activity"].as_array().unwrap().is_empty());
+    assert!(v["open_intents"].as_array().unwrap().is_empty());
+    assert!(v["attention"].as_array().unwrap().is_empty());
+}


### PR DESCRIPTION
Closes #282.

## Summary

`lex docs --for-agent` emits a single structured JSON envelope giving an agent the workspace context it needs without grep-and-discover overhead. Six sections, all derivable from existing on-disk state:

- **workspace** — `lex_version`, `current_branch`, `default_branch`, list of branches.
- **stdlib** — every active sig on the branch with rendered type signature, declared effects (with args like `budget(50)`), and an optional `budget` field.
- **recent_activity** — last N ops with `op_id`, kind tag, sig_id, stage_id, intent_id.
- **open_intents** — intents referenced by recent ops, resolved against `IntentLog`, with their `produced_ops` list.
- **policy** — `required_attestations`, `blocked_producers`, `gc_retention` from `policy.json`.
- **attention** — stages with active `Block` attestations (consults `lex_vcs::is_stage_blocked`).

Flags: `--branch B`, `--limit-recent N` (default 50), `--store DIR`. Schema versioned via `lex_docs_version: 1` so future agents can detect breakage.

## Test plan

- [x] 7 conformance tests in `crates/lex-cli/tests/docs_for_agent.rs` driving the `lex` binary as a subprocess (versioned envelope shape, workspace section, stdlib sigs, recent_activity contents, `--limit-recent 0`, unknown subcommand fails, fresh-store envelope).
- [x] `cargo test --workspace` — 168 test groups pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.

## Out of scope

- Streaming/push — agents poll between turns.
- LLM-rendered prose explanations — separate flow.
- Whole-program type environment dump — sigs already carry the rendered type signature; deeper info is via `lex search`.

## Strategic context

From the 0.5.0 review: pure UX win, no architectural risk, cuts agent onboarding tokens 5–10× per session. Independent of #280 (typed transforms) and #283 (real embedder); can land in parallel.

https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_