### PR TITLE
chore: bump workspace to 0.6.0 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+## [0.6.0] — 2026-05-10
+
+The agent-onboarding + agent-feedback wave from the post-0.5.0
+strategic review. Four issues land in one release:
+
+- **#280 typed refactoring operations** — four AST transforms
+  (`ReplaceMatchArm`, `RenameLocal`, `InlineLet`, `ExtractFunction`)
+  that let agents express edits as typed deltas rather than as
+  raw byte rewrites. The op log finally reads as a semantic edit
+  history.
+- **#281 closed repair loop, slice 1** — `RepairHint` attestation
+  auto-emitted by `apply_operation_checked` on `TypeError`, plus
+  `lex repair <op_id>` to read it. The LLM-assisted `--apply`
+  path follows in slice 2.
+- **#282 `lex docs --for-agent`** — single structured JSON
+  envelope giving an agent everything it needs to make sensible
+  writes against a Lex repo (workspace, stdlib, recent activity,
+  open intents, policy, attention queue).
+- **#283 search reindex** — `lex store search reindex` warms the
+  embedding cache eagerly. (The HTTP embedder backends and on-
+  disk cache turned out to already be shipped under #224 — the
+  PR also corrects the stale "deferred to slice 2" note in
+  `lex-search`'s lib.rs.)
+
+Minor bump because every data-layer change is additive: new
+`OperationKind` variants (`ReplaceMatchArm`, `RenameLocal`,
+`InlineLet`) follow the established `skip_if_none` discipline so
+pre-0.6.0 OpIds stay stable; new `AttestationKind` variants
+(`RepairHint`, `RepairAttempt`) are append-only enum extensions;
+new `lex` subcommands (`docs`, `repair`, `op gc`, `search reindex`)
+add surface without changing existing CLIs.
+
 ### Added — agent-feedback (#281)
 
 - **`AttestationKind::RepairHint { failed_op_id, errors,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "EUPL-1.2"
 repository = "https://github.com/alpibrusl/lex-lang"

--- a/crates/lex-api/Cargo.toml
+++ b/crates/lex-api/Cargo.toml
@@ -16,14 +16,14 @@ serde_json.workspace = true
 anyhow.workspace = true
 indexmap.workspace = true
 tiny_http = "0.12"
-lex-syntax = { path = "../lex-syntax", version = "0.5.0" }
-lex-ast = { path = "../lex-ast", version = "0.5.0" }
-lex-types = { path = "../lex-types", version = "0.5.0" }
-lex-bytecode = { path = "../lex-bytecode", version = "0.5.0" }
-lex-runtime = { path = "../lex-runtime", version = "0.5.0" }
-lex-store = { path = "../lex-store", version = "0.5.0" }
-lex-trace = { path = "../lex-trace", version = "0.5.0" }
-lex-vcs = { path = "../lex-vcs", version = "0.5.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.6.0" }
+lex-ast = { path = "../lex-ast", version = "0.6.0" }
+lex-types = { path = "../lex-types", version = "0.6.0" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.6.0" }
+lex-runtime = { path = "../lex-runtime", version = "0.6.0" }
+lex-store = { path = "../lex-store", version = "0.6.0" }
+lex-trace = { path = "../lex-trace", version = "0.6.0" }
+lex-vcs = { path = "../lex-vcs", version = "0.6.0" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/lex-ast/Cargo.toml
+++ b/crates/lex-ast/Cargo.toml
@@ -16,4 +16,4 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-syntax = { path = "../lex-syntax", version = "0.5.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.6.0" }

--- a/crates/lex-bytecode/Cargo.toml
+++ b/crates/lex-bytecode/Cargo.toml
@@ -16,8 +16,8 @@ serde_json.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
 sha2.workspace = true
-lex-ast = { path = "../lex-ast", version = "0.5.0" }
-lex-types = { path = "../lex-types", version = "0.5.0" }
+lex-ast = { path = "../lex-ast", version = "0.6.0" }
+lex-types = { path = "../lex-types", version = "0.6.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.5.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.6.0" }

--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -35,10 +35,10 @@ toml = "1.1"
 serde_yaml = "0.9"
 csv = "1"
 rusqlite = { version = "0.39", features = ["bundled"] }
-lex-bytecode = { path = "../lex-bytecode", version = "0.5.0" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.6.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.5.0" }
-lex-ast = { path = "../lex-ast", version = "0.5.0" }
-lex-types = { path = "../lex-types", version = "0.5.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.6.0" }
+lex-ast = { path = "../lex-ast", version = "0.6.0" }
+lex-types = { path = "../lex-types", version = "0.6.0" }
 tempfile = "3"

--- a/crates/lex-search/Cargo.toml
+++ b/crates/lex-search/Cargo.toml
@@ -17,10 +17,10 @@ thiserror.workspace = true
 sha2.workspace = true
 hex.workspace = true
 ureq = { version = "3.3", default-features = false, features = ["rustls", "platform-verifier", "json"] }
-lex-ast = { path = "../lex-ast", version = "0.5.0" }
-lex-store = { path = "../lex-store", version = "0.5.0" }
+lex-ast = { path = "../lex-ast", version = "0.6.0" }
+lex-store = { path = "../lex-store", version = "0.6.0" }
 
 [dev-dependencies]
 tempfile = "3"
 tiny_http = "0.12"
-lex-syntax = { path = "../lex-syntax", version = "0.5.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.6.0" }

--- a/crates/lex-store/Cargo.toml
+++ b/crates/lex-store/Cargo.toml
@@ -21,11 +21,11 @@ hex.workspace = true
 # transitive dep via tempfile; promoting to direct so the lock
 # call sites compile.
 fs2 = "0.4"
-lex-ast = { path = "../lex-ast", version = "0.5.0" }
-lex-trace = { path = "../lex-trace", version = "0.5.0" }
-lex-types = { path = "../lex-types", version = "0.5.0" }
-lex-vcs = { path = "../lex-vcs", version = "0.5.0" }
+lex-ast = { path = "../lex-ast", version = "0.6.0" }
+lex-trace = { path = "../lex-trace", version = "0.6.0" }
+lex-types = { path = "../lex-types", version = "0.6.0" }
+lex-vcs = { path = "../lex-vcs", version = "0.6.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.5.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.6.0" }
 tempfile = "3"

--- a/crates/lex-trace/Cargo.toml
+++ b/crates/lex-trace/Cargo.toml
@@ -16,9 +16,9 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-bytecode = { path = "../lex-bytecode", version = "0.5.0" }
-lex-ast = { path = "../lex-ast", version = "0.5.0" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.6.0" }
+lex-ast = { path = "../lex-ast", version = "0.6.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.5.0" }
-lex-runtime = { path = "../lex-runtime", version = "0.5.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.6.0" }
+lex-runtime = { path = "../lex-runtime", version = "0.6.0" }

--- a/crates/lex-types/Cargo.toml
+++ b/crates/lex-types/Cargo.toml
@@ -15,7 +15,7 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-ast = { path = "../lex-ast", version = "0.5.0" }
+lex-ast = { path = "../lex-ast", version = "0.6.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.5.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.6.0" }

--- a/crates/lex-vcs/Cargo.toml
+++ b/crates/lex-vcs/Cargo.toml
@@ -11,8 +11,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-lex-ast = { path = "../lex-ast", version = "0.5.0" }
-lex-types = { path = "../lex-types", version = "0.5.0" }
+lex-ast = { path = "../lex-ast", version = "0.6.0" }
+lex-types = { path = "../lex-types", version = "0.6.0" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
@@ -24,4 +24,4 @@ hex.workspace = true
 
 [dev-dependencies]
 tempfile = "3"
-lex-syntax = { path = "../lex-syntax", version = "0.5.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.6.0" }

--- a/crates/spec-checker/Cargo.toml
+++ b/crates/spec-checker/Cargo.toml
@@ -16,11 +16,11 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-syntax = { path = "../lex-syntax", version = "0.5.0" }
-lex-ast = { path = "../lex-ast", version = "0.5.0" }
-lex-types = { path = "../lex-types", version = "0.5.0" }
-lex-bytecode = { path = "../lex-bytecode", version = "0.5.0" }
-lex-runtime = { path = "../lex-runtime", version = "0.5.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.6.0" }
+lex-ast = { path = "../lex-ast", version = "0.6.0" }
+lex-types = { path = "../lex-types", version = "0.6.0" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.6.0" }
+lex-runtime = { path = "../lex-runtime", version = "0.6.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.5.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.6.0" }


### PR DESCRIPTION
Promotes [Unreleased] → [0.6.0] — 2026-05-10. Workspace + inter-crate version pins move from `0.5.0` to `0.6.0`.

## What's in 0.6.0

The post-0.5.0 strategic-review wave — four issues land in one release:

- **#280 typed refactoring operations** (#284, #287, #288, #289) — four AST transforms (`ReplaceMatchArm`, `RenameLocal`, `InlineLet`, `ExtractFunction`) so agents express edits as typed deltas rather than raw byte rewrites. The op log finally reads as a semantic edit history.
- **#281 closed repair loop, slice 1** (#290) — `AttestationKind::RepairHint` auto-emitted by `apply_operation_checked` on `TypeError`, plus `lex repair <op_id>` to read it. LLM-assisted `--apply` path follows in slice 2.
- **#282 `lex docs --for-agent`** (#285) — single structured JSON envelope (workspace + stdlib + recent activity + open intents + policy + attention queue).
- **#283 search reindex** (#286) — `lex store search reindex` warms the embedding cache eagerly.

## Why a minor bump

All data-layer changes are additive:

- New `OperationKind` variants (`ReplaceMatchArm`, `RenameLocal`, `InlineLet`) follow the established `skip_if_none` discipline so pre-0.6.0 OpIds stay stable.
- New `AttestationKind` variants (`RepairHint`, `RepairAttempt`) are append-only enum extensions.
- New `lex` subcommands (`docs`, `repair`) add surface without changing existing CLIs.

## One behavior change worth calling out

`apply_operation_checked` now emits a `RepairHint` attestation when it rejects an op for `TypeError`. Pre-0.6.0 callers that asserted "no attestations on rejection" need to update — the existing test in `apply_operation_checked.rs` is renamed and updated as part of #290 (in this PR's history).

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — 174 test groups pass on a clean run (the documented `lex-api/m8` port-race flake hits intermittently; passes on retry, same shape as pre-0.6.0)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean

https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_