### PR TITLE
lex-store+cli: per-session budget ledger (#292, slice 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+### Added — agent-safety (#292, slice 1)
+
+- **`Store::session_budget(session_id)`** and
+  **`Store::all_session_budgets()`** — read-only ledger of how
+  much budget each agent session has spent across every op
+  attributed to it via `intent_id → session_id`. New
+  `SessionBudget { session_id, spent, op_count }` public type.
+- **Spend model**: monotonic. `AddFunction` contributes its full
+  `budget_cost`; `ModifyBody` / `ChangeEffectSig` / the typed
+  transform variants contribute `max(0, to - from)` (decreases
+  don't refund). Ops without `intent_id` or with a dangling
+  intent are silently skipped — the ledger degrades gracefully
+  rather than failing the read.
+- **`lex audit --budget --by-session [--session <id>]`** rolls up
+  the ledger and emits per-session spend. Without `--by-session`,
+  `--budget` keeps its existing per-sig history shape (#247).
+- 8 conformance tests in `crates/lex-store/tests/session_budget.rs`
+  (zero on empty / unknown; AddFunction attribution; ops without
+  intent skipped; multiple sessions kept separate; ModifyBody
+  increase contributes delta only; decrease doesn't refund;
+  dangling intent skipped gracefully). 3 CLI tests in
+  `crates/lex-cli/tests/audit_session_budget.rs` (empty store;
+  filter-by-missing-session zero-pads; `--by-session` requires
+  `--budget`).
+
+Slice 1 is **read-only**; slices 2 (`policy.json` `session_budgets`
+schema) and 3 (apply-path gate that refuses ops over cap) follow.
+
 ### Added — agent-feedback (#281, slice 2a)
 
 - **`lex repair <op_id> --apply --transform '<json>'`** executes a

--- a/crates/lex-cli/src/audit.rs
+++ b/crates/lex-cli/src/audit.rs
@@ -61,6 +61,13 @@ struct AuditOpts {
     /// declared `[budget(N)]` cost across the chain. Mutually
     /// exclusive with `--query`.
     budget_history: bool,
+    /// `--budget --by-session` (#292 slice 1). Roll up monotonic
+    /// budget spend across every distinct session that produced
+    /// budget-bearing ops. Only meaningful with `--budget`.
+    budget_by_session: bool,
+    /// `--budget --session <id>` (#292 slice 1). Restrict the
+    /// rollup to a single session.
+    budget_session: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -84,6 +91,16 @@ pub fn cmd_audit(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     if matches!(fmt, OutputFormat::Json) { opts.json = true; }
     if opts.query.is_some() && opts.budget_history {
         return Err(anyhow!("--query and --budget are mutually exclusive"));
+    }
+    if (opts.budget_by_session || opts.budget_session.is_some())
+        && !opts.budget_history
+    {
+        return Err(anyhow!(
+            "--by-session / --session require --budget"
+        ));
+    }
+    if opts.budget_history && (opts.budget_by_session || opts.budget_session.is_some()) {
+        return cmd_audit_budget_by_session(fmt, &opts);
     }
     if opts.budget_history {
         return cmd_audit_budget(fmt, &opts);
@@ -268,6 +285,13 @@ fn parse_audit_args(args: &[String]) -> Result<AuditOpts> {
                 i += 2;
             }
             "--budget" => { o.budget_history = true; i += 1; }
+            "--by-session" => { o.budget_by_session = true; i += 1; }
+            "--session" => {
+                let v = args.get(i + 1)
+                    .ok_or_else(|| anyhow!("--session needs a session_id"))?;
+                o.budget_session = Some(v.clone());
+                i += 2;
+            }
             other => { o.paths.push(PathBuf::from(other)); i += 1; }
         }
     }
@@ -604,6 +628,72 @@ fn cmd_audit_budget(fmt: &OutputFormat, opts: &AuditOpts) -> Result<()> {
                 println!("      {op_id:.16}…  {label}");
             }
             println!();
+        }
+    });
+    Ok(())
+}
+
+/// `lex audit --budget --by-session [--session <id>]` (#292 slice 1).
+/// Walks every branch's op log, joins through the IntentLog to
+/// resolve `session_id` per op, and sums monotonic budget spend
+/// per session.
+fn cmd_audit_budget_by_session(
+    fmt: &OutputFormat,
+    opts: &AuditOpts,
+) -> Result<()> {
+    let root = opts.store_root.clone().unwrap_or_else(default_store_root);
+    let store = lex_store::Store::open(&root)
+        .with_context(|| format!("opening store at {}", root.display()))?;
+
+    let mut rollups = store.all_session_budgets()
+        .map_err(|e| anyhow!("computing session budgets: {e}"))?;
+    if let Some(filter) = &opts.budget_session {
+        rollups.retain(|b| &b.session_id == filter);
+        // Pad with a zero entry if the session wasn't found so the
+        // envelope's shape stays predictable for tooling.
+        if rollups.is_empty() {
+            rollups.push(lex_store::SessionBudget {
+                session_id: filter.clone(),
+                spent: 0,
+                op_count: 0,
+            });
+        }
+    }
+
+    let sessions_json: Vec<serde_json::Value> = rollups.iter().map(|b| {
+        serde_json::json!({
+            "session_id": b.session_id,
+            "spent": b.spent,
+            "op_count": b.op_count,
+        })
+    }).collect();
+    let total_spent: u64 = rollups.iter().map(|b| b.spent).sum();
+    let data = serde_json::json!({
+        "sessions": sessions_json,
+        "total_spent": total_spent,
+    });
+    let printable = rollups.clone();
+    let single = opts.budget_session.clone();
+    acli_mod::emit_or_text("audit", data, fmt, move || {
+        if printable.is_empty() {
+            println!("(no budget-bearing ops attributed to any session)");
+            return;
+        }
+        match &single {
+            Some(sid) => {
+                let b = &printable[0];
+                println!("session `{sid}`");
+                println!("    spent:   {}", b.spent);
+                println!("    op_count: {}", b.op_count);
+            }
+            None => {
+                println!("budget spend across {} session(s):", printable.len());
+                for b in &printable {
+                    println!("    {} → {} ({} ops)",
+                        b.session_id, b.spent, b.op_count);
+                }
+                println!("    total: {total_spent}");
+            }
         }
     });
     Ok(())

--- a/crates/lex-cli/tests/audit_session_budget.rs
+++ b/crates/lex-cli/tests/audit_session_budget.rs
@@ -1,0 +1,68 @@
+//! Conformance for `lex audit --budget --by-session` (#292 slice 1).
+//! Drives the CLI as a subprocess against a seeded store.
+
+use std::process::Command;
+
+fn lex_bin() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_lex"))
+}
+
+fn run_json(args: &[&str]) -> (bool, serde_json::Value) {
+    let out = Command::new(lex_bin()).args(args).output().unwrap();
+    let env: serde_json::Value = serde_json::from_slice(&out.stdout)
+        .unwrap_or_else(|e| panic!(
+            "expected JSON on stdout, got: {}\nstderr={}\nerr={e}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        ));
+    (out.status.success(), env)
+}
+
+#[test]
+fn budget_by_session_on_empty_store_emits_empty_envelope() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (ok, env) = run_json(&[
+        "--output", "json",
+        "audit", "--budget", "--by-session",
+        "--store", tmp.path().to_str().unwrap(),
+    ]);
+    assert!(ok);
+    let v = &env["data"];
+    assert!(v["sessions"].as_array().unwrap().is_empty());
+    assert_eq!(v["total_spent"], 0);
+}
+
+#[test]
+fn budget_by_session_with_specific_session_pads_with_zero() {
+    // When the filter session doesn't exist, the envelope still
+    // emits one row with zero spend so tooling can rely on the
+    // shape.
+    let tmp = tempfile::tempdir().unwrap();
+    let (ok, env) = run_json(&[
+        "--output", "json",
+        "audit", "--budget", "--session", "ses_missing",
+        "--store", tmp.path().to_str().unwrap(),
+    ]);
+    assert!(ok);
+    let v = &env["data"];
+    let sessions = v["sessions"].as_array().unwrap();
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0]["session_id"], "ses_missing");
+    assert_eq!(sessions[0]["spent"], 0);
+    assert_eq!(sessions[0]["op_count"], 0);
+}
+
+#[test]
+fn by_session_or_session_without_budget_errors() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = Command::new(lex_bin())
+        .args([
+            "audit", "--by-session",
+            "--store", tmp.path().to_str().unwrap(),
+        ])
+        .output().unwrap();
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("require --budget"),
+        "expected '--by-session require --budget' message, got: {stderr}");
+}

