### PR TITLE
lex-types+bytecode: overload `+` for Str operands (#308)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+### Added
+
+- **#308: `+` operator overloaded for `Str` operands.** Lex already
+  shipped `std.str.concat` and the `Op::StrConcat` bytecode, but
+  the surface-language `+` only accepted `Int | Float`, forcing
+  agents to reach for stdlib calls for the most common operation
+  in code-generation paths. Now `a + b` works uniformly across
+  `Int + Int`, `Float + Float`, and `Str + Str`; the type checker
+  admits all three for `+` while keeping `-/*/%` numeric-only, and
+  the VM dispatches `Op::NumAdd` to string concatenation when both
+  operands resolve to `Str`. No coercion: `Str + Int` still errors
+  with a clear `TypeMismatch` diagnostic. Closes the first of the
+  five agent-UX gaps filed as #304–#308.
+
 ## [0.7.1] — 2026-05-11
 
 Patch release containing a single bug fix that surfaced in CI

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -905,7 +905,23 @@ impl<'a> Vm<'a> {
                 Op::FloatEq => self.bin_float(|a, b| Value::Bool(a == b))?,
                 Op::FloatLt => self.bin_float(|a, b| Value::Bool(a < b))?,
                 Op::FloatLe => self.bin_float(|a, b| Value::Bool(a <= b))?,
-                Op::NumAdd => self.bin_num(|a, b| Value::Int(a + b), |a, b| Value::Float(a + b))?,
+                Op::NumAdd => {
+                    // #308: `+` is overloaded — Str+Str concatenates,
+                    // numerics add. Other arithmetic ops (-, *, /, %)
+                    // still reject Str at the type-checker layer.
+                    let b = self.pop()?;
+                    let a = self.pop()?;
+                    match (a, b) {
+                        (Value::Int(x), Value::Int(y)) => self.stack.push(Value::Int(x + y)),
+                        (Value::Float(x), Value::Float(y)) => self.stack.push(Value::Float(x + y)),
+                        (Value::Str(x), Value::Str(y)) => {
+                            let mut s = x;
+                            s.push_str(&y);
+                            self.stack.push(Value::Str(s));
+                        }
+                        (a, b) => return Err(VmError::TypeMismatch(format!("Num op: {a:?} {b:?}"))),
+                    }
+                }
                 Op::NumSub => self.bin_num(|a, b| Value::Int(a - b), |a, b| Value::Float(a - b))?,
                 Op::NumMul => self.bin_num(|a, b| Value::Int(a * b), |a, b| Value::Float(a * b))?,
                 Op::NumDiv => self.bin_num(|a, b| Value::Int(a / b), |a, b| Value::Float(a / b))?,

--- a/crates/lex-runtime/tests/str_plus_operator.rs
+++ b/crates/lex-runtime/tests/str_plus_operator.rs
@@ -1,0 +1,112 @@
+//! #308: end-to-end coverage for `+` overloaded over Str.
+//!
+//! Pre-#308, `a + b` for `a, b :: Str` failed type-check with
+//! `expected: "Int or Float"`. With #308 the type checker admits
+//! Str+Str and the VM dispatches `Op::NumAdd` to string concat.
+//! Other arithmetic ops (-, *, /, %) still reject Str so the
+//! overload is intentionally minimal.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::vm::Vm;
+use lex_bytecode::Value;
+use lex_runtime::{check_program, DefaultHandler, Policy};
+use lex_syntax::parse_source;
+
+fn run_one(src: &str, entry: &str, args: Vec<Value>) -> Value {
+    let prog = parse_source(src).unwrap();
+    let stages = canonicalize_program(&prog);
+    let bc = lex_bytecode::compile_program(&stages);
+    let policy = Policy::pure();
+    check_program(&bc, &policy).expect("program type-checks under pure policy");
+    let handler = DefaultHandler::new(policy);
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(entry, args).unwrap()
+}
+
+#[test]
+fn str_plus_str_concatenates() {
+    let src = r#"
+fn cat(a :: Str, b :: Str) -> Str { a + b }
+"#;
+    let r = run_one(
+        src,
+        "cat",
+        vec![Value::Str("hello, ".into()), Value::Str("world".into())],
+    );
+    assert_eq!(r, Value::Str("hello, world".into()));
+}
+
+#[test]
+fn str_plus_chains_left_to_right() {
+    let src = r#"
+fn three(a :: Str, b :: Str, c :: Str) -> Str { a + b + c }
+"#;
+    let r = run_one(
+        src,
+        "three",
+        vec![
+            Value::Str("foo".into()),
+            Value::Str("-".into()),
+            Value::Str("bar".into()),
+        ],
+    );
+    assert_eq!(r, Value::Str("foo-bar".into()));
+}
+
+#[test]
+fn int_plus_still_works() {
+    // Regression: extending `+` to Str must not break numeric `+`.
+    let src = r#"
+fn add(a :: Int, b :: Int) -> Int { a + b }
+"#;
+    let r = run_one(src, "add", vec![Value::Int(2), Value::Int(40)]);
+    assert_eq!(r, Value::Int(42));
+}
+
+#[test]
+fn float_plus_still_works() {
+    let src = r#"
+fn addf(a :: Float, b :: Float) -> Float { a + b }
+"#;
+    let r = run_one(src, "addf", vec![Value::Float(1.5), Value::Float(2.25)]);
+    assert_eq!(r, Value::Float(3.75));
+}
+
+fn type_errors(src: &str) -> Vec<lex_types::TypeError> {
+    let prog = parse_source(src).unwrap();
+    let stages = canonicalize_program(&prog);
+    match lex_types::check_program(&stages) {
+        Err(errs) => errs,
+        Ok(_) => panic!("type check unexpectedly succeeded"),
+    }
+}
+
+#[test]
+fn str_minus_str_is_a_type_error() {
+    // The overload is intentionally limited to `+`. Other arithmetic
+    // ops on Str should still surface a TypeMismatch with the
+    // "Int or Float" expectation, leaving the door open for a future
+    // distinct semantics (e.g. strip-suffix) without forcing one now.
+    let errs = type_errors(r#"
+fn bad(a :: Str, b :: Str) -> Str { a - b }
+"#);
+    let msg = format!("{errs:?}");
+    assert!(
+        msg.contains("Int or Float"),
+        "expected the numeric-only diagnostic, got: {msg}"
+    );
+}
+
+#[test]
+fn str_plus_int_is_a_type_error() {
+    // Mixed Str + Int is rejected — no implicit coercion. The error
+    // should still mention Str or Int so the diagnostic is useful.
+    let errs = type_errors(r#"
+fn bad(a :: Str, b :: Int) -> Str { a + b }
+"#);
+    let msg = format!("{errs:?}");
+    assert!(
+        msg.contains("Str") || msg.contains("Int"),
+        "expected a useful diagnostic mentioning Str or Int, got: {msg}"
+    );
+}

--- a/crates/lex-types/src/checker.rs
+++ b/crates/lex-types/src/checker.rs
@@ -685,7 +685,27 @@ impl Checker {
         let lt = self.check_expr(lhs, node_id, locals, effs)?;
         let rt = self.check_expr(rhs, node_id, locals, effs)?;
         match op {
-            "+" | "-" | "*" | "/" | "%" => {
+            "+" => {
+                // #308: `+` is overloaded over Int, Float, and Str.
+                // Str concatenation dispatches at the VM layer
+                // (Op::NumAdd in bytecode handles all three).
+                self.u.unify(&lt, &rt).map_err(|e| mismatch_err(node_id, e, &self.u, vec![format!("operator `{op}`")]))?;
+                let r = self.u.resolve(&lt);
+                match r {
+                    Ty::Prim(Prim::Int) | Ty::Prim(Prim::Float) | Ty::Prim(Prim::Str) => Ok(lt),
+                    Ty::Var(_) => {
+                        self.u.unify(&lt, &Ty::int()).map_err(|e| mismatch_err(node_id, e, &self.u, vec![format!("operator `{op}`")]))?;
+                        Ok(Ty::int())
+                    }
+                    other => Err(TypeError::TypeMismatch {
+                        at_node: node_id.into(),
+                        expected: "Int, Float, or Str".into(),
+                        got: other.pretty(),
+                        context: vec![format!("operator `{op}`")],
+                    }),
+                }
+            }
+            "-" | "*" | "/" | "%" => {
                 self.u.unify(&lt, &rt).map_err(|e| mismatch_err(node_id, e, &self.u, vec![format!("operator `{op}`")]))?;
                 let r = self.u.resolve(&lt);
                 match r {


### PR DESCRIPTION
## Summary

Closes #308 — the first of the five agent-UX gaps filed as #304–#308.

Lex already had `std.str.concat` and `Op::StrConcat`, but surface `+`
only accepted `Int | Float`. Code-generation agents reach for `+` first,
so the missing overload pushed them into stdlib detours for the most
common operation in their loop.

- Type checker: admits `Str + Str` (keeps `-`, `*`, `/`, `%` numeric-only).
- VM: `Op::NumAdd` now dispatches Str+Str to concatenation in addition
  to Int+Int and Float+Float. No new opcode — runtime dispatch only.
- No implicit coercion: mixed `Str + Int` still surfaces a clear
  `TypeMismatch`.

## Test plan

- [x] `cargo test -p lex-runtime --test str_plus_operator` — 6/6
  (Str+Str, chained, Int regression, Float regression, `Str-Str`
  rejected with "Int or Float", `Str+Int` rejected usefully)
- [x] `cargo test -p lex-bytecode -p lex-types -p lex-syntax -p lex-ast`
  — 180/180
- [x] `cargo test -p lex-runtime` — 441/441
- [x] `cargo test -p conformance` — clean
- [x] `cargo clippy -p lex-types -p lex-bytecode -p lex-runtime --tests
  -- -D warnings` — clean

https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_