### PR TITLE
chore: bump workspace to 0.7.0 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+## [0.7.0] — 2026-05-11
+
+The post-0.6.0 strategic-amplifier wave. Five issues land in
+one release — the four amplifiers identified in the 0.5.0
+review plus the closure of #281's LLM-driven repair path:
+
+- **#281 closed repair loop, slices 2a + 2b** — `lex repair
+  --apply --transform '<json>'` for typed-transform execution
+  with a `RepairAttempt` audit trail, and `lex repair --apply`
+  (no `--transform`) for LLM-driven transform generation. The
+  `LEX_REPAIR_LLM_FIXTURE` env var short-circuits the LLM call
+  for tests; production calls `lex_runtime::llm::cloud_complete`.
+- **#292 per-session budget enforcement** — `Store::session_budget`
+  ledger (slice 1, shipped in 0.6.0 mid-cycle), `policy.session_budgets`
+  schema with `default_cap` + per-session `overrides` (slice 2),
+  and an `apply_operation_checked` budget gate with
+  `StoreError::BudgetExceeded` mapped to HTTP 503 + `Retry-After: 0`
+  (slice 3).
+- **#293 positive `ProducerTrust`** — `AttestationKind::ProducerTrust
+  { tool_id, score_thousandths, ... }` complementing #248's
+  `ProducerBlock`; `policy.required_attestations[].skip_if_producer_trust_thousandths_above`
+  waiver hook; `TrustWaived` audit attestation;
+  `lex producer-trust recompute` CLI. Hard-vetoes blocked producers.
+- **#294 multi-agent Candidate/Promote ops** —
+  `OperationKind::Candidate` proposes a stage without advancing the
+  branch (no CAS contention between concurrent agents);
+  `OperationKind::Promote` picks a winner and lists every other
+  live candidate in `supersedes`. `lex stage candidates <sig_id>`
+  and `lex stage promote-candidate <op_id>` CLI.
+
+Minor bump because every data-layer change is additive: new
+`OperationKind` variants (`Candidate`, `Promote`) and new
+`AttestationKind` variants (`ProducerTrust`, `TrustWaived`)
+are append-only enum extensions; new `policy.json` fields
+(`session_budgets`, `skip_if_producer_trust_thousandths_above`)
+all use `skip_if_none` so pre-0.7.0 policy files load
+unchanged; new CLI subcommands add surface without changing
+existing commands.
+
+One behavior change worth calling out: `apply_operation_checked`
+now consults the per-session budget cap after typecheck passes
+and may surface `StoreError::BudgetExceeded`. Callers that
+weren't pattern-matching on `StoreError` exhaustively (i.e.
+used a wildcard arm) are unaffected. Stores with no
+`policy.session_budgets` (the pre-0.7.0 shape) keep their
+current behavior — the gate is no-op when no cap is set.
+
 ### Added — agent-coordination (#294)
 
 - **`OperationKind::Candidate { sig_id, stage_id }`** — proposes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "EUPL-1.2"
 repository = "https://github.com/alpibrusl/lex-lang"

--- a/crates/lex-api/Cargo.toml
+++ b/crates/lex-api/Cargo.toml
@@ -16,14 +16,14 @@ serde_json.workspace = true
 anyhow.workspace = true
 indexmap.workspace = true
 tiny_http = "0.12"
-lex-syntax = { path = "../lex-syntax", version = "0.6.0" }
-lex-ast = { path = "../lex-ast", version = "0.6.0" }
-lex-types = { path = "../lex-types", version = "0.6.0" }
-lex-bytecode = { path = "../lex-bytecode", version = "0.6.0" }
-lex-runtime = { path = "../lex-runtime", version = "0.6.0" }
-lex-store = { path = "../lex-store", version = "0.6.0" }
-lex-trace = { path = "../lex-trace", version = "0.6.0" }
-lex-vcs = { path = "../lex-vcs", version = "0.6.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.7.0" }
+lex-ast = { path = "../lex-ast", version = "0.7.0" }
+lex-types = { path = "../lex-types", version = "0.7.0" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.7.0" }
+lex-runtime = { path = "../lex-runtime", version = "0.7.0" }
+lex-store = { path = "../lex-store", version = "0.7.0" }
+lex-trace = { path = "../lex-trace", version = "0.7.0" }
+lex-vcs = { path = "../lex-vcs", version = "0.7.0" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/lex-ast/Cargo.toml
+++ b/crates/lex-ast/Cargo.toml
@@ -16,4 +16,4 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-syntax = { path = "../lex-syntax", version = "0.6.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.7.0" }

--- a/crates/lex-bytecode/Cargo.toml
+++ b/crates/lex-bytecode/Cargo.toml
@@ -16,8 +16,8 @@ serde_json.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
 sha2.workspace = true
-lex-ast = { path = "../lex-ast", version = "0.6.0" }
-lex-types = { path = "../lex-types", version = "0.6.0" }
+lex-ast = { path = "../lex-ast", version = "0.7.0" }
+lex-types = { path = "../lex-types", version = "0.7.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.6.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.7.0" }

--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -35,10 +35,10 @@ toml = "1.1"
 serde_yaml = "0.9"
 csv = "1"
 rusqlite = { version = "0.39", features = ["bundled"] }
-lex-bytecode = { path = "../lex-bytecode", version = "0.6.0" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.7.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.6.0" }
-lex-ast = { path = "../lex-ast", version = "0.6.0" }
-lex-types = { path = "../lex-types", version = "0.6.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.7.0" }
+lex-ast = { path = "../lex-ast", version = "0.7.0" }
+lex-types = { path = "../lex-types", version = "0.7.0" }
 tempfile = "3"

--- a/crates/lex-search/Cargo.toml
+++ b/crates/lex-search/Cargo.toml
@@ -17,10 +17,10 @@ thiserror.workspace = true
 sha2.workspace = true
 hex.workspace = true
 ureq = { version = "3.3", default-features = false, features = ["rustls", "platform-verifier", "json"] }
-lex-ast = { path = "../lex-ast", version = "0.6.0" }
-lex-store = { path = "../lex-store", version = "0.6.0" }
+lex-ast = { path = "../lex-ast", version = "0.7.0" }
+lex-store = { path = "../lex-store", version = "0.7.0" }
 
 [dev-dependencies]
 tempfile = "3"
 tiny_http = "0.12"
-lex-syntax = { path = "../lex-syntax", version = "0.6.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.7.0" }

--- a/crates/lex-store/Cargo.toml
+++ b/crates/lex-store/Cargo.toml
@@ -21,11 +21,11 @@ hex.workspace = true
 # transitive dep via tempfile; promoting to direct so the lock
 # call sites compile.
 fs2 = "0.4"
-lex-ast = { path = "../lex-ast", version = "0.6.0" }
-lex-trace = { path = "../lex-trace", version = "0.6.0" }
-lex-types = { path = "../lex-types", version = "0.6.0" }
-lex-vcs = { path = "../lex-vcs", version = "0.6.0" }
+lex-ast = { path = "../lex-ast", version = "0.7.0" }
+lex-trace = { path = "../lex-trace", version = "0.7.0" }
+lex-types = { path = "../lex-types", version = "0.7.0" }
+lex-vcs = { path = "../lex-vcs", version = "0.7.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.6.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.7.0" }
 tempfile = "3"

--- a/crates/lex-trace/Cargo.toml
+++ b/crates/lex-trace/Cargo.toml
@@ -16,9 +16,9 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-bytecode = { path = "../lex-bytecode", version = "0.6.0" }
-lex-ast = { path = "../lex-ast", version = "0.6.0" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.7.0" }
+lex-ast = { path = "../lex-ast", version = "0.7.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.6.0" }
-lex-runtime = { path = "../lex-runtime", version = "0.6.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.7.0" }
+lex-runtime = { path = "../lex-runtime", version = "0.7.0" }

--- a/crates/lex-types/Cargo.toml
+++ b/crates/lex-types/Cargo.toml
@@ -15,7 +15,7 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-ast = { path = "../lex-ast", version = "0.6.0" }
+lex-ast = { path = "../lex-ast", version = "0.7.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.6.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.7.0" }

--- a/crates/lex-vcs/Cargo.toml
+++ b/crates/lex-vcs/Cargo.toml
@@ -11,8 +11,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-lex-ast = { path = "../lex-ast", version = "0.6.0" }
-lex-types = { path = "../lex-types", version = "0.6.0" }
+lex-ast = { path = "../lex-ast", version = "0.7.0" }
+lex-types = { path = "../lex-types", version = "0.7.0" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
@@ -24,4 +24,4 @@ hex.workspace = true
 
 [dev-dependencies]
 tempfile = "3"
-lex-syntax = { path = "../lex-syntax", version = "0.6.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.7.0" }

--- a/crates/spec-checker/Cargo.toml
+++ b/crates/spec-checker/Cargo.toml
@@ -16,11 +16,11 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-syntax = { path = "../lex-syntax", version = "0.6.0" }
-lex-ast = { path = "../lex-ast", version = "0.6.0" }
-lex-types = { path = "../lex-types", version = "0.6.0" }
-lex-bytecode = { path = "../lex-bytecode", version = "0.6.0" }
-lex-runtime = { path = "../lex-runtime", version = "0.6.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.7.0" }
+lex-ast = { path = "../lex-ast", version = "0.7.0" }
+lex-types = { path = "../lex-types", version = "0.7.0" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.7.0" }
+lex-runtime = { path = "../lex-runtime", version = "0.7.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.6.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.7.0" }


### PR DESCRIPTION
Promotes [Unreleased] → [0.7.0] — 2026-05-11. Workspace + inter-crate version pins move from `0.6.0` to `0.7.0`.

## What's in 0.7.0

The post-0.6.0 strategic-amplifier wave — the four amplifier issues from the 0.5.0 review plus the closure of #281's LLM-driven repair path:

- **#281 closed repair loop, slices 2a + 2b** (#295, #298) — `lex repair --apply --transform '<json>'` for explicit typed-transform execution, and `lex repair --apply` (no `--transform`) for LLM-driven generation. `LEX_REPAIR_LLM_FIXTURE` env var short-circuits the LLM call for tests.
- **#292 per-session budget enforcement** (#296, #297) — `Store::session_budget` ledger, `policy.session_budgets` schema with `default_cap` + per-session `overrides`, apply-path gate with `StoreError::BudgetExceeded` mapped to HTTP 503 + `Retry-After: 0`.
- **#293 positive `ProducerTrust`** (#299) — complement to #248's `ProducerBlock`; `skip_if_producer_trust_thousandths_above` waiver hook; `TrustWaived` audit attestation; `lex producer-trust recompute` CLI. Hard-vetoes blocked producers.
- **#294 multi-agent Candidate/Promote ops** (#300) — `OperationKind::Candidate` proposes a stage without advancing the branch (no CAS contention); `OperationKind::Promote` picks a winner + lists `supersedes`. `lex stage candidates` / `promote-candidate` CLI.

## Why a minor bump

All data-layer changes are additive:

- New `OperationKind` variants (`Candidate`, `Promote`) and new `AttestationKind` variants (`ProducerTrust`, `TrustWaived`) are append-only enum extensions.
- New `policy.json` fields (`session_budgets`, `skip_if_producer_trust_thousandths_above`) use `skip_if_none` so pre-0.7.0 policy files load unchanged.
- New CLI subcommands (`lex repair`, `lex policy session-budget`, `lex producer-trust`, `lex stage candidates`/`promote-candidate`) add surface without changing existing commands.

Pre-0.7.0 OpIds and attestation_ids are stable.

## One behavior change worth calling out

`apply_operation_checked` now consults the per-session budget cap (after typecheck passes) and may surface `StoreError::BudgetExceeded`. Callers using a wildcard arm on `StoreError` are unaffected. Stores with no `policy.session_budgets` (the pre-0.7.0 shape) keep their current behavior — the gate is no-op when no cap is set.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — 183 test groups pass (one re-run needed; the pre-existing `lex-api/m8` port-race flake hit on the first attempt, same as previous bumps)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean

## Strategic context

With 0.7.0, every issue from the post-0.5.0 strategic review is closed. The only remaining open issue in the repo is #173 (federation tier-3 meta tracker, deliberately deferred until a second-store use case materializes).

https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_