--- a/crates/lex-store/src/budget.rs
+++ b/crates/lex-store/src/budget.rs
@@ -1,0 +1,179 @@
+//! Per-session budget ledger (#292 slice 1).
+//!
+//! Today `OperationKind::budget_delta()` records `(from, to)`
+//! budget pairs on every op that touches a `[budget(N)]`-bearing
+//! function. `lex audit --budget` already rolls those up per
+//! signature. What's missing is the per-session aggregate: "how
+//! much budget did session X cause to be spent across all the ops
+//! it authored?"
+//!
+//! This module is the read-only ledger. Slice 2 layers a
+//! `policy.json` cap on top; slice 3 wires the apply-path gate.
+//!
+//! # Spend model
+//!
+//! For each op tagged with an `intent_id` resolving to a session:
+//!
+//! - `AddFunction` with `budget_cost = Some(n)` contributes `n`.
+//! - `ModifyBody` / `ChangeEffectSig` / `ReplaceMatchArm` /
+//!   `RenameLocal` / `InlineLet` with `(from_budget, to_budget)`
+//!   contribute `max(0, to - from)` (only budget *increases*
+//!   count toward spend; refactor-to-cheaper doesn't refund).
+//! - Ops without `intent_id` are excluded — there's no session to
+//!   attribute them to.
+//!
+//! # Cost
+//!
+//! Single walk of the op log + one `IntentLog::get` per distinct
+//! intent. For studies past ~100k ops, slice 2 will add an on-disk
+//! cache keyed by `(session_id, head_op)` so re-reads are O(1).
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+use crate::store::{Store, StoreError};
+
+/// Rollup of a single session's budget spend.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionBudget {
+    pub session_id: String,
+    /// Sum of monotonic budget cost over all ops in this session.
+    pub spent: u64,
+    /// How many ops were attributed to this session (only those
+    /// that contributed a non-zero increment count).
+    pub op_count: usize,
+}
+
+impl Store {
+    /// Compute the budget spent by the given `session_id` across
+    /// every op currently reachable from any branch head. Returns
+    /// `(spent: 0, op_count: 0)` for unknown sessions.
+    pub fn session_budget(&self, session_id: &str) -> Result<SessionBudget, StoreError> {
+        let all = self.all_session_budgets()?;
+        Ok(all.into_iter()
+            .find(|b| b.session_id == session_id)
+            .unwrap_or(SessionBudget {
+                session_id: session_id.into(),
+                spent: 0,
+                op_count: 0,
+            }))
+    }
+
+    /// Compute per-session budget rollups across every branch.
+    /// Returns one entry per distinct session that contributed at
+    /// least one budget-bearing op. Sorted by `session_id` so the
+    /// output is deterministic.
+    pub fn all_session_budgets(&self) -> Result<Vec<SessionBudget>, StoreError> {
+        let log = lex_vcs::OpLog::open(self.root())?;
+        let intent_log = lex_vcs::IntentLog::open(self.root())?;
+
+        // Collect the union of ops reachable from every branch
+        // head. Walking each branch separately and unioning by
+        // op_id avoids double-counting on diamond histories.
+        let mut visited: std::collections::BTreeSet<lex_vcs::OpId> = Default::default();
+        let mut records: Vec<lex_vcs::OperationRecord> = Vec::new();
+        for branch_name in self.list_branches()? {
+            let Some(branch) = self.get_branch(&branch_name)? else { continue };
+            let Some(head) = branch.head_op else { continue };
+            for rec in log.walk_back(&head, None)? {
+                if visited.insert(rec.op_id.clone()) {
+                    records.push(rec);
+                }
+            }
+        }
+
+        // Walk records → resolve intent → resolve session → tally.
+        // Intent lookups are cached so we don't hit the IntentLog
+        // once per op when many ops share an intent.
+        let mut intent_to_session: BTreeMap<String, Option<String>> = BTreeMap::new();
+        let mut buckets: BTreeMap<String, (u64, usize)> = BTreeMap::new();
+        for rec in &records {
+            let Some(intent_id) = rec.op.intent_id.as_deref() else { continue };
+            let session = match intent_to_session.get(intent_id) {
+                Some(s) => s.clone(),
+                None => {
+                    let s = intent_log.get(&intent_id.to_string())?
+                        .map(|i| i.session_id);
+                    intent_to_session.insert(intent_id.into(), s.clone());
+                    s
+                }
+            };
+            let Some(session_id) = session else { continue };
+
+            let increment = monotonic_spend(&rec.op.kind);
+            if increment == 0 { continue; }
+            let entry = buckets.entry(session_id).or_insert((0, 0));
+            entry.0 += increment;
+            entry.1 += 1;
+        }
+
+        let out: Vec<SessionBudget> = buckets
+            .into_iter()
+            .map(|(session_id, (spent, op_count))| SessionBudget {
+                session_id,
+                spent,
+                op_count,
+            })
+            .collect();
+        Ok(out)
+    }
+}
+
+/// Convert an op's `budget_delta` into a monotonic spend amount.
+/// `AddFunction` contributes its full `budget_cost`; modify-shape
+/// ops contribute the delta only when budget *increased*.
+fn monotonic_spend(kind: &lex_vcs::OperationKind) -> u64 {
+    let (from, to) = kind.budget_delta();
+    match (from, to) {
+        (None, Some(n)) => n,
+        (Some(f), Some(t)) if t > f => t - f,
+        _ => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn monotonic_spend_handles_each_shape() {
+        use lex_vcs::OperationKind;
+        // AddFunction: full cost contributes.
+        let k = OperationKind::AddFunction {
+            sig_id: "f".into(),
+            stage_id: "s".into(),
+            effects: Default::default(),
+            budget_cost: Some(10),
+        };
+        assert_eq!(monotonic_spend(&k), 10);
+
+        // ModifyBody: only increases count.
+        let k = OperationKind::ModifyBody {
+            sig_id: "f".into(),
+            from_stage_id: "a".into(),
+            to_stage_id: "b".into(),
+            from_budget: Some(10),
+            to_budget: Some(15),
+        };
+        assert_eq!(monotonic_spend(&k), 5);
+
+        let k = OperationKind::ModifyBody {
+            sig_id: "f".into(),
+            from_stage_id: "a".into(),
+            to_stage_id: "b".into(),
+            from_budget: Some(15),
+            to_budget: Some(10),
+        };
+        assert_eq!(monotonic_spend(&k), 0, "decrease doesn't refund");
+
+        // ModifyBody with no budget data on either side: zero.
+        let k = OperationKind::ModifyBody {
+            sig_id: "f".into(),
+            from_stage_id: "a".into(),
+            to_stage_id: "b".into(),
+            from_budget: None,
+            to_budget: None,
+        };
+        assert_eq!(monotonic_spend(&k), 0);
+    }
+}

--- a/crates/lex-store/src/lib.rs
+++ b/crates/lex-store/src/lib.rs
@@ -25,6 +25,7 @@
 //! produces identical results regardless of cache state — the obvious way
 //! to honor that is to keep the cache trivially derivable.
 
+mod budget;
 mod store;
 mod model;
 mod branches;
@@ -33,6 +34,7 @@ mod gc;
 pub mod users;
 pub mod policy;
 
+pub use budget::SessionBudget;
 pub use delta::{StageDelta, DELTA_CHAIN_CAP, DELTA_RATIO_THRESHOLD};
 pub use gc::{GcPlan, RetentionReason};
 

--- a/crates/lex-store/tests/session_budget.rs
+++ b/crates/lex-store/tests/session_budget.rs
@@ -1,0 +1,202 @@
+//! Conformance tests for #292 slice 1 — per-session budget ledger.
+
+use lex_store::{Operation, OperationKind, StageTransition, Store, DEFAULT_BRANCH};
+use std::collections::BTreeSet;
+use tempfile::TempDir;
+
+fn fresh() -> (Store, TempDir) {
+    let tmp = TempDir::new().unwrap();
+    let s = Store::open(tmp.path()).unwrap();
+    (s, tmp)
+}
+
+fn anthropic() -> lex_vcs::ModelDescriptor {
+    lex_vcs::ModelDescriptor {
+        provider: "anthropic".into(),
+        name: "claude-test".into(),
+        version: None,
+    }
+}
+
+/// Persist an Intent and return its IntentId.
+fn create_intent(store: &Store, prompt: &str, session: &str) -> String {
+    let intent = lex_vcs::Intent::new(prompt, session, anthropic(), None);
+    let id = intent.intent_id.clone();
+    lex_vcs::IntentLog::open(store.root()).unwrap()
+        .put(&intent).unwrap();
+    id
+}
+
+/// Add a fn with the given budget cost, tagged with `intent_id`.
+/// Chains off the current branch head so multiple calls compose.
+fn add_fn_with_budget(
+    store: &Store,
+    sig: &str,
+    stage: &str,
+    cost: u64,
+    intent_id: Option<&str>,
+) {
+    let mut effects = BTreeSet::new();
+    effects.insert(format!("budget({cost})"));
+    let parents: Vec<lex_vcs::OpId> = store
+        .get_branch(DEFAULT_BRANCH).unwrap()
+        .and_then(|b| b.head_op)
+        .into_iter().collect();
+    let mut op = Operation::new(
+        OperationKind::AddFunction {
+            sig_id: sig.into(),
+            stage_id: stage.into(),
+            effects,
+            budget_cost: Some(cost),
+        },
+        parents,
+    );
+    if let Some(id) = intent_id {
+        op = op.with_intent(id);
+    }
+    let t = StageTransition::Create {
+        sig_id: sig.into(),
+        stage_id: stage.into(),
+    };
+    store.apply_operation(DEFAULT_BRANCH, op, t).unwrap();
+}
+
+#[test]
+fn fresh_store_reports_zero_for_unknown_session() {
+    let (store, _tmp) = fresh();
+    let b = store.session_budget("unknown-session").unwrap();
+    assert_eq!(b.session_id, "unknown-session");
+    assert_eq!(b.spent, 0);
+    assert_eq!(b.op_count, 0);
+}
+
+#[test]
+fn fresh_store_reports_no_session_rollups() {
+    let (store, _tmp) = fresh();
+    let all = store.all_session_budgets().unwrap();
+    assert!(all.is_empty());
+}
+
+#[test]
+fn add_function_with_budget_attributed_to_session() {
+    let (store, _tmp) = fresh();
+    let intent = create_intent(&store, "build a calculator", "ses_alpha");
+    add_fn_with_budget(&store, "fac", "stg-1", 10, Some(&intent));
+
+    let b = store.session_budget("ses_alpha").unwrap();
+    assert_eq!(b.spent, 10);
+    assert_eq!(b.op_count, 1);
+}
+
+#[test]
+fn ops_without_intent_are_excluded() {
+    let (store, _tmp) = fresh();
+    // No intent_id on the op → no session to attribute to.
+    add_fn_with_budget(&store, "fac", "stg-1", 10, None);
+
+    let all = store.all_session_budgets().unwrap();
+    assert!(all.is_empty(),
+        "ops without intent_id must not contribute; got {all:?}");
+}
+
+#[test]
+fn multiple_sessions_kept_separate() {
+    let (store, _tmp) = fresh();
+    let alpha = create_intent(&store, "build calculator", "ses_alpha");
+    let beta = create_intent(&store, "fix bug", "ses_beta");
+
+    add_fn_with_budget(&store, "fac", "stg-1", 5, Some(&alpha));
+    add_fn_with_budget(&store, "fib", "stg-2", 7, Some(&beta));
+    add_fn_with_budget(&store, "sum", "stg-3", 3, Some(&alpha));
+
+    let alpha_b = store.session_budget("ses_alpha").unwrap();
+    assert_eq!(alpha_b.spent, 5 + 3);
+    assert_eq!(alpha_b.op_count, 2);
+
+    let beta_b = store.session_budget("ses_beta").unwrap();
+    assert_eq!(beta_b.spent, 7);
+    assert_eq!(beta_b.op_count, 1);
+
+    let all = store.all_session_budgets().unwrap();
+    assert_eq!(all.len(), 2);
+    let sessions: Vec<&str> = all.iter().map(|b| b.session_id.as_str()).collect();
+    assert_eq!(sessions, vec!["ses_alpha", "ses_beta"],
+        "sorted by session_id");
+}
+
+#[test]
+fn modify_body_increase_contributes_delta_only() {
+    let (store, _tmp) = fresh();
+    let alpha = create_intent(&store, "tune", "ses_alpha");
+    // First op: AddFunction with budget=5 → spend = 5.
+    add_fn_with_budget(&store, "fac", "stg-1", 5, Some(&alpha));
+
+    // Second op: ModifyBody from_budget=5 to_budget=12 → spend
+    // contribution = 12 - 5 = 7.
+    let parent = store.get_branch(DEFAULT_BRANCH).unwrap().unwrap().head_op.unwrap();
+    let mod_op = Operation::new(
+        OperationKind::ModifyBody {
+            sig_id: "fac".into(),
+            from_stage_id: "stg-1".into(),
+            to_stage_id: "stg-2".into(),
+            from_budget: Some(5),
+            to_budget: Some(12),
+        },
+        [parent],
+    ).with_intent(&alpha);
+    let t = StageTransition::Replace {
+        sig_id: "fac".into(),
+        from: "stg-1".into(),
+        to: "stg-2".into(),
+    };
+    store.apply_operation(DEFAULT_BRANCH, mod_op, t).unwrap();
+
+    let b = store.session_budget("ses_alpha").unwrap();
+    assert_eq!(b.spent, 5 + 7);
+    assert_eq!(b.op_count, 2);
+}
+
+#[test]
+fn modify_body_decrease_does_not_refund() {
+    let (store, _tmp) = fresh();
+    let alpha = create_intent(&store, "tune", "ses_alpha");
+    add_fn_with_budget(&store, "fac", "stg-1", 20, Some(&alpha));
+
+    let parent = store.get_branch(DEFAULT_BRANCH).unwrap().unwrap().head_op.unwrap();
+    let mod_op = Operation::new(
+        OperationKind::ModifyBody {
+            sig_id: "fac".into(),
+            from_stage_id: "stg-1".into(),
+            to_stage_id: "stg-2".into(),
+            from_budget: Some(20),
+            to_budget: Some(5),
+        },
+        [parent],
+    ).with_intent(&alpha);
+    let t = StageTransition::Replace {
+        sig_id: "fac".into(),
+        from: "stg-1".into(),
+        to: "stg-2".into(),
+    };
+    store.apply_operation(DEFAULT_BRANCH, mod_op, t).unwrap();
+
+    let b = store.session_budget("ses_alpha").unwrap();
+    // Only the initial 20 counts; the decrease doesn't deduct.
+    assert_eq!(b.spent, 20);
+    // op_count is just the ops that contributed a non-zero
+    // increment; the decrease contributed 0 so it's not counted.
+    assert_eq!(b.op_count, 1);
+}
+
+#[test]
+fn intent_not_in_log_is_skipped_gracefully() {
+    let (store, _tmp) = fresh();
+    // Tag the op with an intent_id that doesn't exist in the
+    // IntentLog. Real workflows always persist the intent first,
+    // but the ledger should degrade gracefully.
+    add_fn_with_budget(&store, "fac", "stg-1", 10, Some("dangling-intent"));
+
+    let all = store.all_session_budgets().unwrap();
+    assert!(all.is_empty(),
+        "dangling intent → no session attribution; got {all:?}");
+}


### PR DESCRIPTION
First slice of #292 — read-only per-session budget ledger.

## Summary

Closes the descriptive half of #292. Adds:

- **`Store::session_budget(session_id) -> SessionBudget`** and **`Store::all_session_budgets()`** — walk every branch's op log, resolve `intent_id → session_id` via `IntentLog`, and sum monotonic budget spend per session.
- **`SessionBudget { session_id, spent, op_count }`** — public type re-exported from `lex-store`.
- **`lex audit --budget --by-session [--session <id>]`** — CLI rollup. Without `--by-session`, `--budget` keeps its existing per-sig history shape (#247).

## Spend model

For each op tagged with an `intent_id` that resolves to a session:

- `AddFunction` with `budget_cost = Some(n)` contributes `n`.
- `ModifyBody` / `ChangeEffectSig` / `ReplaceMatchArm` / `RenameLocal` / `InlineLet` with `(from_budget, to_budget)` contribute `max(0, to - from)`. Decreases don't refund.
- Ops without `intent_id`, or with an intent_id that doesn't exist in the IntentLog, are silently skipped — the ledger degrades gracefully rather than failing on stale or adversarial state.

## Slice-2 / slice-3 path forward

This slice is **read-only**. The next two slices layer on top:

- **Slice 2**: `policy.json` `session_budgets` schema (`default_cap`, per-session `overrides`).
- **Slice 3**: apply-path gate (`Store::apply_operation_checked` consults the cap and refuses on overflow with `StoreError::BudgetExceeded`). HTTP API maps to 503.

Splitting lets slice 1 land the ledger as a pure observation primitive that other tooling can use immediately.

## Test plan

- [x] 8 conformance tests in `crates/lex-store/tests/session_budget.rs` (zero on empty / unknown; AddFunction attribution; ops-without-intent skipped; multiple sessions separate; ModifyBody-increase contributes delta only; decrease doesn't refund; dangling intent skipped).
- [x] 3 CLI tests in `crates/lex-cli/tests/audit_session_budget.rs` (empty store envelope; filter-by-missing-session zero-pads; `--by-session` requires `--budget`).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo test -p lex-store --test session_budget` and `cargo test -p lex-cli --test audit_session_budget` — both pass standalone.

The workspace test run hits two documented pre-existing flakes (lex-api/m8 port races, `llm::cloud_config_fails_without_api_key` env-var race) — same shape as on previous PRs, unrelated to this slice.

https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_