### PR TITLE
lex-cli: `lex repair --apply --transform` typed-transform repair (#281, slice 2a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+### Added — agent-feedback (#281, slice 2a)
+
+- **`lex repair <op_id> --apply --transform '<json>'`** executes a
+  typed transform against the branch and emits a `RepairAttempt`
+  attestation tied to the original `RepairHint` (#281). Supports
+  all four #280 transform kinds (`replace_match_arm`,
+  `rename_local`, `inline_let`, `extract_function`) via JSON
+  payload. The CLI exits 0 regardless of the apply outcome —
+  success/failure lives in the envelope's `outcome` field and in
+  the attestation log, not in the exit code.
+- **`--branch B`** flag selects which branch the transform
+  targets (defaults to the current branch).
+- Requires a matching `RepairHint` to exist for the failed op_id;
+  bare apply against an unknown op errors with "no RepairHint
+  exists."
+- The LLM-driven `--apply` mode (no `--transform` flag) ships in
+  slice 2b — when supplied without `--transform`, the command
+  errors with a "requires `--transform`" message pointing at the
+  follow-up slice.
+- 3 end-to-end tests in `crates/lex-cli/tests/repair_apply.rs`
+  (well-typed transform lands op + records RepairAttempt;
+  ill-typed transform records a "failed" RepairAttempt; unknown
+  kind surfaces a structured error). Existing flag-validation
+  tests in `repair_cli.rs` updated.
+
 ## [0.6.0] — 2026-05-10
 
 The agent-onboarding + agent-feedback wave from the post-0.5.0

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -941,18 +941,19 @@ pub(crate) fn build_embedder(store_root: &std::path::Path) -> Result<Box<dyn lex
     }
 }
 
-/// `lex repair <op_id> [--store DIR]` (#281). Walks the latest
-/// `RepairHint` attestation referencing the given failed op_id
-/// and emits its structured contents (errors + suggested
-/// transform, if any) so an agent can read the rejection cause
-/// without re-running the type-checker.
+/// `lex repair <op_id> [--apply --transform '<json>'] [--branch B] [--store DIR]`
+/// (#281). Reads the latest `RepairHint` for the failed op_id and
+/// — in `--apply` mode — executes a typed transform supplied as
+/// JSON. Emits a `RepairAttempt` attestation with the outcome.
 ///
-/// The `--apply` mode (LLM-assisted automatic fix) is deferred to
-/// a follow-up slice; today the command is read-only.
+/// Slice 2a ships the explicit-transform path; the LLM-driven
+/// path (`--apply` without `--transform`) follows in slice 2b.
 fn cmd_repair(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let mut op_id: Option<String> = None;
     let mut root: Option<PathBuf> = None;
     let mut apply = false;
+    let mut transform_json: Option<String> = None;
+    let mut branch: Option<String> = None;
     let mut it = args.iter();
     while let Some(a) = it.next() {
         match a.as_str() {
@@ -961,9 +962,18 @@ fn cmd_repair(fmt: &OutputFormat, args: &[String]) -> Result<()> {
                     .ok_or_else(|| anyhow!("--store needs a path"))?));
             }
             "--apply" => apply = true,
+            "--transform" => {
+                transform_json = Some(it.next()
+                    .ok_or_else(|| anyhow!("--transform needs a JSON payload"))?
+                    .clone());
+            }
+            "--branch" => {
+                branch = Some(it.next()
+                    .ok_or_else(|| anyhow!("--branch needs a name"))?.clone());
+            }
             other if !other.starts_with("--") => {
                 if op_id.is_some() {
-                    bail!("usage: lex repair <op_id> [--apply] [--store DIR]");
+                    bail!("usage: lex repair <op_id> [--apply --transform '<json>'] [--branch B] [--store DIR]");
                 }
                 op_id = Some(other.to_string());
             }
@@ -971,31 +981,41 @@ fn cmd_repair(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         }
     }
     let op_id = op_id.ok_or_else(|| anyhow!(
-        "usage: lex repair <op_id> [--apply] [--store DIR]"))?;
-    if apply {
-        // Slice 1 ships the read-only path; the LLM-assisted apply
-        // mode is the next slice — see #281's "Out of scope" note.
-        bail!("`lex repair --apply` is not yet implemented; ships in a follow-up slice");
-    }
+        "usage: lex repair <op_id> [--apply --transform '<json>'] [--branch B] [--store DIR]"))?;
     let root = root.unwrap_or_else(|| {
         let home = std::env::var("HOME").map(PathBuf::from)
             .unwrap_or_else(|_| PathBuf::from("."));
         home.join(".lex/store")
     });
     let store = Store::open(&root)?;
