### PR TITLE
lex-store: fix cas_retry_advance race for empty-parents ops (#262 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+### Fixed
+
+- **CAS retry race in `apply_operation` for empty-parents ops**
+  (#262 follow-up). `cas_retry_advance`'s attempt-1
+  "honor caller's exact op" semantics surfaced `StaleParent`
+  on a legitimate race: when a sibling writer landed between
+  the read of `head_op` and the local persist, the caller's
+  `parents = []` op was rejected by `lex_vcs::apply` instead of
+  retrying. CI hit this on the multi-writer stress test. Fix:
+  on attempt 1, rebuild the op against the just-read head when
+  the caller's `parents` is empty — that's the "I don't care,
+  chain off whatever the current head is" intent. Non-empty
+  parents on attempt 1 still surface `StaleParent` so the
+  explicit-bogus-parent test (`apply_operation_with_stale_parent_errors`)
+  keeps its contract. New regression test
+  `empty_parents_op_chains_off_existing_head` covers the path
+  single-threaded so the race is deterministically reproducible.
+
 ## [0.7.0] — 2026-05-11
 
 The post-0.6.0 strategic-amplifier wave. Five issues land in

--- a/crates/lex-store/src/store.rs
+++ b/crates/lex-store/src/store.rs
@@ -1782,8 +1782,17 @@ impl Store {
         let mut current_op = op;
         let current_transition = transition;
         // Only rebuild on retries — attempt 1 honors the caller's
-        // exact op so a user-supplied bogus parent surfaces as
-        // `StaleParent` instead of being silently corrected.
+        // exact op so a user-supplied bogus parent (parents =
+        // ["someone-else"]) surfaces as `StaleParent` instead of
+        // being silently corrected.
+        //
+        // Exception (#262 follow-up): an op with `parents = []`
+        // means "I don't care; chain off whatever the current
+        // head is." Under concurrent apply, attempt 1 can read
+        // `head_op = Some(opA)` after a sibling writer landed,
+        // and the persist's parent check fails StaleParent
+        // unprompted. Rebuild attempt 1 for the empty-parents
+        // case so the legitimate-race path retries cleanly.
         let mut rebuilt_already = false;
         for attempt in 1..=MAX_ATTEMPTS {
             // Read the current head BEFORE we persist — this is
@@ -1796,7 +1805,14 @@ impl Store {
             // on retries (not the caller's first attempt) and
             // only for single-parent operations. Multi-parent
             // (merge) ops are passed through unchanged.
-            if is_rebuildable && rebuilt_already {
+            //
+            // Empty-parents ops also rebuild on attempt 1 (see
+            // the exception note above) so concurrent apply
+            // doesn't false-positive on StaleParent.
+            let should_rebuild = is_rebuildable
+                && (rebuilt_already
+                    || (current_op.parents.is_empty() && parent.is_some()));
+            if should_rebuild {
                 current_op = lex_vcs::Operation {
                     kind: kind.clone(),
                     parents: parent.iter().cloned().collect(),

--- a/crates/lex-store/tests/concurrent_apply.rs
+++ b/crates/lex-store/tests/concurrent_apply.rs
@@ -172,3 +172,52 @@ fn concurrent_writers_do_not_lose_op_records() {
         n_ops
     );
 }
+
+#[test]
+fn empty_parents_op_chains_off_existing_head() {
+    // Deterministic regression for the cas_retry_advance race that
+    // surfaced in CI for #262: a caller submitting an op with
+    // `parents = []` against a branch that already has a head
+    // should chain off the existing head rather than fail
+    // StaleParent. This is the single-threaded analogue of the
+    // sibling-writer race in `n_concurrent_writers_all_land`.
+    let tmp = tempfile::tempdir().unwrap();
+    let s = Store::open(tmp.path()).unwrap();
+    fn add(sig: &str, stage: &str) -> (Operation, StageTransition) {
+        let op = Operation::new(
+            OperationKind::AddFunction {
+                sig_id: sig.into(),
+                stage_id: stage.into(),
+                effects: BTreeSet::new(),
+                budget_cost: None,
+            },
+            [],
+        );
+        let t = StageTransition::Create {
+            sig_id: sig.into(),
+            stage_id: stage.into(),
+        };
+        (op, t)
+    }
+
+    // First op lands cleanly.
+    let (op1, t1) = add("first", "stg-first");
+    let head1 = s.apply_operation(DEFAULT_BRANCH, op1, t1).unwrap();
+
+    // Second op is built with parents = [] (same shape as the
+    // concurrent-writer test). Pre-fix this would have failed
+    // StaleParent because attempt 1 doesn't rebuild.
+    let (op2, t2) = add("second", "stg-second");
+    assert!(op2.parents.is_empty(), "op2 must have empty parents to exercise the race");
+    let head2 = s.apply_operation(DEFAULT_BRANCH, op2, t2).unwrap();
+    assert_ne!(head1, head2, "second op should produce a fresh op_id");
+
+    // History walks back from head2 → head1, confirming the
+    // empty-parents op was rebuilt with head1 as parent.
+    let log = lex_vcs::OpLog::open(s.root()).unwrap();
+    let walked = log.walk_back(&head2, None).unwrap();
+    assert_eq!(walked.len(), 2);
+    assert_eq!(walked[0].op_id, head2);
+    assert_eq!(walked[1].op_id, head1);
+    assert_eq!(walked[0].op.parents, vec![head1.clone()]);
+}


### PR DESCRIPTION
Fixes a CAS retry race in `Store::apply_operation` that CI surfaced as `concurrent_apply` exit 101 against v0.7.0.

## Root cause

`cas_retry_advance`'s attempt-1 "don't rebuild" semantics — added to make user-supplied bogus parents surface as `StaleParent` — was rejecting legitimate concurrent-writer races:

1. Thread T1 reads `head_op = None`, persists op1, CAS sets `head_op = Some(opA)`.
2. Thread T2 enters `cas_retry_advance` with `parents = []`. Reads `head_op = Some(opA)` (T1 committed in the gap).
3. Attempt 1 doesn't rebuild → `persist_op_only_with_parent(branch, Some(opA), op{parents=[]}, …)` is called.
4. `lex_vcs::apply` checks `parents.len()=0` vs `head_op=Some(opA)` → `StaleParent`.
5. The retry arm requires `rebuilt_already` to continue; it's `false` on attempt 1 → error propagates → test panics on `.expect(...)`.

## Fix

On attempt 1, also rebuild when the caller's `parents` is empty AND the read head is `Some`. Empty parents means "I don't care; chain off whatever the current head is" — that's the shape used by the multi-writer stress test and by `Store::publish_program` for the first op of a fresh program.

Non-empty parents on attempt 1 still surface `StaleParent` because the rebuild condition checks `parents.is_empty()`, not "parents don't match current head." The `apply_operation_with_stale_parent_errors` test continues to pass unchanged.

## Regression test

`empty_parents_op_chains_off_existing_head` reproduces the race single-threaded by running two `apply_operation` calls with `parents = []` in sequence:

- **Pre-fix**: the second call fails `StaleParent` (verified locally via `git stash` of the store.rs change).
- **Post-fix**: chains off `head1`, producing a `head2 → head1` walk-back chain.

## Test plan

- [x] `cargo test -p lex-store --test concurrent_apply` — 4 tests pass (3 existing + 1 regression).
- [x] `cargo test -p lex-store --test apply_operation` — 4 tests pass, including `apply_operation_with_stale_parent_errors` which depends on the preserved-contract semantics.
- [x] `cargo test --workspace` — 183 test groups pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.

## Released-yet impact

v0.7.0 was just tagged with this bug present. Options:
- Merge this as `0.7.1` patch (recommended).
- Hold and roll into 0.8.0.

The race only manifests under concurrent apply with `parents = []`. Single-threaded callers and callers that always set `parents` explicitly are unaffected. Suggest a 0.7.1 release.

https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_