### PR TITLE
lex-cli: LLM-driven `lex repair --apply` (#281, slice 2b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+### Added — agent-feedback (#281, slice 2b)
+
+- **`lex repair <op_id> --apply`** (no `--transform`) now invokes
+  the configured LLM to generate a typed transform from the
+  failed-op context, then dispatches via slice-2a's apply path.
+  Closes the full agent feedback loop: an ill-typed op produces
+  a structured `RepairHint`; `lex repair --apply` reads the hint,
+  asks the LLM for a single typed transform across the four #280
+  variants, and lands it (or records the failed attempt).
+- **Structured prompt** with inlined JSON schemas for each
+  transform, the branch-head stage AST (the one transforms
+  operate against), the candidate stage that didn't typecheck
+  (informative), and the type errors. The model is instructed
+  to respond with ONLY the transform JSON — no prose, no
+  markdown fences.
+- **Test infrastructure**: `LEX_REPAIR_LLM_FIXTURE=<path>` env
+  var short-circuits the live LLM call by reading the response
+  from that file. Lets the CLI subprocess tests assert
+  end-to-end behavior without any network dependency. Production
+  callers (env var unset) hit `lex_runtime::llm::cloud_complete`.
+- **Graceful degradation**: a malformed LLM response (not JSON,
+  or missing `kind`) is recorded as a `RepairAttempt` failure
+  rather than propagated as exit-non-zero. The command itself
+  always exits 0; outcome lives in the envelope and the
+  attestation log. Same shape as slice 2a's ill-typed-transform
+  path.
+- 4 conformance tests in `crates/lex-cli/tests/repair_llm.rs`
+  driving the fixture path (well-typed lands; malformed JSON
+  records failure; unknown kind records failure; ill-typed
+  transform records failure).
+- The slice-2a "requires `--transform`" error is gone — the LLM
+  path is now the default behavior of `--apply`.
+
+With slices 1 + 2a + 2b shipped, **#281 is complete** modulo the
+explicitly-out-of-scope `--max-iters` looping (single-shot
+today).
+
 ### Added — agent-safety (#292, slices 2 + 3)
 
 - **`policy.session_budgets` schema** with `default_cap` and

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -990,12 +990,14 @@ fn cmd_repair(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let store = Store::open(&root)?;
 
     if apply {
-        let transform_json = transform_json.ok_or_else(|| anyhow!(
-            "`lex repair --apply` requires `--transform '<json>'` in slice 2a; \
-             LLM-driven generation ships in slice 2b"
-        ))?;
         let branch = branch.unwrap_or_else(|| store.current_branch());
-        return cmd_repair_apply(fmt, &store, &op_id, &branch, &transform_json);
+        // With `--transform`: slice-2a behavior — execute exactly
+        // what the agent provided. Without it: slice-2b — call
+        // the LLM (or fixture) to generate the transform.
+        return match transform_json {
+            Some(t) => cmd_repair_apply(fmt, &store, &op_id, &branch, &t),
+            None => cmd_repair_apply_llm(fmt, &store, &op_id, &branch),
+        };
     }
     if transform_json.is_some() {
         bail!("`--transform` requires `--apply`");
@@ -1165,6 +1167,220 @@ fn repair_attempt_producer() -> lex_vcs::ProducerDescriptor {
         version: env!("CARGO_PKG_VERSION").into(),
         model: None,
     }
+}
+
+/// `lex repair <op_id> --apply` (no `--transform`) — slice 2b.
+///
+/// Reads the latest `RepairHint` for the failed op_id, builds a
+/// structured prompt describing the four typed transforms +
+/// the failure context, asks the configured LLM for a single
+/// transform JSON, then hands the response off to
+/// [`cmd_repair_apply`]'s machinery.
+///
+/// # Test infrastructure
+///
+/// Tests can short-circuit the LLM call by setting the
+/// `LEX_REPAIR_LLM_FIXTURE` env var to a path. The contents of
+/// that file replace the live LLM response. This lets the
+/// subprocess-based CLI tests assert end-to-end behavior without
+/// any network dependency.
+fn cmd_repair_apply_llm(
+    fmt: &OutputFormat,
+    store: &Store,
+    failed_op_id: &str,
+    branch: &str,
+) -> Result<()> {
+    let attlog = store.attestation_log()
+        .map_err(|e| anyhow!("opening attestation log: {e}"))?;
+    let hint = attlog.list_all()
+        .map_err(|e| anyhow!("listing attestations: {e}"))?
+        .into_iter()
+        .filter(|a| matches!(&a.kind,
+            lex_vcs::AttestationKind::RepairHint { failed_op_id: f, .. }
+                if f == failed_op_id))
+        .max_by_key(|a| a.timestamp)
+        .ok_or_else(|| anyhow!(
+            "no RepairHint exists for op_id `{failed_op_id}` — \
+             a hint is required to apply a repair"
+        ))?;
+    let lex_vcs::AttestationKind::RepairHint { errors, .. } = &hint.kind
+        else { unreachable!() };
+
+    let candidate_stage_id = &hint.stage_id;
+    let candidate_stage = store.get_ast(candidate_stage_id)
+        .map_err(|e| anyhow!("loading candidate stage `{candidate_stage_id}`: {e}"))?;
+    let sig = lex_ast::sig_id(&candidate_stage)
+        .ok_or_else(|| anyhow!("candidate stage has no sig_id"))?;
+    let head = store.branch_head(branch)
+        .map_err(|e| anyhow!("reading branch head: {e}"))?;
+    let from_stage_id = head.get(&sig).cloned();
+    let from_stage = match &from_stage_id {
+        Some(id) => Some(store.get_ast(id)
+            .map_err(|e| anyhow!("loading branch-head stage `{id}`: {e}"))?),
+        None => None,
+    };
+
+    let prompt = build_repair_prompt(
+        candidate_stage_id,
+        &candidate_stage,
+        from_stage_id.as_deref(),
+        from_stage.as_ref(),
+        errors,
+    );
+    let response = call_repair_llm(&prompt)?;
+    let transform_json = response.trim().to_string();
+
+    // Pre-validate that the response is at least parseable JSON
+    // and has a `kind` field. A malformed response is recorded
+    // as a `RepairAttempt` failure rather than propagated as
+    // exit-non-zero — the LLM gave a bad answer; the command
+    // itself processed correctly.
+    let parse_err: Option<String> = match serde_json::from_str::<serde_json::Value>(&transform_json) {
+        Ok(v) => {
+            if v.get("kind").and_then(|x| x.as_str()).is_none() {
+                Some("LLM response missing `kind` field".into())
+            } else {
+                None
+            }
+        }
+        Err(e) => Some(format!("LLM response is not valid JSON: {e}")),
+    };
+    if let Some(reason) = parse_err {
+        let attlog = store.attestation_log()
+            .map_err(|e| anyhow!("opening attestation log: {e}"))?;
+        let attempt = lex_vcs::Attestation::new(
+            hint.stage_id.clone(),
+            None,
+            None,
+            lex_vcs::AttestationKind::RepairAttempt {
+                hint_id: hint.attestation_id.clone(),
+                outcome: "failed".into(),
+                applied_op_id: None,
+            },
+            lex_vcs::AttestationResult::Failed { detail: reason.clone() },
+            repair_attempt_producer(),
+            None,
+        );
+        attlog.put(&attempt)
+            .map_err(|e| anyhow!("recording RepairAttempt: {e}"))?;
+        let env = serde_json::json!({
+            "outcome": "failed",
+            "hint_id": hint.attestation_id,
+            "applied_op_id": serde_json::Value::Null,
+            "error": reason,
+        });
+        let env_for_text = env.clone();
+        acli::emit_or_text("repair-apply", env, fmt, move || {
+            println!("repair failed: {}", env_for_text["error"].as_str().unwrap_or("?"));
+        });
+        return Ok(());
+    }
+
+    cmd_repair_apply(fmt, store, failed_op_id, branch, &transform_json)
+}
+
+/// Build the prompt for the LLM repair call. Inlines the JSON
+/// schemas for the four typed transforms so the model can choose
+/// one without a separate spec fetch. Includes the candidate
+/// stage (the one that didn't typecheck), the branch-head stage
+/// (the one transforms should operate against), and the type
+/// errors.
+fn build_repair_prompt(
+    candidate_stage_id: &str,
+    candidate_stage: &lex_ast::Stage,
+    from_stage_id: Option<&str>,
+    from_stage: Option<&lex_ast::Stage>,
+    errors: &serde_json::Value,
+) -> String {
+    let candidate_json = serde_json::to_string_pretty(candidate_stage)
+        .unwrap_or_default();
+    let from_json = from_stage
+        .map(|s| serde_json::to_string_pretty(s).unwrap_or_default())
+        .unwrap_or_else(|| "(no current branch-head stage for this sig)".into());
+    let from_id_render = from_stage_id.unwrap_or("(none)");
+    let errors_json = serde_json::to_string_pretty(errors)
+        .unwrap_or_default();
+
+    format!(r#"You are a Lex type-error repair assistant. The user attempted a
+typed transform; the resulting stage didn't typecheck. Suggest
+exactly one typed AST transform that would fix the type errors.
+
+# Available transforms (return JSON for ONE of these)
+
+1) replace_match_arm — replace the body of one Match arm.
+{{
+  "kind": "replace_match_arm",
+  "from_stage_id": "<branch-head stage_id>",
+  "match_node": "<NodeId of the Match>",
+  "arm_index": <0-based>,
+  "new_body": <CExpr JSON>
+}}
+
+2) rename_local — rename a let-bound local (scope-aware).
+{{
+  "kind": "rename_local",
+  "from_stage_id": "<branch-head stage_id>",
+  "let_node": "<NodeId of the Let>",
+  "new_name": "<identifier>"
+}}
+
+3) inline_let — eliminate `let x := v; body` by substituting v.
+   v must be a literal/var/field-access/binop tree (no calls,
+   no side effects).
+{{
+  "kind": "inline_let",
+  "from_stage_id": "<branch-head stage_id>",
+  "let_node": "<NodeId of the Let>"
+}}
+
+4) extract_function — extract a sub-expression into a new fn.
+{{
+  "kind": "extract_function",
+  "from_stage_id": "<branch-head stage_id>",
+  "expr_node": "<NodeId of the expr>",
+  "spec": {{
+    "name": "<new fn name>",
+    "type_params": [],
+    "params": [{{"name": "n", "type": {{"node": "Named", "name": "Int", "args": []}}}}],
+    "return_type": {{"node": "Named", "name": "Int", "args": []}},
+    "effects": []
+  }}
+}}
+
+# Failure context
+
+Branch-head stage_id (use this as `from_stage_id`):
+{from_id_render}
+
+Branch-head stage AST (the one the transform should operate on):
+{from_json}
+
+Candidate stage_id (the one that didn't typecheck): {candidate_stage_id}
+
+Candidate stage AST (what the agent tried; informative only):
+{candidate_json}
+
+Type errors:
+{errors_json}
+
+# Response format
+
+Output ONLY the JSON object for your chosen transform. No prose,
+no markdown fences, no surrounding commentary.
+"#)
+}
+
+/// Call the configured LLM. Test escape hatch: when
+/// `LEX_REPAIR_LLM_FIXTURE` is set, read the response from that
+/// file instead of calling the live model. Lets the subprocess-
+/// based CLI tests assert end-to-end behavior without network.
+fn call_repair_llm(prompt: &str) -> Result<String> {
+    if let Ok(path) = std::env::var("LEX_REPAIR_LLM_FIXTURE") {
+        return std::fs::read_to_string(&path)
+            .with_context(|| format!("reading LEX_REPAIR_LLM_FIXTURE at `{path}`"));
+    }
+    lex_runtime::llm::cloud_complete(prompt)
+        .map_err(|e| anyhow!("LLM cloud_complete: {e}"))
 }
 
 /// Dispatch a `--transform` payload to the matching