+
+    if apply {
+        let transform_json = transform_json.ok_or_else(|| anyhow!(
+            "`lex repair --apply` requires `--transform '<json>'` in slice 2a; \
+             LLM-driven generation ships in slice 2b"
+        ))?;
+        let branch = branch.unwrap_or_else(|| store.current_branch());
+        return cmd_repair_apply(fmt, &store, &op_id, &branch, &transform_json);
+    }
+    if transform_json.is_some() {
+        bail!("`--transform` requires `--apply`");
+    }
+    cmd_repair_read(fmt, &store, &op_id)
+}
+
+fn cmd_repair_read(
+    fmt: &OutputFormat,
+    store: &Store,
+    op_id: &str,
+) -> Result<()> {
     let attlog = store.attestation_log()
         .map_err(|e| anyhow!("opening attestation log: {e}"))?;
-
-    // Scan every attestation; pick the most-recent RepairHint
-    // whose `failed_op_id` matches. Cheaper than maintaining a
-    // by-failed-op index — the scan stays O(n) and n is bounded
-    // because RepairHints land only on TypeError-rejected ops.
     let mut hits: Vec<lex_vcs::Attestation> = attlog.list_all()
         .map_err(|e| anyhow!("listing attestations: {e}"))?
         .into_iter()
         .filter(|a| matches!(&a.kind,
             lex_vcs::AttestationKind::RepairHint { failed_op_id, .. }
-                if failed_op_id == &op_id))
+                if failed_op_id == op_id))
         .collect();
     hits.sort_by_key(|a| a.timestamp);
     let latest = hits.last().cloned();
@@ -1021,25 +1041,229 @@ fn cmd_repair(fmt: &OutputFormat, args: &[String]) -> Result<()> {
             "failed_op_id": op_id,
         }),
     };
+    let op_id_owned = op_id.to_string();
     acli::emit_or_text("repair", envelope.clone(), fmt, || {
         if envelope["found"] == false {
-            println!("no RepairHint found for op_id `{op_id}`");
+            println!("no RepairHint found for op_id `{op_id_owned}`");
         } else {
             let n = envelope["errors"].as_array()
                 .map(|a| a.len()).unwrap_or(0);
             let stage = envelope["stage_id"].as_str().unwrap_or("?");
-            println!("RepairHint for op_id `{op_id}`:");
+            println!("RepairHint for op_id `{op_id_owned}`:");
             println!("  stage:  {stage}");
             println!("  errors: {n}");
             println!("  suggested_transform: {}",
                 if envelope["suggested_transform"].is_null() {
-                    "(none — populated by future --apply slice)".to_string()
+                    "(none — supply one via `lex repair --apply --transform ...`)".to_string()
                 } else {
                     envelope["suggested_transform"].to_string()
                 });
         }
     });
     Ok(())
