### PR TITLE
lex-types+store: auto-populate suggested_transform on RepairHint (#306 slice 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ bumps may carry breaking changes when justified).
 
 ### Added
 
+- **#306 slice 3: auto-populated `suggested_transform` on
+  `RepairHint`.** Closes #306. When
+  `Store::apply_operation_checked` rejects an op for a `TypeError`,
+  the gate now consults a static (rule_tag → likely_transform)
+  table and pre-populates the `RepairHint` attestation's
+  `suggested_transform` payload. Seven rule_tags ship with a
+  static hint: `type-mismatch` → `ReplaceMatchArm`,
+  `unknown-identifier` → `RenameLocal`, `non-exhaustive-match` →
+  `ReplaceMatchArm`, `effect-not-declared` → `ChangeEffectSig`,
+  `arity-mismatch` → `ModifyBody`, `unknown-field` →
+  `ModifyBody`, `ambiguous-type` → `ModifyBody`. Each suggestion
+  includes a one-sentence `summary` and longer `details` prose
+  suitable for an LLM repair prompt. The LLM-driven `lex repair
+  --apply` path still works for rules without a static suggestion
+  and can overwrite a static suggestion with a higher-quality
+  one. New `lex_types::suggested_transform_for(rule_tag)` is
+  available for any tooling that wants to render the same hint
+  inline (LSP code-actions, repair-flow prompts).
+
 - **#306 slice 2: rule-tagged type errors + `lex docs --rules`.**
   Every `TypeError` variant gains a stable `rule_tag(&self) -> &'static str`
   (kebab-case identifier: `"type-mismatch"`, `"unknown-identifier"`,

--- a/crates/lex-store/src/store.rs
+++ b/crates/lex-store/src/store.rs
@@ -1065,8 +1065,13 @@ impl Store {
     /// (#281). One per candidate stage in the transition. The hint
     /// records the *would-be* op_id (deterministic, content-
     /// addressed even though the op record was never persisted)
-    /// and the structured errors. `suggested_transform` is left
-    /// `None`; the slice-2 LLM-assisted path will populate it.
+    /// and the structured errors.
+    ///
+    /// #306 slice 3: `suggested_transform` is populated from the
+    /// static (rule_tag → likely_transform) table for the *first*
+    /// error in the batch. The LLM-driven `lex repair --apply`
+    /// flow can still overwrite this with a higher-quality
+    /// suggestion; the static value is the floor, not the ceiling.
     ///
     /// Best-effort: a write failure here is swallowed by the
     /// caller (the original `TypeError` is the load-bearing
@@ -1082,6 +1087,14 @@ impl Store {
         }
         let errors_json = serde_json::to_value(errors)
             .map_err(StoreError::Serde)?;
+        // #306 slice 3: look up the static suggested_transform for
+        // the first error's rule_tag. Multiple errors per op are
+        // possible — when they fire in lockstep (e.g. one bad let
+        // binding propagates to several use sites), the first
+        // error's rule_tag is usually the load-bearing one to fix.
+        let suggested_transform = errors
+            .first()
+            .and_then(|e| lex_types::suggested_transform_for(e.rule_tag()));
         let log = self.attestation_log()?;
         for stage_id in stage_ids {
             let attestation = lex_vcs::Attestation::new(
@@ -1093,7 +1106,7 @@ impl Store {
                 lex_vcs::AttestationKind::RepairHint {
                     failed_op_id: failed_op_id.clone(),
                     errors: errors_json.clone(),
-                    suggested_transform: None,
+                    suggested_transform: suggested_transform.clone(),
                 },
                 lex_vcs::AttestationResult::Failed {
                     detail: format!("op {} rejected: {} type error(s)",

--- a/crates/lex-store/tests/repair_hint.rs
+++ b/crates/lex-store/tests/repair_hint.rs
@@ -76,8 +76,21 @@ fn type_error_emits_repair_hint_attestation() {
     } = &hint.kind else { unreachable!() };
     assert!(!failed_op_id.is_empty(),
         "failed_op_id is the would-be op_id");
-    assert!(suggested_transform.is_none(),
-        "slice 1 leaves the suggestion empty");
+    // #306 slice 3: the static (rule_tag → likely_transform) table
+    // now auto-populates `suggested_transform`. A type-mismatch
+    // error maps to a `ReplaceMatchArm` hint.
+    let s = suggested_transform.as_ref()
+        .expect("slice 3 must auto-populate a suggested_transform");
+    assert_eq!(
+        s.get("rule_tag").and_then(|v| v.as_str()),
+        Some("type-mismatch"),
+        "suggestion echoes the rule_tag: {s}"
+    );
+    assert_eq!(
+        s.get("kind_hint").and_then(|v| v.as_str()),
+        Some("ReplaceMatchArm"),
+        "type-mismatch maps to ReplaceMatchArm: {s}"
+    );
     let arr = errors.as_array().expect("errors is an array");
     assert!(!arr.is_empty(), "TypeError carries at least one entry");
 }
@@ -102,6 +115,51 @@ fn successful_apply_does_not_emit_a_repair_hint() {
         .filter(|a| matches!(a.kind, lex_vcs::AttestationKind::RepairHint { .. }))
         .count();
     assert_eq!(n_hints, 0, "no RepairHint on successful apply");
+}
+
+#[test]
+fn unknown_identifier_yields_rename_local_suggestion() {
+    // #306 slice 3: a different rule_tag must yield a different
+    // suggested_transform. The static table maps
+    // `unknown-identifier` → `RenameLocal` because the most common
+    // cause is a typo on a sibling binding.
+    let (store, _tmp) = fresh();
+    let (_sig, from_stage_id) = publish_initial_pick(&store);
+
+    // Replace arm 0's body with a reference to an undeclared name.
+    let undeclared = CExpr::Var { name: "definitely_not_in_scope".into() };
+    let err = store
+        .apply_replace_match_arm(
+            DEFAULT_BRANCH, &from_stage_id, &NodeId("n_0.2".into()),
+            0, undeclared,
+        )
+        .unwrap_err();
+    assert!(matches!(err, lex_store::StoreError::TypeError(_)));
+
+    let attlog = store.attestation_log().unwrap();
+    let hint = attlog.list_all().unwrap()
+        .into_iter()
+        .find(|a| matches!(a.kind, lex_vcs::AttestationKind::RepairHint { .. }))
+        .expect("at least one RepairHint emitted");
+    let lex_vcs::AttestationKind::RepairHint { suggested_transform, .. } = &hint.kind
+        else { unreachable!() };
+    let s = suggested_transform.as_ref()
+        .expect("suggested_transform auto-populated");
+    assert_eq!(
+        s.get("rule_tag").and_then(|v| v.as_str()),
+        Some("unknown-identifier"),
+        "expected unknown-identifier rule, got: {s}"
+    );
+    assert_eq!(
+        s.get("kind_hint").and_then(|v| v.as_str()),
+        Some("RenameLocal"),
+        "unknown-identifier maps to RenameLocal: {s}"
+    );
+    let details = s.get("details").and_then(|v| v.as_str()).unwrap_or("");
+    assert!(
+        details.len() > 40,
+        "details must be non-trivial prose: {details}"
+    );
 }
 
 #[test]

--- a/crates/lex-types/src/lib.rs
+++ b/crates/lex-types/src/lib.rs
@@ -17,5 +17,5 @@ pub use checker::{
 };
 pub use error::{PositionedError, TypeError};
 pub use position::{byte_to_line_col, Position};
-pub use rules::{all_rules, RuleInfo};
+pub use rules::{all_rules, suggested_transform_for, RuleInfo};
 pub use types::{EffectSet, Prim, Scheme, Ty, TyVarId};

--- a/crates/lex-types/src/rules.rs
+++ b/crates/lex-types/src/rules.rs
@@ -107,6 +107,87 @@ pub fn all_rules() -> &'static [RuleInfo] {
     ]
 }
 
+/// Static (rule_tag → suggested_transform) table for #306 slice 3.
+///
+/// When `Store::apply_operation_checked` rejects an op for a
+/// `TypeError`, the gate consults this table and pre-populates the
+/// `RepairHint` attestation's `suggested_transform` payload so the
+/// LLM repair flow (or a human reading `lex repair <op>`) has a
+/// concrete starting point. `None` means no static suggestion
+/// exists for this rule; the LLM-driven `lex repair --apply` path
+/// still works.
+///
+/// The returned shape is a JSON object with:
+/// - `kind_hint`: name of the typed transform most likely to fix it
+///   (`"ReplaceMatchArm"`, `"RenameLocal"`, `"InlineLet"`,
+///   `"ChangeEffectSig"`, `"ModifyBody"`).
+/// - `rule_tag`: echo of the rule that fired (for downstream
+///   correlation).
+/// - `summary`: one-sentence direction.
+/// - `details`: longer prose suitable for an LLM repair prompt.
+pub fn suggested_transform_for(rule_tag: &str) -> Option<serde_json::Value> {
+    let (kind_hint, summary, details) = match rule_tag {
+        "type-mismatch" => (
+            "ReplaceMatchArm",
+            "Replace the offending match arm (or expression) so its body produces the expected type.",
+            "When a function body's inferred type doesn't match its signature, the easiest \
+typed-transform fix is `ReplaceMatchArm` — rebuild whichever arm produces the wrong type so it \
+returns the expected one. For non-match expressions, the LLM-driven `lex repair --apply` flow \
+can rewrite the body via `ModifyBody`.",
+        ),
+        "unknown-identifier" => (
+            "RenameLocal",
+            "If the name is a typo, rename a similarly-spelled in-scope binding to match.",
+            "An `unknown-identifier` error is most often a typo. Search the function's lexical \
+scope for a binding whose name is a single edit away and apply `RenameLocal` to switch references. \
+If no nearby name exists, the missing binding probably needs a `let` or an `import` — fall back to \
+LLM-driven repair.",
+        ),
+        "non-exhaustive-match" => (
+            "ReplaceMatchArm",
+            "Add the missing match arms (or a `_` wildcard) covering the unhandled variants.",
+            "Use `ReplaceMatchArm` to append arms for the variants listed in the error's \
+`missing` field. If catching the remainder is intended, a single `_` wildcard arm suffices; \
+otherwise add one explicit arm per missing variant so the audit trail records the new semantics.",
+        ),
+        "effect-not-declared" => (
+            "ChangeEffectSig",
+            "Add the inferred effect to the function's `[effects]` declaration.",
+            "The function body invokes an effect that the signature doesn't declare. Either add \
+the effect to the signature via `ChangeEffectSig` (preferred — the effect is genuinely needed) or \
+remove the call that produces it via `ModifyBody` (preferred when the effect was unintentional).",
+        ),
+        "arity-mismatch" => (
+            "ModifyBody",
+            "Match the call site's argument count to the function's declared arity.",
+            "The number of arguments at the call site doesn't match the declared signature. \
+Add the missing arguments or remove the extras. No typed transform directly applies — \
+use the LLM-driven `lex repair --apply` flow with `ModifyBody` to rewrite the call site.",
+        ),
+        "unknown-field" => (
+            "ModifyBody",
+            "Verify the field spelling and the record type's declaration; rewrite the access.",
+            "The field name isn't part of the record type. Either correct the spelling or add \
+the missing field to the type declaration. Use the LLM-driven `lex repair --apply` flow with \
+`ModifyBody` to rewrite the field access once the correct name is known.",
+        ),
+        "ambiguous-type" => (
+            "ModifyBody",
+            "Add a type annotation at the ambiguous expression to disambiguate inference.",
+            "Inference couldn't pick a single concrete type. Add an explicit type annotation on \
+the offending `let` binding, function parameter, or function return type via `ModifyBody`. The \
+LLM-driven `lex repair --apply` flow can synthesize the annotation from the surrounding context.",
+        ),
+        _ => return None,
+    };
+    Some(serde_json::json!({
+        "kind_hint": kind_hint,
+        "rule_tag": rule_tag,
+        "summary": summary,
+        "details": details,
+    }))
+}
+
 // Constants keyed off the tag so `all_rules` and
 // `explanation_for_tag` produce identical strings without
 // duplicating the prose.
@@ -211,5 +292,47 @@ mod tests {
             let expl = catalog.get(tag).unwrap_or_else(|| panic!("tag `{tag}` not in catalog"));
             assert_eq!(e.rule_explanation(), *expl, "tag/explanation mismatch on {tag}");
         }
+    }
+
+    #[test]
+    fn suggested_transform_covers_at_least_five_rules() {
+        // #306 slice 3 AC: ≥5 rule_tags have a non-None
+        // suggested_transform. Catches accidental removal.
+        let mut covered = 0;
+        for rule in all_rules() {
+            if suggested_transform_for(rule.tag).is_some() {
+                covered += 1;
+            }
+        }
+        assert!(
+            covered >= 5,
+            "suggested_transform must cover ≥5 rule_tags; got {covered}"
+        );
+    }
+
+    #[test]
+    fn suggested_transform_shape_is_consistent() {
+        // Every non-None suggestion must carry the four fields
+        // documented in `suggested_transform_for`.
+        for rule in all_rules() {
+            let Some(s) = suggested_transform_for(rule.tag) else { continue };
+            for field in ["kind_hint", "rule_tag", "summary", "details"] {
+                assert!(
+                    s.get(field).and_then(|v| v.as_str()).is_some_and(|v| !v.is_empty()),
+                    "rule `{}` suggestion missing/empty `{field}`: {s}",
+                    rule.tag
+                );
+            }
+            assert_eq!(
+                s.get("rule_tag").and_then(|v| v.as_str()),
+                Some(rule.tag),
+                "suggestion's rule_tag must echo the input tag"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_rule_tag_returns_none() {
+        assert!(suggested_transform_for("does-not-exist").is_none());
     }
 }


### PR DESCRIPTION
## Summary

Closes #306. Slice 3 lands the last AC: when
`Store::apply_operation_checked` rejects an op for a `TypeError`,
the gate consults a static (rule_tag → likely_transform) table
and pre-populates the `RepairHint` attestation's
`suggested_transform`. The LLM repair flow no longer starts cold.

Seven rule_tags ship with static hints (≥5 required by AC):

| rule_tag | kind_hint |
|---|---|
| type-mismatch | ReplaceMatchArm |
| unknown-identifier | RenameLocal |
| non-exhaustive-match | ReplaceMatchArm |
| effect-not-declared | ChangeEffectSig |
| arity-mismatch | ModifyBody |
| unknown-field | ModifyBody |
| ambiguous-type | ModifyBody |

Each suggestion includes `kind_hint`, `rule_tag`, a one-sentence
`summary`, and longer `details` suitable for an LLM repair prompt.
The LLM-driven `lex repair --apply` path still runs unchanged for
rule_tags without a static hint and can overwrite the static
hint with a higher-quality one.

Content-addressed attestation dedup still holds because the
suggestion is deterministically derived from the rule_tag — the
attestation hash for a given (errors, rule_tag) pair is stable
across reruns.

## Test plan

- [x] `cargo test -p lex-store --test repair_hint` — 4/4 (existing
  type-mismatch test updated to assert `ReplaceMatchArm` hint; new
  `unknown_identifier_yields_rename_local_suggestion` covers the
  second mapping end-to-end)
- [x] `cargo test -p lex-types` — 3 new unit tests on the table
  (≥5 covered, shape consistency, unknown-tag fallback)
- [x] `cargo test -p lex-types -p lex-store -p lex-vcs` — 389/389
- [x] `cargo test -p lex-cli -p lex-runtime -p lex-api` — 724/724
- [x] `cargo clippy -p lex-types -p lex-store --tests -- -D warnings` — clean

## #306 close-out

With this PR the issue is fully shipped:
- Slice 1 (#310): position-aware errors.
- Slice 2 (#311): rule_tag + rule_explanation + `lex docs --rules`.
- Slice 3 (this PR): auto-populated `suggested_transform`.

## Out of scope

- Per-expression position precision (queued as slice 1.5 — separate
  per-NodeId span plumbing through canonicalize).
- ML-driven rule prediction (the static table is curated;
  learning what rule maps to what transform is a follow-up).

https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_