### PR TITLE
lex-store+vcs+api+cli: per-session budget enforcement (#292, slices 2+3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+### Added — agent-safety (#292, slices 2 + 3)
+
+- **`policy.session_budgets` schema** with `default_cap` and
+  per-session `overrides` (#292 slice 2). An override entry of
+  `Some(n)` sets a session-specific cap; an entry with explicit
+  `null` means unbounded for that session (escape hatch for human
+  interventions). Absent `session_budgets` keeps slice-1 behavior
+  (descriptive ledger only, no enforcement).
+- **`Store::session_budget_cap(session_id)`** resolves the
+  effective cap (per-session override → default_cap → None).
+- **`SessionBudget` envelope** extended with optional `cap` and
+  `remaining` fields. JSON shape stays backward-compatible via
+  `skip_serializing_if = "Option::is_none"`.
+- **`Store::apply_operation_checked` budget gate** (#292 slice 3).
+  After typecheck passes, refuses ops that would push the
+  session's monotonic spend over the configured cap. New
+  `StoreError::BudgetExceeded { session_id, cap, spent_after }`
+  variant. Ops without an `intent_id`, with a dangling intent, or
+  whose session has no cap configured sail through.
+- **HTTP API** maps `BudgetExceeded` to **503 with `Retry-After:
+  0`** and a `{kind: "budget_exceeded", session_id, cap,
+  spent_after}` detail envelope. Unlike Contention (where retry
+  might land later), there's no point retrying as-is — the caller
+  needs to raise the cap, switch sessions, or refactor.
+- **`lex policy session-budget {set-default <N> | set <id> <N> |
+  unbounded <id> | clear <id> | clear-default}`** CLI manages
+  the policy file. Writes are atomic (tempfile + rename).
+- 14 new tests (9 store-gate + 5 CLI-policy).
+
+With slices 1 + 2 + 3 all shipped, **#292 is complete**.
+
 ### Added — agent-safety (#292, slice 1)
 
 - **`Store::session_budget(session_id)`** and

--- a/crates/lex-api/src/handlers.rs
+++ b/crates/lex-api/src/handlers.rs
@@ -107,6 +107,31 @@ fn write_error_response(prefix: &str, err: lex_store::StoreError)
             .with_header(Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..]).unwrap())
             .with_header(Header::from_bytes(&b"Retry-After"[..], &b"1"[..]).unwrap());
     }
+    // #292 slice 3: budget overflow → 503 with `Retry-After: 0`.
+    // Unlike Contention (where a retry might land after another
+    // writer finishes), there's no point retrying a budget-
+    // exceeded op — the caller needs to raise the cap, switch
+    // sessions, or refactor the work. The `Retry-After: 0`
+    // signals "don't bother retrying as-is" while still using
+    // the canonical "service refused" status code.
+    if let lex_store::StoreError::BudgetExceeded { session_id, cap, spent_after } = &err {
+        let body = serde_json::to_vec(&ErrorEnvelope {
+            error: format!(
+                "{prefix}: session `{session_id}` budget exceeded \
+                 (spent_after={spent_after}, cap={cap})"
+            ),
+            detail: Some(serde_json::json!({
+                "kind": "budget_exceeded",
+                "session_id": session_id,
+                "cap": cap,
+                "spent_after": spent_after,
+            })),
+        }).unwrap_or_else(|_| b"{}".to_vec());
+        return Response::from_data(body)
+            .with_status_code(503)
+            .with_header(Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..]).unwrap())
+            .with_header(Header::from_bytes(&b"Retry-After"[..], &b"0"[..]).unwrap());
+    }
     error_response(500, format!("{prefix}: {err}"))
 }
 

--- a/crates/lex-cli/src/audit.rs
+++ b/crates/lex-cli/src/audit.rs
@@ -652,10 +652,18 @@ fn cmd_audit_budget_by_session(
         // Pad with a zero entry if the session wasn't found so the
         // envelope's shape stays predictable for tooling.
         if rollups.is_empty() {
+            // Pad with a zero entry; resolve any configured cap so
+            // the envelope shows the budget envelope this session
+            // would be subject to once it lands its first op.
+            let cap = store.session_budget_cap(filter)
+                .map_err(|e| anyhow!("reading session-budget cap: {e}"))?;
+            let remaining = cap.map(|c| c as i64);
             rollups.push(lex_store::SessionBudget {
                 session_id: filter.clone(),
                 spent: 0,
                 op_count: 0,
+                cap,
+                remaining,
             });
         }
     }