+}
+
+/// `lex repair <op_id> --apply --transform '<json>'` — slice 2a.
+///
+/// Parses the transform payload (one of #280's four typed transforms)
+/// and dispatches to the matching `Store::apply_*` method. The
+/// outcome is recorded as a `RepairAttempt` attestation tied to the
+/// original RepairHint's attestation_id so blame walks the repair
+/// chain. Returns the new op_id (or pair, for ExtractFunction) on
+/// success.
+fn cmd_repair_apply(
+    fmt: &OutputFormat,
+    store: &Store,
+    failed_op_id: &str,
+    branch: &str,
+    transform_json: &str,
+) -> Result<()> {
+    // Find the hint we're attesting against. Required so the
+    // RepairAttempt's `hint_id` field is meaningful; without one,
+    // a repair has no target to record progress against.
+    let attlog = store.attestation_log()
+        .map_err(|e| anyhow!("opening attestation log: {e}"))?;
+    let hint = attlog.list_all()
+        .map_err(|e| anyhow!("listing attestations: {e}"))?
+        .into_iter()
+        .filter(|a| matches!(&a.kind,
+            lex_vcs::AttestationKind::RepairHint { failed_op_id: f, .. }
+                if f == failed_op_id))
+        .max_by_key(|a| a.timestamp)
+        .ok_or_else(|| anyhow!(
+            "no RepairHint exists for op_id `{failed_op_id}` — \
+             a hint is required to apply a repair"
+        ))?;
+    let hint_attestation_id = hint.attestation_id.clone();
+    let hint_stage_id = hint.stage_id.clone();
+
+    let parsed: serde_json::Value = serde_json::from_str(transform_json)
+        .with_context(|| format!("parsing --transform JSON: {transform_json}"))?;
+    let kind = parsed.get("kind").and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("--transform JSON missing `kind` field"))?;
+
+    let result = dispatch_repair_transform(store, branch, &parsed, kind);
+    let (outcome, applied_op_id, error_detail) = match &result {
+        Ok(op_ids) => ("passed".to_string(), op_ids.first().cloned(), None),
+        Err(e) => ("failed".to_string(), None, Some(format!("{e}"))),
+    };
+
+    // Emit the RepairAttempt regardless of outcome — the audit
+    // trail is load-bearing whether the attempt succeeded or not.
+    let attempt = lex_vcs::Attestation::new(
+        hint_stage_id.clone(),
+        applied_op_id.clone(),
+        None,
+        lex_vcs::AttestationKind::RepairAttempt {
+            hint_id: hint_attestation_id.clone(),
+            outcome: outcome.clone(),
+            applied_op_id: applied_op_id.clone(),
+        },
+        if outcome == "passed" {
+            lex_vcs::AttestationResult::Passed
+        } else {
+            lex_vcs::AttestationResult::Failed {
+                detail: error_detail.clone().unwrap_or_default(),
+            }
+        },
+        repair_attempt_producer(),
+        None,
+    );
+    attlog.put(&attempt)
+        .map_err(|e| anyhow!("recording RepairAttempt: {e}"))?;
+
+    let env = serde_json::json!({
+        "outcome": outcome,
+        "hint_id": hint_attestation_id,
+        "applied_op_id": applied_op_id,
+        "error": error_detail,
+    });
+    acli::emit_or_text("repair-apply", env.clone(), fmt, || {
+        match env["outcome"].as_str() {
+            Some("passed") => println!(
+                "repair applied: new op_id = {}",
+                env["applied_op_id"].as_str().unwrap_or("?")
+            ),
+            _ => println!(
+                "repair failed: {}",
+                env["error"].as_str().unwrap_or("?")
+            ),
+        }
+    });
+
+    // The command itself succeeded — it ran the transform and
+    // recorded a RepairAttempt. The `outcome` field in the
+    // envelope and the attestation's result carry the inner
+    // success/failure. Exiting non-zero would have stdout emit
+    // a second wrapper envelope, which we don't want.
+    Ok(())
+}
+
+fn repair_attempt_producer() -> lex_vcs::ProducerDescriptor {
+    lex_vcs::ProducerDescriptor {
+        tool: "lex repair".into(),
+        version: env!("CARGO_PKG_VERSION").into(),
+        model: None,
+    }
+}
+
+/// Dispatch a `--transform` payload to the matching
+/// `Store::apply_*` method. Returns the resulting op_ids
+/// (singleton for the body transforms; pair for ExtractFunction).
+fn dispatch_repair_transform(
+    store: &Store,
+    branch: &str,
+    payload: &serde_json::Value,
+    kind: &str,
+) -> Result<Vec<lex_vcs::OpId>> {
+    match kind {
+        "replace_match_arm" => {
+            let from = require_str(payload, "from_stage_id")?;
+            let match_node = require_str(payload, "match_node")?;
+            let arm_index = payload.get("arm_index")
+                .and_then(|v| v.as_u64())
+                .ok_or_else(|| anyhow!("replace_match_arm: missing arm_index"))?
+                as usize;
+            let new_body: lex_ast::CExpr = serde_json::from_value(
+                payload.get("new_body").cloned()
+                    .ok_or_else(|| anyhow!("replace_match_arm: missing new_body"))?
+            ).context("parsing new_body CExpr")?;
+            let op = store.apply_replace_match_arm(
+                branch, from, &lex_ast::NodeId(match_node.into()),
+                arm_index, new_body,
+            )?;
+            Ok(vec![op])
+        }
+        "rename_local" => {
+            let from = require_str(payload, "from_stage_id")?;
+            let let_node = require_str(payload, "let_node")?;
+            let new_name = require_str(payload, "new_name")?;
+            let op = store.apply_rename_local(
+                branch, from, &lex_ast::NodeId(let_node.into()), new_name,
+            )?;
+            Ok(vec![op])
+        }
+        "inline_let" => {
+            let from = require_str(payload, "from_stage_id")?;
+            let let_node = require_str(payload, "let_node")?;
+            let op = store.apply_inline_let(
+                branch, from, &lex_ast::NodeId(let_node.into()),
+            )?;
+            Ok(vec![op])
+        }
+        "extract_function" => {
+            let from = require_str(payload, "from_stage_id")?;
+            let expr_node = require_str(payload, "expr_node")?;
+            let spec: lex_ast::ExtractFnSpec = parse_extract_spec(
+                payload.get("spec")
+                    .ok_or_else(|| anyhow!("extract_function: missing spec"))?
+            )?;
+            let (add, modify) = store.apply_extract_function(
+                branch, from, &lex_ast::NodeId(expr_node.into()), spec,
+            )?;
+            Ok(vec![add, modify])
+        }
+        other => bail!(
+            "unknown transform kind `{other}` — valid kinds are \
+             replace_match_arm | rename_local | inline_let | extract_function"
+        ),
+    }
+}
+
+fn require_str<'a>(v: &'a serde_json::Value, key: &str) -> Result<&'a str> {
+    v.get(key)
+        .and_then(|x| x.as_str())
+        .ok_or_else(|| anyhow!("--transform JSON missing string field `{key}`"))
+}
+
+/// Parse an `ExtractFnSpec` from JSON. The schema mirrors the
+/// `lex_ast::ExtractFnSpec` struct field-for-field; we hand-parse
+/// rather than `serde_json::from_value` because `Param`/`TypeExpr`/
+/// `Effect` go through `lex-ast`'s canonical-JSON form (which is
+/// the same shape, but worth being explicit).
+fn parse_extract_spec(v: &serde_json::Value) -> Result<lex_ast::ExtractFnSpec> {
+    let name = v.get("name").and_then(|x| x.as_str())
+        .ok_or_else(|| anyhow!("extract_function spec: missing name"))?
+        .to_string();
+    let type_params: Vec<String> = v.get("type_params")
+        .map(|x| serde_json::from_value(x.clone()))
+        .transpose().context("extract_function spec.type_params")?
+        .unwrap_or_default();
+    let params: Vec<lex_ast::Param> = serde_json::from_value(
+        v.get("params").cloned()
+            .ok_or_else(|| anyhow!("extract_function spec: missing params"))?
+    ).context("extract_function spec.params")?;
+    let return_type: lex_ast::TypeExpr = serde_json::from_value(
+        v.get("return_type").cloned()
+            .ok_or_else(|| anyhow!("extract_function spec: missing return_type"))?
+    ).context("extract_function spec.return_type")?;
+    let effects: Vec<lex_ast::Effect> = v.get("effects")
+        .map(|x| serde_json::from_value(x.clone()))
+        .transpose().context("extract_function spec.effects")?
+        .unwrap_or_default();
+    Ok(lex_ast::ExtractFnSpec {
+        name, type_params, params, return_type, effects,
+    })
 }
 
 fn cmd_keygen(fmt: &OutputFormat, _args: &[String]) -> Result<()> {

--- a/crates/lex-cli/tests/repair_apply.rs
+++ b/crates/lex-cli/tests/repair_apply.rs
@@ -1,0 +1,216 @@
+//! End-to-end conformance for `lex repair --apply --transform` (#281
+//! slice 2a). Tests the full hint → apply → RepairAttempt flow.
+//!
+//! Run in-process against the Store API rather than as a CLI
+//! subprocess because the transform JSON's CExpr payload is
+//! cleanest constructed in Rust.
+
+use lex_ast::{canonicalize_program, sig_id, stage_id, CExpr, CLit, NodeId, Stage};
+use lex_store::{Store, DEFAULT_BRANCH};
+use lex_syntax::parse_source;
+use tempfile::TempDir;
+
+fn fresh() -> (Store, TempDir) {
+    let tmp = TempDir::new().unwrap();
+    let s = Store::open(tmp.path()).unwrap();
+    (s, tmp)
+}
+
+fn stage_named(src: &str, name: &str) -> Stage {
+    let prog = parse_source(src).unwrap();
+    canonicalize_program(&prog)
+        .into_iter()
+        .find(|s| match s {
+            Stage::FnDecl(fd) => fd.name == name,
+            _ => false,
+        })
+        .expect("stage not found")
+}
+
+const PICK_SRC: &str = "fn pick(n :: Int) -> Int { match n { 0 => 1, _ => 2 } }\n";
+
+fn publish_initial_pick(store: &Store) -> (String, String) {
+    let s = stage_named(PICK_SRC, "pick");
+    let sig = sig_id(&s).unwrap();
+    let stg = stage_id(&s).unwrap();
+    store.publish(&s).unwrap();
+    let op = lex_vcs::Operation::new(
+        lex_vcs::OperationKind::AddFunction {
+            sig_id: sig.clone(),
+            stage_id: stg.clone(),
+            effects: Default::default(),
+            budget_cost: None,
+        },
+        [],
+    );
+    let t = lex_vcs::StageTransition::Create {
+        sig_id: sig.clone(),
+        stage_id: stg.clone(),
+    };
+    store.apply_operation(DEFAULT_BRANCH, op, t).unwrap();
+    (sig, stg)
+}
+
+/// Trigger a TypeError that emits a RepairHint, then apply a
+/// well-typed transform against the original stage. The
+/// RepairAttempt records the success.
+#[test]
+fn repair_apply_with_well_typed_transform_lands_and_emits_repair_attempt() {
+    let (store, tmp) = fresh();
+    let (_sig, from_stage_id) = publish_initial_pick(&store);
+
+    // Step 1 — provoke a RepairHint via an ill-typed transform.
+    let ill_typed = CExpr::Literal { value: CLit::Str { value: "boom".into() } };
+    let err = store
+        .apply_replace_match_arm(
+            DEFAULT_BRANCH, &from_stage_id, &NodeId("n_0.2".into()),
+            0, ill_typed,
+        )
+        .unwrap_err();
+    assert!(matches!(err, lex_store::StoreError::TypeError(_)));
+
+    let attlog = store.attestation_log().unwrap();
+    let hint = attlog.list_all().unwrap().into_iter()
+        .find(|a| matches!(a.kind, lex_vcs::AttestationKind::RepairHint { .. }))
+        .expect("RepairHint should land on the ill-typed attempt");
+    let failed_op_id = match &hint.kind {
+        lex_vcs::AttestationKind::RepairHint { failed_op_id, .. } => failed_op_id.clone(),
+        _ => unreachable!(),
+    };
+
+    // Step 2 — drive the CLI's `repair --apply --transform` via
+    // a subprocess so the integration covers the JSON parser.
+    let transform_json = serde_json::json!({
+        "kind": "replace_match_arm",
+        "from_stage_id": from_stage_id,
+        "match_node": "n_0.2",
+        "arm_index": 0,
+        "new_body": { "node": "Literal", "value": { "kind": "Int", "value": 42 } }
+    }).to_string();
+
+    let out = std::process::Command::new(
+        std::path::PathBuf::from(env!("CARGO_BIN_EXE_lex")))
+        .args([
+            "--output", "json",
+            "repair", &failed_op_id,
+            "--apply", "--transform", &transform_json,
+            "--store", tmp.path().to_str().unwrap(),
+        ])
+        .output().unwrap();
+    assert!(out.status.success(),
+        "repair --apply failed: stderr={}\nstdout={}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout));
+    let env: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(env["data"]["outcome"], "passed");
+    assert!(env["data"]["applied_op_id"].is_string(),
+        "applied_op_id should be set on success");
+
+    // Step 3 — RepairAttempt attestation lands.
+    let post = attlog.list_all().unwrap();
+    let attempts: Vec<_> = post.iter()
+        .filter(|a| matches!(a.kind, lex_vcs::AttestationKind::RepairAttempt { .. }))
+        .collect();
+    assert_eq!(attempts.len(), 1, "exactly one RepairAttempt should land");
+    let lex_vcs::AttestationKind::RepairAttempt { hint_id, outcome, applied_op_id } =
+        &attempts[0].kind else { unreachable!() };
+    assert_eq!(hint_id, &hint.attestation_id);
+    assert_eq!(outcome, "passed");
+    assert!(applied_op_id.is_some());
+}
+
+#[test]
+fn repair_apply_with_ill_typed_transform_records_failure() {
+    let (store, tmp) = fresh();
+    let (_sig, from_stage_id) = publish_initial_pick(&store);
+
+    // Seed a hint.
+    let _ = store.apply_replace_match_arm(
+        DEFAULT_BRANCH, &from_stage_id, &NodeId("n_0.2".into()),
+        0, CExpr::Literal { value: CLit::Str { value: "x".into() } },
+    );
+
+    let attlog = store.attestation_log().unwrap();
+    let hint = attlog.list_all().unwrap().into_iter()
+        .find(|a| matches!(a.kind, lex_vcs::AttestationKind::RepairHint { .. }))
+        .unwrap();
+    let failed_op_id = match &hint.kind {
+        lex_vcs::AttestationKind::RepairHint { failed_op_id, .. } => failed_op_id.clone(),
+        _ => unreachable!(),
+    };
+
+    // Apply another ill-typed transform — still a string literal.
+    let transform_json = serde_json::json!({
+        "kind": "replace_match_arm",
+        "from_stage_id": from_stage_id,
+        "match_node": "n_0.2",
+        "arm_index": 0,
+        "new_body": { "node": "Literal", "value": { "kind": "Str", "value": "still wrong" } }
+    }).to_string();
+
+    let out = std::process::Command::new(
+        std::path::PathBuf::from(env!("CARGO_BIN_EXE_lex")))
+        .args([
+            "--output", "json",
+            "repair", &failed_op_id,
+            "--apply", "--transform", &transform_json,
+            "--store", tmp.path().to_str().unwrap(),
+        ])
+        .output().unwrap();
+    // The command itself succeeds — the failure outcome lives in
+    // the envelope. Exit code reflects "did the command run", not
+    // "did the repair land."
+    assert!(out.status.success(),
+        "command ran cleanly; outcome lives in the envelope: stderr={}",
+        String::from_utf8_lossy(&out.stderr));
+    let env: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(env["data"]["outcome"], "failed");
+
+    // RepairAttempt with failed outcome should still land — the
+    // audit trail records the attempt regardless of outcome.
+    let post = attlog.list_all().unwrap();
+    let attempts: Vec<_> = post.iter()
+        .filter_map(|a| match &a.kind {
+            lex_vcs::AttestationKind::RepairAttempt { outcome, .. } => Some(outcome.clone()),
+            _ => None,
+        })
+        .collect();
+    assert!(attempts.iter().any(|o| o == "failed"),
+        "a 'failed' RepairAttempt should land; got {attempts:?}");
+}
+
+#[test]
+fn repair_apply_rejects_unknown_transform_kind() {
+    let (store, tmp) = fresh();
+    let (_sig, from_stage_id) = publish_initial_pick(&store);
+
+    // Seed a hint.
+    let _ = store.apply_replace_match_arm(
+        DEFAULT_BRANCH, &from_stage_id, &NodeId("n_0.2".into()),
+        0, CExpr::Literal { value: CLit::Str { value: "x".into() } },
+    );
+
+    let attlog = store.attestation_log().unwrap();
+    let hint = attlog.list_all().unwrap().into_iter()
+        .find(|a| matches!(a.kind, lex_vcs::AttestationKind::RepairHint { .. }))
+        .unwrap();
+    let failed_op_id = match &hint.kind {
+        lex_vcs::AttestationKind::RepairHint { failed_op_id, .. } => failed_op_id.clone(),
+        _ => unreachable!(),
+    };
+
+    let out = std::process::Command::new(
+        std::path::PathBuf::from(env!("CARGO_BIN_EXE_lex")))
+        .args([
+            "--output", "json",
+            "repair", &failed_op_id,
+            "--apply", "--transform", r#"{"kind":"not_a_real_transform"}"#,
+            "--store", tmp.path().to_str().unwrap(),
+        ])
+        .output().unwrap();
+    assert!(out.status.success(), "command ran cleanly");
+    let env: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(env["data"]["outcome"], "failed");
+    assert!(env["data"]["error"].as_str().unwrap().contains("unknown transform kind"),
+        "envelope should describe the kind error, got: {}", env["data"]["error"]);
+}

--- a/crates/lex-cli/tests/repair_cli.rs
+++ b/crates/lex-cli/tests/repair_cli.rs
@@ -24,16 +24,48 @@ fn repair_with_no_hint_reports_not_found() {
 }
 
 #[test]
-fn repair_apply_is_unsupported_today() {
+fn repair_apply_without_transform_errors() {
+    // Slice 2a: `--apply` requires `--transform '<json>'`. The
+    // LLM-driven path (no `--transform`) ships in slice 2b.
     let tmp = tempfile::tempdir().unwrap();
     let out = Command::new(lex_bin())
         .args(["repair", "fake-op-id", "--apply",
             "--store", tmp.path().to_str().unwrap()])
         .output().unwrap();
-    assert!(!out.status.success(), "--apply should fail today");
+    assert!(!out.status.success(),
+        "--apply without --transform should fail");
     let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(stderr.contains("not yet implemented"),
-        "expected 'not yet implemented' message, got: {stderr}");
+    assert!(stderr.contains("requires `--transform"),
+        "expected '--apply requires --transform' message, got: {stderr}");
+}
+
+#[test]
+fn repair_transform_without_apply_errors() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = Command::new(lex_bin())
+        .args(["repair", "fake-op-id", "--transform", "{}",
+            "--store", tmp.path().to_str().unwrap()])
+        .output().unwrap();
+    assert!(!out.status.success(),
+        "--transform without --apply should fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("--transform` requires `--apply"),
+        "expected message, got: {stderr}");
+}
+
+#[test]
+fn repair_apply_without_hint_errors() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = Command::new(lex_bin())
+        .args(["repair", "fake-op-id", "--apply",
+            "--transform", r#"{"kind":"inline_let","from_stage_id":"x","let_node":"n_0.1"}"#,
+            "--store", tmp.path().to_str().unwrap()])
+        .output().unwrap();
+    assert!(!out.status.success(),
+        "applying without a matching RepairHint should fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("no RepairHint exists"),
+        "expected hint-required message, got: {stderr}");
 }
 
 #[test]


### PR DESCRIPTION
Second slice of #281 — the read-only `lex repair <op_id>` from slice 1 gets a write path.

## Summary

**`lex repair <op_id> --apply --transform '<json>' [--branch B]`** executes a typed transform against the branch and emits a `RepairAttempt` attestation linked to the original `RepairHint`. Supports all four #280 transform kinds via JSON payload:

```json
// replace_match_arm
{"kind": "replace_match_arm", "from_stage_id": "...", "match_node": "n_0.2",
 "arm_index": 0, "new_body": { "node": "Literal", "value": { "kind": "Int", "value": 42 } }}

// rename_local
{"kind": "rename_local", "from_stage_id": "...", "let_node": "n_0.2", "new_name": "y"}

// inline_let
{"kind": "inline_let", "from_stage_id": "...", "let_node": "n_0.2"}

// extract_function
{"kind": "extract_function", "from_stage_id": "...", "expr_node": "n_0.3.0",
 "spec": { "name": "double_n", "params": [...], "return_type": ..., "effects": [] }}
```

## Design decisions

- **Exit 0 regardless of inner outcome.** The CLI's job is to *run the transform and record the attempt*. The success/failure signal lives in two places: the envelope's `outcome` field and the persisted `RepairAttempt` attestation. Propagating Err to `main()` would double-emit (acli's structured-error wrapper on top of my envelope) and break JSON-parsing tools.
- **Requires a matching `RepairHint`**. Apply without a hint errors with "no RepairHint exists" — the audit chain is load-bearing; you can't repair what wasn't first flagged.
- **`--apply` without `--transform`** errors with a pointer to slice 2b. Slice 2b adds LLM-driven generation; this slice is the structural foundation.

## Test plan

- [x] 3 end-to-end tests in `crates/lex-cli/tests/repair_apply.rs` (well-typed lands op + RepairAttempt; ill-typed records "failed" RepairAttempt; unknown kind structured error).
- [x] 3 flag-validation tests in `crates/lex-cli/tests/repair_cli.rs` (`--apply` without `--transform`, `--transform` without `--apply`, `--apply` without a matching hint).
- [x] `cargo test --workspace` — 175 test groups pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.

## What's still out

- **#281 slice 2b** — `lex repair --apply` (no `--transform` flag) calls `[llm_cloud]` to generate the transform JSON from the failed-op context + type errors. Needs an LLM-fixture/mock design before it can ship cleanly; the existing `cloud_config_fails_without_api_key` env-var flake is a tell that real LLM tests are hard to write.
- `--max-iters` looping. Slice 2a is single-shot; once 2b lands, iteration can layer on top.

https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_