### PR TITLE
lex-ast+store: typed ExtractFunction transform (#280 slice 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+### Added — agent-VCS roadmap (#280, slice 4)
+
+- **Typed `ExtractFunction` transform** (#280 slice 4). Closes the
+  last of the four typed refactoring operations from the 0.5.0
+  review. New `lex_ast::extract_function(stage, expr_node, spec)`
+  produces `(modified_source, new_fn)`: the original stage with
+  the extracted sub-expression replaced by a call, and the new
+  top-level fn carrying the extracted body.
+- **`ExtractFnSpec`** carries the agent-provided signature
+  (name, type_params, params, return_type, effects). The
+  transform verifies that `spec.params` covers exactly the free
+  variables of the extracted expression — names must match; extra
+  params or missing free vars are refused with
+  `TransformError::ExtractFnRefused`. Type checking against the
+  spec happens *after* the transform in the apply path.
+- **`Store::apply_extract_function`** emits two ops linked by a
+  shared synthetic `Intent`: an `AddFunction` for the new fn and
+  a `ModifyBody` for the source's call-site rewrite. The intent's
+  prompt is structured (`[lex.transform.extract_function]\nnew_fn=...`)
+  so `lex op log --intent <id>` recovers the typed-transform
+  shape from the op-log + intent-log join. No new
+  `OperationKind` variant — the typed view comes from the intent
+  linkage.
+- 5 unit tests in `lex_ast::transforms` (replacement, extra-param
+  refusal, missing-param refusal, zero-free-var case, TypeDecl
+  rejection) and 5 conformance tests in
+  `crates/lex-store/tests/extract_function.rs` (two linked ops,
+  structured intent, branch-state consistency, transform-error
+  surface, param-mismatch surface).
+
+**#280 is now complete** — all four typed refactoring transforms
+(`ReplaceMatchArm`, `RenameLocal`, `InlineLet`, `ExtractFunction`)
+are shipped with end-to-end conformance.
+
 ### Added — agent-VCS roadmap (#280, slice 3)
 
 - **Typed `InlineLet` transform** (#280 slice 3). Eliminates a

--- a/crates/lex-ast/src/lib.rs
+++ b/crates/lex-ast/src/lib.rs
@@ -17,7 +17,10 @@ pub use canonicalize::{canonicalize_program, canonicalize_item};
 pub use canon_print::print_stages;
 pub use ids::{collect_ids, expr_ids, NodeId, NodeRef};
 pub use patch::{apply_patch, Patch, PatchError};
-pub use transforms::{inline_let, rename_local, replace_match_arm, TransformError};
+pub use transforms::{
+    extract_function, inline_let, rename_local, replace_match_arm,
+    ExtractFnSpec, TransformError,
+};
 
 /// SHA-256 over the canonical-JSON encoding of a stage. Excludes NodeIds
 /// (the canonical AST data does not carry IDs; they're derived).

--- a/crates/lex-ast/src/transforms.rs
+++ b/crates/lex-ast/src/transforms.rs
@@ -27,10 +27,15 @@
 //!   substituting `v` for every unshadowed `x` in `body`. The let
 //!   value is restricted to capture-free, side-effect-free
 //!   expressions (literals, vars, field access, binops on those).
-//!
-//! Future slices: `extract_function`.
+//! - [`extract_function`] — extracts a sub-expression from a fn
+//!   body into a new top-level function, replacing the original
+//!   site with a call. The agent provides the new fn's signature
+//!   (params, return type, effects); the transform verifies free
+//!   variables match the params.
 
-use crate::canonical::{CExpr, Pattern, Stage};
+use crate::canonical::{
+    CExpr, Effect, FnDecl, Param, Pattern, Stage, TypeExpr,
+};
 use crate::ids::NodeId;
 
 #[derive(Debug, Clone, thiserror::Error, serde::Serialize, serde::Deserialize)]
@@ -52,6 +57,23 @@ pub enum TransformError {
     RenameNoOp { name: String },
     #[error("inline_let refused: `{reason}`")]
     InlineLetRefused { reason: String },
+    #[error("extract_function refused: `{reason}`")]
+    ExtractFnRefused { reason: String },
+}
+
+/// Specification of the new function that [`extract_function`]
+/// produces. The agent provides this — slice 4 doesn't infer
+/// types or effects from the surrounding context. The transform
+/// verifies the param set matches the extracted expression's free
+/// variables; the type-checker (downstream) catches mismatches in
+/// types, effects, and return type.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExtractFnSpec {
+    pub name: String,
+    pub type_params: Vec<String>,
+    pub params: Vec<Param>,
+    pub return_type: TypeExpr,
+    pub effects: Vec<Effect>,
 }
 
 /// Replace `match_node`'s arm at `arm_index` with a new body,
@@ -545,6 +567,92 @@ fn pattern_binds(p: &Pattern, name: &str) -> bool {
     }
 }
 
+/// Extract a sub-expression from a fn body into a new top-level
+/// function (#280 slice 4). Returns `(modified_source, new_fn)`:
+/// the original stage with the extracted expression replaced by a
+/// call to the new fn, and the new fn itself as a fresh `Stage`.
+///
+/// `expr_node` is the [`NodeId`] of the expression to extract.
+/// `spec` describes the new fn's full signature; the transform
+/// verifies that `spec.params` covers exactly the free variables
+/// of the extracted expression — names must match. Type checking
+/// of the extracted body against the spec happens *after* the
+/// transform, in the apply path's re-typecheck.
+///
+/// The replacement call site uses the parameter order from
+/// `spec.params`: `f(a, b, c)` for `params = [a, b, c]`.
+pub fn extract_function(
+    stage: &Stage,
+    expr_node: &NodeId,
+    spec: ExtractFnSpec,
+) -> Result<(Stage, Stage), TransformError> {
+    // Locate + clone the expression to extract from a fresh stage
+    // copy; we need a separate mutable clone for the modification.
+    let mut modified = stage.clone();
+    let (body, n_params) = match &mut modified {
+        Stage::FnDecl(fd) => {
+            let n = fd.params.len();
+            (&mut fd.body, n)
+        }
+        Stage::TypeDecl(_) => return Err(TransformError::NonFnTarget { stage_kind: "TypeDecl" }),
+        Stage::Import(_) => return Err(TransformError::NonFnTarget { stage_kind: "Import" }),
+    };
+    let path = parse_node_id(expr_node.as_str())?;
+    if path.is_empty() {
+        return Err(TransformError::UnknownNode { at: expr_node.as_str().into() });
+    }
+    if path[0] != n_params + 1 {
+        return Err(TransformError::UnknownNode { at: expr_node.as_str().into() });
+    }
+    let inner = &path[1..];
+    let target = navigate_to_expr(body, inner, expr_node.as_str())?;
+
+    // Snapshot the expression we're about to extract. We need a
+    // value, not a reference, because we'll move it into the new
+    // fn's body.
+    let extracted_expr = target.clone();
+
+    // Free vars of the extracted expr must exactly match the
+    // declared param names. If the agent passed extra params or
+    // missed any, refuse — the agent did the analysis wrong.
+    let free = free_vars(&extracted_expr);
+    let declared: std::collections::BTreeSet<String> =
+        spec.params.iter().map(|p| p.name.clone()).collect();
+    if free != declared {
+        let only_in_free: Vec<&String> = free.difference(&declared).collect();
+        let only_in_declared: Vec<&String> = declared.difference(&free).collect();
+        return Err(TransformError::ExtractFnRefused {
+            reason: format!(
+                "free vars {free:?} differ from declared params {declared:?}: \
+                 missing {only_in_free:?}, extra {only_in_declared:?}"
+            ),
+        });
+    }
+
+    // Replace the extracted expr with a call to the new fn. Args
+    // are `Var { name }` for each declared param, in the spec's
+    // declared order.
+    let call = CExpr::Call {
+        callee: Box::new(CExpr::Var { name: spec.name.clone() }),
+        args: spec.params.iter()
+            .map(|p| CExpr::Var { name: p.name.clone() })
+            .collect(),
+    };
+    *target = call;
+
+    // Build the new fn stage from the extracted body + spec.
+    let new_fn = Stage::FnDecl(FnDecl {
+        name: spec.name,
+        type_params: spec.type_params,
+        params: spec.params,
+        effects: spec.effects,
+        return_type: spec.return_type,
+        body: extracted_expr,
+    });
+
+    Ok((modified, new_fn))
+}
+
 fn parse_node_id(id: &str) -> Result<Vec<usize>, TransformError> {
     let s = id.strip_prefix("n_").ok_or_else(|| TransformError::BadNodeId(id.into()))?;
     let mut parts = s.split('.');
@@ -981,6 +1089,159 @@ mod tests {
         let stage = match_stage_with_two_arms();
         let err = inline_let(&stage, &NodeId("n_0.2".into())).unwrap_err();
         assert!(matches!(err, TransformError::NotALet { found_kind: "Match", .. }));
+    }
+
+    // ---- extract_function tests ------------------------------------
+
+    /// `fn caller(n :: Int, m :: Int) -> Int { (n * 2) + m }`
+    /// We'll extract the `n * 2` sub-expression into a new fn.
+    fn extract_stage() -> Stage {
+        let body = CExpr::BinOp {
+            op: "+".into(),
+            lhs: Box::new(CExpr::BinOp {
+                op: "*".into(),
+                lhs: Box::new(CExpr::Var { name: "n".into() }),
+                rhs: Box::new(CExpr::Literal { value: CLit::Int { value: 2 } }),
+            }),
+            rhs: Box::new(CExpr::Var { name: "m".into() }),
+        };
+        Stage::FnDecl(FnDecl {
+            name: "caller".into(),
+            type_params: Vec::new(),
+            params: vec![
+                Param {
+                    name: "n".into(),
+                    ty: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
+                },
+                Param {
+                    name: "m".into(),
+                    ty: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
+                },
+            ],
+            effects: Vec::new(),
+            return_type: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
+            body,
+        })
+    }
+
+    fn double_n_spec() -> ExtractFnSpec {
+        ExtractFnSpec {
+            name: "double_n".into(),
+            type_params: Vec::new(),
+            params: vec![Param {
+                name: "n".into(),
+                ty: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
+            }],
+            effects: Vec::new(),
+            return_type: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
+        }
+    }
+
+    #[test]
+    fn extract_function_replaces_subexpression_with_call() {
+        // 2 params + return + body slot → body is at child 3.
+        // The body is a BinOp; lhs (the `n * 2` sub-expr) is at
+        // child 0 of the body. So target NodeId = `n_0.3.0`.
+        let stage = extract_stage();
+        let (modified, new_fn) = extract_function(
+            &stage,
+            &NodeId("n_0.3.0".into()),
+            double_n_spec(),
+        ).unwrap();
+
+        // Modified source: lhs is now `Call { Var(double_n), [Var(n)] }`.
+        let Stage::FnDecl(fd) = modified else { panic!() };
+        let CExpr::BinOp { lhs, .. } = fd.body else { panic!() };
+        let CExpr::Call { callee, args } = *lhs else { panic!() };
+        assert!(matches!(*callee, CExpr::Var { name: ref n } if n == "double_n"));
+        assert_eq!(args.len(), 1);
+        assert!(matches!(args[0], CExpr::Var { name: ref n } if n == "n"));
+
+        // New fn: name + params + body all match.
+        let Stage::FnDecl(new_fd) = new_fn else { panic!() };
+        assert_eq!(new_fd.name, "double_n");
+        assert_eq!(new_fd.params.len(), 1);
+        assert_eq!(new_fd.params[0].name, "n");
+        // Body is the original `n * 2`.
+        let CExpr::BinOp { op, lhs, rhs, .. } = new_fd.body else { panic!() };
+        assert_eq!(op, "*");
+        assert!(matches!(*lhs, CExpr::Var { name: ref n } if n == "n"));
+        assert!(matches!(*rhs, CExpr::Literal { value: CLit::Int { value: 2 } }));
+    }
+
+    #[test]
+    fn extract_function_refuses_extra_params() {
+        // Spec declares an extra param `z` not free in `n * 2`.
+        let stage = extract_stage();
+        let mut spec = double_n_spec();
+        spec.params.push(Param {
+            name: "z".into(),
+            ty: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
+        });
+        let err = extract_function(&stage, &NodeId("n_0.3.0".into()), spec).unwrap_err();
+        assert!(matches!(err, TransformError::ExtractFnRefused { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn extract_function_refuses_missing_params() {
+        // Spec omits `n`, which IS free in `n * 2`.
+        let stage = extract_stage();
+        let spec = ExtractFnSpec {
+            name: "no_args".into(),
+            type_params: Vec::new(),
+            params: Vec::new(),
+            effects: Vec::new(),
+            return_type: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
+        };
+        let err = extract_function(&stage, &NodeId("n_0.3.0".into()), spec).unwrap_err();
+        assert!(matches!(err, TransformError::ExtractFnRefused { .. }), "got {err:?}");
+    }
+
+    #[test]
+    fn extract_function_handles_zero_free_vars() {
+        // Body: `1 + 2`. Extract the LHS literal `1`. No free vars.
+        let body = CExpr::BinOp {
+            op: "+".into(),
+            lhs: Box::new(CExpr::Literal { value: CLit::Int { value: 1 } }),
+            rhs: Box::new(CExpr::Literal { value: CLit::Int { value: 2 } }),
+        };
+        let stage = Stage::FnDecl(FnDecl {
+            name: "caller".into(),
+            type_params: Vec::new(),
+            params: Vec::new(),
+            effects: Vec::new(),
+            return_type: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
+            body,
+        });
+        let spec = ExtractFnSpec {
+            name: "one".into(),
+            type_params: Vec::new(),
+            params: Vec::new(),
+            effects: Vec::new(),
+            return_type: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
+        };
+        // 0 params + return + body = body at child 1; lhs at 1.0.
+        let (modified, new_fn) = extract_function(
+            &stage, &NodeId("n_0.1.0".into()), spec,
+        ).unwrap();
+        let Stage::FnDecl(fd) = modified else { panic!() };
+        let CExpr::BinOp { lhs, .. } = fd.body else { panic!() };
+        let CExpr::Call { args, .. } = *lhs else { panic!() };
+        assert_eq!(args.len(), 0, "no args for zero-free-var extract");
+        let Stage::FnDecl(new_fd) = new_fn else { panic!() };
+        assert!(matches!(new_fd.body, CExpr::Literal { value: CLit::Int { value: 1 } }));
+    }
+
+    #[test]
+    fn extract_function_typedecl_target_errors() {
+        let stage = Stage::TypeDecl(crate::canonical::TypeDecl {
+            name: "T".into(),
+            params: Vec::new(),
+            definition: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
+        });
+        let err = extract_function(&stage, &NodeId("n_0.0".into()), double_n_spec())
+            .unwrap_err();
+        assert!(matches!(err, TransformError::NonFnTarget { stage_kind: "TypeDecl" }));
     }
 
     // ---- replace_match_arm fixtures + tests ------------------------

--- a/crates/lex-store/src/store.rs
+++ b/crates/lex-store/src/store.rs
@@ -1213,6 +1213,150 @@ impl Store {
         self.apply_operation_checked(branch, op, transition, &candidate)
     }
 
+    /// Apply a typed `ExtractFunction` transform (#280 slice 4) —
+    /// extract a sub-expression of `from_stage_id`'s body into a
+    /// new top-level fn defined by `spec`, and emit two ops tied
+    /// together by a shared synthetic Intent so `lex op log
+    /// --intent <id>` groups them.
+    ///
+    /// The two ops:
+    ///   1. `AddFunction { sig_id: <new_fn_sig>, stage_id: <new_fn_stage> }`
+    ///   2. `ModifyBody { sig_id: <source_sig>, from_stage_id, to_stage_id: <modified> }`
+    ///
+    /// The shared Intent's prompt is structured (`extract_function:
+    /// <new_fn_name>` plus the source identity) so downstream
+    /// tooling can recover the typed-transform shape from the
+    /// op-log + intent-log join.
+    ///
+    /// Returns `(add_fn_op_id, modify_body_op_id)`.
+    pub fn apply_extract_function(
+        &self,
+        branch: &str,
+        from_stage_id: &str,
+        expr_node: &lex_ast::NodeId,
+        spec: lex_ast::ExtractFnSpec,
+    ) -> Result<(lex_vcs::OpId, lex_vcs::OpId), StoreError> {
+        let from_stage = self.get_ast(from_stage_id)?;
+        let new_fn_name = spec.name.clone();
+        let (modified_stage, new_fn_stage) =
+            lex_ast::extract_function(&from_stage, expr_node, spec)
+                .map_err(StoreError::TransformError)?;
+
+        let source_sig = lex_ast::sig_id(&from_stage)
+            .ok_or(StoreError::CannotPublishImport)?;
+        let new_fn_sig = lex_ast::sig_id(&new_fn_stage)
+            .ok_or(StoreError::CannotPublishImport)?;
+        if source_sig == new_fn_sig {
+            return Err(StoreError::InvalidTransition(format!(
+                "extract_function produced a sig matching the source `{source_sig}`"
+            )));
+        }
+        let new_fn_stage_id = self.publish(&new_fn_stage)?;
+        let modified_stage_id = self.publish(&modified_stage)?;
+        if modified_stage_id == from_stage_id {
+            return Err(StoreError::InvalidTransition(format!(
+                "extract_function produced the same stage_id `{from_stage_id}` for the source"
+            )));
+        }
+
+        let head = self.branch_head(branch)?;
+        if !head.contains_key(&source_sig) {
+            return Err(StoreError::InvalidTransition(format!(
+                "sig `{source_sig}` not on branch `{branch}`'s head"
+            )));
+        }
+
+        // Synthesize an Intent linking the two ops. The session_id
+        // / model fields here are not load-bearing — they exist to
+        // make the IntentId content-addressed; downstream tooling
+        // reads `prompt` to reconstruct the typed-transform shape.
+        let intent = lex_vcs::Intent::new(
+            format!(
+                "[lex.transform.extract_function]\nnew_fn={new_fn_name}\nsource_sig={source_sig}\nfrom_stage={from_stage_id}\nexpr_node={node}",
+                node = expr_node.as_str(),
+            ),
+            "lex-store::apply_extract_function",
+            lex_vcs::ModelDescriptor {
+                provider: "lex-store".into(),
+                name: env!("CARGO_PKG_VERSION").into(),
+                version: None,
+            },
+            None,
+        );
+        let intent_id = intent.intent_id.clone();
+        lex_vcs::IntentLog::open(self.root())?.put(&intent)?;
+
+        // Step 1 — emit the AddFunction op for the new fn. Build
+        // the candidate program by appending the new fn to every
+        // stage on the current branch head.
+        let new_fn_effects: std::collections::BTreeSet<String> = match &new_fn_stage {
+            lex_ast::Stage::FnDecl(fd) => fd.effects.iter()
+                .map(|e| e.name.clone()).collect(),
+            _ => Default::default(),
+        };
+        let new_fn_budget = budget_of_stage(&new_fn_stage);
+        let mut candidate_with_new_fn: Vec<lex_ast::Stage> =
+            Vec::with_capacity(head.len() + 1);
+        for stage_id in head.values() {
+            candidate_with_new_fn.push(self.get_ast(stage_id)?);
+        }
+        candidate_with_new_fn.push(new_fn_stage.clone());
+        let head_now = self.get_branch(branch)?.and_then(|b| b.head_op);
+        let add_op = lex_vcs::Operation::new(
+            lex_vcs::OperationKind::AddFunction {
+                sig_id: new_fn_sig.clone(),
+                stage_id: new_fn_stage_id.clone(),
+                effects: new_fn_effects,
+                budget_cost: new_fn_budget,
+            },
+            head_now.into_iter().collect::<Vec<_>>(),
+        ).with_intent(intent_id.clone());
+        let add_transition = lex_vcs::StageTransition::Create {
+            sig_id: new_fn_sig.clone(),
+            stage_id: new_fn_stage_id.clone(),
+        };
+        let add_op_id = self.apply_operation_checked(
+            branch, add_op, add_transition, &candidate_with_new_fn,
+        )?;
+
+        // Step 2 — emit the ModifyBody op for the source. Build
+        // the candidate program by replacing the source's stage
+        // with `modified_stage` and keeping the new fn alongside.
+        let from_budget = budget_of_stage(&from_stage);
+        let to_budget = budget_of_stage(&modified_stage);
+        let mut candidate_with_modified: Vec<lex_ast::Stage> =
+            Vec::with_capacity(head.len() + 1);
+        for (other_sig, other_stage_id) in &head {
+            if other_sig == &source_sig {
+                candidate_with_modified.push(modified_stage.clone());
+            } else {
+                candidate_with_modified.push(self.get_ast(other_stage_id)?);
+            }
+        }
+        candidate_with_modified.push(new_fn_stage.clone());
+        let head_now = self.get_branch(branch)?.and_then(|b| b.head_op);
+        let modify_op = lex_vcs::Operation::new(
+            lex_vcs::OperationKind::ModifyBody {
+                sig_id: source_sig.clone(),
+                from_stage_id: from_stage_id.to_string(),
+                to_stage_id: modified_stage_id.clone(),
+                from_budget,
+                to_budget,
+            },
+            head_now.into_iter().collect::<Vec<_>>(),
+        ).with_intent(intent_id);
+        let modify_transition = lex_vcs::StageTransition::Replace {
+            sig_id: source_sig,
+            from: from_stage_id.to_string(),
+            to: modified_stage_id,
+        };
+        let modify_op_id = self.apply_operation_checked(
+            branch, modify_op, modify_transition, &candidate_with_modified,
+        )?;
+
+        Ok((add_op_id, modify_op_id))
+    }
+
     /// `set_branch_head_op` for the durability story on the branch
     /// file itself.
     pub fn apply_operation(

--- a/crates/lex-store/tests/extract_function.rs
+++ b/crates/lex-store/tests/extract_function.rs
@@ -1,0 +1,199 @@
+//! Conformance tests for #280 slice 4: typed `ExtractFunction`
+//! transform — emits AddFunction + ModifyBody ops linked by a
+//! shared synthetic Intent.
+
+use lex_ast::{
+    canonicalize_program, sig_id, stage_id, CExpr, ExtractFnSpec,
+    NodeId, Param, Stage, TypeExpr,
+};
+use lex_store::{Store, DEFAULT_BRANCH};
+use lex_syntax::parse_source;
+use tempfile::TempDir;
+
+fn fresh() -> (Store, TempDir) {
+    let tmp = TempDir::new().unwrap();
+    let s = Store::open(tmp.path()).unwrap();
+    (s, tmp)
+}
+
+fn stage_named(src: &str, name: &str) -> Stage {
+    let prog = parse_source(src).unwrap();
+    canonicalize_program(&prog)
+        .into_iter()
+        .find(|s| match s {
+            Stage::FnDecl(fd) => fd.name == name,
+            _ => false,
+        })
+        .expect("stage not found")
+}
+
+const COMBINE_SRC: &str = "fn combine(n :: Int, m :: Int) -> Int { (n * 2) + m }\n";
+
+fn publish_initial(store: &Store) -> (String, String) {
+    let s = stage_named(COMBINE_SRC, "combine");
+    let sig = sig_id(&s).unwrap();
+    let stg = stage_id(&s).unwrap();
+    store.publish(&s).unwrap();
+    let op = lex_vcs::Operation::new(
+        lex_vcs::OperationKind::AddFunction {
+            sig_id: sig.clone(),
+            stage_id: stg.clone(),
+            effects: Default::default(),
+            budget_cost: None,
+        },
+        [],
+    );
+    let t = lex_vcs::StageTransition::Create {
+        sig_id: sig.clone(),
+        stage_id: stg.clone(),
+    };
+    store.apply_operation(DEFAULT_BRANCH, op, t).unwrap();
+    (sig, stg)
+}
+
+fn double_n_spec() -> ExtractFnSpec {
+    ExtractFnSpec {
+        name: "double_n".into(),
+        type_params: Vec::new(),
+        params: vec![Param {
+            name: "n".into(),
+            ty: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
+        }],
+        effects: Vec::new(),
+        return_type: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
+    }
+}
+
+#[test]
+fn extract_function_emits_two_linked_ops() {
+    let (store, _tmp) = fresh();
+    let (source_sig, from_stage_id) = publish_initial(&store);
+
+    // The body is `(n * 2) + m`. Its lhs at NodeId `n_0.3.0` is
+    // the `n * 2` sub-expression. (2 params + return + body slot
+    // = body at child 3; lhs of the BinOp at 3.0.)
+    let (add_op, modify_op) = store
+        .apply_extract_function(
+            DEFAULT_BRANCH,
+            &from_stage_id,
+            &NodeId("n_0.3.0".into()),
+            double_n_spec(),
+        )
+        .expect("extract should succeed on well-typed input");
+
+    let log = lex_vcs::OpLog::open(store.root()).unwrap();
+    let add_rec = log.get(&add_op).unwrap().unwrap();
+    let mod_rec = log.get(&modify_op).unwrap().unwrap();
+
+    // Add op carries an AddFunction kind for the new fn.
+    let lex_vcs::OperationKind::AddFunction { sig_id: add_sig, .. } = &add_rec.op.kind else {
+        panic!("expected AddFunction, got {:?}", add_rec.op.kind);
+    };
+    assert_ne!(add_sig, &source_sig, "new fn has its own sig");
+
+    // Modify op carries a ModifyBody kind on the source sig.
+    let lex_vcs::OperationKind::ModifyBody { sig_id: mod_sig, .. } = &mod_rec.op.kind else {
+        panic!("expected ModifyBody, got {:?}", mod_rec.op.kind);
+    };
+    assert_eq!(mod_sig, &source_sig);
+
+    // Both ops share the same intent_id.
+    let intent_a = add_rec.op.intent_id.as_deref().expect("add op has intent");
+    let intent_b = mod_rec.op.intent_id.as_deref().expect("modify op has intent");
+    assert_eq!(intent_a, intent_b, "both ops share the synthetic Intent");
+}
+
+#[test]
+fn extract_function_intent_carries_structured_prompt() {
+    let (store, _tmp) = fresh();
+    let (_sig, from_stage_id) = publish_initial(&store);
+
+    let (add_op, _modify_op) = store
+        .apply_extract_function(
+            DEFAULT_BRANCH,
+            &from_stage_id,
+            &NodeId("n_0.3.0".into()),
+            double_n_spec(),
+        )
+        .unwrap();
+    let log = lex_vcs::OpLog::open(store.root()).unwrap();
+    let rec = log.get(&add_op).unwrap().unwrap();
+    let intent_id = rec.op.intent_id.as_deref().unwrap().to_string();
+
+    let intent_log = lex_vcs::IntentLog::open(store.root()).unwrap();
+    let intent = intent_log.get(&intent_id).unwrap().unwrap();
+    assert!(intent.prompt.starts_with("[lex.transform.extract_function]"));
+    assert!(intent.prompt.contains("new_fn=double_n"));
+    assert!(intent.prompt.contains("expr_node=n_0.3.0"));
+}
+
+#[test]
+fn extract_function_branch_state_is_consistent_after_both_ops() {
+    let (store, _tmp) = fresh();
+    let (source_sig, _from_stage_id) = publish_initial(&store);
+
+    let (_add, _modify) = store
+        .apply_extract_function(
+            DEFAULT_BRANCH,
+            &_from_stage_id,
+            &NodeId("n_0.3.0".into()),
+            double_n_spec(),
+        )
+        .unwrap();
+
+    // After both ops the branch carries: source sig (modified) +
+    // new fn sig (added).
+    let head = store.branch_head(DEFAULT_BRANCH).unwrap();
+    assert_eq!(head.len(), 2, "two sigs on branch head, got {head:?}");
+    assert!(head.contains_key(&source_sig));
+    assert!(head.keys().any(|k| k != &source_sig), "new sig present");
+
+    // Reload the source's modified body — its lhs is now a Call.
+    let modified_source_id = head.get(&source_sig).unwrap();
+    let ast = store.get_ast(modified_source_id).unwrap();
+    let Stage::FnDecl(fd) = ast else { panic!() };
+    let CExpr::BinOp { lhs, .. } = fd.body else { panic!() };
+    let CExpr::Call { callee, args } = *lhs else { panic!() };
+    assert!(matches!(*callee, CExpr::Var { name: ref n } if n == "double_n"));
+    assert_eq!(args.len(), 1);
+}
+
+#[test]
+fn extract_function_surfaces_transform_errors() {
+    // Targeting a node that doesn't address an expression.
+    let (store, _tmp) = fresh();
+    let (_sig, from_stage_id) = publish_initial(&store);
+    let err = store
+        .apply_extract_function(
+            DEFAULT_BRANCH,
+            &from_stage_id,
+            &NodeId("n_0.99".into()),
+            double_n_spec(),
+        )
+        .unwrap_err();
+    assert!(matches!(err, lex_store::StoreError::TransformError(_)),
+        "got {err:?}");
+}
+
+#[test]
+fn extract_function_surfaces_param_mismatch() {
+    // Spec has an extra param not free in the extracted expr.
+    let (store, _tmp) = fresh();
+    let (_sig, from_stage_id) = publish_initial(&store);
+    let mut spec = double_n_spec();
+    spec.params.push(Param {
+        name: "z".into(),
+        ty: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
+    });
+    let err = store
+        .apply_extract_function(
+            DEFAULT_BRANCH,
+            &from_stage_id,
+            &NodeId("n_0.3.0".into()),
+            spec,
+        )
+        .unwrap_err();
+    assert!(matches!(err, lex_store::StoreError::TransformError(
+        lex_ast::TransformError::ExtractFnRefused { .. }
+    )), "got {err:?}");
+}


### PR DESCRIPTION
Final slice of #280 — typed refactoring operations.

## Summary

`ExtractFunction` extracts a sub-expression from a fn body into a new top-level function, replacing the original site with a call.

- **`lex_ast::extract_function(stage, expr_node, spec)`** — pure-function AST transform. Returns `(modified_source, new_fn)`. The agent provides the new fn's full signature via `ExtractFnSpec` (name, type_params, params, return_type, effects); the transform verifies that `spec.params` covers exactly the free variables of the extracted expression — extra params or missing free vars are refused with `TransformError::ExtractFnRefused`.

- **`Store::apply_extract_function`** emits **two ops linked by a shared synthetic Intent**: `AddFunction` for the new fn and `ModifyBody` for the source's call-site rewrite. The intent's prompt is structured:
  ```
  [lex.transform.extract_function]
  new_fn=double_n
  source_sig=combine::(Int,Int)->Int
  from_stage=...
  expr_node=n_0.3.0
  ```
  so `lex op log --intent <id>` recovers the typed-transform shape from the op-log + intent-log join.

- **No new `OperationKind` variant.** The typed view comes from the intent linkage. This avoided designing a new multi-stage `StageTransition` shape and reused the existing `AddFunction` + `ModifyBody` + `intent_id` machinery.

## Test plan

- [x] 5 unit tests in `lex_ast::transforms` (replacement, extra-param refusal, missing-param refusal, zero-free-var case, TypeDecl rejection).
- [x] 5 conformance tests in `crates/lex-store/tests/extract_function.rs` (two linked ops, structured intent, branch-state consistency, transform-error surface, param-mismatch surface).
- [x] `cargo test --workspace` — 172 test groups pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.

## #280 status: **complete**

| Slice | Status |
|-------|--------|
| ReplaceMatchArm | merged (#284) |
| RenameLocal | merged (#287) |
| InlineLet | merged (#288) |
| **ExtractFunction** | **this PR** |

All four typed refactoring transforms shipped with end-to-end conformance. The repair loop (#281) can now compose against the full set.

https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_