--- a/crates/lex-cli/tests/repair_cli.rs
+++ b/crates/lex-cli/tests/repair_cli.rs
@@ -24,19 +24,22 @@ fn repair_with_no_hint_reports_not_found() {
 }
 
 #[test]
-fn repair_apply_without_transform_errors() {
-    // Slice 2a: `--apply` requires `--transform '<json>'`. The
-    // LLM-driven path (no `--transform`) ships in slice 2b.
+fn repair_apply_without_transform_calls_llm_path_and_needs_hint() {
+    // Slice 2b: `--apply` without `--transform` invokes the
+    // LLM path, which still requires a matching RepairHint to
+    // exist. Without a hint, the command errors as in slice 2a
+    // — the LLM call never happens because there's nothing to
+    // repair.
     let tmp = tempfile::tempdir().unwrap();
     let out = Command::new(lex_bin())
         .args(["repair", "fake-op-id", "--apply",
             "--store", tmp.path().to_str().unwrap()])
         .output().unwrap();
     assert!(!out.status.success(),
-        "--apply without --transform should fail");
+        "--apply without a hint should fail");
     let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(stderr.contains("requires `--transform"),
-        "expected '--apply requires --transform' message, got: {stderr}");
+    assert!(stderr.contains("no RepairHint exists"),
+        "expected hint-required message, got: {stderr}");
 }
 
 #[test]