@@ -665,6 +673,8 @@ fn cmd_audit_budget_by_session(
             "session_id": b.session_id,
             "spent": b.spent,
             "op_count": b.op_count,
+            "cap": b.cap,
+            "remaining": b.remaining,
         })
     }).collect();
     let total_spent: u64 = rollups.iter().map(|b| b.spent).sum();

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -3191,6 +3191,7 @@ fn cmd_policy(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let sub = args.first().ok_or_else(|| anyhow!(
         "usage: lex policy {{block-producer <name> --reason \"...\" | unblock-producer <name> | \
          require-attestation <kind> [--when-effects e1,e2,...] | unrequire-attestation <kind> | \
+         session-budget {{set-default <N> | set <id> <N> | unbounded <id> | clear <id> | clear-default}} | \
          list | show}} [--store DIR]"
     ))?;
     let rest = &args[1..];
@@ -3199,11 +3200,74 @@ fn cmd_policy(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         "unblock-producer"      => cmd_policy_unblock(fmt, rest),
         "require-attestation"   => cmd_policy_require_attestation(fmt, rest),
         "unrequire-attestation" => cmd_policy_unrequire_attestation(fmt, rest),
+        "session-budget"        => cmd_policy_session_budget(fmt, rest),
         // `show` is the new name; `list` is kept as an alias for the
         // pre-#245 muscle memory.
         "list" | "show"         => cmd_policy_show(fmt, rest),
         other => bail!("unknown `lex policy` subcommand: {other}"),
     }
+}
+
+/// `lex policy session-budget <subcmd>` — manage
+/// `policy.session_budgets` (#292 slices 2 + 3).
+fn cmd_policy_session_budget(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    let sub = args.first().ok_or_else(|| anyhow!(
+        "usage: lex policy session-budget {{set-default <N> | set <id> <N> | \
+         unbounded <id> | clear <id> | clear-default}} [--store DIR]"
+    ))?;
+    let (root, rest, _, _) = parse_store_flag(&args[1..]);
+    let mut policy = lex_store::policy::load(&root)
+        .map_err(|e| anyhow!("loading policy.json: {e}"))?
+        .unwrap_or_default();
+    let action;
+    match sub.as_str() {
+        "set-default" => {
+            let n: u64 = rest.first().ok_or_else(|| anyhow!(
+                "usage: lex policy session-budget set-default <N>"))?
+                .parse().map_err(|e| anyhow!("invalid N: {e}"))?;
+            policy.session_budgets.default_cap = Some(n);
+            action = format!("set default_cap to {n}");
+        }
+        "set" => {
+            let id = rest.first().ok_or_else(|| anyhow!(
+                "usage: lex policy session-budget set <session_id> <N>"))?
+                .clone();
+            let n: u64 = rest.get(1).ok_or_else(|| anyhow!(
+                "usage: lex policy session-budget set <session_id> <N>"))?
+                .parse().map_err(|e| anyhow!("invalid N: {e}"))?;
+            policy.session_budgets.overrides.insert(id.clone(), Some(n));
+            action = format!("set override `{id}` to {n}");
+        }
+        "unbounded" => {
+            let id = rest.first().ok_or_else(|| anyhow!(
+                "usage: lex policy session-budget unbounded <session_id>"))?
+                .clone();
+            policy.session_budgets.overrides.insert(id.clone(), None);
+            action = format!("set override `{id}` to unbounded");
+        }
+        "clear" => {
+            let id = rest.first().ok_or_else(|| anyhow!(
+                "usage: lex policy session-budget clear <session_id>"))?;
+            policy.session_budgets.overrides.remove(id);
+            action = format!("cleared override `{id}`");
+        }
+        "clear-default" => {
+            policy.session_budgets.default_cap = None;
+            action = "cleared default_cap".into();
+        }
+        other => bail!("unknown `session-budget` subcommand: {other}"),
+    }
+    lex_store::policy::save(&root, &policy)
+        .map_err(|e| anyhow!("writing policy.json: {e}"))?;
+    let action_for_text = action.clone();
+    let data = serde_json::json!({
+        "action": action,
+        "session_budgets": serde_json::to_value(&policy.session_budgets)?,
+    });
+    acli::emit_or_text("policy", data, fmt, move || {
+        println!("policy.session_budgets: {action_for_text}");
+    });
+    Ok(())
 }
 
 fn cmd_policy_block(fmt: &OutputFormat, args: &[String]) -> Result<()> {

--- a/crates/lex-cli/tests/policy_session_budget.rs
+++ b/crates/lex-cli/tests/policy_session_budget.rs
@@ -1,0 +1,92 @@
+//! Conformance for `lex policy session-budget` (#292 slice 2).
+//! Drives the CLI as a subprocess against a fresh store and
+//! checks the resulting `policy.json`.
+
+use std::process::Command;
+
+fn lex_bin() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_lex"))
+}
+
+fn run(args: &[&str]) -> (bool, String, String) {
+    let out = Command::new(lex_bin()).args(args).output().unwrap();
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+fn read_policy(root: &std::path::Path) -> serde_json::Value {
+    let bytes = std::fs::read(root.join("policy.json")).unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+#[test]
+fn set_default_cap_persists_in_policy_json() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (ok, stdout, stderr) = run(&[
+        "policy", "session-budget", "set-default", "5000",
+        "--store", tmp.path().to_str().unwrap(),
+    ]);
+    assert!(ok, "stderr={stderr}\nstdout={stdout}");
+    let policy = read_policy(tmp.path());
+    assert_eq!(policy["session_budgets"]["default_cap"], 5000);
+}
+
+#[test]
+fn set_per_session_override_persists() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (ok, _, stderr) = run(&[
+        "policy", "session-budget", "set", "ses_alpha", "8000",
+        "--store", tmp.path().to_str().unwrap(),
+    ]);
+    assert!(ok, "stderr={stderr}");
+    let policy = read_policy(tmp.path());
+    assert_eq!(policy["session_budgets"]["overrides"]["ses_alpha"], 8000);
+}
+
+#[test]
+fn unbounded_override_writes_null() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (ok, _, _) = run(&[
+        "policy", "session-budget", "unbounded", "ses_human",
+        "--store", tmp.path().to_str().unwrap(),
+    ]);
+    assert!(ok);
+    let policy = read_policy(tmp.path());
+    assert!(policy["session_budgets"]["overrides"]["ses_human"].is_null(),
+        "explicit-null override must serialize as null; got {:?}",
+        policy["session_budgets"]["overrides"]["ses_human"]);
+}
+
+#[test]
+fn clear_removes_the_override() {
+    let tmp = tempfile::tempdir().unwrap();
+    run(&[
+        "policy", "session-budget", "set", "ses_alpha", "8000",
+        "--store", tmp.path().to_str().unwrap(),
+    ]);
+    let (ok, _, _) = run(&[
+        "policy", "session-budget", "clear", "ses_alpha",
+        "--store", tmp.path().to_str().unwrap(),
+    ]);
+    assert!(ok);
+    let policy = read_policy(tmp.path());
+    assert!(policy["session_budgets"]["overrides"].as_object()
+        .map(|m| m.is_empty()).unwrap_or(true),
+        "override should be removed; got {:?}",
+        policy["session_budgets"]["overrides"]);
+}
+
+#[test]
+fn unknown_subcommand_errors() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (ok, _, stderr) = run(&[
+        "policy", "session-budget", "nuke-everything",
+        "--store", tmp.path().to_str().unwrap(),
+    ]);
+    assert!(!ok);
+    assert!(stderr.contains("unknown `session-budget` subcommand"),
+        "expected unknown-subcommand message, got: {stderr}");
+}

