### PR TITLE
lex-ast+vcs+store: typed InlineLet transform (#280 slice 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+### Added — agent-VCS roadmap (#280, slice 3)
+
+- **Typed `InlineLet` transform** (#280 slice 3). Eliminates a
+  `let x := v; body` by substituting `v` for every unshadowed `x`
+  in `body`, then replacing the `Let` node with the substituted
+  body. New `lex_ast::inline_let(stage, let_node)` runs the
+  transform deterministically.
+- **Safety restrictions**: `v` must be capture-free and
+  side-effect-free — only `Literal`, `Var`, `FieldAccess`, and
+  `BinOp`/`UnaryOp`/`TupleLit`/`ListLit` trees over those leaves
+  are accepted. Calls, lambdas, blocks, lets, matches in `v` are
+  refused with `TransformError::InlineLetRefused` so a future
+  slice can lift the restriction without changing the error
+  contract. Free-variable capture (a free var of `v` is re-bound
+  in `body`) is detected and refused too.
+- **`OperationKind::InlineLet { sig_id, from_stage_id,
+  to_stage_id, let_node, binding_name, from_budget, to_budget }`**
+  records the inlined name + position. Same `skip_if_none` budget
+  discipline as the other transform variants.
+- **`Store::apply_inline_let`** wraps the end-to-end flow.
+- 5 unit tests (substitution, call refusal, capture refusal,
+  shadowing, not-a-Let target). 4 conformance tests
+  (`crates/lex-store/tests/inline_let.rs`) covering op landing,
+  AST reconstruction, attestation emission, transform-error
+  surface.
+
+The fourth and final slice (`ExtractFunction`) remains a
+follow-up on #280.
+
 ### Added — agent-VCS roadmap (#280, slice 2)
 
 - **Typed `RenameLocal` transform** (#280 slice 2). Second of the

--- a/crates/lex-ast/src/lib.rs
+++ b/crates/lex-ast/src/lib.rs
@@ -17,7 +17,7 @@ pub use canonicalize::{canonicalize_program, canonicalize_item};
 pub use canon_print::print_stages;
 pub use ids::{collect_ids, expr_ids, NodeId, NodeRef};
 pub use patch::{apply_patch, Patch, PatchError};
-pub use transforms::{rename_local, replace_match_arm, TransformError};
+pub use transforms::{inline_let, rename_local, replace_match_arm, TransformError};
 
 /// SHA-256 over the canonical-JSON encoding of a stage. Excludes NodeIds
 /// (the canonical AST data does not carry IDs; they're derived).

--- a/crates/lex-ast/src/transforms.rs
+++ b/crates/lex-ast/src/transforms.rs
@@ -23,8 +23,12 @@
 //!   match expression. Pattern is preserved.
 //! - [`rename_local`] — renames a `let`-bound local. Walks the
 //!   binding's body scope and rewrites every unshadowed reference.
+//! - [`inline_let`] — eliminates a `let x := v; body` by
+//!   substituting `v` for every unshadowed `x` in `body`. The let
+//!   value is restricted to capture-free, side-effect-free
+//!   expressions (literals, vars, field access, binops on those).
 //!
-//! Future slices: `inline_let`, `extract_function`.
+//! Future slices: `extract_function`.
 
 use crate::canonical::{CExpr, Pattern, Stage};
 use crate::ids::NodeId;
@@ -46,6 +50,8 @@ pub enum TransformError {
     NonFnTarget { stage_kind: &'static str },
     #[error("rename is a no-op: old and new name are both `{name}`")]
     RenameNoOp { name: String },
+    #[error("inline_let refused: `{reason}`")]
+    InlineLetRefused { reason: String },
 }
 
 /// Replace `match_node`'s arm at `arm_index` with a new body,
@@ -160,6 +166,316 @@ pub fn rename_local(
     // Walk the body scope. Stop renaming at shadow points.
     rewrite_var_in_expr(let_body, &old_name, new_name);
     Ok(out)
+}
+
+/// Inline a `let x := v; body` by substituting `v` for every
+/// unshadowed occurrence of `x` in `body`, then replacing the
+/// entire `Let` node with the substituted `body`.
+///
+/// Restrictions (slice 3):
+/// - `v` must be capture-free, side-effect-free, and cheap to
+///   duplicate: only `Literal`, `Var`, `FieldAccess`, and `BinOp`/
+///   `UnaryOp` trees over those primitives are accepted. Calls,
+///   lambdas, blocks, lets, matches in `v` are refused with
+///   `InlineLetRefused` so a future slice can lift the restriction
+///   without changing the error contract.
+/// - None of `v`'s free variables may be re-bound (shadowed)
+///   anywhere in `body`. Inlining `let x := y; let y := …; x` is
+///   refused because the inner `let y` would capture the inlined
+///   `y` and silently change semantics.
+///
+/// Refuses no-ops at the API boundary: a `let x := v; x` body
+/// (single direct reference) is fine; a `let x := v; { }` body
+/// with zero references is *not* refused — the let is still
+/// eliminated, which is the user-visible point of inlining.
+pub fn inline_let(
+    stage: &Stage,
+    let_node: &NodeId,
+) -> Result<Stage, TransformError> {
+    let mut out = stage.clone();
+    let (body, n_params) = match &mut out {
+        Stage::FnDecl(fd) => {
+            let n = fd.params.len();
+            (&mut fd.body, n)
+        }
+        Stage::TypeDecl(_) => return Err(TransformError::NonFnTarget { stage_kind: "TypeDecl" }),
+        Stage::Import(_) => return Err(TransformError::NonFnTarget { stage_kind: "Import" }),
+    };
+    let path = parse_node_id(let_node.as_str())?;
+    if path.is_empty() {
+        return Err(TransformError::NotALet {
+            at: let_node.as_str().into(),
+            found_kind: "stage_root",
+        });
+    }
+    if path[0] != n_params + 1 {
+        return Err(TransformError::UnknownNode { at: let_node.as_str().into() });
+    }
+    let inner = &path[1..];
+    // Special case: when the path is `n_<n+1>` exactly (no further
+    // descent), the target is the FnDecl's body root. We swap it
+    // for the inlined body wholesale.
+    if inner.is_empty() {
+        let CExpr::Let { name, value, body: let_body, .. } = body.clone() else {
+            return Err(TransformError::NotALet {
+                at: let_node.as_str().into(),
+                found_kind: cexpr_kind(body),
+            });
+        };
+        check_inlinable(&value)?;
+        let captures = free_vars(&value);
+        check_no_capture(&let_body, &captures)?;
+        let mut replaced = *let_body;
+        substitute_in_expr(&mut replaced, &name, &value);
+        *body = replaced;
+        return Ok(out);
+    }
+    // Otherwise descend to the parent of the let node, capture the
+    // let's owned contents, and splice the inlined body into its
+    // slot. We re-use `navigate_to_expr` to reach the let, clone
+    // its parts, then mutate the slot in place.
+    let target = navigate_to_expr(body, inner, let_node.as_str())?;
+    let CExpr::Let { name, value, body: let_body, .. } = target.clone() else {
+        return Err(TransformError::NotALet {
+            at: let_node.as_str().into(),
+            found_kind: cexpr_kind(target),
+        });
+    };
+    check_inlinable(&value)?;
+    let captures = free_vars(&value);
+    check_no_capture(&let_body, &captures)?;
+    let mut replaced = *let_body;
+    substitute_in_expr(&mut replaced, &name, &value);
+    *target = replaced;
+    Ok(out)
+}
+
+/// True when `v` is restricted to the slice-3 inline-safe shape:
+/// literals, vars, field accesses, binops/unaryops on those. No
+/// calls, lambdas, blocks, lets, matches, constructors, record
+/// literals, or returns.
+fn check_inlinable(v: &CExpr) -> Result<(), TransformError> {
+    match v {
+        CExpr::Literal { .. } | CExpr::Var { .. } => Ok(()),
+        CExpr::FieldAccess { value, .. } => check_inlinable(value),
+        CExpr::BinOp { lhs, rhs, .. } => {
+            check_inlinable(lhs)?;
+            check_inlinable(rhs)
+        }
+        CExpr::UnaryOp { expr, .. } => check_inlinable(expr),
+        CExpr::TupleLit { items } | CExpr::ListLit { items } => {
+            for it in items { check_inlinable(it)?; }
+            Ok(())
+        }
+        other => Err(TransformError::InlineLetRefused {
+            reason: format!(
+                "let value contains a `{}` expression; slice 3 only inlines literal/var/field/binop/unaryop/tuple/list trees",
+                cexpr_kind(other)
+            ),
+        }),
+    }
+}
+
+/// Collect the set of variable names that appear free in `v`.
+/// Order-independent (`BTreeSet` for determinism in tests).
+fn free_vars(v: &CExpr) -> std::collections::BTreeSet<String> {
+    let mut out = std::collections::BTreeSet::new();
+    collect_free_vars(v, &mut out);
+    out
+}
+
+fn collect_free_vars(e: &CExpr, out: &mut std::collections::BTreeSet<String>) {
+    match e {
+        CExpr::Var { name } => { out.insert(name.clone()); }
+        CExpr::Literal { .. } => {}
+        CExpr::Call { callee, args } => {
+            collect_free_vars(callee, out);
+            for a in args { collect_free_vars(a, out); }
+        }
+        CExpr::Let { value, body, name, .. } => {
+            collect_free_vars(value, out);
+            // Body sees the let binding. We approximate: collect
+            // body's free vars, then remove the let's name.
+            let mut inner = std::collections::BTreeSet::new();
+            collect_free_vars(body, &mut inner);
+            inner.remove(name);
+            out.extend(inner);
+        }
+        CExpr::Match { scrutinee, arms } => {
+            collect_free_vars(scrutinee, out);
+            for arm in arms {
+                let mut inner = std::collections::BTreeSet::new();
+                collect_free_vars(&arm.body, &mut inner);
+                let bound = pattern_bindings(&arm.pattern);
+                for b in bound { inner.remove(&b); }
+                out.extend(inner);
+            }
+        }
+        CExpr::Block { statements, result } => {
+            for s in statements { collect_free_vars(s, out); }
+            collect_free_vars(result, out);
+        }
+        CExpr::Constructor { args, .. } => {
+            for a in args { collect_free_vars(a, out); }
+        }
+        CExpr::RecordLit { fields } => {
+            for f in fields { collect_free_vars(&f.value, out); }
+        }
+        CExpr::TupleLit { items } | CExpr::ListLit { items } => {
+            for i in items { collect_free_vars(i, out); }
+        }
+        CExpr::FieldAccess { value, .. } => collect_free_vars(value, out),
+        CExpr::Lambda { params, body, .. } => {
+            let mut inner = std::collections::BTreeSet::new();
+            collect_free_vars(body, &mut inner);
+            for p in params { inner.remove(&p.name); }
+            out.extend(inner);
+        }
+        CExpr::BinOp { lhs, rhs, .. } => {
+            collect_free_vars(lhs, out);
+            collect_free_vars(rhs, out);
+        }
+        CExpr::UnaryOp { expr, .. } => collect_free_vars(expr, out),
+        CExpr::Return { value } => collect_free_vars(value, out),
+    }
+}
+
+fn pattern_bindings(p: &Pattern) -> Vec<String> {
+    let mut out = Vec::new();
+    collect_pattern_bindings(p, &mut out);
+    out
+}
+
+fn collect_pattern_bindings(p: &Pattern, out: &mut Vec<String>) {
+    match p {
+        Pattern::PVar { name } => out.push(name.clone()),
+        Pattern::PLiteral { .. } | Pattern::PWild => {}
+        Pattern::PConstructor { args, .. } => for p in args { collect_pattern_bindings(p, out); }
+        Pattern::PRecord { fields } => for f in fields { collect_pattern_bindings(&f.pattern, out); }
+        Pattern::PTuple { items } => for p in items { collect_pattern_bindings(p, out); }
+    }
+}
+
+/// Walk `body`; if any sub-tree introduces a binder whose name is
+/// in `captures`, refuse the inline. We don't need to track scope
+/// here — any shadow at any depth is a problem, because once we
+/// inline, that shadow would capture a name in the substituted
+/// value.
+fn check_no_capture(
+    body: &CExpr,
+    captures: &std::collections::BTreeSet<String>,
+) -> Result<(), TransformError> {
+    let mut conflict: Option<String> = None;
+    walk_binders(body, &mut |name| {
+        if captures.contains(name) && conflict.is_none() {
+            conflict = Some(name.to_string());
+        }
+    });
+    if let Some(name) = conflict {
+        return Err(TransformError::InlineLetRefused {
+            reason: format!(
+                "value's free var `{name}` is re-bound in the body; inlining would capture"
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn walk_binders(e: &CExpr, on_binder: &mut dyn FnMut(&str)) {
+    match e {
+        CExpr::Let { name, value, body, .. } => {
+            on_binder(name);
+            walk_binders(value, on_binder);
+            walk_binders(body, on_binder);
+        }
+        CExpr::Lambda { params, body, .. } => {
+            for p in params { on_binder(&p.name); }
+            walk_binders(body, on_binder);
+        }
+        CExpr::Match { scrutinee, arms } => {
+            walk_binders(scrutinee, on_binder);
+            for arm in arms {
+                for b in pattern_bindings(&arm.pattern) { on_binder(&b); }
+                walk_binders(&arm.body, on_binder);
+            }
+        }
+        CExpr::Call { callee, args } => {
+            walk_binders(callee, on_binder);
+            for a in args { walk_binders(a, on_binder); }
+        }
+        CExpr::Block { statements, result } => {
+            for s in statements { walk_binders(s, on_binder); }
+            walk_binders(result, on_binder);
+        }
+        CExpr::Constructor { args, .. } => for a in args { walk_binders(a, on_binder); }
+        CExpr::RecordLit { fields } => for f in fields { walk_binders(&f.value, on_binder); }
+        CExpr::TupleLit { items } | CExpr::ListLit { items } => {
+            for i in items { walk_binders(i, on_binder); }
+        }
+        CExpr::FieldAccess { value, .. } => walk_binders(value, on_binder),
+        CExpr::BinOp { lhs, rhs, .. } => {
+            walk_binders(lhs, on_binder); walk_binders(rhs, on_binder);
+        }
+        CExpr::UnaryOp { expr, .. } => walk_binders(expr, on_binder),
+        CExpr::Return { value } => walk_binders(value, on_binder),
+        CExpr::Var { .. } | CExpr::Literal { .. } => {}
+    }
+}
+
+/// Substitute every unshadowed reference to `name` in `e` with a
+/// clone of `replacement`. Shadowing rules match `rewrite_var_in_expr`:
+/// inner `Let` / `Lambda param` / `Match pattern` that re-binds
+/// `name` cuts off descent.
+fn substitute_in_expr(e: &mut CExpr, name: &str, replacement: &CExpr) {
+    match e {
+        CExpr::Var { name: n } if n == name => {
+            *e = replacement.clone();
+        }
+        CExpr::Var { .. } | CExpr::Literal { .. } => {}
+        CExpr::Call { callee, args } => {
+            substitute_in_expr(callee, name, replacement);
+            for a in args { substitute_in_expr(a, name, replacement); }
+        }
+        CExpr::Let { name: binder, value, body, .. } => {
+            substitute_in_expr(value, name, replacement);
+            if binder != name {
+                substitute_in_expr(body, name, replacement);
+            }
+        }
+        CExpr::Match { scrutinee, arms } => {
+            substitute_in_expr(scrutinee, name, replacement);
+            for arm in arms {
+                if !pattern_binds(&arm.pattern, name) {
+                    substitute_in_expr(&mut arm.body, name, replacement);
+                }
+            }
+        }
+        CExpr::Block { statements, result } => {
+            for s in statements { substitute_in_expr(s, name, replacement); }
+            substitute_in_expr(result, name, replacement);
+        }
+        CExpr::Constructor { args, .. } => {
+            for a in args { substitute_in_expr(a, name, replacement); }
+        }
+        CExpr::RecordLit { fields } => {
+            for f in fields { substitute_in_expr(&mut f.value, name, replacement); }
+        }
+        CExpr::TupleLit { items } | CExpr::ListLit { items } => {
+            for i in items { substitute_in_expr(i, name, replacement); }
+        }
+        CExpr::FieldAccess { value, .. } => substitute_in_expr(value, name, replacement),
+        CExpr::Lambda { params, body, .. } => {
+            if !params.iter().any(|p| p.name == name) {
+                substitute_in_expr(body, name, replacement);
+            }
+        }
+        CExpr::BinOp { lhs, rhs, .. } => {
+            substitute_in_expr(lhs, name, replacement);
+            substitute_in_expr(rhs, name, replacement);
+        }
+        CExpr::UnaryOp { expr, .. } => substitute_in_expr(expr, name, replacement),
+        CExpr::Return { value } => substitute_in_expr(value, name, replacement),
+    }
 }
 
 fn rewrite_var_in_expr(e: &mut CExpr, old: &str, new: &str) {
@@ -521,6 +837,150 @@ mod tests {
         let err = rename_local(&stage, &NodeId("n_0.2".into()), "y").unwrap_err();
         assert!(matches!(err, TransformError::NotALet { found_kind: "Match", .. }),
             "got {err:?}");
+    }
+
+    // ---- inline_let fixtures + tests -------------------------------
+
+    /// `fn f(n :: Int) -> Int { let x := 5; x + n }`
+    fn inlinable_stage() -> Stage {
+        let body = CExpr::Let {
+            name: "x".into(),
+            ty: None,
+            value: Box::new(CExpr::Literal { value: CLit::Int { value: 5 } }),
+            body: Box::new(CExpr::BinOp {
+                op: "+".into(),
+                lhs: Box::new(CExpr::Var { name: "x".into() }),
+                rhs: Box::new(CExpr::Var { name: "n".into() }),
+            }),
+        };
+        Stage::FnDecl(FnDecl {
+            name: "f".into(),
+            type_params: Vec::new(),
+            params: vec![Param {
+                name: "n".into(),
+                ty: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
+            }],
+            effects: Vec::new(),
+            return_type: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
+            body,
+        })
+    }
+
+    #[test]
+    fn inline_let_substitutes_literal_value() {
+        let stage = inlinable_stage();
+        let out = inline_let(&stage, &NodeId("n_0.2".into())).unwrap();
+        let Stage::FnDecl(fd) = out else { panic!() };
+        // The Let is gone; body root is now `5 + n`.
+        let CExpr::BinOp { lhs, .. } = fd.body else { panic!() };
+        assert!(matches!(*lhs, CExpr::Literal { value: CLit::Int { value: 5 } }));
+    }
+
+    #[test]
+    fn inline_let_refuses_call_in_value() {
+        // `let x := f(); x`  →  refused, `f()` may have effects.
+        let body = CExpr::Let {
+            name: "x".into(),
+            ty: None,
+            value: Box::new(CExpr::Call {
+                callee: Box::new(CExpr::Var { name: "f".into() }),
+                args: Vec::new(),
+            }),
+            body: Box::new(CExpr::Var { name: "x".into() }),
+        };
+        let stage = Stage::FnDecl(FnDecl {
+            name: "g".into(),
+            type_params: Vec::new(),
+            params: Vec::new(),
+            effects: Vec::new(),
+            return_type: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
+            body,
+        });
+        let err = inline_let(&stage, &NodeId("n_0.1".into())).unwrap_err();
+        assert!(matches!(err, TransformError::InlineLetRefused { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn inline_let_refuses_capture() {
+        // `let x := y; let y := 7; x + y`
+        // Inlining `x` would capture `y`. Must refuse.
+        let inner = CExpr::Let {
+            name: "y".into(),
+            ty: None,
+            value: Box::new(CExpr::Literal { value: CLit::Int { value: 7 } }),
+            body: Box::new(CExpr::BinOp {
+                op: "+".into(),
+                lhs: Box::new(CExpr::Var { name: "x".into() }),
+                rhs: Box::new(CExpr::Var { name: "y".into() }),
+            }),
+        };
+        let body = CExpr::Let {
+            name: "x".into(),
+            ty: None,
+            value: Box::new(CExpr::Var { name: "y".into() }),
+            body: Box::new(inner),
+        };
+        let stage = Stage::FnDecl(FnDecl {
+            name: "g".into(),
+            type_params: Vec::new(),
+            params: vec![Param {
+                name: "y".into(),
+                ty: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
+            }],
+            effects: Vec::new(),
+            return_type: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
+            body,
+        });
+        // Let `x` is at child index 2 (1 param + return + body slot).
+        let err = inline_let(&stage, &NodeId("n_0.2".into())).unwrap_err();
+        assert!(matches!(err, TransformError::InlineLetRefused { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn inline_let_substitutes_under_shadowing() {
+        // `let x := 5; let x := n; x + 1`
+        // Inner let SHADOWS the outer `x`. Inlining the OUTER `x`
+        // should affect nothing because the inner shadow cuts off
+        // descent. The outer let is still eliminated.
+        let inner = CExpr::Let {
+            name: "x".into(),
+            ty: None,
+            value: Box::new(CExpr::Var { name: "n".into() }),
+            body: Box::new(CExpr::BinOp {
+                op: "+".into(),
+                lhs: Box::new(CExpr::Var { name: "x".into() }),
+                rhs: Box::new(CExpr::Literal { value: CLit::Int { value: 1 } }),
+            }),
+        };
+        let body = CExpr::Let {
+            name: "x".into(),
+            ty: None,
+            value: Box::new(CExpr::Literal { value: CLit::Int { value: 5 } }),
+            body: Box::new(inner),
+        };
+        let stage = Stage::FnDecl(FnDecl {
+            name: "g".into(),
+            type_params: Vec::new(),
+            params: vec![Param {
+                name: "n".into(),
+                ty: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
+            }],
+            effects: Vec::new(),
+            return_type: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
+            body,
+        });
+        let out = inline_let(&stage, &NodeId("n_0.2".into())).unwrap();
+        let Stage::FnDecl(fd) = out else { panic!() };
+        // Outer let removed; body is the inner Let.
+        let CExpr::Let { name, .. } = fd.body else { panic!() };
+        assert_eq!(name, "x", "inner let preserved");
+    }
+
+    #[test]
+    fn inline_let_not_a_let_target_errors() {
+        let stage = match_stage_with_two_arms();
+        let err = inline_let(&stage, &NodeId("n_0.2".into())).unwrap_err();
+        assert!(matches!(err, TransformError::NotALet { found_kind: "Match", .. }));
     }
 
     // ---- replace_match_arm fixtures + tests ------------------------

--- a/crates/lex-cli/src/docs.rs
+++ b/crates/lex-cli/src/docs.rs
@@ -258,6 +258,7 @@ fn op_kind_tag(k: &lex_vcs::OperationKind) -> &'static str {
         Merge { .. }           => "merge",
         ReplaceMatchArm { .. } => "replace_match_arm",
         RenameLocal { .. }     => "rename_local",
+        InlineLet { .. }       => "inline_let",
     }
 }
 

--- a/crates/lex-store/src/store.rs
+++ b/crates/lex-store/src/store.rs
@@ -1151,6 +1151,68 @@ impl Store {
         self.apply_operation_checked(branch, op, transition, &candidate)
     }
 
+    /// Apply a typed `InlineLet` transform (#280) — eliminate a
+    /// `let x := v; body` by substituting `v` for every unshadowed
+    /// `x` in `body`, then replacing the `Let` node with the
+    /// substituted body. Same end-to-end shape as
+    /// [`Self::apply_replace_match_arm`].
+    pub fn apply_inline_let(
+        &self,
+        branch: &str,
+        from_stage_id: &str,
+        let_node: &lex_ast::NodeId,
+    ) -> Result<lex_vcs::OpId, StoreError> {
+        let from_stage = self.get_ast(from_stage_id)?;
+        let binding_name = read_let_name(&from_stage, let_node)
+            .map_err(StoreError::TransformError)?;
+        let new_stage = lex_ast::inline_let(&from_stage, let_node)
+            .map_err(StoreError::TransformError)?;
+        let sig = lex_ast::sig_id(&from_stage)
+            .ok_or(StoreError::CannotPublishImport)?;
+        let to_stage_id = self.publish(&new_stage)?;
+        if to_stage_id == from_stage_id {
+            return Err(StoreError::InvalidTransition(format!(
+                "inline_let produced the same stage_id `{from_stage_id}`"
+            )));
+        }
+        let head = self.branch_head(branch)?;
+        let mut candidate: Vec<lex_ast::Stage> = Vec::with_capacity(head.len());
+        for (other_sig, other_stage_id) in &head {
+            if other_sig == &sig {
+                candidate.push(new_stage.clone());
+            } else {
+                candidate.push(self.get_ast(other_stage_id)?);
+            }
+        }
+        if !head.contains_key(&sig) {
+            return Err(StoreError::InvalidTransition(format!(
+                "sig `{sig}` not on branch `{branch}`'s head"
+            )));
+        }
+        let from_budget = budget_of_stage(&from_stage);
+        let to_budget = budget_of_stage(&new_stage);
+        let head_now = self.get_branch(branch)?.and_then(|b| b.head_op);
+        let kind = lex_vcs::OperationKind::InlineLet {
+            sig_id: sig.clone(),
+            from_stage_id: from_stage_id.to_string(),
+            to_stage_id: to_stage_id.clone(),
+            let_node: let_node.as_str().to_string(),
+            binding_name,
+            from_budget,
+            to_budget,
+        };
+        let transition = lex_vcs::StageTransition::Replace {
+            sig_id: sig.clone(),
+            from: from_stage_id.to_string(),
+            to: to_stage_id.clone(),
+        };
+        let op = lex_vcs::Operation::new(
+            kind,
+            head_now.into_iter().collect::<Vec<_>>(),
+        );
+        self.apply_operation_checked(branch, op, transition, &candidate)
+    }
+
     /// `set_branch_head_op` for the durability story on the branch
     /// file itself.
     pub fn apply_operation(
@@ -1465,7 +1527,8 @@ fn transition_for_kind(kind: &lex_vcs::OperationKind) -> lex_vcs::StageTransitio
         | ChangeEffectSig { sig_id, from_stage_id, to_stage_id, .. }
         | ModifyType { sig_id, from_stage_id, to_stage_id }
         | ReplaceMatchArm { sig_id, from_stage_id, to_stage_id, .. }
-        | RenameLocal { sig_id, from_stage_id, to_stage_id, .. } => StageTransition::Replace {
+        | RenameLocal { sig_id, from_stage_id, to_stage_id, .. }
+        | InlineLet { sig_id, from_stage_id, to_stage_id, .. } => StageTransition::Replace {
             sig_id: sig_id.clone(),
             from: from_stage_id.clone(),
             to:   to_stage_id.clone(),

--- a/crates/lex-store/tests/inline_let.rs
+++ b/crates/lex-store/tests/inline_let.rs
@@ -1,0 +1,133 @@
+//! Conformance tests for #280 slice 3: typed `InlineLet` transform
+//! + matching `OperationKind::InlineLet` op.
+
+use lex_ast::{canonicalize_program, sig_id, stage_id, CExpr, NodeId, Stage};
+use lex_store::{Store, DEFAULT_BRANCH};
+use lex_syntax::parse_source;
+use tempfile::TempDir;
+
+fn fresh() -> (Store, TempDir) {
+    let tmp = TempDir::new().unwrap();
+    let s = Store::open(tmp.path()).unwrap();
+    (s, tmp)
+}
+
+fn stage_named(src: &str, name: &str) -> Stage {
+    let prog = parse_source(src).unwrap();
+    canonicalize_program(&prog)
+        .into_iter()
+        .find(|s| match s {
+            Stage::FnDecl(fd) => fd.name == name,
+            _ => false,
+        })
+        .expect("stage not found")
+}
+
+const PLUS_FIVE_SRC: &str =
+    "fn plus_five(n :: Int) -> Int { let x := 5; n + x }\n";
+
+fn let_node() -> NodeId { NodeId("n_0.2".into()) }
+
+fn publish_initial(store: &Store) -> (String, String) {
+    let s = stage_named(PLUS_FIVE_SRC, "plus_five");
+    let sig = sig_id(&s).unwrap();
+    let stg = stage_id(&s).unwrap();
+    store.publish(&s).unwrap();
+    let op = lex_vcs::Operation::new(
+        lex_vcs::OperationKind::AddFunction {
+            sig_id: sig.clone(),
+            stage_id: stg.clone(),
+            effects: Default::default(),
+            budget_cost: None,
+        },
+        [],
+    );
+    let t = lex_vcs::StageTransition::Create {
+        sig_id: sig.clone(),
+        stage_id: stg.clone(),
+    };
+    store.apply_operation(DEFAULT_BRANCH, op, t).unwrap();
+    (sig, stg)
+}
+
+#[test]
+fn inline_let_lands_a_typed_op_on_the_branch() {
+    let (store, _tmp) = fresh();
+    let (sig, from_stage_id) = publish_initial(&store);
+
+    let op_id = store
+        .apply_inline_let(DEFAULT_BRANCH, &from_stage_id, &let_node())
+        .expect("inline should succeed on well-typed input");
+
+    let log = lex_vcs::OpLog::open(store.root()).unwrap();
+    let rec = log.get(&op_id).unwrap().unwrap();
+    let lex_vcs::OperationKind::InlineLet {
+        sig_id: rec_sig,
+        from_stage_id: rec_from,
+        binding_name,
+        let_node: rec_node,
+        ..
+    } = &rec.op.kind else {
+        panic!("expected InlineLet op kind, got {:?}", rec.op.kind);
+    };
+    assert_eq!(rec_sig, &sig);
+    assert_eq!(rec_from, &from_stage_id);
+    assert_eq!(binding_name, "x");
+    assert_eq!(rec_node, "n_0.2");
+
+    let head = store.branch_head(DEFAULT_BRANCH).unwrap();
+    assert_ne!(head.get(&sig), Some(&from_stage_id));
+}
+
+#[test]
+fn inline_let_reconstructs_through_get_ast() {
+    let (store, _tmp) = fresh();
+    let (_sig, from_stage_id) = publish_initial(&store);
+
+    let op_id = store
+        .apply_inline_let(DEFAULT_BRANCH, &from_stage_id, &let_node())
+        .unwrap();
+    let log = lex_vcs::OpLog::open(store.root()).unwrap();
+    let rec = log.get(&op_id).unwrap().unwrap();
+    let lex_vcs::OperationKind::InlineLet { to_stage_id, .. } = &rec.op.kind else { panic!() };
+
+    let reloaded = store.get_ast(to_stage_id).unwrap();
+    let Stage::FnDecl(fd) = reloaded else { panic!() };
+    // Body is now `n + 5` — the Let is gone.
+    let CExpr::BinOp { lhs, rhs, .. } = fd.body else { panic!() };
+    assert!(matches!(*lhs, CExpr::Var { name: ref n } if n == "n"));
+    assert!(matches!(*rhs, CExpr::Literal { value: lex_ast::CLit::Int { value: 5 } }));
+}
+
+#[test]
+fn inline_let_emits_typecheck_attestation() {
+    let (store, _tmp) = fresh();
+    let (_sig, from_stage_id) = publish_initial(&store);
+
+    let op_id = store
+        .apply_inline_let(DEFAULT_BRANCH, &from_stage_id, &let_node())
+        .unwrap();
+
+    let log = lex_vcs::OpLog::open(store.root()).unwrap();
+    let rec = log.get(&op_id).unwrap().unwrap();
+    let lex_vcs::OperationKind::InlineLet { to_stage_id, .. } = &rec.op.kind else { panic!() };
+    let attlog = store.attestation_log().unwrap();
+    let by_stage = attlog.list_for_stage(to_stage_id).unwrap();
+    assert!(
+        by_stage.iter().any(|a| matches!(a.kind, lex_vcs::AttestationKind::TypeCheck)),
+        "TypeCheck attestation should accompany the inlined stage"
+    );
+}
+
+#[test]
+fn inline_let_surface_transform_errors_for_wrong_node() {
+    let (store, _tmp) = fresh();
+    let (_sig, from_stage_id) = publish_initial(&store);
+
+    // Address a non-Let node.
+    let err = store
+        .apply_inline_let(DEFAULT_BRANCH, &from_stage_id, &NodeId("n_0.99".into()))
+        .unwrap_err();
+    assert!(matches!(err, lex_store::StoreError::TransformError(_)),
+        "got {err:?}");
+}

--- a/crates/lex-vcs/src/merge.rs
+++ b/crates/lex-vcs/src/merge.rs
@@ -138,7 +138,8 @@ fn touched_sigs(k: &OperationKind) -> Vec<SigId> {
         | OperationKind::RemoveType { sig_id, .. }
         | OperationKind::ModifyType { sig_id, .. }
         | OperationKind::ReplaceMatchArm { sig_id, .. }
-        | OperationKind::RenameLocal { sig_id, .. } => vec![sig_id.clone()],
+        | OperationKind::RenameLocal { sig_id, .. }
+        | OperationKind::InlineLet { sig_id, .. } => vec![sig_id.clone()],
         // A rename touches both sides — concurrent modifies on `from`
         // must surface as a conflict, not as a disjoint set.
         OperationKind::RenameSymbol { from, to, .. } => vec![from.clone(), to.clone()],

--- a/crates/lex-vcs/src/operation.rs
+++ b/crates/lex-vcs/src/operation.rs
@@ -219,6 +219,23 @@ pub enum OperationKind {
     Merge {
         resolved: usize,
     },
+    /// Typed transform: inlined a `let x := v; body` by
+    /// substituting `v` for every unshadowed `x` in `body`, then
+    /// replacing the entire `Let` node with the substituted body
+    /// (#280). The op records the let-binding's position and the
+    /// inlined name; the actual substituted value lives in the
+    /// content-addressed `to_stage_id` so the op_id stays compact.
+    InlineLet {
+        sig_id: SigId,
+        from_stage_id: StageId,
+        to_stage_id: StageId,
+        let_node: String,
+        binding_name: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        from_budget: Option<u64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        to_budget: Option<u64>,
+    },
     /// Typed transform: renamed a `let`-bound local within a fn
     /// body (#280). Records the old/new identifiers and the position
     /// of the let-binding in the AST. Body-shape-stable: the renamed
@@ -291,6 +308,7 @@ impl OperationKind {
             | ModifyType { sig_id, to_stage_id, .. }
             | ReplaceMatchArm { sig_id, to_stage_id, .. }
             | RenameLocal { sig_id, to_stage_id, .. }
+            | InlineLet { sig_id, to_stage_id, .. }
                 => Some((sig_id.clone(), Some(to_stage_id.clone()))),
             RemoveFunction { sig_id, .. }
             | RemoveType { sig_id, .. }
@@ -314,7 +332,8 @@ impl OperationKind {
             ModifyBody { from_budget, to_budget, .. }
             | ChangeEffectSig { from_budget, to_budget, .. }
             | ReplaceMatchArm { from_budget, to_budget, .. }
-            | RenameLocal { from_budget, to_budget, .. } => (*from_budget, *to_budget),
+            | RenameLocal { from_budget, to_budget, .. }
+            | InlineLet { from_budget, to_budget, .. } => (*from_budget, *to_budget),
             _ => (None, None),
         }
     }
@@ -330,7 +349,8 @@ impl OperationKind {
             | ModifyBody { sig_id, .. }
             | ChangeEffectSig { sig_id, .. }
             | ReplaceMatchArm { sig_id, .. }
-            | RenameLocal { sig_id, .. } => Some(sig_id),
+            | RenameLocal { sig_id, .. }
+            | InlineLet { sig_id, .. } => Some(sig_id),
             _ => None,
         }
     }

--- a/crates/lex-vcs/tests/opid_golden.rs
+++ b/crates/lex-vcs/tests/opid_golden.rs
@@ -334,5 +334,6 @@ fn variant_tag(k: &OperationKind) -> &'static str {
         OperationKind::Merge { .. } => "merge",
         OperationKind::ReplaceMatchArm { .. } => "replace_match_arm",
         OperationKind::RenameLocal { .. } => "rename_local",
+        OperationKind::InlineLet { .. } => "inline_let",
     }
 }


### PR DESCRIPTION
Third slice of #280 — typed refactoring operations.

## Summary

`InlineLet` eliminates a `let x := v; body` by substituting `v` for every unshadowed `x` in `body`, then replacing the `Let` node with the substituted body.

**Safety restrictions** (slice 3):

- **Value shape**: `v` must be `Literal`, `Var`, `FieldAccess`, or a `BinOp`/`UnaryOp`/`TupleLit`/`ListLit` tree of those leaves. Calls, lambdas, blocks, lets, matches in `v` are refused with `TransformError::InlineLetRefused` so a future slice can lift the restriction without changing the error contract.
- **Capture detection**: if any free var of `v` is re-bound (shadowed) anywhere in `body`, the inline is refused — substituting would silently capture and change semantics. Example: `let x := y; let y := 7; x` is refused because inlining `x` makes the inner `y` capture the substituted `y`.
- **Shadow-aware substitution**: inside `body`, descent stops at inner binders that re-bind `x` (matches the same scope rules used in `rename_local`).

## API

- `lex_ast::inline_let(stage, let_node) -> Result<Stage, TransformError>` — pure-function AST transform.
- `OperationKind::InlineLet { sig_id, from_stage_id, to_stage_id, let_node, binding_name, from_budget, to_budget }` — same `skip_if_none` budget discipline as the other #280 variants.
- `Store::apply_inline_let(branch, from_stage_id, let_node)` — end-to-end: load AST → transform → publish → re-typecheck → emit op.

## Test plan

- [x] 5 unit tests in `lex_ast::transforms` (literal substitution, call-in-value refusal, capture refusal, shadowing inside body, not-a-Let target).
- [x] 4 conformance tests in `crates/lex-store/tests/inline_let.rs` (lands typed op, `get_ast` reconstruction, TypeCheck attestation, transform-error surface).
- [x] `cargo test --workspace` — 171 test groups pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.

## Status of #280

| Slice | Status |
|-------|--------|
| ReplaceMatchArm | merged (#284) |
| RenameLocal | merged (#287) |
| **InlineLet** | **this PR** |
| ExtractFunction | follow-up |

https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_