### PR TITLE
lex-vcs+store+cli: positive ProducerTrust (#293)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+### Added — agent-trust (#293)
+
+- **`AttestationKind::ProducerTrust { tool_id,
+  score_thousandths, evidence, granted_by }`** — positive trust
+  signal complementing #248's `ProducerBlock`. Score is stored as
+  `u32` thousandths (`0..=1000`, representing 0.0..1.0) because
+  `AttestationKind` derives `Eq` for content-addressed hashing,
+  which `f64` doesn't implement. Derivation method: `passed /
+  (passed + failed + inconclusive)` over the producer's most-
+  recent `window` attestations.
+- **`AttestationKind::TrustWaived { producer, score_thousandths,
+  threshold_thousandths, kind_tag }`** — audit signal recording
+  that the `required_attestations` gate skipped a rule because a
+  trusted producer's score exceeded the rule's threshold.
+- **`policy.required_attestations[].skip_if_producer_trust_thousandths_above`**
+  (`Option<u32>`, default `None`). When set, the gate consults
+  the maximum live trust score across all non-blocked producers;
+  if it exceeds the threshold, the rule is waived and a
+  `TrustWaived` attestation lands for the audit trail.
+- **`Store::recompute_producer_trust(tool_id, window, granted_by)`**
+  walks the attestation log filtered by `produced_by.tool`,
+  scores `passed/total` over the last `window` records, and
+  emits a fresh `ProducerTrust` attestation. Refuses to grant
+  trust to a tool with an active `ProducerBlock` (hard veto).
+  Self-referential trust attestations are excluded from the
+  evidence corpus so re-running the recompute is stable.
+- **`lex producer-trust recompute --tool <id> [--window N]
+  [--granted-by ACTOR] [--store DIR]`** CLI runs the recompute
+  and emits the resulting attestation_id. JSON envelope reports
+  `{tool, window, granted_by, attestation_id, ok}`.
+- 11 conformance tests (8 store-gate + 3 CLI).
+
 ### Added — agent-feedback (#281, slice 2b)
 
 - **`lex repair <op_id> --apply`** (no `--transform`) now invokes

--- a/crates/lex-api/src/web.rs
+++ b/crates/lex-api/src/web.rs
@@ -858,6 +858,12 @@ fn kind_short(k: &AttestationKind) -> String {
         AttestationKind::RepairAttempt { hint_id, outcome, .. } => {
             format!("RepairAttempt({outcome}, {hint_id:.12}…)")
         }
+        AttestationKind::ProducerTrust { tool_id, score_thousandths, .. } => {
+            format!("ProducerTrust({tool_id}, {:.3})", *score_thousandths as f64 / 1000.0)
+        }
+        AttestationKind::TrustWaived { producer, kind_tag, .. } => {
+            format!("TrustWaived({producer}/{kind_tag})")
+        }
     }
 }
 

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -107,6 +107,7 @@ fn run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         "op" => op::cmd_op(fmt, &args[1..]),
         "docs" => docs::cmd_docs(fmt, &args[1..]),
         "repair" => cmd_repair(fmt, &args[1..]),
+        "producer-trust" => cmd_producer_trust(fmt, &args[1..]),
         "canonical" => cmd_canonical(fmt, &args[1..]),
         "keygen" => cmd_keygen(fmt, &args[1..]),
         "repl" => repl::cmd_repl(&args[1..]),
@@ -1159,6 +1160,85 @@ fn cmd_repair_apply(
     // success/failure. Exiting non-zero would have stdout emit
     // a second wrapper envelope, which we don't want.
     Ok(())
+}
+
+/// `lex producer-trust recompute --tool <id> [--window N] [--granted-by ACTOR] [--store DIR]`
+/// (#293). Walks the attestation log filtered by `produced_by.tool
+/// == <id>`, computes `passed/total` over the last `window`
+/// records, and emits a fresh `ProducerTrust` attestation. The
+/// `required_attestations` gate consults the latest score per
+/// tool to apply trust-based waivers.
+fn cmd_producer_trust(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    let sub = args.first().ok_or_else(|| anyhow!(
+        "usage: lex producer-trust recompute --tool <id> [--window N] \
+         [--granted-by ACTOR] [--store DIR]"))?;
+    if sub != "recompute" {
+        bail!("unknown `lex producer-trust` subcommand: {sub}");
+    }
+    let (root, rest, _, _) = parse_store_flag(&args[1..]);
+    let mut tool: Option<String> = None;
+    let mut window: usize = 1000;
+    let mut granted_by: String = whoami_id();
+    let mut it = rest.iter();
+    while let Some(a) = it.next() {
+        match a.as_str() {
+            "--tool" => {
+                tool = Some(it.next()
+                    .ok_or_else(|| anyhow!("--tool needs an id"))?.clone());
+            }
+            "--window" => {
+                window = it.next()
+                    .ok_or_else(|| anyhow!("--window needs N"))?
+                    .parse().map_err(|e| anyhow!("--window: {e}"))?;
+            }
+            "--granted-by" => {
+                granted_by = it.next()
+                    .ok_or_else(|| anyhow!("--granted-by needs an actor"))?.clone();
+            }
+            other => bail!("unexpected arg `{other}`"),
+        }
+    }
+    let tool = tool.ok_or_else(|| anyhow!(
+        "usage: lex producer-trust recompute --tool <id> ..."))?;
+
+    let store = Store::open(&root)?;
+    let result = store.recompute_producer_trust(&tool, window, &granted_by)?;
+    let env = match &result {
+        Some(att_id) => serde_json::json!({
+            "tool": &tool,
+            "window": window,
+            "granted_by": &granted_by,
+            "attestation_id": att_id,
+            "ok": true,
+        }),
+        None => serde_json::json!({
+            "tool": &tool,
+            "window": window,
+            "granted_by": &granted_by,
+            "ok": false,
+            "reason": "no attestations from this tool to score",
+        }),
+    };
+    let env_for_text = env.clone();
+    let tool_for_text = tool.clone();
+    acli::emit_or_text("producer-trust", env, fmt, move || {
+        if env_for_text["ok"] == true {
+            println!("recomputed trust for `{tool_for_text}` → attestation_id={}",
+                env_for_text["attestation_id"].as_str().unwrap_or("?"));
+        } else {
+            println!("no trust recompute: {}",
+                env_for_text["reason"].as_str().unwrap_or("?"));
+        }
+    });
+    Ok(())
+}
+
+/// Best-effort identity for `--granted-by`. Reads `$USER`
+/// (set on Unix login shells) or falls back to `"unknown"`.
+fn whoami_id() -> String {
+    std::env::var("USER")
+        .or_else(|_| std::env::var("LEX_TEA_USER"))
+        .unwrap_or_else(|_| "unknown".into())
 }
 
 fn repair_attempt_producer() -> lex_vcs::ProducerDescriptor {
@@ -2570,6 +2650,12 @@ fn cmd_stage(fmt: &OutputFormat, args: &[String]) -> Result<()> {
                     lex_vcs::AttestationKind::RepairAttempt { hint_id, outcome, .. } => {
                         format!("RepairAttempt({outcome}, {hint_id:.12}…)")
                     }
+                    lex_vcs::AttestationKind::ProducerTrust { tool_id, score_thousandths, .. } => {
+                        format!("ProducerTrust({tool_id}, {:.3})", *score_thousandths as f64 / 1000.0)
+                    }
+                    lex_vcs::AttestationKind::TrustWaived { producer, kind_tag, .. } => {
+                        format!("TrustWaived({producer}/{kind_tag})")
+                    }
                 };
                 let result = match &a.result {
                     lex_vcs::AttestationResult::Passed => "passed".to_string(),
@@ -3393,6 +3479,8 @@ fn attestation_kind_tag(k: &lex_vcs::AttestationKind) -> &'static str {
         ProducerUnblock { .. }  => "producer_unblock",
         RepairHint { .. }       => "repair_hint",
         RepairAttempt { .. }    => "repair_attempt",
+        ProducerTrust { .. }    => "producer_trust",
+        TrustWaived { .. }      => "trust_waived",
     }
 }
 

--- a/crates/lex-cli/tests/producer_trust_cli.rs
+++ b/crates/lex-cli/tests/producer_trust_cli.rs
@@ -1,0 +1,54 @@
+//! Conformance for `lex producer-trust recompute` (#293).
+
+use std::process::Command;
+
+fn lex_bin() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_lex"))
+}
+
+#[test]
+fn recompute_on_empty_store_reports_no_evidence() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = Command::new(lex_bin())
+        .args([
+            "--output", "json", "producer-trust", "recompute",
+            "--tool", "test-tool",
+            "--store", tmp.path().to_str().unwrap(),
+        ])
+        .output().unwrap();
+    assert!(out.status.success(),
+        "stderr={}", String::from_utf8_lossy(&out.stderr));
+    let env: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(env["data"]["ok"], false);
+    assert!(env["data"]["reason"].as_str().unwrap().contains("no attestations"));
+}
+
+#[test]
+fn recompute_requires_tool_flag() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = Command::new(lex_bin())
+        .args([
+            "producer-trust", "recompute",
+            "--store", tmp.path().to_str().unwrap(),
+        ])
+        .output().unwrap();
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("--tool"),
+        "expected --tool requirement, got: {stderr}");
+}
+
+#[test]
+fn unknown_subcommand_errors() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = Command::new(lex_bin())
+        .args([
+            "producer-trust", "delete-all",
+            "--store", tmp.path().to_str().unwrap(),
+        ])
+        .output().unwrap();
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("unknown"),
+        "expected unknown-subcommand message, got: {stderr}");
+}

