### PR TITLE
lex-bytecode+runtime: per-thread effect handler for list.par_map (#305 slice 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ bumps may carry breaking changes when justified).
 
 ### Added
 
+- **#305 slice 2: per-thread effect handler split for
+  `list.par_map`.** Slice 1 ran each worker with `DenyAllEffects`,
+  so effectful closures (MCP calls, LLM invocations, io.print)
+  failed at runtime — the actual agent use case for par_map was
+  blocked. Slice 2 adds `EffectHandler::spawn_for_worker(&self) ->
+  Option<Box<dyn EffectHandler + Send>>` (default `None` keeps
+  slice-1 behavior). `DefaultHandler` implements it by yielding a
+  fresh `DefaultHandler` per worker that **shares the parent's
+  budget pool** via `Arc<AtomicU64>` (so parallel work can't escape
+  the run-wide ceiling) while keeping `mcp_clients` and `sink`
+  per-worker to avoid mutex-serializing the dispatch path.
+  `chat_registry` and `program` (both `Arc`) are cloned across
+  workers. The `ParallelMap` op now consults the parent's
+  `spawn_for_worker` and pre-builds one handler per worker on the
+  main thread before `std::thread::scope`, so the worker owns its
+  handler outright with no shared mutable state. Two new
+  conformance tests pin the contract: an effectful par_map under
+  `DefaultHandler` now succeeds; a par_map whose total budget
+  cost exceeds the parent ceiling is rejected by the shared pool.
+
 - **#305 slice 1: `list.par_map` with OS-thread parallelism.**
   Lex's runtime was fully synchronous; multiple concurrent effect
   calls or CPU-bound work from a single program had no way to be

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -56,6 +56,25 @@ pub trait EffectHandler {
     fn note_call_budget(&mut self, _budget_cost: u64) -> Result<(), String> {
         Ok(())
     }
+
+    /// `list.par_map` worker-handler factory (#305 slice 2).
+    ///
+    /// Each parallel worker thread runs its own `Vm` and therefore
+    /// needs its own effect handler. The parent handler may opt in
+    /// to per-worker dispatch by returning `Some(handler)` here;
+    /// returning `None` (the default) keeps slice-1 behavior: the
+    /// worker runs `DenyAllEffects` and any effect call inside the
+    /// closure fails with `VmError::Effect`.
+    ///
+    /// The returned handler must be `Send` so the worker can take
+    /// ownership across a thread boundary. Shared state (budget
+    /// pool, chat registry, etc.) is wired up by the implementer.
+    /// Per-worker independence (MCP client cache, output sink)
+    /// is intentional — the alternative is mutex-serialization of
+    /// the whole effect dispatch, which would defeat the parallelism.
+    fn spawn_for_worker(&self) -> Option<Box<dyn EffectHandler + Send>> {
+        None
+    }
 }
 
 /// `Vm` exposes itself as a `ClosureCaller` so the parser interpreter
@@ -328,15 +347,15 @@ fn par_map_run<'a>(
     program: &'a Program,
     closure: Value,
     items: Vec<Value>,
+    worker_handlers: Vec<Box<dyn EffectHandler + Send>>,
 ) -> Result<Vec<Value>, VmError> {
     if items.is_empty() {
         return Ok(Vec::new());
     }
-    let max = par_max_concurrency().max(1);
-    // Carve items into `max` round-robin buckets so each worker
-    // processes (indices, items) pairs and we can reassemble in
-    // input order.
-    let n_workers = max.min(items.len());
+    let n_workers = worker_handlers.len().min(items.len()).max(1);
+    // Carve items into `n_workers` round-robin buckets so each
+    // worker processes (indices, items) pairs and we can reassemble
+    // in input order.
     let mut buckets: Vec<Vec<(usize, Value)>> = (0..n_workers).map(|_| Vec::new()).collect();
     for (i, v) in items.into_iter().enumerate() {
         buckets[i % n_workers].push((i, v));
@@ -345,14 +364,26 @@ fn par_map_run<'a>(
     let results: std::sync::Mutex<Vec<Option<Result<Value, String>>>> =
         std::sync::Mutex::new((0..n_total).map(|_| None).collect());
 
+    // Pair each bucket with its pre-built handler so workers own
+    // their handler outright — no shared mutable state across
+    // worker threads.
+    let mut worker_handlers = worker_handlers;
+    worker_handlers.truncate(n_workers);
+    type Pair = (Vec<(usize, Value)>, Box<dyn EffectHandler + Send>);
+    let pairs: Vec<Pair> = buckets.into_iter().zip(worker_handlers).collect();
+
     std::thread::scope(|s| {
-        let mut handles = Vec::with_capacity(buckets.len());
-        for bucket in buckets {
+        let mut handles = Vec::with_capacity(pairs.len());
+        for (bucket, handler) in pairs {
             let closure = closure.clone();
             let results = &results;
             handles.push(s.spawn(move || {
-                let handler: Box<dyn EffectHandler + 'a> = Box::new(DenyAllEffects);
-                let mut vm = Vm::with_handler(program, handler);
+                // `Box<dyn EffectHandler + Send>` has implicit
+                // `+ 'static`; that coerces to `+ 'a` because
+                // `'static` outlives any `'a`. The `Send` bound is
+                // auto-erased on the unsize coercion.
+                let handler_for_vm: Box<dyn EffectHandler + 'a> = handler;
+                let mut vm = Vm::with_handler(program, handler_for_vm);
                 for (idx, item) in bucket {
                     let r = vm
                         .invoke_closure_value(closure.clone(), vec![item])
@@ -766,11 +797,15 @@ impl<'a> Vm<'a> {
                 }
                 Op::ParallelMap { node_id_idx: _ } => {
                     // #305 slice 1: pop (xs, f) and apply f to each
-                    // element across OS threads. Slice 1 limitation:
-                    // closures invoking effects get DenyAllEffects in
-                    // the worker, so an effectful body fails with
-                    // VmError::Effect. Effectful par_map is queued as
-                    // slice 2 (per-thread effect-handler split).
+                    // element across OS threads.
+                    //
+                    // #305 slice 2: each worker now asks the parent
+                    // handler for a thread-safe per-worker handler via
+                    // `EffectHandler::spawn_for_worker`. Handlers that
+                    // opt in (e.g. `DefaultHandler`) yield a fresh
+                    // instance sharing the budget pool; handlers that
+                    // don't fall back to the slice-1 behavior of
+                    // `DenyAllEffects` in the worker.
                     let f = self.pop()?;
                     let xs = self.pop()?;
                     let items = match xs {
@@ -782,7 +817,23 @@ impl<'a> Vm<'a> {
                         return Err(VmError::TypeMismatch(
                             format!("ParallelMap requires a closure, got: {f:?}")));
                     }
-                    let results = par_map_run(self.program, f, items)?;
+                    // Pre-build one handler per worker on the main
+                    // thread so the worker just owns its handler with
+                    // no shared borrowing. The actual worker count is
+                    // capped by `LEX_PAR_MAX_CONCURRENCY` (resolved
+                    // inside par_map_run); cap ≤ items.len() so we
+                    // never over-allocate handlers.
+                    let n_workers = par_max_concurrency().max(1).min(items.len().max(1));
+                    let mut worker_handlers: Vec<Box<dyn EffectHandler + Send>> =
+                        Vec::with_capacity(n_workers);
+                    for _ in 0..n_workers {
+                        worker_handlers.push(
+                            self.handler
+                                .spawn_for_worker()
+                                .unwrap_or_else(|| Box::new(DenyAllEffects)),
+                        );
+                    }
+                    let results = par_map_run(self.program, f, items, worker_handlers)?;
                     self.stack.push(Value::List(results));
                 }
                 Op::Call { fn_id, arity, node_id_idx } => {

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -1110,6 +1110,40 @@ impl EffectHandler for DefaultHandler {
             other => Err(format!("unsupported effect {}.{}", other.0, other.1)),
         }
     }
+
+    /// `list.par_map` worker-handler factory (#305 slice 2).
+    ///
+    /// Builds a fresh `DefaultHandler` per worker that shares the
+    /// budget pool with the parent (`Arc<AtomicU64>`) so a parallel
+    /// batch can't escape the run-wide budget ceiling. Other state
+    /// is intentionally split per-worker:
+    ///
+    /// - `sink`: a `StdoutSink` per worker. Tests that capture
+    ///   output via a `SharedSink` wrapped in `Arc<Mutex<…>>` see
+    ///   each worker as a fresh handler. Print interleaving on
+    ///   stdout is acceptable; tests that need ordered capture run
+    ///   workloads serially anyway.
+    /// - `mcp_clients`: a fresh per-worker LRU cache. The parent's
+    ///   subprocess handles can't be shared across threads without
+    ///   mutex-serialising every MCP call, which would defeat the
+    ///   parallelism. Cache hit rate is sub-optimal across the
+    ///   first call per worker; warmed caches still amortise within
+    ///   a worker.
+    /// - `chat_registry`: cloned `Arc<ChatRegistry>` so all workers
+    ///   route into the same chat dispatch layer.
+    /// - `program`: cloned `Arc<Program>` so `net.serve` (if a
+    ///   worker invokes it) sees the same compiled program.
+    fn spawn_for_worker(&self) -> Option<Box<dyn lex_bytecode::vm::EffectHandler + Send>> {
+        let mut fresh = DefaultHandler::new(self.policy.clone());
+        // Share the budget pool atomically — slice 2's correctness
+        // contract: parallel work counts against the same ceiling.
+        fresh.budget_remaining = std::sync::Arc::clone(&self.budget_remaining);
+        fresh.budget_ceiling = self.budget_ceiling;
+        fresh.read_root = self.read_root.clone();
+        fresh.program = self.program.clone();
+        fresh.chat_registry = self.chat_registry.clone();
+        Some(Box::new(fresh))
+    }
 }
 
 /// Blocks the calling thread, accepts incoming HTTP requests on

--- a/crates/lex-runtime/tests/list_par_map.rs
+++ b/crates/lex-runtime/tests/list_par_map.rs
@@ -184,10 +184,19 @@ fn run_(xs :: List[Int]) -> List[Int] {
 }
 
 #[test]
-fn par_map_effectful_closure_is_refused() {
-    // Slice 1: effectful closures get DenyAllEffects in the worker.
-    // The closure compiles and type-checks; it fails at runtime when
-    // it attempts to dispatch an effect.
+fn par_map_effectful_closure_works_with_default_handler() {
+    // #305 slice 2: DefaultHandler implements `spawn_for_worker`,
+    // so each parallel worker gets its own DefaultHandler sharing
+    // the parent's budget pool. Effectful closures (io, mcp, llm,
+    // …) now succeed in par_map bodies.
+    use std::sync::{Arc, Mutex};
+    struct SharedSink(Arc<Mutex<Vec<String>>>);
+    impl lex_runtime::IoSink for SharedSink {
+        fn print_line(&mut self, s: &str) {
+            self.0.lock().unwrap().push(s.into());
+        }
+    }
+
     let src = r#"
 import "std.list" as list
 import "std.io" as io
@@ -201,14 +210,68 @@ fn echo_par(xs :: List[Str]) -> [io] List[Unit] {
     let mut policy = Policy::pure();
     policy.allow_effects.insert("io".into());
     check_program(&bc, &policy).expect("type-checks under io policy");
+    // Note: each per-worker handler gets its own StdoutSink (slice-2
+    // contract). The captured-sink injected here only sees output
+    // from the PARENT vm, not from the workers. We assert success
+    // here (no panic); ordered output capture is not part of slice 2.
+    let captured: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let handler = DefaultHandler::new(policy)
+        .with_sink(Box::new(SharedSink(Arc::clone(&captured))));
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    let r = vm
+        .call(
+            "echo_par",
+            vec![Value::List(vec![
+                Value::Str("a".into()),
+                Value::Str("b".into()),
+                Value::Str("c".into()),
+            ])],
+        )
+        .expect("effectful par_map runs under DefaultHandler");
+    // Result is a list of three Unit values — one per worker call.
+    assert_eq!(
+        r,
+        Value::List(vec![Value::Unit, Value::Unit, Value::Unit]),
+        "result list shape: one Unit per input"
+    );
+}
+
+#[test]
+fn par_map_workers_share_budget_pool() {
+    // #305 slice 2: per-worker DefaultHandlers share the parent's
+    // budget pool. A par_map across N items, each costing K budget,
+    // exceeds a ceiling of N*K-1 — and the failure must surface
+    // through the worker's effect path, not be hidden by parallelism.
+    let src = r#"
+import "std.list" as list
+fn step() -> [budget(10)] Int { 1 }
+fn par_steps(xs :: List[Int]) -> List[Int] {
+    list.par_map(xs, fn(x :: Int) -> Int { step() })
+}
+"#;
+    let prog = parse_source(src).unwrap();
+    let stages = canonicalize_program(&prog);
+    let bc = lex_bytecode::compile_program(&stages);
+    let mut policy = Policy::pure();
+    policy.allow_effects.insert("budget".into());
+    check_program(&bc, &policy).expect("pure-with-budget policy accepts the program");
+    // Ceiling = 25 forces a budget exceedance when 4 calls × 10 each
+    // = 40 land. The exact worker that trips the ceiling depends on
+    // scheduling; we just assert the run as a whole errors.
+    policy.budget = Some(25);
     let handler = DefaultHandler::new(policy);
     let mut vm = Vm::with_handler(&bc, Box::new(handler));
-    let err = vm
-        .call("echo_par", vec![Value::List(vec![Value::Str("hi".into())])])
-        .expect_err("slice 1 must reject effectful par_map closures");
-    let msg = format!("{err:?}");
+    let r = vm.call(
+        "par_steps",
+        vec![Value::List(vec![Value::Int(0); 4])],
+    );
     assert!(
-        msg.contains("effect") || msg.contains("Effect"),
-        "expected an effect-refusal error, got: {msg}"
+        r.is_err(),
+        "shared budget pool must reject the over-ceiling par_map: {r:?}"
+    );
+    let msg = format!("{:?}", r.unwrap_err());
+    assert!(
+        msg.contains("budget"),
+        "expected a budget-exceeded error, got: {msg}"
     );
 }


### PR DESCRIPTION
## Summary

Slice 2 of #305 — `list.par_map` now supports **effectful**
closures. Slice 1 only allowed pure bodies (workers ran with
`DenyAllEffects`); the actual agent use case (parallel MCP, parallel
LLM, io.print across a batch) was blocked.

## Wire

- `EffectHandler::spawn_for_worker(&self) -> Option<Box<dyn EffectHandler + Send>>`
  with `None` default. Handlers opt in to per-worker dispatch.
- `DefaultHandler` opts in: yields a fresh DefaultHandler per
  worker that **shares the parent's budget pool** via
  `Arc<AtomicU64>` so parallel work can't escape the run-wide
  ceiling. `chat_registry` and `program` (both `Arc`) are shared.
  `mcp_clients` and `sink` stay per-worker on purpose — the
  alternative is mutex-serializing every effect call.
- `Op::ParallelMap` pre-builds one handler per worker on the main
  thread before `std::thread::scope`. Each worker owns its handler;
  zero shared mutable state across worker threads.

## Behavioral shift

The slice-1 test `par_map_effectful_closure_is_refused` is
replaced by `par_map_effectful_closure_works_with_default_handler`
which asserts the same code path now succeeds. A new
`par_map_workers_share_budget_pool` pins the shared-budget contract.

## Test plan

- [x] `cargo test -p lex-runtime --test list_par_map -- --test-threads=1`
  → 6/6 passed (1 wallclock test still `#[ignore]` — unchanged sandbox
  limitation from #313)
- [x] `cargo test -p lex-bytecode -p lex-runtime` — 480/480
- [x] `cargo test -p lex-store -p lex-cli -p lex-types -p lex-api` — 491/491
- [x] `cargo clippy -p lex-bytecode -p lex-runtime --tests -- -D warnings` — clean

## Out of scope

- Sink capture across workers — each worker writes to its own
  `StdoutSink`. Test fixtures that need ordered capture run
  serially, not via par_map.
- MCP cache hit rate — each worker has its own LRU. First MCP
  call per worker pays spawn cost.
- Wall-clock-speedup AC verification under sandboxed CI (test is
  `#[ignore]`-d as in #313).
- `Stream[T]` + `llm.cloud_stream` (slice 3).

https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_