### PR TITLE
chore: bump workspace to 0.7.1 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+## [0.7.1] — 2026-05-11
+
+Patch release containing a single bug fix that surfaced in CI
+after 0.7.0 tagged.
+
 ### Fixed
 
 - **CAS retry race in `apply_operation` for empty-parents ops**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 license = "EUPL-1.2"
 repository = "https://github.com/alpibrusl/lex-lang"

--- a/crates/lex-api/Cargo.toml
+++ b/crates/lex-api/Cargo.toml
@@ -16,14 +16,14 @@ serde_json.workspace = true
 anyhow.workspace = true
 indexmap.workspace = true
 tiny_http = "0.12"
-lex-syntax = { path = "../lex-syntax", version = "0.7.0" }
-lex-ast = { path = "../lex-ast", version = "0.7.0" }
-lex-types = { path = "../lex-types", version = "0.7.0" }
-lex-bytecode = { path = "../lex-bytecode", version = "0.7.0" }
-lex-runtime = { path = "../lex-runtime", version = "0.7.0" }
-lex-store = { path = "../lex-store", version = "0.7.0" }
-lex-trace = { path = "../lex-trace", version = "0.7.0" }
-lex-vcs = { path = "../lex-vcs", version = "0.7.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.7.1" }
+lex-ast = { path = "../lex-ast", version = "0.7.1" }
+lex-types = { path = "../lex-types", version = "0.7.1" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.7.1" }
+lex-runtime = { path = "../lex-runtime", version = "0.7.1" }
+lex-store = { path = "../lex-store", version = "0.7.1" }
+lex-trace = { path = "../lex-trace", version = "0.7.1" }
+lex-vcs = { path = "../lex-vcs", version = "0.7.1" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/lex-ast/Cargo.toml
+++ b/crates/lex-ast/Cargo.toml
@@ -16,4 +16,4 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-syntax = { path = "../lex-syntax", version = "0.7.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.7.1" }

--- a/crates/lex-bytecode/Cargo.toml
+++ b/crates/lex-bytecode/Cargo.toml
@@ -16,8 +16,8 @@ serde_json.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
 sha2.workspace = true
-lex-ast = { path = "../lex-ast", version = "0.7.0" }
-lex-types = { path = "../lex-types", version = "0.7.0" }
+lex-ast = { path = "../lex-ast", version = "0.7.1" }
+lex-types = { path = "../lex-types", version = "0.7.1" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.7.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.7.1" }

--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -35,10 +35,10 @@ toml = "1.1"
 serde_yaml = "0.9"
 csv = "1"
 rusqlite = { version = "0.39", features = ["bundled"] }
-lex-bytecode = { path = "../lex-bytecode", version = "0.7.0" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.7.1" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.7.0" }
-lex-ast = { path = "../lex-ast", version = "0.7.0" }
-lex-types = { path = "../lex-types", version = "0.7.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.7.1" }
+lex-ast = { path = "../lex-ast", version = "0.7.1" }
+lex-types = { path = "../lex-types", version = "0.7.1" }
 tempfile = "3"

--- a/crates/lex-search/Cargo.toml
+++ b/crates/lex-search/Cargo.toml
@@ -17,10 +17,10 @@ thiserror.workspace = true
 sha2.workspace = true
 hex.workspace = true
 ureq = { version = "3.3", default-features = false, features = ["rustls", "platform-verifier", "json"] }
-lex-ast = { path = "../lex-ast", version = "0.7.0" }
-lex-store = { path = "../lex-store", version = "0.7.0" }
+lex-ast = { path = "../lex-ast", version = "0.7.1" }
+lex-store = { path = "../lex-store", version = "0.7.1" }
 
 [dev-dependencies]
 tempfile = "3"
 tiny_http = "0.12"
-lex-syntax = { path = "../lex-syntax", version = "0.7.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.7.1" }

--- a/crates/lex-store/Cargo.toml
+++ b/crates/lex-store/Cargo.toml
@@ -21,11 +21,11 @@ hex.workspace = true
 # transitive dep via tempfile; promoting to direct so the lock
 # call sites compile.
 fs2 = "0.4"
-lex-ast = { path = "../lex-ast", version = "0.7.0" }
-lex-trace = { path = "../lex-trace", version = "0.7.0" }
-lex-types = { path = "../lex-types", version = "0.7.0" }
-lex-vcs = { path = "../lex-vcs", version = "0.7.0" }
+lex-ast = { path = "../lex-ast", version = "0.7.1" }
+lex-trace = { path = "../lex-trace", version = "0.7.1" }
+lex-types = { path = "../lex-types", version = "0.7.1" }
+lex-vcs = { path = "../lex-vcs", version = "0.7.1" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.7.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.7.1" }
 tempfile = "3"

--- a/crates/lex-trace/Cargo.toml
+++ b/crates/lex-trace/Cargo.toml
@@ -16,9 +16,9 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-bytecode = { path = "../lex-bytecode", version = "0.7.0" }
-lex-ast = { path = "../lex-ast", version = "0.7.0" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.7.1" }
+lex-ast = { path = "../lex-ast", version = "0.7.1" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.7.0" }
-lex-runtime = { path = "../lex-runtime", version = "0.7.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.7.1" }
+lex-runtime = { path = "../lex-runtime", version = "0.7.1" }

--- a/crates/lex-types/Cargo.toml
+++ b/crates/lex-types/Cargo.toml
@@ -15,7 +15,7 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-ast = { path = "../lex-ast", version = "0.7.0" }
+lex-ast = { path = "../lex-ast", version = "0.7.1" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.7.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.7.1" }

--- a/crates/lex-vcs/Cargo.toml
+++ b/crates/lex-vcs/Cargo.toml
@@ -11,8 +11,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-lex-ast = { path = "../lex-ast", version = "0.7.0" }
-lex-types = { path = "../lex-types", version = "0.7.0" }
+lex-ast = { path = "../lex-ast", version = "0.7.1" }
+lex-types = { path = "../lex-types", version = "0.7.1" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
@@ -24,4 +24,4 @@ hex.workspace = true
 
 [dev-dependencies]
 tempfile = "3"
-lex-syntax = { path = "../lex-syntax", version = "0.7.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.7.1" }

--- a/crates/spec-checker/Cargo.toml
+++ b/crates/spec-checker/Cargo.toml
@@ -16,11 +16,11 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-syntax = { path = "../lex-syntax", version = "0.7.0" }
-lex-ast = { path = "../lex-ast", version = "0.7.0" }
-lex-types = { path = "../lex-types", version = "0.7.0" }
-lex-bytecode = { path = "../lex-bytecode", version = "0.7.0" }
-lex-runtime = { path = "../lex-runtime", version = "0.7.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.7.1" }
+lex-ast = { path = "../lex-ast", version = "0.7.1" }
+lex-types = { path = "../lex-types", version = "0.7.1" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.7.1" }
+lex-runtime = { path = "../lex-runtime", version = "0.7.1" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.7.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.7.1" }


### PR DESCRIPTION
Promotes `[Unreleased]` → `[0.7.1] — 2026-05-11`. Patch release containing only the CAS-race fix from #302.

## What's in 0.7.1

Single bug fix:

- **CAS retry race in `apply_operation` for empty-parents ops** — `cas_retry_advance`'s attempt-1 "honor caller's exact op" semantics was rejecting legitimate concurrent-writer races as `StaleParent`. Fix: on attempt 1, rebuild the op against the just-read head when the caller's `parents` is empty. Non-empty-parents semantics (explicit-bogus-parent test) preserved unchanged.

CI failure that triggered the patch: `cargo test -p lex-store --test concurrent_apply` exited 101 intermittently on the v0.7.0 release pipeline. The race only manifests under concurrent apply with `parents = []`; single-threaded callers and callers that always set `parents` explicitly are unaffected.

## Test plan

- [x] `cargo test --workspace` — 183 test groups pass (one re-run for the documented `llm` env-var flake, unrelated)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] New `empty_parents_op_chains_off_existing_head` regression test verifies pre-fix → fail / post-fix → pass deterministically

https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_