--- a/crates/lex-store/src/budget.rs
+++ b/crates/lex-store/src/budget.rs
@@ -34,6 +34,11 @@ use std::collections::BTreeMap;
 use crate::store::{Store, StoreError};
 
 /// Rollup of a single session's budget spend.
+///
+/// `cap` and `remaining` are populated from `policy.json`'s
+/// `session_budgets` (#292 slices 2 + 3). When no cap is set
+/// either by per-session override or by `default_cap`, both
+/// fields are `None`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SessionBudget {
     pub session_id: String,
@@ -42,21 +47,46 @@ pub struct SessionBudget {
     /// How many ops were attributed to this session (only those
     /// that contributed a non-zero increment count).
     pub op_count: usize,
+    /// Resolved cap from `policy.session_budgets`. `None` means
+    /// no enforcement.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cap: Option<u64>,
+    /// `cap - spent` when `cap` is set. Negative when over.
+    /// `None` when uncapped.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remaining: Option<i64>,
 }
 
 impl Store {
     /// Compute the budget spent by the given `session_id` across
     /// every op currently reachable from any branch head. Returns
-    /// `(spent: 0, op_count: 0)` for unknown sessions.
+    /// `(spent: 0, op_count: 0)` for unknown sessions, with cap
+    /// populated from `policy.session_budgets`.
     pub fn session_budget(&self, session_id: &str) -> Result<SessionBudget, StoreError> {
         let all = self.all_session_budgets()?;
-        Ok(all.into_iter()
-            .find(|b| b.session_id == session_id)
-            .unwrap_or(SessionBudget {
-                session_id: session_id.into(),
-                spent: 0,
-                op_count: 0,
-            }))
+        if let Some(b) = all.into_iter().find(|b| b.session_id == session_id) {
+            return Ok(b);
+        }
+        // Unknown session: zero spend, but the cap (if any) still
+        // applies. Useful for "show me what budget this brand-new
+        // session has" queries.
+        let cap = self.session_budget_cap(session_id)?;
+        let remaining = cap.map(|c| c as i64);
+        Ok(SessionBudget {
+            session_id: session_id.into(),
+            spent: 0,
+            op_count: 0,
+            cap,
+            remaining,
+        })
+    }
+
+    /// Resolve the budget cap configured for `session_id` from
+    /// `policy.json`'s `session_budgets` (#292 slice 2). Returns
+    /// `None` when no enforcement is configured.
+    pub fn session_budget_cap(&self, session_id: &str) -> Result<Option<u64>, StoreError> {
+        let policy = crate::policy::load(self.root())?.unwrap_or_default();
+        Ok(policy.session_budgets.cap_for(session_id))
     }
 
     /// Compute per-session budget rollups across every branch.
@@ -107,12 +137,13 @@ impl Store {
             entry.1 += 1;
         }
 
+        let policy = crate::policy::load(self.root())?.unwrap_or_default();
         let out: Vec<SessionBudget> = buckets
             .into_iter()
-            .map(|(session_id, (spent, op_count))| SessionBudget {
-                session_id,
-                spent,
-                op_count,
+            .map(|(session_id, (spent, op_count))| {
+                let cap = policy.session_budgets.cap_for(&session_id);
+                let remaining = cap.map(|c| (c as i64) - (spent as i64));
+                SessionBudget { session_id, spent, op_count, cap, remaining }
             })
             .collect();
         Ok(out)
@@ -123,6 +154,14 @@ impl Store {
 /// `AddFunction` contributes its full `budget_cost`; modify-shape
 /// ops contribute the delta only when budget *increased*.
 fn monotonic_spend(kind: &lex_vcs::OperationKind) -> u64 {
+    monotonic_spend_of(kind)
+}
+
+/// Crate-public form used by [`crate::Store::apply_operation_checked`]'s
+/// budget gate (#292 slice 3). Same semantics as the private
+/// helper; exposed under a separate name so the test-only
+/// `monotonic_spend` keeps its `#[cfg(test)]`-friendly shape.
+pub(crate) fn monotonic_spend_of(kind: &lex_vcs::OperationKind) -> u64 {
     let (from, to) = kind.budget_delta();
     match (from, to) {
         (None, Some(n)) => n,

--- a/crates/lex-store/src/policy.rs
+++ b/crates/lex-store/src/policy.rs
@@ -62,6 +62,50 @@ pub struct PolicyFile {
     /// from a branch head" — branch reachability is always honored.
     #[serde(default, skip_serializing_if = "GcRetention::is_empty")]
     pub gc_retention: GcRetention,
+    /// Per-session budget caps (#292 slices 2 + 3). Absence /
+    /// empty value means "no enforcement; ledger stays
+    /// descriptive (slice 1)." See [`SessionBudgetPolicy`].
+    #[serde(default, skip_serializing_if = "SessionBudgetPolicy::is_empty")]
+    pub session_budgets: SessionBudgetPolicy,
+}
+
+/// Per-session budget caps for the apply-path gate (#292 slices 2
+/// and 3). The `default_cap` field applies to every session not
+/// listed in `overrides`. Within the overrides map, a value of
+/// `Some(n)` sets that session's cap to `n`, and an explicit
+/// `null` means the session is unbounded — the escape hatch for
+/// ops outside the budget envelope, e.g. one-shot human
+/// interventions.
+///
+/// Absence of `session_budgets` keeps current (#292 slice 1)
+/// behavior: spending is recorded but never refused.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionBudgetPolicy {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_cap: Option<u64>,
+    /// Per-session overrides. Outer `Option`: presence in the
+    /// map. Inner `Option`: `Some(n)` is a cap of `n`; `None` is
+    /// the explicit "unbounded for this session."
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub overrides: std::collections::BTreeMap<String, Option<u64>>,
+}
+
+impl SessionBudgetPolicy {
+    pub fn is_empty(&self) -> bool {
+        self.default_cap.is_none() && self.overrides.is_empty()
+    }
+
+    /// Resolve the cap for a given session. The lookup is:
+    ///   1. If `overrides` has the session_id, use that entry's
+    ///      value (which itself may be `None` meaning unbounded).
+    ///   2. Otherwise fall back to `default_cap`.
+    ///   3. Return `None` for "no cap; don't enforce."
+    pub fn cap_for(&self, session_id: &str) -> Option<u64> {
+        match self.overrides.get(session_id) {
+            Some(explicit) => *explicit,
+            None => self.default_cap,
+        }
+    }
 }
 
 /// Retention policy for the predicate-driven op-log GC (#261 slice

--- a/crates/lex-store/src/store.rs
+++ b/crates/lex-store/src/store.rs
@@ -81,6 +81,19 @@ pub enum StoreError {
         .0.op_id, .0.stage_id, .0.tool_id, .0.blocked_at, .0.attestation_at
     )]
     ProducerBlocked(crate::policy::ProducerBlocked),
+    /// The op would push its session's monotonic budget over the
+    /// cap configured in `policy.session_budgets` (#292 slice 3).
+    /// The op is *not* persisted; the branch head is unchanged.
+    /// The caller should either start a new session, raise the
+    /// cap, or refactor to fit the budget. HTTP API maps to 503.
+    #[error(
+        "session `{session_id}` budget exceeded: spent_after={spent_after} > cap={cap}"
+    )]
+    BudgetExceeded {
+        session_id: String,
+        cap: u64,
+        spent_after: u64,
+    },
 }
 
 /// The outcome returned by [`Store::publish_program`].
@@ -845,6 +858,12 @@ impl Store {
             let _ = self.record_repair_hint(&attestable, &failed_op_id, &errors);
             return Err(StoreError::TypeError(errors));
         }
+        // #292 slice 3: per-session budget gate. After typecheck
+        // passes, refuse the op if it would push its session's
+        // monotonic spend over the configured cap. Sessions
+        // without an intent_id, or with an intent whose session
+        // has no cap configured, sail through.
+        self.check_session_budget(&op)?;
         let attestable = attestable_stage_ids(&transition);
         let op_effects = op_declared_effects(&op.kind);
         // #262: CAS retry loop. Single-parent ops can be safely
@@ -903,6 +922,46 @@ impl Store {
                 None,
             );
             log.put(&attestation)?;
+        }
+        Ok(())
+    }
+
+    /// Consult `policy.session_budgets` for the op's session
+    /// (resolved via `op.intent_id → Intent.session_id`) and
+    /// refuse if applying would push the session's monotonic spend
+    /// over the configured cap (#292 slice 3).
+    ///
+    /// Ops without an `intent_id`, or whose intent has no
+    /// configured cap, return Ok without any disk read.
+    fn check_session_budget(
+        &self,
+        op: &lex_vcs::Operation,
+    ) -> Result<(), StoreError> {
+        let Some(intent_id) = op.intent_id.as_deref() else { return Ok(()); };
+        let intent_log = lex_vcs::IntentLog::open(self.root())?;
+        let Some(intent) = intent_log.get(&intent_id.to_string())? else {
+            // Dangling intent — treat as "no session" and let it
+            // sail through. Slice 1's ledger already documents
+            // this as graceful-degradation semantics.
+            return Ok(());
+        };
+        let policy = crate::policy::load(self.root())?.unwrap_or_default();
+        let Some(cap) = policy.session_budgets.cap_for(&intent.session_id) else {
+            return Ok(());
+        };
+        // Recompute the session's current spend + the contribution
+        // from this op. Re-running the ledger walk on every gated
+        // op is O(branch history); see #292 slice 1's note about
+        // a future on-disk cache.
+        let current = self.session_budget(&intent.session_id)?;
+        let increment = crate::budget::monotonic_spend_of(&op.kind);
+        let spent_after = current.spent.saturating_add(increment);
+        if spent_after > cap {
+            return Err(StoreError::BudgetExceeded {
+                session_id: intent.session_id,
+                cap,
+                spent_after,
+            });
         }
         Ok(())
     }

