### PR TITLE
lex-types+syntax+cli: position-aware type errors (#306 slice 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ bumps may carry breaking changes when justified).
 
 ### Added
 
+- **#306 slice 1: position-aware type errors.** LLM repair flows
+  measurably need `file:line:col` on type errors, not bare NodeIds.
+  The `lex_types` crate gains a `Position { file, line, col }`
+  struct, a `PositionedError` wrapper that carries
+  `TypeError + Option<Position>`, and a new
+  `check_program_with_positions(stages, &BTreeMap<fn_name, Position>)`
+  entry point. The parser side gains
+  `parse_source_with_positions` which yields each `fn`
+  declaration's byte-offset start position; the `byte_to_line_col`
+  helper translates that to a 1-based `(line, col)`. The `lex
+  check` CLI wires the two together and now emits `position` on
+  every type error in its JSON envelope. Granularity is function-
+  level for this slice — every error from a given `fn` is stamped
+  with that `fn`'s position; slice 1.5 will plumb per-expression
+  spans through canonicalize so deep-body errors point at the
+  exact sub-expression. The bare `check_program` API keeps its
+  old `Vec<TypeError>` shape so existing callers and tests are
+  unaffected.
+
 - **#308: `+` operator overloaded for `Str` operands.** Lex already
   shipped `std.str.concat` and the `Op::StrConcat` bytecode, but
   the surface-language `+` only accepted `Int | Float`, forcing

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -320,7 +320,34 @@ fn cmd_check(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let path = path.ok_or_else(|| anyhow!(
         "usage: lex check [--from-canonical] <file>"))?;
     let stages = load_stages(path, from_canonical)?;
-    match lex_types::check_program(&stages) {
+
+    // #306 slice 1: when checking a `.lex` source file (not a
+    // pre-built canonical AST), collect each `fn` declaration's
+    // source position so type errors can be reported as
+    // `file:line:col` instead of bare NodeIds. Skipped under
+    // `--from-canonical` since canonical bytes carry no source span.
+    let positions: Option<std::collections::BTreeMap<String, lex_types::Position>> =
+        if !from_canonical && path != "-" {
+            std::fs::read_to_string(path).ok().and_then(|src| {
+                lex_syntax::parse_source_with_positions(&src).ok().map(|(_, fn_pos)| {
+                    fn_pos.into_iter().map(|(name, byte)| {
+                        let (line, col) = lex_types::byte_to_line_col(&src, byte);
+                        (name, lex_types::Position::new(Some(path.to_string()), line, col))
+                    }).collect()
+                })
+            })
+        } else {
+            None
+        };
+
+    let check_result = match &positions {
+        Some(pos) => lex_types::check_program_with_positions(&stages, pos)
+            .map_err(|errs| errs.into_iter().collect::<Vec<_>>()),
+        None => lex_types::check_program(&stages)
+            .map_err(|errs| errs.into_iter().map(lex_types::PositionedError::from).collect()),
+    };
+
+    match check_result {
         Ok(_) => {
             let summary = effects_summary(&stages);
             let data = serde_json::json!({

--- a/crates/lex-cli/tests/check_position_errors.rs
+++ b/crates/lex-cli/tests/check_position_errors.rs
@@ -1,0 +1,129 @@
+//! `lex check` emits source positions for type errors (#306 slice 1).
+//!
+//! LLM-driven repair flows rely on `file:line:col` to locate the
+//! offending function; this test pins the contract that the JSON
+//! envelope carries `position { file, line, col }` for every error.
+
+use std::process::{Command, Stdio};
+
+fn lex_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_lex")
+}
+
+fn run(args: &[&str]) -> (i32, String) {
+    let out = Command::new(lex_bin())
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn lex");
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+    )
+}
+
+fn write_to_tempfile(name: &str, src: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("lex-check-pos-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(name);
+    std::fs::write(&path, src).unwrap();
+    path
+}
+
+#[test]
+fn type_error_carries_source_position() {
+    // The `bad` function on line 3 has a return-type mismatch:
+    // the body produces a Str but the signature declares Int.
+    let src = "\
+fn ok_fn(x :: Int) -> Int { x }
+
+fn bad(x :: Int) -> Int { \"oops\" }
+";
+    let path = write_to_tempfile("posbad.lex", src);
+    let (code, stdout) = run(&["--output", "json", "check", path.to_str().unwrap()]);
+    assert_eq!(code, 2, "must exit nonzero on type error: {stdout}");
+
+    let envelope: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|_| panic!("envelope parses as JSON: {stdout}"));
+    let errors = envelope.pointer("/data/errors").expect("errors array present");
+    let arr = errors.as_array().expect("errors is an array");
+    assert!(!arr.is_empty(), "at least one error: {stdout}");
+
+    // Find the type-mismatch error for `bad` and check its position.
+    let first = &arr[0];
+    let pos = first
+        .get("position")
+        .unwrap_or_else(|| panic!("position present: {first}"));
+    assert_eq!(
+        pos.get("line").and_then(|v| v.as_u64()),
+        Some(3),
+        "fn `bad` is on line 3: {first}"
+    );
+    assert_eq!(
+        pos.get("col").and_then(|v| v.as_u64()),
+        Some(1),
+        "fn `bad` starts at col 1: {first}"
+    );
+    let file = pos.get("file").and_then(|v| v.as_str()).unwrap_or("");
+    assert!(
+        file.ends_with("posbad.lex"),
+        "file path should match the input: {file}"
+    );
+}
+
+#[test]
+fn ok_program_does_not_break_on_position_plumbing() {
+    // Regression: enriching the check pipeline with positions must
+    // not break the ok-path. The pure-program envelope still emits
+    // ok:true with no errors and exit 0.
+    let path = write_to_tempfile(
+        "posgood.lex",
+        "fn add(x :: Int, y :: Int) -> Int { x + y }\n",
+    );
+    let (code, stdout) = run(&["--output", "json", "check", path.to_str().unwrap()]);
+    assert_eq!(code, 0, "ok program: {stdout}");
+    let envelope: serde_json::Value = serde_json::from_str(&stdout).expect("envelope parses");
+    let ok = envelope.pointer("/data/ok").and_then(|v| v.as_bool());
+    assert_eq!(ok, Some(true), "ok: true expected: {stdout}");
+}
+
+#[test]
+fn position_resolves_to_correct_function_when_multiple_fail() {
+    // Two functions, both broken. Each error must report the line
+    // of its own function — not of the first or last only.
+    let src = "\
+fn first_broken(x :: Int) -> Str { x }
+
+
+fn second_ok(x :: Int) -> Int { x }
+
+
+fn third_broken(s :: Str) -> Int { s }
+";
+    let path = write_to_tempfile("posmulti.lex", src);
+    let (code, stdout) = run(&["--output", "json", "check", path.to_str().unwrap()]);
+    assert_eq!(code, 2);
+
+    let envelope: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let arr = envelope
+        .pointer("/data/errors")
+        .and_then(|v| v.as_array())
+        .expect("errors array");
+    assert_eq!(arr.len(), 2, "two distinct fn errors: {stdout}");
+
+    let lines: Vec<u64> = arr
+        .iter()
+        .map(|e| {
+            e.get("position")
+                .and_then(|p| p.get("line"))
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0)
+        })
+        .collect();
+    assert!(
+        lines.contains(&1) && lines.contains(&7),
+        "errors must report lines of their own fns (1 and 7), got {:?}",
+        lines
+    );
+}

--- a/crates/lex-syntax/src/lib.rs
+++ b/crates/lex-syntax/src/lib.rs
@@ -20,6 +20,46 @@ pub fn parse_source(src: &str) -> Result<Program, SyntaxError> {
     parse(toks).map_err(SyntaxError::Parse)
 }
 
+/// Byte-offset start position of each `fn` declaration, keyed by
+/// function name (#306 slice 1). Used by `lex_types::Position`
+/// renderers to map a type error back to its `fn` location.
+pub type FnPositions = std::collections::BTreeMap<String, usize>;
+
+/// Variant of [`parse_source`] that also returns the byte-offset
+/// position of each top-level `fn` declaration in `src`. Used by
+/// the `lex check` CLI (and any other LLM-facing tooling) to stamp
+/// source positions onto `lex_types::PositionedError`s.
+pub fn parse_source_with_positions(src: &str) -> Result<(Program, FnPositions), SyntaxError> {
+    let toks = lex(src).map_err(SyntaxError::Lex)?;
+    // Capture `fn`-token byte offsets *before* parse consumes them.
+    // The token stream preserves source order, so a single linear
+    // scan recovering `Fn` → next `Ident` pairs is sufficient. Names
+    // collide → last wins; the type checker rejects duplicates
+    // upstream so a collision here is structurally impossible.
+    let mut fn_positions = FnPositions::new();
+    let mut i = 0;
+    while i < toks.len() {
+        if matches!(toks[i].kind, TokenKind::Fn) {
+            let fn_start = toks[i].span.start;
+            // Walk forward to the first Ident (skipping newlines).
+            let mut j = i + 1;
+            while j < toks.len() {
+                match &toks[j].kind {
+                    TokenKind::Ident(name) => {
+                        fn_positions.insert(name.clone(), fn_start);
+                        break;
+                    }
+                    TokenKind::Newline => { j += 1; }
+                    _ => break,
+                }
+            }
+        }
+        i += 1;
+    }
+    let program = parse(toks).map_err(SyntaxError::Parse)?;
+    Ok((program, fn_positions))
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum SyntaxError {
     #[error(transparent)]

--- a/crates/lex-types/src/checker.rs
+++ b/crates/lex-types/src/checker.rs
@@ -3,12 +3,13 @@
 
 use crate::builtins::{module_for_import, module_scope};
 use crate::env::{TypeDefKind, TypeEnv, ty_from_canon};
-use crate::error::TypeError;
+use crate::error::{PositionedError, TypeError};
+use crate::position::Position;
 use crate::types::*;
 use crate::unifier::{UnifyError, Unifier};
 use indexmap::IndexMap;
 use lex_ast as a;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 /// Result of checking a whole program.
 pub struct ProgramTypes {
@@ -25,9 +26,43 @@ pub struct ProgramTypes {
     pub parse_required_fields: HashMap<usize, Vec<String>>,
 }
 
+/// Variant of [`check_program`] that stamps a source [`Position`]
+/// onto every emitted error (#306 slice 1).
+///
+/// `positions` is keyed by function name and supplies the position
+/// of each `fn` declaration in the source. Errors from a given
+/// function are tagged with that function's position; errors that
+/// don't map to a single function (e.g. type-decl-level errors)
+/// keep `position = None`.
+///
+/// Slice 1 ships function-level granularity. Slice 1.5 will plumb
+/// per-expression spans through canonicalize so deep-body errors
+/// land on the offending sub-expression rather than its enclosing
+/// function.
+pub fn check_program_with_positions(
+    stages: &[a::Stage],
+    positions: &BTreeMap<String, Position>,
+) -> Result<ProgramTypes, Vec<PositionedError>> {
+    check_program_inner(stages, Some(positions))
+        .map_err(|errs| errs.into_iter().map(|(e, fn_name)| {
+            let pos = fn_name.as_deref().and_then(|n| positions.get(n)).cloned();
+            PositionedError::new(e, pos)
+        }).collect())
+}
+
 pub fn check_program(stages: &[a::Stage]) -> Result<ProgramTypes, Vec<TypeError>> {
+    check_program_inner(stages, None)
+        .map_err(|errs| errs.into_iter().map(|(e, _)| e).collect())
+}
+
+fn check_program_inner(
+    stages: &[a::Stage],
+    _positions: Option<&BTreeMap<String, Position>>,
+) -> Result<ProgramTypes, Vec<(TypeError, Option<String>)>> {
     let mut tcx = Checker::new();
-    let mut errors = Vec::new();
+    // Each entry is (error, optional fn name the error came from)
+    // so callers can resolve the error to a source position.
+    let mut errors: Vec<(TypeError, Option<String>)> = Vec::new();
 
     // Pass 1: gather imports → bring module values into scope.
     for stage in stages {
@@ -52,10 +87,10 @@ pub fn check_program(stages: &[a::Stage]) -> Result<ProgramTypes, Vec<TypeError>
     for stage in stages {
         if let a::Stage::TypeDecl(td) = stage {
             if let Err(e) = tcx.type_env.add_user_type(&td.name, td.clone()) {
-                errors.push(TypeError::RecursiveTypeWithoutConstructor {
+                errors.push((TypeError::RecursiveTypeWithoutConstructor {
                     at_node: "n_0".into(),
                     name: e,
-                });
+                }, None));
             }
         }
     }
@@ -72,13 +107,18 @@ pub fn check_program(stages: &[a::Stage]) -> Result<ProgramTypes, Vec<TypeError>
         }
     }
 
-    // Pass 4: check each fn body.
+    // Pass 4: check each fn body. With #306 slice 1, every emitted
+    // error is paired with the source fn it came from so the public
+    // [`check_program_with_positions`] wrapper can stamp the
+    // function's source position onto a [`PositionedError`].
     let mut signatures = IndexMap::new();
     for stage in stages {
         if let a::Stage::FnDecl(fd) = stage {
             match tcx.check_fn(fd) {
                 Ok(scheme) => { signatures.insert(fd.name.clone(), scheme); }
-                Err(es) => errors.extend(es),
+                Err(es) => {
+                    errors.extend(es.into_iter().map(|e| (e, Some(fd.name.clone()))));
+                }
             }
         }
     }

--- a/crates/lex-types/src/error.rs
+++ b/crates/lex-types/src/error.rs
@@ -1,5 +1,6 @@
 //! Structured type errors per spec §6.7.
 
+use crate::position::Position;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -110,3 +111,51 @@ impl std::fmt::Display for TypeError {
 }
 
 impl std::error::Error for TypeError {}
+
+/// `TypeError` enriched with an optional source `Position` (#306
+/// slice 1). `lex_types::check_program_with_positions` returns a
+/// `Vec<PositionedError>`; the bare `check_program` keeps the old
+/// `Vec<TypeError>` shape for backwards compatibility.
+///
+/// Serializes as a flat JSON object: the wrapped error's fields
+/// (`kind`, `at_node`, `expected`, …) plus a `position` field
+/// when one was attached. Consumers can downcast via the `error`
+/// field or pattern-match on the `kind` tag in the JSON.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PositionedError {
+    #[serde(flatten)]
+    pub error: TypeError,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub position: Option<Position>,
+}
+
+impl PositionedError {
+    pub fn new(error: TypeError, position: Option<Position>) -> Self {
+        Self { error, position }
+    }
+
+    pub fn without_position(error: TypeError) -> Self {
+        Self { error, position: None }
+    }
+
+    pub fn node(&self) -> &str {
+        self.error.node()
+    }
+}
+
+impl std::fmt::Display for PositionedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match &self.position {
+            Some(p) => write!(f, "[{}] {}", p.render(), self.error),
+            None => self.error.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for PositionedError {}
+
+impl From<TypeError> for PositionedError {
+    fn from(e: TypeError) -> Self {
+        Self::without_position(e)
+    }
+}

--- a/crates/lex-types/src/lib.rs
+++ b/crates/lex-types/src/lib.rs
@@ -6,10 +6,14 @@ pub mod types;
 pub mod unifier;
 pub mod env;
 pub mod error;
+pub mod position;
 pub mod builtins;
 pub mod checker;
 pub mod discharge;
 
-pub use checker::{check_and_rewrite_program, check_program, ProgramTypes};
-pub use error::TypeError;
+pub use checker::{
+    check_and_rewrite_program, check_program, check_program_with_positions, ProgramTypes,
+};
+pub use error::{PositionedError, TypeError};
+pub use position::{byte_to_line_col, Position};
 pub use types::{EffectSet, Prim, Scheme, Ty, TyVarId};

--- a/crates/lex-types/src/position.rs
+++ b/crates/lex-types/src/position.rs
@@ -1,0 +1,104 @@
+//! Source positions attached to `TypeError`s (#306 slice 1).
+//!
+//! LLM-driven repair flows need errors that point at a concrete
+//! file:line:col, not just a NodeId. `Position` carries that triple;
+//! `TypeError` variants gain an `Option<Position>` that the type
+//! checker fills in via [`check_program_with_positions`](crate::check_program_with_positions).
+//!
+//! Slice 1 ships function-level granularity: every error from a
+//! given `fn` is stamped with that function's start position. Slice
+//! 1.5 will plumb per-expression spans through the canonicalizer
+//! so deep-body errors land on the offending sub-expression.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Position {
+    /// Source file path, when known. `lex check`'s CLI fills this
+    /// from the path argument; programmatic callers may leave it
+    /// `None` and still benefit from line:col.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+    /// 1-based line number.
+    pub line: u32,
+    /// 1-based column number, in chars (not bytes).
+    pub col: u32,
+}
+
+impl Position {
+    pub fn new(file: Option<String>, line: u32, col: u32) -> Self {
+        Self { file, line, col }
+    }
+
+    /// Render as `file:line:col` (or `line:col` if no file).
+    pub fn render(&self) -> String {
+        match &self.file {
+            Some(f) => format!("{f}:{}:{}", self.line, self.col),
+            None => format!("{}:{}", self.line, self.col),
+        }
+    }
+}
+
+/// Translate a byte offset into the source string into a 1-based
+/// `(line, col)`. Lines split on `\n`; columns count chars (not
+/// bytes), so multi-byte UTF-8 doesn't double-count. Out-of-range
+/// offsets clamp to end-of-source.
+pub fn byte_to_line_col(src: &str, byte_offset: usize) -> (u32, u32) {
+    let cap = byte_offset.min(src.len());
+    let mut line: u32 = 1;
+    let mut last_line_start = 0usize;
+    for (i, b) in src.as_bytes().iter().enumerate().take(cap) {
+        if *b == b'\n' {
+            line += 1;
+            last_line_start = i + 1;
+        }
+    }
+    let col = src[last_line_start..cap].chars().count() as u32 + 1;
+    (line, col)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn line_col_at_start_of_file() {
+        assert_eq!(byte_to_line_col("hello", 0), (1, 1));
+    }
+
+    #[test]
+    fn line_col_after_newline() {
+        // "ab\ncd" — offset 3 is 'c' on line 2 col 1.
+        assert_eq!(byte_to_line_col("ab\ncd", 3), (2, 1));
+    }
+
+    #[test]
+    fn line_col_mid_second_line() {
+        // "ab\ncde" — offset 5 points at 'e' (c=col 1, d=2, e=3).
+        assert_eq!(byte_to_line_col("ab\ncde", 5), (2, 3));
+    }
+
+    #[test]
+    fn line_col_with_multibyte_chars() {
+        // "héllo" — 'é' is 2 bytes; offset past it should still
+        // count as col 3 (chars), not col 4 (bytes).
+        let s = "héllo";
+        let off = s.find('l').unwrap();
+        let (line, col) = byte_to_line_col(s, off);
+        assert_eq!((line, col), (1, 3));
+    }
+
+    #[test]
+    fn out_of_range_offset_clamps() {
+        let (line, col) = byte_to_line_col("abc", 999);
+        assert_eq!((line, col), (1, 4));
+    }
+
+    #[test]
+    fn position_renders_with_and_without_file() {
+        let p = Position::new(Some("hello.lex".into()), 12, 3);
+        assert_eq!(p.render(), "hello.lex:12:3");
+        let p = Position::new(None, 5, 7);
+        assert_eq!(p.render(), "5:7");
+    }
+}


### PR DESCRIPTION
## Summary

Closes the first slice of #306 — type errors carry `file:line:col`.

LLMs writing Lex do measurably better when errors point at a
concrete source location instead of an opaque `at n_0.3.2.1`.
Slice 1 ships the infrastructure plus function-level granularity:

- `lex_types::Position { file, line, col }` + `PositionedError`
  wrapper (keeps 46 existing `TypeError::*` constructors untouched).
- New `lex_types::check_program_with_positions(stages, &positions)`.
- New `lex_syntax::parse_source_with_positions` collects each
  `fn` declaration's byte offset; `byte_to_line_col` translates.
- `lex check` JSON envelope now emits `position` on every error.

Slice 1.5 will plumb per-expression spans through canonicalize so
deep-body errors land on the exact sub-expression rather than the
enclosing function.

Slices 2 (rule_tag + rule_explanation) and 3 (auto-populated
`suggested_transform`) remain open in #306.

## Test plan

- [x] `cargo test -p lex-cli --test check_position_errors` — 3/3
  (single-fn error has position, ok-path still passes, two
  simultaneous errors each report their own fn's line)
- [x] `cargo test -p lex-types` — 6 new unit tests on
  `byte_to_line_col` (start, after-newline, mid-line, UTF-8 multibyte,
  out-of-range clamp, render) all pass
- [x] `cargo test -p lex-types -p lex-syntax -p lex-ast -p lex-bytecode`
  — 186/186 (zero regressions)
- [x] `cargo test -p lex-runtime -p lex-cli -p conformance` — 680/680
- [x] `cargo clippy -p lex-types -p lex-syntax -p lex-cli --tests
  -- -D warnings` — clean

## Out of scope

- Per-expression position precision (queued as slice 1.5).
- `rule_tag` / `rule_explanation` (slice 2).
- Auto-populated `suggested_transform` (slice 3).
- LSP / inline rendering (#304).

https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_