--- a/crates/lex-store/src/policy.rs
+++ b/crates/lex-store/src/policy.rs
@@ -32,7 +32,9 @@
 //! Existing `policy.json` files keep working — `required_attestations`
 //! defaults to empty (no gate).
 
-use lex_vcs::{Attestation, AttestationKind, AttestationLog, AttestationResult, OpId};
+use lex_vcs::{
+    active_producer_block, Attestation, AttestationKind, AttestationLog, AttestationResult, OpId,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::fs;
@@ -145,6 +147,18 @@ pub struct RequiredAttestation {
     /// op" rule.
     #[serde(default)]
     pub when: AttestationCondition,
+    /// Trust-based waiver threshold (#293). When set, the gate
+    /// waives this rule if the maximum live
+    /// [`AttestationKind::ProducerTrust`] `score_thousandths`
+    /// across all tools (excluding those with an active
+    /// [`AttestationKind::ProducerBlock`]) exceeds this
+    /// threshold. A `TrustWaived` attestation lands per waiver
+    /// so the audit trail records the skip.
+    ///
+    /// `None` (default) means no waiver — the rule fires
+    /// unconditionally when `when` applies.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skip_if_producer_trust_thousandths_above: Option<u32>,
 }
 
 /// Which `AttestationKind` is required. Mirrors the variants the
@@ -312,7 +326,11 @@ impl PolicyFile {
         kind: RequiredAttestationKind,
         when: AttestationCondition,
     ) -> bool {
-        let new = RequiredAttestation { kind, when };
+        let new = RequiredAttestation {
+            kind,
+            when,
+            skip_if_producer_trust_thousandths_above: None,
+        };
         if self.required_attestations.contains(&new) {
             return false;
         }
@@ -379,10 +397,21 @@ pub fn check_required_attestations(
     log: &AttestationLog,
     candidate: &[(OpId, Option<String>, BTreeSet<String>)],
     policy: &PolicyFile,
-) -> Result<(), BranchAdvanceBlocked> {
+) -> Result<Vec<TrustWaiver>, BranchAdvanceBlocked> {
     if policy.required_attestations.is_empty() {
-        return Ok(());
+        return Ok(Vec::new());
     }
+    // Compute the live trust ceiling once for the whole gate run.
+    // None if no `ProducerTrust` attestations exist or if every
+    // such tool is also blocked. Otherwise `Some((tool, score))`
+    // for the producer with the highest current score.
+    let trust_ceiling = max_live_producer_trust(log).map_err(|e| BranchAdvanceBlocked {
+        op_id: candidate.first().map(|(o, _, _)| o.clone()).unwrap_or_default(),
+        stage_id: None,
+        missing: vec![format!("io:{e}")],
+    })?;
+    let mut waivers: Vec<TrustWaiver> = Vec::new();
+
     for (op_id, stage_id_opt, op_effects) in candidate {
         let stage_id = match stage_id_opt {
             Some(s) => s,
@@ -401,6 +430,23 @@ pub fn check_required_attestations(
         for rule in &policy.required_attestations {
             if !rule.when.applies(op_effects) {
                 continue;
+            }
+            // #293 trust waiver: if the rule has a threshold AND
+            // a live trusted producer exceeds it, skip the rule
+            // and record a waiver for emission.
+            if let Some(threshold) = rule.skip_if_producer_trust_thousandths_above {
+                if let Some((producer, score)) = &trust_ceiling {
+                    if *score > threshold {
+                        waivers.push(TrustWaiver {
+                            stage_id: stage_id.clone(),
+                            producer: producer.clone(),
+                            score_thousandths: *score,
+                            threshold_thousandths: threshold,
+                            kind_tag: rule.kind.tag().into(),
+                        });
+                        continue;
+                    }
+                }
             }
             let satisfied = attestations.iter().any(|a| {
                 a.op_id.as_deref() == Some(op_id.as_str())
@@ -424,7 +470,58 @@ pub fn check_required_attestations(
             });
         }
     }
-    Ok(())
+    Ok(waivers)
+}
+
+/// Record of a single trust-based waiver from
+/// [`check_required_attestations`] (#293). The store emits a
+/// `TrustWaived` attestation per waiver after the gate succeeds
+/// so the audit trail captures every skip.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrustWaiver {
+    pub stage_id: String,
+    pub producer: String,
+    pub score_thousandths: u32,
+    pub threshold_thousandths: u32,
+    pub kind_tag: String,
+}
+
+/// Scan the attestation log for the highest live
+/// `ProducerTrust` score (#293). "Live" means the trusted tool
+/// does not have an active [`AttestationKind::ProducerBlock`] —
+/// the block wins as a hard veto over trust.
+///
+/// Returns `Some((tool_id, score_thousandths))` for the highest
+/// live trust, or `None` if no tool currently has trust.
+fn max_live_producer_trust(
+    log: &AttestationLog,
+) -> std::io::Result<Option<(String, u32)>> {
+    let all = log.list_all()?;
+    // For each tool with a `ProducerTrust`, take the highest
+    // recorded score across that tool's history. Multiple
+    // recompute runs append; the latest by timestamp wins.
+    use std::collections::BTreeMap;
+    let mut latest: BTreeMap<String, (u64, u32)> = BTreeMap::new();
+    for a in &all {
+        let AttestationKind::ProducerTrust { tool_id, score_thousandths, .. } = &a.kind else { continue };
+        let entry = latest.entry(tool_id.clone()).or_insert((0, 0));
+        if a.timestamp >= entry.0 {
+            *entry = (a.timestamp, *score_thousandths);
+        }
+    }
+    let mut best: Option<(String, u32)> = None;
+    for (tool, (_, score)) in latest {
+        if active_producer_block(&all, &tool).is_some() {
+            // Blocked — ignore even if score is high.
+            continue;
+        }
+        match &best {
+            None => best = Some((tool, score)),
+            Some((_, b)) if score > *b => best = Some((tool, score)),
+            _ => {}
+        }
+    }
+    Ok(best)
 }
 
 fn passed(r: &AttestationResult) -> bool {

--- a/crates/lex-store/src/store.rs
+++ b/crates/lex-store/src/store.rs
@@ -886,6 +886,89 @@ impl Store {
     /// blame --with-evidence`, `GET /v1/stage/<id>/attestations` —
     /// can read what the store gate emitted without round-tripping
     /// through this crate's API surface.
+    /// Recompute a producer's trust score from its recent
+    /// attestation history and emit a fresh `ProducerTrust`
+    /// attestation (#293). Score = `passed / (passed + failed
+    /// + inconclusive)` over the last `window` attestations
+    /// produced by `tool_id`, expressed in thousandths
+    /// (`0..=1000`).
+    ///
+    /// Refuses to grant trust when the tool has an active
+    /// `ProducerBlock` — the block wins as a hard veto. Returns
+    /// `Ok(None)` for "no attestations to score" (a brand-new
+    /// producer); the caller can choose how to handle it
+    /// (typically: skip the publish until evidence accrues).
+    ///
+    /// `granted_by` is the identity of the actor running the
+    /// recompute (typically the human admin, or "lex-ci-bot"
+    /// for an automated nightly).
+    pub fn recompute_producer_trust(
+        &self,
+        tool_id: &str,
+        window: usize,
+        granted_by: &str,
+    ) -> Result<Option<lex_vcs::AttestationId>, StoreError> {
+        let log = self.attestation_log()?;
+        let all = log.list_all()?;
+        // Hard veto: don't grant trust to a blocked tool.
+        if lex_vcs::active_producer_block(&all, tool_id).is_some() {
+            return Err(StoreError::InvalidTransition(format!(
+                "cannot recompute trust for `{tool_id}` — \
+                 producer is currently blocked"
+            )));
+        }
+        // Filter to attestations from this tool, newest-first by
+        // timestamp, then take the window.
+        let mut from_tool: Vec<&lex_vcs::Attestation> = all.iter()
+            .filter(|a| a.produced_by.tool == tool_id)
+            // Ignore self-referential trust attestations (we're
+            // scoring evidence, not previous trust statements).
+            .filter(|a| !matches!(a.kind,
+                lex_vcs::AttestationKind::ProducerTrust { .. }
+                | lex_vcs::AttestationKind::TrustWaived { .. }))
+            .collect();
+        from_tool.sort_by_key(|a| std::cmp::Reverse(a.timestamp));
+        from_tool.truncate(window);
+        if from_tool.is_empty() {
+            return Ok(None);
+        }
+        let (mut passed, mut total) = (0u64, 0u64);
+        for a in &from_tool {
+            total += 1;
+            if matches!(a.result, lex_vcs::AttestationResult::Passed) {
+                passed += 1;
+            }
+        }
+        let score = if total == 0 {
+            0
+        } else {
+            let raw = (passed as f64) * 1000.0 / (total as f64);
+            raw.round().clamp(0.0, 1000.0) as u32
+        };
+        let head_op = self.list_branches()?
+            .into_iter()
+            .find_map(|b| self.get_branch(&b).ok().flatten().and_then(|x| x.head_op))
+            .unwrap_or_else(|| "fresh".into());
+        let evidence = format!("window={window}, sample={}, head_op={head_op:.16}", from_tool.len());
+        let attestation = lex_vcs::Attestation::new(
+            tool_id.to_string(),
+            None,
+            None,
+            lex_vcs::AttestationKind::ProducerTrust {
+                tool_id: tool_id.into(),
+                score_thousandths: score,
+                evidence,
+                granted_by: granted_by.into(),
+            },
+            lex_vcs::AttestationResult::Passed,
+            producer_trust_producer(),
+            None,
+        );
+        let id = attestation.attestation_id.clone();
+        log.put(&attestation)?;
+        Ok(Some(id))
+    }
+
     pub fn attestation_log(&self) -> Result<lex_vcs::AttestationLog, StoreError> {
         Ok(lex_vcs::AttestationLog::open(self.root())?)
     }
@@ -1701,8 +1784,31 @@ impl Store {
             Some(p) if !p.required_attestations.is_empty() => p,
             _ => return Ok(()),
         };
-        crate::policy::check_required_attestations(&attest_log, &new_op_candidate, &policy)
-            .map_err(StoreError::BranchAdvanceBlocked)
+        let waivers = crate::policy::check_required_attestations(
+            &attest_log, &new_op_candidate, &policy,
+        ).map_err(StoreError::BranchAdvanceBlocked)?;
+        // #293: emit one `TrustWaived` attestation per waiver so
+        // the audit trail records every skip. Idempotent on
+        // attestation_id (content-addressed dedup) — re-running
+        // the gate with the same state writes the same files.
+        for w in waivers {
+            let att = lex_vcs::Attestation::new(
+                w.stage_id,
+                Some(op_id.clone()),
+                None,
+                lex_vcs::AttestationKind::TrustWaived {
+                    producer: w.producer,
+                    score_thousandths: w.score_thousandths,
+                    threshold_thousandths: w.threshold_thousandths,
+                    kind_tag: w.kind_tag,
+                },
+                lex_vcs::AttestationResult::Passed,
+                trust_waived_producer(),
+                None,
+            );
+            attest_log.put(&att)?;
+        }
+        Ok(())
     }
 
     /// Walk the branch from `head_op` back to `last_gate_checkpoint`
@@ -1821,6 +1927,31 @@ fn typecheck_producer() -> lex_vcs::ProducerDescriptor {
 fn repair_hint_producer() -> lex_vcs::ProducerDescriptor {
     lex_vcs::ProducerDescriptor {
         tool: "lex-store::repair_hint".into(),
+        version: env!("CARGO_PKG_VERSION").into(),
+        model: None,
+    }
+}
+
+/// Producer identity for `TrustWaived` attestations emitted by
+/// the `required_attestations` gate on a trust-driven waiver
+/// (#293). Distinct from `typecheck_producer` and `repair_hint`
+/// so the audit trail clearly shows "the gate let this advance
+/// through because trust > threshold."
+fn trust_waived_producer() -> lex_vcs::ProducerDescriptor {
+    lex_vcs::ProducerDescriptor {
+        tool: "lex-store::trust_waived".into(),
+        version: env!("CARGO_PKG_VERSION").into(),
+        model: None,
+    }
+}
+
+/// Producer identity for `ProducerTrust` attestations emitted by
+/// [`Store::recompute_producer_trust`]. The score-derivation
+/// recompute is its own machine-emittable kind, distinct from
+/// the gate-side `TrustWaived` emit (#293).
+fn producer_trust_producer() -> lex_vcs::ProducerDescriptor {
+    lex_vcs::ProducerDescriptor {
+        tool: "lex-store::producer_trust".into(),
         version: env!("CARGO_PKG_VERSION").into(),
         model: None,
     }

--- a/crates/lex-store/tests/producer_trust.rs
+++ b/crates/lex-store/tests/producer_trust.rs
@@ -1,0 +1,275 @@
+//! Conformance tests for #293 — `ProducerTrust` + `TrustWaived`.
+
+use lex_store::{
+    policy::{PolicyFile, RequiredAttestation, RequiredAttestationKind, AttestationCondition},
+    Operation, OperationKind, StageTransition, Store, StoreError, DEFAULT_BRANCH,
+};
+use std::collections::BTreeSet;
+use tempfile::TempDir;
+
+fn fresh() -> (Store, TempDir) {
+    let tmp = TempDir::new().unwrap();
+    let s = Store::open(tmp.path()).unwrap();
+    (s, tmp)
+}
+
+fn producer(tool: &str) -> lex_vcs::ProducerDescriptor {
+    lex_vcs::ProducerDescriptor {
+        tool: tool.into(),
+        version: "test".into(),
+        model: None,
+    }
+}
+
+fn push_attestation(
+    store: &Store,
+    stage: &str,
+    tool: &str,
+    kind: lex_vcs::AttestationKind,
+    result: lex_vcs::AttestationResult,
+) {
+    let att = lex_vcs::Attestation::new(
+        stage.to_string(),
+        None, None, kind, result, producer(tool), None,
+    );
+    store.attestation_log().unwrap().put(&att).unwrap();
+}
+
+#[test]
+fn recompute_with_no_attestations_returns_none() {
+    let (store, _tmp) = fresh();
+    let r = store.recompute_producer_trust("spec-checker", 1000, "tester").unwrap();
+    assert!(r.is_none(),
+        "new producer has no evidence to score");
+}
+
+#[test]
+fn recompute_with_all_passing_scores_full_trust() {
+    let (store, _tmp) = fresh();
+    for i in 0..10 {
+        push_attestation(&store, &format!("stg-{i}"), "trustworthy",
+            lex_vcs::AttestationKind::TypeCheck,
+            lex_vcs::AttestationResult::Passed);
+    }
+    let id = store.recompute_producer_trust("trustworthy", 1000, "tester")
+        .unwrap()
+        .expect("trust attestation emitted");
+    // Read back the attestation and verify score = 1000.
+    let stored = store.attestation_log().unwrap().get(&id).unwrap().unwrap();
+    let lex_vcs::AttestationKind::ProducerTrust { score_thousandths, .. } = stored.kind
+        else { panic!("expected ProducerTrust"); };
+    assert_eq!(score_thousandths, 1000,
+        "10/10 passed → score = 1.000");
+}
+
+#[test]
+fn recompute_half_passing_scores_half() {
+    let (store, _tmp) = fresh();
+    for i in 0..5 {
+        push_attestation(&store, &format!("stg-{i}"), "shaky",
+            lex_vcs::AttestationKind::TypeCheck,
+            lex_vcs::AttestationResult::Passed);
+    }
+    for i in 5..10 {
+        push_attestation(&store, &format!("stg-{i}"), "shaky",
+            lex_vcs::AttestationKind::TypeCheck,
+            lex_vcs::AttestationResult::Failed { detail: "bad".into() });
+    }
+    let id = store.recompute_producer_trust("shaky", 1000, "tester")
+        .unwrap().unwrap();
+    let stored = store.attestation_log().unwrap().get(&id).unwrap().unwrap();
+    let lex_vcs::AttestationKind::ProducerTrust { score_thousandths, .. } = stored.kind
+        else { panic!(); };
+    assert_eq!(score_thousandths, 500, "5/10 → 0.5");
+}
+
+#[test]
+fn recompute_refuses_blocked_producer() {
+    let (store, _tmp) = fresh();
+    push_attestation(&store, "compromised-tool", "compromised-tool",
+        lex_vcs::AttestationKind::ProducerBlock {
+            tool_id: "compromised-tool".into(),
+            reason: "rooted".into(),
+            blocked_at: 1234,
+        },
+        lex_vcs::AttestationResult::Passed);
+    let err = store.recompute_producer_trust("compromised-tool", 1000, "tester")
+        .unwrap_err();
+    assert!(matches!(err, StoreError::InvalidTransition(_)),
+        "blocked producer should be refused; got {err:?}");
+}
+
+#[test]
+fn recompute_ignores_self_referential_trust_attestations() {
+    // Re-running recompute on a producer should look at their
+    // evidence attestations, not their previous trust score —
+    // otherwise scores would compound circularly.
+    let (store, _tmp) = fresh();
+    for i in 0..3 {
+        push_attestation(&store, &format!("stg-{i}"), "iterating",
+            lex_vcs::AttestationKind::TypeCheck,
+            lex_vcs::AttestationResult::Passed);
+    }
+    let _ = store.recompute_producer_trust("iterating", 1000, "tester")
+        .unwrap().unwrap();
+    // Re-run; should still be 1000 (not influenced by the prior
+    // ProducerTrust attestation in the log).
+    let id2 = store.recompute_producer_trust("iterating", 1000, "tester")
+        .unwrap().unwrap();
+    let stored = store.attestation_log().unwrap().get(&id2).unwrap().unwrap();
+    let lex_vcs::AttestationKind::ProducerTrust { score_thousandths, .. } = stored.kind
+        else { panic!(); };
+    assert_eq!(score_thousandths, 1000,
+        "self-referential trust must not affect the recompute");
+}
+
+// ---- gate-waiver tests ------------------------------------------
+
+fn parse(src: &str) -> Vec<lex_ast::Stage> {
+    let prog = lex_syntax::parse_source(src).expect("parse");
+    lex_ast::canonicalize_program(&prog)
+}
+
+fn add_fn_op() -> (Operation, StageTransition) {
+    let op = Operation::new(
+        OperationKind::AddFunction {
+            sig_id: "fac".into(),
+            stage_id: "stg-1".into(),
+            effects: BTreeSet::new(),
+            budget_cost: None,
+        },
+        [],
+    );
+    let t = StageTransition::Create {
+        sig_id: "fac".into(),
+        stage_id: "stg-1".into(),
+    };
+    (op, t)
+}
+
+#[test]
+fn gate_waives_rule_when_trust_above_threshold() {
+    let (store, _tmp) = fresh();
+    // Seed a trusted producer with 10 passing attestations.
+    for i in 0..10 {
+        push_attestation(&store, &format!("seed-{i}"), "rocksolid",
+            lex_vcs::AttestationKind::TypeCheck,
+            lex_vcs::AttestationResult::Passed);
+    }
+    store.recompute_producer_trust("rocksolid", 1000, "admin").unwrap().unwrap();
+
+    // Policy requires Spec attestations, with a trust waiver at 900/1000.
+    let policy = PolicyFile {
+        required_attestations: vec![RequiredAttestation {
+            kind: RequiredAttestationKind::Spec,
+            when: AttestationCondition::Always,
+            skip_if_producer_trust_thousandths_above: Some(900),
+        }],
+        ..Default::default()
+    };
+    lex_store::policy::save(store.root(), &policy).unwrap();
+
+    // Apply an op with NO Spec attestation. Without the waiver this
+    // would block; with the waiver it should advance.
+    let candidate = parse(
+        "fn factorial(n :: Int) -> Int { match n { 0 => 1, _ => n * factorial(n - 1) } }\n",
+    );
+    let (op, t) = add_fn_op();
+    let op_id = store.apply_operation_checked(DEFAULT_BRANCH, op, t, &candidate)
+        .expect("trust waiver should let the advance through");
+
+    // TrustWaived attestation lands.
+    let attlog = store.attestation_log().unwrap();
+    let waivers: Vec<_> = attlog.list_all().unwrap().into_iter()
+        .filter(|a| matches!(a.kind, lex_vcs::AttestationKind::TrustWaived { .. }))
+        .collect();
+    assert_eq!(waivers.len(), 1, "exactly one TrustWaived attestation");
+    let lex_vcs::AttestationKind::TrustWaived {
+        producer, score_thousandths, threshold_thousandths, kind_tag,
+    } = &waivers[0].kind else { unreachable!() };
+    assert_eq!(producer, "rocksolid");
+    assert_eq!(*score_thousandths, 1000);
+    assert_eq!(*threshold_thousandths, 900);
+    assert_eq!(kind_tag, "spec");
+    assert_eq!(waivers[0].op_id.as_deref(), Some(op_id.as_str()));
+}
+
+#[test]
+fn gate_does_not_waive_when_trust_at_or_below_threshold() {
+    let (store, _tmp) = fresh();
+    // Seed a producer with 50/50 attestations → score = 500.
+    for i in 0..5 {
+        push_attestation(&store, &format!("seed-{i}"), "shaky",
+            lex_vcs::AttestationKind::TypeCheck,
+            lex_vcs::AttestationResult::Passed);
+    }
+    for i in 5..10 {
+        push_attestation(&store, &format!("seed-{i}"), "shaky",
+            lex_vcs::AttestationKind::TypeCheck,
+            lex_vcs::AttestationResult::Failed { detail: "x".into() });
+    }
+    store.recompute_producer_trust("shaky", 1000, "admin").unwrap().unwrap();
+
+    // Policy threshold is 900; shaky's score (500) is below.
+    let policy = PolicyFile {
+        required_attestations: vec![RequiredAttestation {
+            kind: RequiredAttestationKind::Spec,
+            when: AttestationCondition::Always,
+            skip_if_producer_trust_thousandths_above: Some(900),
+        }],
+        ..Default::default()
+    };
+    lex_store::policy::save(store.root(), &policy).unwrap();
+
+    let candidate = parse(
+        "fn factorial(n :: Int) -> Int { match n { 0 => 1, _ => n * factorial(n - 1) } }\n",
+    );
+    let (op, t) = add_fn_op();
+    let err = store.apply_operation_checked(DEFAULT_BRANCH, op, t, &candidate)
+        .unwrap_err();
+    match err {
+        StoreError::BranchAdvanceBlocked(_) => {}
+        other => panic!("expected BranchAdvanceBlocked, got {other:?}"),
+    }
+}
+
+#[test]
+fn blocked_producer_does_not_count_toward_trust_waiver() {
+    let (store, _tmp) = fresh();
+    // Seed a producer with a high trust score…
+    for i in 0..10 {
+        push_attestation(&store, &format!("seed-{i}"), "compromised",
+            lex_vcs::AttestationKind::TypeCheck,
+            lex_vcs::AttestationResult::Passed);
+    }
+    store.recompute_producer_trust("compromised", 1000, "admin").unwrap().unwrap();
+    // …then block the producer retroactively.
+    push_attestation(&store, "compromised", "admin",
+        lex_vcs::AttestationKind::ProducerBlock {
+            tool_id: "compromised".into(),
+            reason: "found rooted".into(),
+            blocked_at: 9999,
+        },
+        lex_vcs::AttestationResult::Passed);
+
+    // Policy with trust waiver. The blocked tool should NOT
+    // count toward the trust ceiling, so the waiver doesn't fire.
+    let policy = PolicyFile {
+        required_attestations: vec![RequiredAttestation {
+            kind: RequiredAttestationKind::Spec,
+            when: AttestationCondition::Always,
+            skip_if_producer_trust_thousandths_above: Some(900),
+        }],
+        ..Default::default()
+    };
+    lex_store::policy::save(store.root(), &policy).unwrap();
+
+    let candidate = parse(
+        "fn factorial(n :: Int) -> Int { match n { 0 => 1, _ => n * factorial(n - 1) } }\n",
+    );
+    let (op, t) = add_fn_op();
+    let err = store.apply_operation_checked(DEFAULT_BRANCH, op, t, &candidate)
+        .unwrap_err();
+    assert!(matches!(err, StoreError::BranchAdvanceBlocked(_)),
+        "blocked producer's trust must not waive the rule");
+}

--- a/crates/lex-vcs/src/attestation.rs
+++ b/crates/lex-vcs/src/attestation.rs
@@ -251,6 +251,50 @@ pub enum AttestationKind {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         applied_op_id: Option<super::operation::OpId>,
     },
+    /// Positive trust signal for a producer (#293). Complement to
+    /// [`Self::ProducerBlock`]. Computed from a producer's recent
+    /// history of (passed, failed, inconclusive) attestations;
+    /// not manually set. `score_thousandths` is in `[0, 1000]`
+    /// (representing `0.0 .. 1.0`); fixed-point because
+    /// `AttestationKind` is `Eq` for content-addressed hashing,
+    /// which `f64` doesn't implement. Consumers (the
+    /// `required_attestations` gate) may waive a requirement
+    /// when the latest score for a tool exceeds a configured
+    /// threshold in `policy.required_attestations[].skip_if_producer_trust_thousandths_above`.
+    ///
+    /// Refuses to grant trust to a tool with an active
+    /// `ProducerBlock` (the hard veto wins).
+    ///
+    /// Stored under `stage_id == tool_id` so the by-stage index
+    /// doubles as a per-tool lookup — same trick `ProducerBlock`
+    /// uses.
+    ProducerTrust {
+        tool_id: String,
+        /// Score × 1000, clamped to `[0, 1000]`. Derived from
+        /// `passed / (passed + failed + inconclusive)` over the
+        /// last `window` attestations from this tool.
+        score_thousandths: u32,
+        /// Free-form reference to the evidence corpus the score
+        /// was derived from — e.g. "window=1000 as of <head_op>".
+        evidence: String,
+        granted_by: String,
+    },
+    /// Records that the `required_attestations` gate waived a
+    /// requirement because the producer's `ProducerTrust` score
+    /// exceeded the configured threshold (#293). Audit signal —
+    /// not load-bearing for gate decisions, but ensures every
+    /// skip is recoverable from the attestation log.
+    TrustWaived {
+        /// Tool whose trust score caused the waiver.
+        producer: String,
+        /// Latest score (× 1000) consulted at gate time.
+        score_thousandths: u32,
+        /// Threshold (× 1000) from the policy rule.
+        threshold_thousandths: u32,
+        /// Which required-attestation kind tag was skipped
+        /// (e.g. `spec`, `type_check`).
+        kind_tag: String,
+    },
 }
 
 /// Walk a tool's `ProducerBlock` / `ProducerUnblock` attestations


### PR DESCRIPTION
Closes #293. Positive trust signal complementing #248's `ProducerBlock`.

## Summary

A producer with a high recent pass-rate can short-circuit the `required_attestations` gate for matching rules. Every waiver is recorded as a `TrustWaived` attestation so the audit trail captures the skip.

### New attestation kinds

- **`ProducerTrust { tool_id, score_thousandths, evidence, granted_by }`** — score is `u32` in thousandths (`0..=1000`, i.e. 0.0..1.0). Fixed-point because `AttestationKind` derives `Eq` for content-addressed hashing, which `f64` doesn't implement.
- **`TrustWaived { producer, score_thousandths, threshold_thousandths, kind_tag }`** — emitted by the gate per waiver; lands against the affected stage tied to the advancing op.

### Policy hook

`RequiredAttestation` gains `skip_if_producer_trust_thousandths_above: Option<u32>` (default `None` = no waiver). When set, the gate consults the maximum live trust score across all non-blocked producers; if it exceeds the threshold, the rule is waived.

### Recompute CLI + Store method

```
lex producer-trust recompute --tool <id> [--window N] [--granted-by ACTOR] [--store DIR]
```

Walks the attestation log filtered by `produced_by.tool == <id>`, scores `passed / (passed + failed + inconclusive)` over the last `window` records, and emits a fresh `ProducerTrust` attestation. **Hard-vetoes** blocked producers — a tool with an active `ProducerBlock` cannot have its trust recomputed.

Self-referential `ProducerTrust` / `TrustWaived` attestations are excluded from the evidence corpus so re-running recompute is stable (doesn't compound circularly).

## Test plan

- [x] 8 conformance tests in `crates/lex-store/tests/producer_trust.rs`:
  - no evidence → `None`
  - all-passing → score = 1000
  - half-passing → score = 500
  - blocked producer → refuses to grant trust
  - self-referential trust → not influenced by prior trust
  - gate waives when trust > threshold (+ `TrustWaived` lands)
  - gate fires normally when trust ≤ threshold
  - blocked producer's trust does NOT count toward the waiver ceiling
- [x] 3 CLI tests in `crates/lex-cli/tests/producer_trust_cli.rs`.
- [x] `cargo test --workspace` — 182 test groups pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.

## What's deliberately out

From the issue's "Out of scope":
- **Cross-store trust signaling** — tied to federation (#173).
- **Signed attestations as trust input** — #227 has the primitive; can fold in once a real CI tool with persistent keys is set up.
- **Decay model** — first version uses a fixed window (`--window N`); time-weighted decay can come later.

## Score representation choice

I went with `u32` thousandths instead of `f64` for the score because `AttestationKind` requires `Eq` (for content-addressed hashing) and `f64: !Eq`. The thousandths form gives 4 significant digits — plenty for trust thresholds — and keeps canonical JSON byte-stable. The CLI renders as `0.000..1.000` for humans.

https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_