### PR TITLE
lex-ast+vcs+store: typed RenameLocal transform (#280 slice 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+### Added — agent-VCS roadmap (#280, slice 2)
+
+- **Typed `RenameLocal` transform** (#280 slice 2). Second of the
+  typed refactoring operations from the 0.5.0 review. New
+  `lex_ast::rename_local(stage, let_node, new_name)` walks the
+  binding's body scope and rewrites every unshadowed reference to
+  the old name. Pure function — same shape as
+  `lex_ast::replace_match_arm`.
+- **Scope-aware**: shadowing by inner `Let`, `Lambda` params, or
+  `Match` pattern bindings cuts off the rewrite. `value`-side
+  references are left untouched because Lex `let` is
+  non-recursive.
+- **`OperationKind::RenameLocal { sig_id, from_stage_id,
+  to_stage_id, let_node, old_name, new_name, from_budget,
+  to_budget }`** records the rename in the op log; same
+  `skip_if_none` budget discipline as the rest of #280's variants.
+- **`Store::apply_rename_local`** end-to-end: load AST → transform
+  → publish new stage → re-typecheck → emit op. Failure modes
+  match `apply_replace_match_arm`: `TransformError` for malformed
+  targets, `TypeError` for ill-typed results, `InvalidTransition`
+  for no-op renames.
+- 6 unit tests in `lex_ast::transforms` (rename + body refs;
+  no-op refusal; inner-`Let` shadow; `Lambda` param shadow;
+  `Match` pattern shadow; not-a-Let target). 5 conformance tests
+  in `crates/lex-store/tests/rename_local.rs` (lands typed op,
+  `get_ast` reconstruction, no-op refusal, TypeCheck attestation,
+  transform-error surface for wrong node).
+
+Slices for `InlineLet` and `ExtractFunction` remain follow-ups.
+
 ### Added — agent-discovery (#283)
 
 - **`lex store search reindex`** warms the embedding cache eagerly

--- a/crates/lex-ast/src/lib.rs
+++ b/crates/lex-ast/src/lib.rs
@@ -17,7 +17,7 @@ pub use canonicalize::{canonicalize_program, canonicalize_item};
 pub use canon_print::print_stages;
 pub use ids::{collect_ids, expr_ids, NodeId, NodeRef};
 pub use patch::{apply_patch, Patch, PatchError};
-pub use transforms::{replace_match_arm, TransformError};
+pub use transforms::{rename_local, replace_match_arm, TransformError};
 
 /// SHA-256 over the canonical-JSON encoding of a stage. Excludes NodeIds
 /// (the canonical AST data does not carry IDs; they're derived).

--- a/crates/lex-ast/src/transforms.rs
+++ b/crates/lex-ast/src/transforms.rs
@@ -17,15 +17,16 @@
 //! produces an ill-typed AST surfaces as `StoreError::TypeError`
 //! rather than failing inside the transformer.
 //!
-//! # Slice 1 (#280)
+//! # Shipped transforms
 //!
-//! [`replace_match_arm`] — replaces the body of one arm in a match
-//! expression. Pattern is preserved; the new body must be a valid
-//! `CExpr`. This is the simplest position-targeted transform and
-//! establishes the pattern for the rest (`RenameLocal`,
-//! `InlineLet`, `ExtractFunction` — separate slices).
+//! - [`replace_match_arm`] — replaces the body of one arm in a
+//!   match expression. Pattern is preserved.
+//! - [`rename_local`] — renames a `let`-bound local. Walks the
+//!   binding's body scope and rewrites every unshadowed reference.
+//!
+//! Future slices: `inline_let`, `extract_function`.
 
-use crate::canonical::{CExpr, Stage};
+use crate::canonical::{CExpr, Pattern, Stage};
 use crate::ids::NodeId;
 
 #[derive(Debug, Clone, thiserror::Error, serde::Serialize, serde::Deserialize)]
@@ -35,12 +36,16 @@ pub enum TransformError {
     UnknownNode { at: String },
     #[error("expected a Match expression at `{at}` but found `{found_kind}`")]
     NotAMatch { at: String, found_kind: &'static str },
+    #[error("expected a Let expression at `{at}` but found `{found_kind}`")]
+    NotALet { at: String, found_kind: &'static str },
     #[error("arm index {requested} out of range (arm count = {arm_count}) at `{at}`")]
     ArmIndexOutOfRange { at: String, arm_count: usize, requested: usize },
     #[error("malformed NodeId `{0}`")]
     BadNodeId(String),
     #[error("cannot transform inside `{stage_kind}` — only FnDecl bodies are transformable")]
     NonFnTarget { stage_kind: &'static str },
+    #[error("rename is a no-op: old and new name are both `{name}`")]
+    RenameNoOp { name: String },
 }
 
 /// Replace `match_node`'s arm at `arm_index` with a new body,
@@ -96,6 +101,132 @@ pub fn replace_match_arm(
     }
     arms[arm_index].body = new_body;
     Ok(out)
+}
+
+/// Rename a `let`-bound local variable. Walks the binding's body
+/// scope and rewrites every unshadowed reference to the old name.
+/// Pure function — produces a new `Stage` with the rename applied.
+///
+/// Scope semantics:
+/// - The let's `value` is evaluated in the outer scope; references
+///   to the old name there belong to whatever bound it before.
+///   We rewrite the `value` only if a renamed outer binding would
+///   reach it — which it can't, since `let` in Lex is
+///   non-recursive. So we leave `value` untouched.
+/// - The let's `body` sees the renamed binding. Shadowing in `body`
+///   (a nested `Let` / `Lambda` param / `Match` pattern that
+///   re-binds the *old* name) cuts off renaming inside the
+///   shadowed sub-tree.
+///
+/// Refuses when `old_name == new_name`. Doesn't otherwise check for
+/// name clashes — if the new name is already bound in scope, the
+/// downstream type-checker surfaces it as a `TypeError`.
+pub fn rename_local(
+    stage: &Stage,
+    let_node: &NodeId,
+    new_name: &str,
+) -> Result<Stage, TransformError> {
+    let mut out = stage.clone();
+    let (body, n_params) = match &mut out {
+        Stage::FnDecl(fd) => {
+            let n = fd.params.len();
+            (&mut fd.body, n)
+        }
+        Stage::TypeDecl(_) => return Err(TransformError::NonFnTarget { stage_kind: "TypeDecl" }),
+        Stage::Import(_) => return Err(TransformError::NonFnTarget { stage_kind: "Import" }),
+    };
+    let path = parse_node_id(let_node.as_str())?;
+    if path.is_empty() {
+        return Err(TransformError::NotALet {
+            at: let_node.as_str().into(),
+            found_kind: "stage_root",
+        });
+    }
+    if path[0] != n_params + 1 {
+        return Err(TransformError::UnknownNode { at: let_node.as_str().into() });
+    }
+    let inner = &path[1..];
+    let target = navigate_to_expr(body, inner, let_node.as_str())?;
+    let CExpr::Let { name, body: let_body, .. } = target else {
+        return Err(TransformError::NotALet {
+            at: let_node.as_str().into(),
+            found_kind: cexpr_kind(target),
+        });
+    };
+    if name == new_name {
+        return Err(TransformError::RenameNoOp { name: name.clone() });
+    }
+    let old_name = std::mem::replace(name, new_name.to_string());
+    // Walk the body scope. Stop renaming at shadow points.
+    rewrite_var_in_expr(let_body, &old_name, new_name);
+    Ok(out)
+}
+
+fn rewrite_var_in_expr(e: &mut CExpr, old: &str, new: &str) {
+    match e {
+        CExpr::Var { name } => {
+            if name == old { *name = new.into(); }
+        }
+        CExpr::Literal { .. } => {}
+        CExpr::Call { callee, args } => {
+            rewrite_var_in_expr(callee, old, new);
+            for a in args { rewrite_var_in_expr(a, old, new); }
+        }
+        CExpr::Let { name, value, body, .. } => {
+            // `value` is evaluated in the outer scope — rewrite
+            // there.
+            rewrite_var_in_expr(value, old, new);
+            // `body` sees the new binding. If THIS let re-binds
+            // `old`, it shadows the rename target; stop descending.
+            if name != old {
+                rewrite_var_in_expr(body, old, new);
+            }
+        }
+        CExpr::Match { scrutinee, arms } => {
+            rewrite_var_in_expr(scrutinee, old, new);
+            for arm in arms {
+                if !pattern_binds(&arm.pattern, old) {
+                    rewrite_var_in_expr(&mut arm.body, old, new);
+                }
+            }
+        }
+        CExpr::Block { statements, result } => {
+            for s in statements { rewrite_var_in_expr(s, old, new); }
+            rewrite_var_in_expr(result, old, new);
+        }
+        CExpr::Constructor { args, .. } => {
+            for a in args { rewrite_var_in_expr(a, old, new); }
+        }
+        CExpr::RecordLit { fields } => {
+            for f in fields { rewrite_var_in_expr(&mut f.value, old, new); }
+        }
+        CExpr::TupleLit { items } | CExpr::ListLit { items } => {
+            for i in items { rewrite_var_in_expr(i, old, new); }
+        }
+        CExpr::FieldAccess { value, .. } => rewrite_var_in_expr(value, old, new),
+        CExpr::Lambda { params, body, .. } => {
+            // Lambda params shadow the outer binding.
+            if !params.iter().any(|p| p.name == old) {
+                rewrite_var_in_expr(body, old, new);
+            }
+        }
+        CExpr::BinOp { lhs, rhs, .. } => {
+            rewrite_var_in_expr(lhs, old, new);
+            rewrite_var_in_expr(rhs, old, new);
+        }
+        CExpr::UnaryOp { expr, .. } => rewrite_var_in_expr(expr, old, new),
+        CExpr::Return { value } => rewrite_var_in_expr(value, old, new),
+    }
+}
+
+fn pattern_binds(p: &Pattern, name: &str) -> bool {
+    match p {
+        Pattern::PVar { name: n } => n == name,
+        Pattern::PLiteral { .. } | Pattern::PWild => false,
+        Pattern::PConstructor { args, .. } => args.iter().any(|p| pattern_binds(p, name)),
+        Pattern::PRecord { fields } => fields.iter().any(|f| pattern_binds(&f.pattern, name)),
+        Pattern::PTuple { items } => items.iter().any(|p| pattern_binds(p, name)),
+    }
 }
 
 fn parse_node_id(id: &str) -> Result<Vec<usize>, TransformError> {
@@ -206,6 +337,193 @@ fn cexpr_kind(e: &CExpr) -> &'static str {
 mod tests {
     use super::*;
     use crate::canonical::{Arm, CLit, FnDecl, Param, Pattern, TypeExpr};
+
+    // ---- rename_local fixtures + tests -----------------------------
+
+    /// `fn outer(n :: Int) -> Int { let x := n + 1; x + 2 }`
+    fn let_stage() -> Stage {
+        let body = CExpr::Let {
+            name: "x".into(),
+            ty: None,
+            value: Box::new(CExpr::BinOp {
+                op: "+".into(),
+                lhs: Box::new(CExpr::Var { name: "n".into() }),
+                rhs: Box::new(CExpr::Literal { value: CLit::Int { value: 1 } }),
+            }),
+            body: Box::new(CExpr::BinOp {
+                op: "+".into(),
+                lhs: Box::new(CExpr::Var { name: "x".into() }),
+                rhs: Box::new(CExpr::Literal { value: CLit::Int { value: 2 } }),
+            }),
+        };
+        Stage::FnDecl(FnDecl {
+            name: "outer".into(),
+            type_params: Vec::new(),
+            params: vec![Param {
+                name: "n".into(),
+                ty: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
+            }],
+            effects: Vec::new(),
+            return_type: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
+            body,
+        })
+    }
+
+    fn let_node_id() -> NodeId { NodeId("n_0.2".into()) }
+
+    #[test]
+    fn rename_local_renames_binding_and_body_reference() {
+        let stage = let_stage();
+        let out = rename_local(&stage, &let_node_id(), "y").unwrap();
+        let Stage::FnDecl(fd) = out else { panic!() };
+        let CExpr::Let { name, value, body, .. } = fd.body else { panic!() };
+        assert_eq!(name, "y", "binding renamed");
+        // value untouched (no `x` ref in `n + 1`).
+        let CExpr::BinOp { lhs, .. } = *value else { panic!() };
+        assert!(matches!(*lhs, CExpr::Var { name: ref n } if n == "n"));
+        // Body's `x` ref renamed to `y`.
+        let CExpr::BinOp { lhs, .. } = *body else { panic!() };
+        assert!(matches!(*lhs, CExpr::Var { name: ref n } if n == "y"));
+    }
+
+    #[test]
+    fn rename_local_refuses_no_op() {
+        let stage = let_stage();
+        let err = rename_local(&stage, &let_node_id(), "x").unwrap_err();
+        assert!(matches!(err, TransformError::RenameNoOp { .. }));
+    }
+
+    #[test]
+    fn rename_local_respects_inner_let_shadowing() {
+        // `fn f() -> Int { let x := 1; let x := 2; x }`
+        // Renaming the OUTER `x` to `y` should leave both inner
+        // references unchanged because the inner let shadows.
+        let inner = CExpr::Let {
+            name: "x".into(),
+            ty: None,
+            value: Box::new(CExpr::Literal { value: CLit::Int { value: 2 } }),
+            body: Box::new(CExpr::Var { name: "x".into() }),
+        };
+        let body = CExpr::Let {
+            name: "x".into(),
+            ty: None,
+            value: Box::new(CExpr::Literal { value: CLit::Int { value: 1 } }),
+            body: Box::new(inner),
+        };
+        let stage = Stage::FnDecl(FnDecl {
+            name: "f".into(),
+            type_params: Vec::new(),
+            params: Vec::new(),
+            effects: Vec::new(),
+            return_type: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
+            body,
+        });
+        let out = rename_local(&stage, &NodeId("n_0.1".into()), "y").unwrap();
+        let Stage::FnDecl(fd) = out else { panic!() };
+        let CExpr::Let { name: outer_name, body: outer_body, .. } = fd.body else { panic!() };
+        assert_eq!(outer_name, "y", "outer let renamed");
+        let CExpr::Let { name: inner_name, body: inner_body, .. } = *outer_body else { panic!() };
+        // Inner let shadows — its name stays "x".
+        assert_eq!(inner_name, "x");
+        // Inner body's `x` is the inner binding, not renamed.
+        assert!(matches!(*inner_body, CExpr::Var { name: ref n } if n == "x"));
+    }
+
+    #[test]
+    fn rename_local_respects_lambda_param_shadowing() {
+        // Body: `let x := 1; (\x. x)`. Lambda param shadows.
+        let lambda = CExpr::Lambda {
+            params: vec![Param {
+                name: "x".into(),
+                ty: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
+            }],
+            return_type: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
+            effects: Vec::new(),
+            body: Box::new(CExpr::Var { name: "x".into() }),
+        };
+        let body = CExpr::Let {
+            name: "x".into(),
+            ty: None,
+            value: Box::new(CExpr::Literal { value: CLit::Int { value: 1 } }),
+            body: Box::new(lambda),
+        };
+        let stage = Stage::FnDecl(FnDecl {
+            name: "f".into(),
+            type_params: Vec::new(),
+            params: Vec::new(),
+            effects: Vec::new(),
+            return_type: TypeExpr::Function {
+                params: vec![TypeExpr::Named { name: "Int".into(), args: Vec::new() }],
+                effects: Vec::new(),
+                ret: Box::new(TypeExpr::Named { name: "Int".into(), args: Vec::new() }),
+            },
+            body,
+        });
+        let out = rename_local(&stage, &NodeId("n_0.1".into()), "y").unwrap();
+        let Stage::FnDecl(fd) = out else { panic!() };
+        let CExpr::Let { name, body: outer_body, .. } = fd.body else { panic!() };
+        assert_eq!(name, "y");
+        let CExpr::Lambda { body: lam_body, .. } = *outer_body else { panic!() };
+        // Lambda body's `x` is the param, not renamed.
+        assert!(matches!(*lam_body, CExpr::Var { name: ref n } if n == "x"));
+    }
+
+    #[test]
+    fn rename_local_respects_match_pattern_shadowing() {
+        // Body: `let x := 1; match foo { x => x, _ => x }`
+        // The first arm's pattern is `PVar { x }` — it binds x,
+        // shadowing the let; that arm's body's `x` is the pattern
+        // binding, not the let binding. Should not be renamed.
+        // The `_` wildcard does NOT shadow; its body's `x` is the
+        // let binding, should be renamed.
+        let match_expr = CExpr::Match {
+            scrutinee: Box::new(CExpr::Var { name: "foo".into() }),
+            arms: vec![
+                Arm {
+                    pattern: Pattern::PVar { name: "x".into() },
+                    body: CExpr::Var { name: "x".into() },
+                },
+                Arm {
+                    pattern: Pattern::PWild,
+                    body: CExpr::Var { name: "x".into() },
+                },
+            ],
+        };
+        let body = CExpr::Let {
+            name: "x".into(),
+            ty: None,
+            value: Box::new(CExpr::Literal { value: CLit::Int { value: 1 } }),
+            body: Box::new(match_expr),
+        };
+        let stage = Stage::FnDecl(FnDecl {
+            name: "f".into(),
+            type_params: Vec::new(),
+            params: Vec::new(),
+            effects: Vec::new(),
+            return_type: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
+            body,
+        });
+        let out = rename_local(&stage, &NodeId("n_0.1".into()), "y").unwrap();
+        let Stage::FnDecl(fd) = out else { panic!() };
+        let CExpr::Let { body: outer_body, .. } = fd.body else { panic!() };
+        let CExpr::Match { arms, .. } = *outer_body else { panic!() };
+        // Arm 0 pattern binds x; arm body's `x` is the pattern, NOT renamed.
+        assert!(matches!(arms[0].body, CExpr::Var { name: ref n } if n == "x"));
+        // Arm 1 has wildcard; body's `x` is the let, renamed to `y`.
+        assert!(matches!(arms[1].body, CExpr::Var { name: ref n } if n == "y"));
+    }
+
+    #[test]
+    fn rename_local_not_a_let_errors() {
+        // Stage with a plain Match body (no Let). Targeting `n_0.2`
+        // should error with NotALet.
+        let stage = match_stage_with_two_arms();
+        let err = rename_local(&stage, &NodeId("n_0.2".into()), "y").unwrap_err();
+        assert!(matches!(err, TransformError::NotALet { found_kind: "Match", .. }),
+            "got {err:?}");
+    }
+
+    // ---- replace_match_arm fixtures + tests ------------------------
 
     fn match_stage_with_two_arms() -> Stage {
         // fn pick(n :: Int) -> Int { match n { 0 => 1, _ => 2 } }

--- a/crates/lex-cli/src/docs.rs
+++ b/crates/lex-cli/src/docs.rs
@@ -257,6 +257,7 @@ fn op_kind_tag(k: &lex_vcs::OperationKind) -> &'static str {
         ModifyType { .. }      => "modify_type",
         Merge { .. }           => "merge",
         ReplaceMatchArm { .. } => "replace_match_arm",
+        RenameLocal { .. }     => "rename_local",
     }
 }
 

--- a/crates/lex-store/src/store.rs
+++ b/crates/lex-store/src/store.rs
@@ -1084,6 +1084,73 @@ impl Store {
         self.apply_operation_checked(branch, op, transition, &candidate)
     }
 
+    /// Apply a typed `RenameLocal` transform (#280) — rename a
+    /// `let`-bound local within a fn body and emit a matching
+    /// `OperationKind::RenameLocal`. Same end-to-end shape as
+    /// [`Self::apply_replace_match_arm`]; see that method for the
+    /// failure-mode taxonomy.
+    pub fn apply_rename_local(
+        &self,
+        branch: &str,
+        from_stage_id: &str,
+        let_node: &lex_ast::NodeId,
+        new_name: &str,
+    ) -> Result<lex_vcs::OpId, StoreError> {
+        let from_stage = self.get_ast(from_stage_id)?;
+        // Read the old name before running the transform, so the
+        // op log records the rename target rather than just the
+        // new value.
+        let old_name = read_let_name(&from_stage, let_node)
+            .map_err(StoreError::TransformError)?;
+        let new_stage = lex_ast::rename_local(&from_stage, let_node, new_name)
+            .map_err(StoreError::TransformError)?;
+        let sig = lex_ast::sig_id(&from_stage)
+            .ok_or(StoreError::CannotPublishImport)?;
+        let to_stage_id = self.publish(&new_stage)?;
+        if to_stage_id == from_stage_id {
+            return Err(StoreError::InvalidTransition(format!(
+                "rename_local produced the same stage_id `{from_stage_id}`"
+            )));
+        }
+        let head = self.branch_head(branch)?;
+        let mut candidate: Vec<lex_ast::Stage> = Vec::with_capacity(head.len());
+        for (other_sig, other_stage_id) in &head {
+            if other_sig == &sig {
+                candidate.push(new_stage.clone());
+            } else {
+                candidate.push(self.get_ast(other_stage_id)?);
+            }
+        }
+        if !head.contains_key(&sig) {
+            return Err(StoreError::InvalidTransition(format!(
+                "sig `{sig}` not on branch `{branch}`'s head"
+            )));
+        }
+        let from_budget = budget_of_stage(&from_stage);
+        let to_budget = budget_of_stage(&new_stage);
+        let head_now = self.get_branch(branch)?.and_then(|b| b.head_op);
+        let kind = lex_vcs::OperationKind::RenameLocal {
+            sig_id: sig.clone(),
+            from_stage_id: from_stage_id.to_string(),
+            to_stage_id: to_stage_id.clone(),
+            let_node: let_node.as_str().to_string(),
+            old_name,
+            new_name: new_name.to_string(),
+            from_budget,
+            to_budget,
+        };
+        let transition = lex_vcs::StageTransition::Replace {
+            sig_id: sig.clone(),
+            from: from_stage_id.to_string(),
+            to: to_stage_id.clone(),
+        };
+        let op = lex_vcs::Operation::new(
+            kind,
+            head_now.into_iter().collect::<Vec<_>>(),
+        );
+        self.apply_operation_checked(branch, op, transition, &candidate)
+    }
+
     /// `set_branch_head_op` for the durability story on the branch
     /// file itself.
     pub fn apply_operation(
@@ -1397,7 +1464,8 @@ fn transition_for_kind(kind: &lex_vcs::OperationKind) -> lex_vcs::StageTransitio
         ModifyBody { sig_id, from_stage_id, to_stage_id, .. }
         | ChangeEffectSig { sig_id, from_stage_id, to_stage_id, .. }
         | ModifyType { sig_id, from_stage_id, to_stage_id }
-        | ReplaceMatchArm { sig_id, from_stage_id, to_stage_id, .. } => StageTransition::Replace {
+        | ReplaceMatchArm { sig_id, from_stage_id, to_stage_id, .. }
+        | RenameLocal { sig_id, from_stage_id, to_stage_id, .. } => StageTransition::Replace {
             sig_id: sig_id.clone(),
             from: from_stage_id.clone(),
             to:   to_stage_id.clone(),
@@ -1474,6 +1542,142 @@ fn write_canonical_json<T: Serialize>(path: &Path, value: &T) -> Result<(), Stor
     if let Some(parent) = path.parent() { fs::create_dir_all(parent)?; }
     fs::write(path, s)?;
     Ok(())
+}
+
+/// Read the `name` of the `Let` expression at `let_node` inside
+/// `stage`'s body. Used by [`Store::apply_rename_local`] to record
+/// the rename source. Returns the same `TransformError` shapes as
+/// the transformer itself so callers see a consistent error
+/// vocabulary.
+fn read_let_name(
+    stage: &Stage,
+    let_node: &lex_ast::NodeId,
+) -> Result<String, lex_ast::TransformError> {
+    // The transformer is itself a pure function; ask it to perform
+    // a rename to a sentinel value and read the resulting let's
+    // original name from the output. Cheaper than duplicating the
+    // node-walk here, and stays correct as the transform evolves.
+    //
+    // We use a sentinel that's invalid as a Lex identifier so even
+    // if the rename somehow lands, downstream parsing would
+    // surface it loudly. (The transform path discards the renamed
+    // value — we only need the *original* name.)
+    let probed = lex_ast::rename_local(stage, let_node, "__lex_rename_probe__")?;
+    let Stage::FnDecl(fd) = probed else {
+        return Err(lex_ast::TransformError::NonFnTarget { stage_kind: "non-FnDecl" });
+    };
+    // Walk back to the probed let to read its old name from the
+    // *original* stage — the probed stage's let has already been
+    // renamed.
+    let Stage::FnDecl(orig_fd) = stage else {
+        return Err(lex_ast::TransformError::NonFnTarget { stage_kind: "non-FnDecl" });
+    };
+    // Path-based lookup matches the transformer's navigation.
+    let path = parse_let_node_path(let_node.as_str())?;
+    if path.is_empty() {
+        return Err(lex_ast::TransformError::NotALet {
+            at: let_node.as_str().into(),
+            found_kind: "stage_root",
+        });
+    }
+    if path[0] != orig_fd.params.len() + 1 {
+        return Err(lex_ast::TransformError::UnknownNode {
+            at: let_node.as_str().into(),
+        });
+    }
+    let inner = &path[1..];
+    let target = navigate_to_let(&orig_fd.body, inner, let_node.as_str())?;
+    let _ = fd; // probed stage discarded
+    Ok(target.to_string())
+}
+
+fn parse_let_node_path(id: &str) -> Result<Vec<usize>, lex_ast::TransformError> {
+    let s = id.strip_prefix("n_")
+        .ok_or_else(|| lex_ast::TransformError::BadNodeId(id.into()))?;
+    let mut parts = s.split('.');
+    let head = parts.next()
+        .ok_or_else(|| lex_ast::TransformError::BadNodeId(id.into()))?;
+    if head != "0" { return Err(lex_ast::TransformError::BadNodeId(id.into())); }
+    let mut out = Vec::new();
+    for p in parts {
+        out.push(p.parse::<usize>()
+            .map_err(|_| lex_ast::TransformError::BadNodeId(id.into()))?);
+    }
+    Ok(out)
+}
+
+fn navigate_to_let<'a>(
+    root: &'a lex_ast::CExpr,
+    path: &[usize],
+    at: &str,
+) -> Result<&'a str, lex_ast::TransformError> {
+    use lex_ast::CExpr::*;
+    let mut current = root;
+    for &idx in path {
+        current = match current {
+            Call { callee, args } => {
+                if idx == 0 { callee } else { args.get(idx - 1)
+                    .ok_or_else(|| lex_ast::TransformError::UnknownNode { at: at.into() })? }
+            }
+            Let { value, body, .. } => match idx {
+                0 => value, 1 => body,
+                _ => return Err(lex_ast::TransformError::UnknownNode { at: at.into() }),
+            },
+            Match { scrutinee, arms } => {
+                if idx == 0 { scrutinee } else {
+                    let arm_off = idx - 1;
+                    if arm_off % 2 != 1 {
+                        return Err(lex_ast::TransformError::UnknownNode { at: at.into() });
+                    }
+                    let arm_index = arm_off / 2;
+                    &arms.get(arm_index)
+                        .ok_or_else(|| lex_ast::TransformError::UnknownNode { at: at.into() })?
+                        .body
+                }
+            }
+            Block { statements, result } => {
+                if idx < statements.len() { &statements[idx] }
+                else if idx == statements.len() { result }
+                else { return Err(lex_ast::TransformError::UnknownNode { at: at.into() }); }
+            }
+            Constructor { args, .. } | TupleLit { items: args, .. }
+            | ListLit { items: args, .. } => args.get(idx)
+                .ok_or_else(|| lex_ast::TransformError::UnknownNode { at: at.into() })?,
+            RecordLit { fields } => &fields.get(idx)
+                .ok_or_else(|| lex_ast::TransformError::UnknownNode { at: at.into() })?
+                .value,
+            FieldAccess { value, .. } if idx == 0 => value,
+            Lambda { body, .. } if idx == 0 => body,
+            BinOp { lhs, rhs, .. } => match idx {
+                0 => lhs, 1 => rhs,
+                _ => return Err(lex_ast::TransformError::UnknownNode { at: at.into() }),
+            },
+            UnaryOp { expr, .. } if idx == 0 => expr,
+            Return { value } if idx == 0 => value,
+            _ => return Err(lex_ast::TransformError::UnknownNode { at: at.into() }),
+        };
+    }
+    let Let { name, .. } = current else {
+        return Err(lex_ast::TransformError::NotALet {
+            at: at.into(),
+            found_kind: lex_cexpr_kind(current),
+        });
+    };
+    Ok(name)
+}
+
+fn lex_cexpr_kind(e: &lex_ast::CExpr) -> &'static str {
+    use lex_ast::CExpr::*;
+    match e {
+        Literal { .. } => "Literal", Var { .. } => "Var",
+        Call { .. } => "Call", Let { .. } => "Let",
+        Match { .. } => "Match", Block { .. } => "Block",
+        Constructor { .. } => "Constructor", RecordLit { .. } => "RecordLit",
+        TupleLit { .. } => "TupleLit", ListLit { .. } => "ListLit",
+        FieldAccess { .. } => "FieldAccess", Lambda { .. } => "Lambda",
+        BinOp { .. } => "BinOp", UnaryOp { .. } => "UnaryOp",
+        Return { .. } => "Return",
+    }
 }
 
 /// Extract the declared `[budget(N)]` integer from a stage's

--- a/crates/lex-store/tests/rename_local.rs
+++ b/crates/lex-store/tests/rename_local.rs
@@ -1,0 +1,154 @@
+//! Conformance tests for #280 slice 2: typed `RenameLocal`
+//! transform + matching `OperationKind::RenameLocal` op.
+
+use lex_ast::{canonicalize_program, sig_id, stage_id, CExpr, NodeId, Stage};
+use lex_store::{Store, DEFAULT_BRANCH};
+use lex_syntax::parse_source;
+use tempfile::TempDir;
+
+fn fresh() -> (Store, TempDir) {
+    let tmp = TempDir::new().unwrap();
+    let s = Store::open(tmp.path()).unwrap();
+    (s, tmp)
+}
+
+fn stage_named(src: &str, name: &str) -> Stage {
+    let prog = parse_source(src).unwrap();
+    canonicalize_program(&prog)
+        .into_iter()
+        .find(|s| match s {
+            Stage::FnDecl(fd) => fd.name == name,
+            _ => false,
+        })
+        .expect("stage not found")
+}
+
+const ADD_TWO_SRC: &str =
+    "fn add_two(n :: Int) -> Int { let x := n + 1; x + 1 }\n";
+
+/// `add_two` has one param + body = let at NodeId `n_0.2`.
+fn let_node() -> NodeId { NodeId("n_0.2".into()) }
+
+fn publish_initial_add_two(store: &Store) -> (String, String) {
+    let s = stage_named(ADD_TWO_SRC, "add_two");
+    let sig = sig_id(&s).unwrap();
+    let stg = stage_id(&s).unwrap();
+    store.publish(&s).unwrap();
+    let op = lex_vcs::Operation::new(
+        lex_vcs::OperationKind::AddFunction {
+            sig_id: sig.clone(),
+            stage_id: stg.clone(),
+            effects: Default::default(),
+            budget_cost: None,
+        },
+        [],
+    );
+    let t = lex_vcs::StageTransition::Create {
+        sig_id: sig.clone(),
+        stage_id: stg.clone(),
+    };
+    store.apply_operation(DEFAULT_BRANCH, op, t).unwrap();
+    (sig, stg)
+}
+
+#[test]
+fn rename_local_lands_a_typed_op_on_the_branch() {
+    let (store, _tmp) = fresh();
+    let (sig, from_stage_id) = publish_initial_add_two(&store);
+
+    let op_id = store
+        .apply_rename_local(DEFAULT_BRANCH, &from_stage_id, &let_node(), "y")
+        .expect("rename should succeed on well-typed input");
+
+    let log = lex_vcs::OpLog::open(store.root()).unwrap();
+    let rec = log.get(&op_id).unwrap().unwrap();
+    let lex_vcs::OperationKind::RenameLocal {
+        sig_id: rec_sig,
+        from_stage_id: rec_from,
+        let_node,
+        old_name,
+        new_name,
+        ..
+    } = &rec.op.kind else {
+        panic!("expected RenameLocal op kind, got {:?}", rec.op.kind);
+    };
+    assert_eq!(rec_sig, &sig);
+    assert_eq!(rec_from, &from_stage_id);
+    assert_eq!(let_node, "n_0.2");
+    assert_eq!(old_name, "x");
+    assert_eq!(new_name, "y");
+
+    let head = store.branch_head(DEFAULT_BRANCH).unwrap();
+    assert_ne!(head.get(&sig), Some(&from_stage_id));
+}
+
+#[test]
+fn rename_local_reconstructs_through_get_ast() {
+    let (store, _tmp) = fresh();
+    let (_sig, from_stage_id) = publish_initial_add_two(&store);
+
+    let op_id = store
+        .apply_rename_local(DEFAULT_BRANCH, &from_stage_id, &let_node(), "y")
+        .unwrap();
+    let log = lex_vcs::OpLog::open(store.root()).unwrap();
+    let rec = log.get(&op_id).unwrap().unwrap();
+    let lex_vcs::OperationKind::RenameLocal { to_stage_id, .. } = &rec.op.kind else {
+        panic!();
+    };
+
+    let reloaded = store.get_ast(to_stage_id).unwrap();
+    let Stage::FnDecl(fd) = reloaded else { panic!() };
+    let CExpr::Let { name, body, .. } = fd.body else { panic!() };
+    assert_eq!(name, "y", "binding renamed");
+    // body's LHS now references `y`.
+    let CExpr::BinOp { lhs, .. } = *body else { panic!() };
+    assert!(matches!(*lhs, CExpr::Var { name: ref n } if n == "y"));
+}
+
+#[test]
+fn rename_local_refuses_no_op() {
+    let (store, _tmp) = fresh();
+    let (_sig, from_stage_id) = publish_initial_add_two(&store);
+
+    let err = store
+        .apply_rename_local(DEFAULT_BRANCH, &from_stage_id, &let_node(), "x")
+        .unwrap_err();
+    assert!(matches!(err, lex_store::StoreError::TransformError(
+        lex_ast::TransformError::RenameNoOp { .. }
+    )), "got {err:?}");
+}
+
+#[test]
+fn rename_local_emits_typecheck_attestation() {
+    let (store, _tmp) = fresh();
+    let (_sig, from_stage_id) = publish_initial_add_two(&store);
+
+    let op_id = store
+        .apply_rename_local(DEFAULT_BRANCH, &from_stage_id, &let_node(), "y")
+        .unwrap();
+
+    let log = lex_vcs::OpLog::open(store.root()).unwrap();
+    let rec = log.get(&op_id).unwrap().unwrap();
+    let lex_vcs::OperationKind::RenameLocal { to_stage_id, .. } = &rec.op.kind else {
+        panic!();
+    };
+    let attlog = store.attestation_log().unwrap();
+    let by_stage = attlog.list_for_stage(to_stage_id).unwrap();
+    assert!(
+        by_stage.iter().any(|a| matches!(a.kind, lex_vcs::AttestationKind::TypeCheck)),
+        "TypeCheck attestation should accompany the renamed stage"
+    );
+}
+
+#[test]
+fn rename_local_surfaces_transform_errors_for_wrong_node() {
+    let (store, _tmp) = fresh();
+    let (_sig, from_stage_id) = publish_initial_add_two(&store);
+
+    // Target a NodeId that doesn't address a Let.
+    let err = store
+        .apply_rename_local(DEFAULT_BRANCH, &from_stage_id, &NodeId("n_0.99".into()), "y")
+        .unwrap_err();
+    assert!(matches!(err, lex_store::StoreError::TransformError(_)),
+        "got {err:?}");
+}

--- a/crates/lex-vcs/src/merge.rs
+++ b/crates/lex-vcs/src/merge.rs
@@ -137,7 +137,8 @@ fn touched_sigs(k: &OperationKind) -> Vec<SigId> {
         | OperationKind::AddType { sig_id, .. }
         | OperationKind::RemoveType { sig_id, .. }
         | OperationKind::ModifyType { sig_id, .. }
-        | OperationKind::ReplaceMatchArm { sig_id, .. } => vec![sig_id.clone()],
+        | OperationKind::ReplaceMatchArm { sig_id, .. }
+        | OperationKind::RenameLocal { sig_id, .. } => vec![sig_id.clone()],
         // A rename touches both sides — concurrent modifies on `from`
         // must surface as a conflict, not as a disjoint set.
         OperationKind::RenameSymbol { from, to, .. } => vec![from.clone(), to.clone()],

--- a/crates/lex-vcs/src/merge_session.rs
+++ b/crates/lex-vcs/src/merge_session.rs
@@ -77,6 +77,12 @@ pub struct ConflictRecord {
 }
 
 /// Choice for a single conflict.
+// `Operation` is the only payload-carrying variant and grew with
+// #280's typed transforms. Clippy flags the size disparity, but
+// boxing the field would churn callers (HTTP handler, CLI, tests)
+// for a heuristic warning — the heap allocation cost vs. the
+// occasional empty variant is not actually a hot path here.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum Resolution {

--- a/crates/lex-vcs/src/operation.rs
+++ b/crates/lex-vcs/src/operation.rs
@@ -219,6 +219,24 @@ pub enum OperationKind {
     Merge {
         resolved: usize,
     },
+    /// Typed transform: renamed a `let`-bound local within a fn
+    /// body (#280). Records the old/new identifiers and the position
+    /// of the let-binding in the AST. Body-shape-stable: the renamed
+    /// stage typically hashes near the original.
+    RenameLocal {
+        sig_id: SigId,
+        from_stage_id: StageId,
+        to_stage_id: StageId,
+        /// Path-style NodeId of the `Let` expression at the time of
+        /// the transform.
+        let_node: String,
+        old_name: String,
+        new_name: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        from_budget: Option<u64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        to_budget: Option<u64>,
+    },
     /// Typed transform: replaced one arm's body in a `Match`
     /// expression (#280). Semantically a `ModifyBody`, but the op
     /// records *which* arm changed and *where* in the AST — so the
@@ -272,6 +290,7 @@ impl OperationKind {
             | ChangeEffectSig { sig_id, to_stage_id, .. }
             | ModifyType { sig_id, to_stage_id, .. }
             | ReplaceMatchArm { sig_id, to_stage_id, .. }
+            | RenameLocal { sig_id, to_stage_id, .. }
                 => Some((sig_id.clone(), Some(to_stage_id.clone()))),
             RemoveFunction { sig_id, .. }
             | RemoveType { sig_id, .. }
@@ -294,7 +313,8 @@ impl OperationKind {
             AddFunction { budget_cost, .. } => (None, *budget_cost),
             ModifyBody { from_budget, to_budget, .. }
             | ChangeEffectSig { from_budget, to_budget, .. }
-            | ReplaceMatchArm { from_budget, to_budget, .. } => (*from_budget, *to_budget),
+            | ReplaceMatchArm { from_budget, to_budget, .. }
+            | RenameLocal { from_budget, to_budget, .. } => (*from_budget, *to_budget),
             _ => (None, None),
         }
     }
@@ -309,7 +329,8 @@ impl OperationKind {
             AddFunction { sig_id, .. }
             | ModifyBody { sig_id, .. }
             | ChangeEffectSig { sig_id, .. }
-            | ReplaceMatchArm { sig_id, .. } => Some(sig_id),
+            | ReplaceMatchArm { sig_id, .. }
+            | RenameLocal { sig_id, .. } => Some(sig_id),
             _ => None,
         }
     }

--- a/crates/lex-vcs/tests/opid_golden.rs
+++ b/crates/lex-vcs/tests/opid_golden.rs
@@ -333,5 +333,6 @@ fn variant_tag(k: &OperationKind) -> &'static str {
         OperationKind::ModifyType { .. } => "modify_type",
         OperationKind::Merge { .. } => "merge",
         OperationKind::ReplaceMatchArm { .. } => "replace_match_arm",
+        OperationKind::RenameLocal { .. } => "rename_local",
     }
 }


### PR DESCRIPTION
Second slice of #280 — typed refactoring operations.

## Summary

`RenameLocal` renames a `let`-bound local within a fn body, walking the binding's body scope and rewriting every unshadowed reference.

- **`lex_ast::rename_local(stage, let_node, new_name)`** — pure-function AST transform. Scope-aware:
  - Inner `Let { name: old }` shadows → don't descend into its body.
  - `Lambda` with a param named `old` shadows → don't descend.
  - `Match` arm with a pattern that binds `old` shadows → don't descend.
  - The let's `value` is evaluated in the outer scope; left untouched (Lex `let` is non-recursive).
  - Refuses no-op renames at the API boundary (`RenameNoOp`).
- **`OperationKind::RenameLocal { sig_id, from_stage_id, to_stage_id, let_node, old_name, new_name, from_budget, to_budget }`** records the rename in the op log; same `skip_if_none` budget discipline as the rest of #280's variants.
- **`Store::apply_rename_local`** — same end-to-end shape as `apply_replace_match_arm`: load AST → transform → publish → re-typecheck → emit op.

## Test plan

- [x] 6 unit tests in `lex_ast::transforms` (rename + body refs; no-op refusal; inner-`Let` shadow; `Lambda` param shadow; `Match` pattern shadow; not-a-Let target).
- [x] 5 conformance tests in `crates/lex-store/tests/rename_local.rs` (lands typed op, `get_ast` reconstruction, no-op refusal, TypeCheck attestation, transform-error surface).
- [x] `cargo test --workspace` — 170 test groups pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.

## Drive-by

`#[allow(clippy::large_enum_variant)]` on `merge_session::Resolution`. `Custom { op: Operation }` is the only payload variant; #280's op-kind growth tripped a size-disparity heuristic. Boxing the field would churn HTTP handler / CLI / test call sites without addressing a real hot path.

## What's still out for #280

`InlineLet` (substitute a let-bound local into its body) and `ExtractFunction` (extract a subexpression into a new sig + stage, with free-variable analysis). Each will land separately.

https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_