--- a/crates/lex-store/tests/session_budget_gate.rs
+++ b/crates/lex-store/tests/session_budget_gate.rs
@@ -1,0 +1,245 @@
+//! Conformance tests for #292 slices 2 + 3 — `policy.session_budgets`
+//! schema + apply-path gate.
+
+use lex_store::{
+    policy::{PolicyFile, SessionBudgetPolicy},
+    Operation, OperationKind, StageTransition, Store, StoreError, DEFAULT_BRANCH,
+};
+use std::collections::BTreeSet;
+use tempfile::TempDir;
+
+fn fresh() -> (Store, TempDir) {
+    let tmp = TempDir::new().unwrap();
+    let s = Store::open(tmp.path()).unwrap();
+    (s, tmp)
+}
+
+fn anthropic() -> lex_vcs::ModelDescriptor {
+    lex_vcs::ModelDescriptor {
+        provider: "anthropic".into(),
+        name: "claude-test".into(),
+        version: None,
+    }
+}
+
+fn create_intent(store: &Store, prompt: &str, session: &str) -> String {
+    let intent = lex_vcs::Intent::new(prompt, session, anthropic(), None);
+    let id = intent.intent_id.clone();
+    lex_vcs::IntentLog::open(store.root()).unwrap().put(&intent).unwrap();
+    id
+}
+
+fn parse(src: &str) -> Vec<lex_ast::Stage> {
+    let prog = lex_syntax::parse_source(src).expect("parse");
+    lex_ast::canonicalize_program(&prog)
+}
+
+fn well_typed_add_op(sig: &str, stage: &str, cost: u64, intent: &str) -> (Operation, StageTransition) {
+    let mut effects = BTreeSet::new();
+    effects.insert(format!("budget({cost})"));
+    let op = Operation::new(
+        OperationKind::AddFunction {
+            sig_id: sig.into(),
+            stage_id: stage.into(),
+            effects,
+            budget_cost: Some(cost),
+        },
+        [],
+    ).with_intent(intent);
+    let t = StageTransition::Create {
+        sig_id: sig.into(),
+        stage_id: stage.into(),
+    };
+    (op, t)
+}
+
+#[test]
+fn budget_lookup_falls_back_to_default_cap() {
+    let (store, _tmp) = fresh();
+    let policy = PolicyFile {
+        session_budgets: SessionBudgetPolicy {
+            default_cap: Some(100),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    lex_store::policy::save(store.root(), &policy).unwrap();
+    assert_eq!(store.session_budget_cap("any-session").unwrap(), Some(100));
+}
+
+#[test]
+fn budget_lookup_per_session_override_wins() {
+    let (store, _tmp) = fresh();
+    let mut overrides = std::collections::BTreeMap::new();
+    overrides.insert("ses_alpha".into(), Some(200));
+    let policy = PolicyFile {
+        session_budgets: SessionBudgetPolicy {
+            default_cap: Some(100),
+            overrides,
+        },
+        ..Default::default()
+    };
+    lex_store::policy::save(store.root(), &policy).unwrap();
+    assert_eq!(store.session_budget_cap("ses_alpha").unwrap(), Some(200));
+    assert_eq!(store.session_budget_cap("other").unwrap(), Some(100));
+}
+
+#[test]
+fn budget_lookup_explicit_null_override_means_unbounded() {
+    let (store, _tmp) = fresh();
+    let mut overrides = std::collections::BTreeMap::new();
+    overrides.insert("ses_human".into(), None);
+    let policy = PolicyFile {
+        session_budgets: SessionBudgetPolicy {
+            default_cap: Some(100),
+            overrides,
+        },
+        ..Default::default()
+    };
+    lex_store::policy::save(store.root(), &policy).unwrap();
+    assert_eq!(store.session_budget_cap("ses_human").unwrap(), None,
+        "explicit null override = unbounded");
+}
+
+#[test]
+fn session_budget_envelope_includes_cap_and_remaining() {
+    let (store, _tmp) = fresh();
+    let policy = PolicyFile {
+        session_budgets: SessionBudgetPolicy {
+            default_cap: Some(50),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    lex_store::policy::save(store.root(), &policy).unwrap();
+
+    let b = store.session_budget("ses_new").unwrap();
+    assert_eq!(b.spent, 0);
+    assert_eq!(b.cap, Some(50));
+    assert_eq!(b.remaining, Some(50));
+}
+
+#[test]
+fn apply_operation_checked_rejects_op_that_would_exceed_cap() {
+    let (store, _tmp) = fresh();
+    let mut overrides = std::collections::BTreeMap::new();
+    overrides.insert("ses_tight".into(), Some(10));
+    let policy = PolicyFile {
+        session_budgets: SessionBudgetPolicy {
+            overrides,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    lex_store::policy::save(store.root(), &policy).unwrap();
+    let intent_id = create_intent(&store, "expensive work", "ses_tight");
+
+    // Op claims budget=20, cap=10 → refuse.
+    let candidate = parse("fn pricey() -> Int { 1 }\n");
+    let (op, t) = well_typed_add_op("pricey", "stg-1", 20, &intent_id);
+    let err = store.apply_operation_checked(DEFAULT_BRANCH, op, t, &candidate)
+        .unwrap_err();
+    match err {
+        StoreError::BudgetExceeded { session_id, cap, spent_after } => {
+            assert_eq!(session_id, "ses_tight");
+            assert_eq!(cap, 10);
+            assert_eq!(spent_after, 20);
+        }
+        other => panic!("expected BudgetExceeded, got {other:?}"),
+    }
+
+    // Branch head must be unchanged — gate fires before the apply.
+    assert!(store.get_branch(DEFAULT_BRANCH).unwrap().is_none(),
+        "rejected op must not create the branch");
+}
+
+#[test]
+fn apply_operation_checked_allows_op_within_cap() {
+    let (store, _tmp) = fresh();
+    let mut overrides = std::collections::BTreeMap::new();
+    overrides.insert("ses_alpha".into(), Some(100));
+    let policy = PolicyFile {
+        session_budgets: SessionBudgetPolicy { overrides, ..Default::default() },
+        ..Default::default()
+    };
+    lex_store::policy::save(store.root(), &policy).unwrap();
+    let intent = create_intent(&store, "tractable", "ses_alpha");
+
+    let candidate = parse("fn cheap() -> Int { 1 }\n");
+    let (op, t) = well_typed_add_op("cheap", "stg-1", 10, &intent);
+    let op_id = store.apply_operation_checked(DEFAULT_BRANCH, op, t, &candidate)
+        .expect("op within cap should land");
+
+    let b = store.session_budget("ses_alpha").unwrap();
+    assert_eq!(b.spent, 10);
+    assert_eq!(b.remaining, Some(90));
+    // Branch head advanced.
+    let head = store.get_branch(DEFAULT_BRANCH).unwrap().unwrap().head_op;
+    assert_eq!(head.as_deref(), Some(op_id.as_str()));
+}
+
+#[test]
+fn apply_operation_checked_no_intent_is_unaffected() {
+    let (store, _tmp) = fresh();
+    let policy = PolicyFile {
+        session_budgets: SessionBudgetPolicy {
+            default_cap: Some(5),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    lex_store::policy::save(store.root(), &policy).unwrap();
+
+    // No intent_id on the op → no session to gate. Even with a
+    // tiny default_cap, the op lands.
+    let candidate = parse("fn untagged() -> Int { 1 }\n");
+    let mut effects = BTreeSet::new();
+    effects.insert("budget(50)".into());
+    let op = Operation::new(
+        OperationKind::AddFunction {
+            sig_id: "untagged".into(),
+            stage_id: "stg-1".into(),
+            effects,
+            budget_cost: Some(50),
+        },
+        [],
+    );
+    let t = StageTransition::Create {
+        sig_id: "untagged".into(),
+        stage_id: "stg-1".into(),
+    };
+    store.apply_operation_checked(DEFAULT_BRANCH, op, t, &candidate)
+        .expect("intent-less ops sail through the budget gate");
+}
+
+#[test]
+fn apply_operation_checked_unbounded_override_disables_default_cap() {
+    let (store, _tmp) = fresh();
+    let mut overrides = std::collections::BTreeMap::new();
+    overrides.insert("ses_human".into(), None);
+    let policy = PolicyFile {
+        session_budgets: SessionBudgetPolicy {
+            default_cap: Some(5),
+            overrides,
+        },
+        ..Default::default()
+    };
+    lex_store::policy::save(store.root(), &policy).unwrap();
+    let intent = create_intent(&store, "manual override", "ses_human");
+
+    let candidate = parse("fn big() -> Int { 1 }\n");
+    let (op, t) = well_typed_add_op("big", "stg-1", 1000, &intent);
+    store.apply_operation_checked(DEFAULT_BRANCH, op, t, &candidate)
+        .expect("unbounded override sails past the default cap");
+}
+
+#[test]
+fn no_policy_means_no_enforcement() {
+    let (store, _tmp) = fresh();
+    let intent = create_intent(&store, "anything", "ses_alpha");
+    // No policy.json at all. Even a huge op lands.
+    let candidate = parse("fn anything() -> Int { 1 }\n");
+    let (op, t) = well_typed_add_op("anything", "stg-1", 9999, &intent);
+    store.apply_operation_checked(DEFAULT_BRANCH, op, t, &candidate)
+        .expect("no policy = no enforcement");
+}


### PR DESCRIPTION
Closes #292 — both remaining slices.

## Summary

Slice 1 (#296) shipped the read-only ledger. This PR layers schema + gate + CLI on top.

### Slice 2 — `policy.session_budgets` schema

```json
{
  "session_budgets": {
    "default_cap": 100000,
    "overrides": {
      "ses_alpha": 200000,
      "ses_human": null
    }
  }
}
```

- `default_cap` applies to every session not present in `overrides`.
- Override `Some(n)` sets that session's cap.
- Override `null` means unbounded — escape hatch for human interventions.
- Absent `session_budgets` keeps slice-1 behavior (descriptive only).

### Slice 3 — apply-path gate

`Store::apply_operation_checked` consults the cap **after typecheck passes** and refuses ops that would push the session's monotonic spend over cap with `StoreError::BudgetExceeded { session_id, cap, spent_after }`. Ops without `intent_id`, with a dangling intent, or whose session has no cap sail through.

### HTTP error mapping

`BudgetExceeded` → **503 with `Retry-After: 0`** and detail envelope:

```json
{"error": "...", "detail": {"kind": "budget_exceeded", "session_id": "...", "cap": 100, "spent_after": 120}}
```

Unlike `Contention` (where a retry might land after another writer finishes), there's no point retrying budget-exceeded as-is — the caller needs to raise the cap, switch sessions, or refactor.

### CLI

```
lex policy session-budget set-default <N>
lex policy session-budget set <session_id> <N>
lex policy session-budget unbounded <session_id>
lex policy session-budget clear <session_id>
lex policy session-budget clear-default
```

Atomic policy.json writes (tempfile + rename).

## Test plan

- [x] 9 conformance tests in `crates/lex-store/tests/session_budget_gate.rs` (cap lookup falls back through default; override wins; null override means unbounded; envelope carries cap+remaining; gate rejects over-cap ops; allows within-cap; intent-less ops sail through; unbounded override disables default; no policy = no enforcement).
- [x] 5 CLI tests in `crates/lex-cli/tests/policy_session_budget.rs` (set-default persists; set per-session persists; unbounded writes null; clear removes override; unknown subcommand errors).
- [x] `cargo test --workspace` — 179 test groups pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.

## Status of #292

| Slice | Status |
|-------|--------|
| 1 — Ledger | merged (#296) |
| 2 — Schema | **this PR** |
| 3 — Gate | **this PR** |

#292 is **complete**. The agent-fleet safety floor for budget runaway has its prescriptive enforcement.

## SessionBudget shape compatibility

`SessionBudget` gains optional `cap` and `remaining` fields with `skip_serializing_if = "Option::is_none"`. Pre-#292-slice-2 JSON consumers continue to read the envelope without changes; new consumers can rely on the fields being present when a cap is configured.

https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_