--- a/crates/lex-cli/tests/repair_llm.rs
+++ b/crates/lex-cli/tests/repair_llm.rs
@@ -1,0 +1,209 @@
+//! Conformance for `lex repair --apply` LLM path (#281 slice 2b).
+//!
+//! The live LLM call is short-circuited by setting
+//! `LEX_REPAIR_LLM_FIXTURE` to a file whose contents replace
+//! the model's response. This lets us exercise the end-to-end
+//! flow — RepairHint → LLM call → transform parse → apply →
+//! RepairAttempt — deterministically.
+
+use lex_ast::{canonicalize_program, sig_id, stage_id, CExpr, CLit, NodeId, Stage};
+use lex_store::{Store, DEFAULT_BRANCH};
+use lex_syntax::parse_source;
+use tempfile::TempDir;
+
+fn fresh() -> (Store, TempDir) {
+    let tmp = TempDir::new().unwrap();
+    let s = Store::open(tmp.path()).unwrap();
+    (s, tmp)
+}
+
+fn stage_named(src: &str, name: &str) -> Stage {
+    let prog = parse_source(src).unwrap();
+    canonicalize_program(&prog)
+        .into_iter()
+        .find(|s| match s {
+            Stage::FnDecl(fd) => fd.name == name,
+            _ => false,
+        })
+        .expect("stage not found")
+}
+
+const PICK_SRC: &str = "fn pick(n :: Int) -> Int { match n { 0 => 1, _ => 2 } }\n";
+
+fn publish_initial_pick(store: &Store) -> (String, String) {
+    let s = stage_named(PICK_SRC, "pick");
+    let sig = sig_id(&s).unwrap();
+    let stg = stage_id(&s).unwrap();
+    store.publish(&s).unwrap();
+    let op = lex_vcs::Operation::new(
+        lex_vcs::OperationKind::AddFunction {
+            sig_id: sig.clone(),
+            stage_id: stg.clone(),
+            effects: Default::default(),
+            budget_cost: None,
+        },
+        [],
+    );
+    let t = lex_vcs::StageTransition::Create {
+        sig_id: sig.clone(),
+        stage_id: stg.clone(),
+    };
+    store.apply_operation(DEFAULT_BRANCH, op, t).unwrap();
+    (sig, stg)
+}
+
+/// Seed a RepairHint by trying a deliberately ill-typed
+/// `replace_match_arm` against `pick`. Returns the failed op_id
+/// and the still-on-branch stage_id (which the LLM path will use
+/// as `from_stage_id`).
+fn seed_hint(store: &Store) -> (String, String) {
+    let (_sig, from_stage_id) = publish_initial_pick(store);
+    let ill_typed = CExpr::Literal { value: CLit::Str { value: "boom".into() } };
+    let err = store
+        .apply_replace_match_arm(
+            DEFAULT_BRANCH, &from_stage_id, &NodeId("n_0.2".into()),
+            0, ill_typed,
+        )
+        .unwrap_err();
+    assert!(matches!(err, lex_store::StoreError::TypeError(_)));
+    let attlog = store.attestation_log().unwrap();
+    let hint = attlog.list_all().unwrap().into_iter()
+        .find(|a| matches!(a.kind, lex_vcs::AttestationKind::RepairHint { .. }))
+        .unwrap();
+    let failed_op_id = match &hint.kind {
+        lex_vcs::AttestationKind::RepairHint { failed_op_id, .. } => failed_op_id.clone(),
+        _ => unreachable!(),
+    };
+    (failed_op_id, from_stage_id)
+}
+
+#[test]
+fn repair_apply_llm_path_lands_well_typed_fixture_response() {
+    let (store, tmp) = fresh();
+    let (failed_op_id, from_stage_id) = seed_hint(&store);
+
+    // Write a fixture response: a well-typed replace_match_arm
+    // transform against the branch-head stage. The LLM path
+    // should parse, dispatch, and record a passed RepairAttempt.
+    let fixture_json = serde_json::json!({
+        "kind": "replace_match_arm",
+        "from_stage_id": from_stage_id,
+        "match_node": "n_0.2",
+        "arm_index": 0,
+        "new_body": { "node": "Literal", "value": { "kind": "Int", "value": 42 } }
+    }).to_string();
+    let fixture_path = tmp.path().join("fixture.json");
+    std::fs::write(&fixture_path, &fixture_json).unwrap();
+
+    let out = std::process::Command::new(
+        std::path::PathBuf::from(env!("CARGO_BIN_EXE_lex")))
+        .args([
+            "--output", "json",
+            "repair", &failed_op_id,
+            "--apply",
+            "--store", tmp.path().to_str().unwrap(),
+        ])
+        .env("LEX_REPAIR_LLM_FIXTURE", &fixture_path)
+        .output().unwrap();
+    assert!(out.status.success(),
+        "stderr={}\nstdout={}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout));
+    let env: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(env["data"]["outcome"], "passed",
+        "expected the well-typed transform to land; got {}", env);
+    assert!(env["data"]["applied_op_id"].is_string());
+
+    // RepairAttempt landed.
+    let attlog = store.attestation_log().unwrap();
+    let attempts: Vec<_> = attlog.list_all().unwrap().into_iter()
+        .filter(|a| matches!(a.kind, lex_vcs::AttestationKind::RepairAttempt { .. }))
+        .collect();
+    assert_eq!(attempts.len(), 1);
+}
+
+#[test]
+fn repair_apply_llm_path_records_failure_on_malformed_fixture() {
+    let (store, tmp) = fresh();
+    let (failed_op_id, _from_stage_id) = seed_hint(&store);
+
+    // Fixture is not JSON. The CLI should record a failed
+    // RepairAttempt and emit the structured error.
+    let fixture_path = tmp.path().join("fixture.json");
+    std::fs::write(&fixture_path, "this is not json").unwrap();
+
+    let out = std::process::Command::new(
+        std::path::PathBuf::from(env!("CARGO_BIN_EXE_lex")))
+        .args([
+            "--output", "json",
+            "repair", &failed_op_id,
+            "--apply",
+            "--store", tmp.path().to_str().unwrap(),
+        ])
+        .env("LEX_REPAIR_LLM_FIXTURE", &fixture_path)
+        .output().unwrap();
+    // Command exits 0 — the failure surfaces in the envelope.
+    assert!(out.status.success());
+    let env: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(env["data"]["outcome"], "failed");
+}
+
+#[test]
+fn repair_apply_llm_path_records_failure_on_unknown_kind_fixture() {
+    let (store, tmp) = fresh();
+    let (failed_op_id, _from_stage_id) = seed_hint(&store);
+
+    let fixture_path = tmp.path().join("fixture.json");
+    std::fs::write(&fixture_path, r#"{"kind":"not_a_transform"}"#).unwrap();
+
+    let out = std::process::Command::new(
+        std::path::PathBuf::from(env!("CARGO_BIN_EXE_lex")))
+        .args([
+            "--output", "json",
+            "repair", &failed_op_id,
+            "--apply",
+            "--store", tmp.path().to_str().unwrap(),
+        ])
+        .env("LEX_REPAIR_LLM_FIXTURE", &fixture_path)
+        .output().unwrap();
+    assert!(out.status.success());
+    let env: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(env["data"]["outcome"], "failed");
+    let err = env["data"]["error"].as_str().unwrap();
+    assert!(err.contains("unknown transform kind"),
+        "expected unknown-kind error, got: {err}");
+}
+
+#[test]
+fn fixture_with_ill_typed_transform_records_failure() {
+    let (store, tmp) = fresh();
+    let (failed_op_id, from_stage_id) = seed_hint(&store);
+
+    // Fixture: an ill-typed transform (string literal in arm
+    // expecting Int). Parses cleanly but the apply path's
+    // re-typecheck refuses it. Outcome = failed; RepairAttempt
+    // records the failure.
+    let fixture_json = serde_json::json!({
+        "kind": "replace_match_arm",
+        "from_stage_id": from_stage_id,
+        "match_node": "n_0.2",
+        "arm_index": 0,
+        "new_body": { "node": "Literal", "value": { "kind": "Str", "value": "still wrong" } }
+    }).to_string();
+    let fixture_path = tmp.path().join("fixture.json");
+    std::fs::write(&fixture_path, &fixture_json).unwrap();
+
+    let out = std::process::Command::new(
+        std::path::PathBuf::from(env!("CARGO_BIN_EXE_lex")))
+        .args([
+            "--output", "json",
+            "repair", &failed_op_id,
+            "--apply",
+            "--store", tmp.path().to_str().unwrap(),
+        ])
+        .env("LEX_REPAIR_LLM_FIXTURE", &fixture_path)
+        .output().unwrap();
+    assert!(out.status.success());
+    let env: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(env["data"]["outcome"], "failed");
+}


### PR DESCRIPTION
Final slice of #281 — LLM-driven `lex repair --apply`.

## Summary

`lex repair <op_id> --apply` (without `--transform`) now invokes the configured LLM to generate a typed transform from the failed-op context, then dispatches via slice 2a's apply path. This closes the full agent feedback loop:

1. Agent makes an ill-typed edit → `apply_operation_checked` rejects with `TypeError`.
2. A `RepairHint` attestation lands on the candidate stage with the structured errors.
3. Agent runs `lex repair <op_id> --apply`.
4. CLI builds a structured prompt (failed errors + candidate stage AST + branch-head stage AST).
5. LLM returns one of the four #280 transform variants as JSON.
6. CLI dispatches via slice 2a's `dispatch_repair_transform` and records a `RepairAttempt` (passed or failed).

## Prompt design

Inlined JSON schemas for all four transforms (`replace_match_arm`, `rename_local`, `inline_let`, `extract_function`) so the model can choose without a separate spec fetch. Includes:

- Branch-head stage ID + AST (the one transforms operate against)
- Candidate stage ID + AST (the one that didn't typecheck, informative only)
- Structured type errors

Model is instructed to respond with ONLY the transform JSON — no prose, no markdown fences.

## Test infrastructure

`LEX_REPAIR_LLM_FIXTURE=<path>` env var short-circuits the live LLM call by reading the response from that file. Lets the CLI subprocess tests assert end-to-end behavior without network dependency and without tripping the documented `cloud_config_fails_without_api_key` parallel-env flake. Production callers (env unset) hit `lex_runtime::llm::cloud_complete`.

## Graceful degradation

Malformed LLM responses (not JSON, missing `kind`) are recorded as `RepairAttempt` failures rather than propagated as exit-non-zero. The command itself always exits 0; outcome lives in the envelope and the attestation log. Same contract as slice 2a's ill-typed-transform path.

## Test plan

- [x] 4 fixture-driven tests in `crates/lex-cli/tests/repair_llm.rs` (well-typed lands; malformed JSON records failure; unknown kind records failure; ill-typed transform records failure).
- [x] Slice 2a's explicit `--transform` path keeps working unchanged.
- [x] `cargo test --workspace` — 180 test groups pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.

## Status of #281

| Slice | Status |
|-------|--------|
| 1 — RepairHint emit + `lex repair` read | merged (#290) |
| 2a — `lex repair --apply --transform` | merged (#295) |
| **2b — `lex repair --apply` LLM-driven** | **this PR** |

**#281 is complete** modulo the explicitly-out-of-scope `--max-iters` looping. Today's behavior is single-shot; iteration would layer on top trivially when the use case materializes.

https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_