### PR TITLE
lex-store+cli: cost-aware planner `lex plan` (#307)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ bumps may carry breaking changes when justified).
 
 ### Added
 
+- **#307: cost-aware planner (`lex plan`).** Closes the loop opened
+  by `[budget(N)]` declarations and the session-budget gate (#292):
+  given a `goal` function, enumerate every linear call chain from
+  `goal` to a leaf, sum declared budget along each chain, and rank
+  cheapest-first. Each path carries the union of declared effects so
+  the agent can also gate by policy. The output is advisory —
+  paths are returned with a `fits` flag against the effective cap
+  (`min(--max-cost, session-remaining)`); the agent (or downstream
+  policy) chooses which path to apply.
+  - New `lex_store::planner` module with `Store::plan(branch,
+    goal, max_cost, session_id) -> Plan`.
+  - Recursive self-calls are detected via a visited-set and
+    budgeted once — no infinite-loop expansion.
+  - When `session_id` is supplied, the planner consults
+    `Store::session_budget` and merges remaining with `--max-cost`.
+  - New `lex plan --goal <fn> [--max-cost N] [--intent <id>]
+    [--branch B] [--store DIR]` CLI subcommand.
+  - 6 conformance tests in `crates/lex-store/tests/planner.rs`
+    pin the contract (linear chain budget sum, max-cost
+    would-exceed marking, branching → multiple sorted paths,
+    recursive self-call budgeted once, effect-set union, unknown
+    goal yields empty paths).
+
 - **#305 slice 2: per-thread effect handler split for
   `list.par_map`.** Slice 1 ran each worker with `DenyAllEffects`,
   so effectful closures (MCP calls, LLM invocations, io.print)

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -106,6 +106,7 @@ fn run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         "log" => branch::cmd_log(fmt, &args[1..]),
         "op" => op::cmd_op(fmt, &args[1..]),
         "docs" => docs::cmd_docs(fmt, &args[1..]),
+        "plan" => cmd_plan(fmt, &args[1..]),
         "repair" => cmd_repair(fmt, &args[1..]),
         "producer-trust" => cmd_producer_trust(fmt, &args[1..]),
         "canonical" => cmd_canonical(fmt, &args[1..]),
@@ -967,6 +968,87 @@ pub(crate) fn build_embedder(store_root: &std::path::Path) -> Result<Box<dyn lex
     } else {
         Ok(Box::new(lex_search::MockEmbedder::new()))
     }
+}
+
+/// `lex plan --goal <fn> [--max-cost N] [--intent <id>] [--branch B] [--store DIR]`
+/// (#307). Cost-aware path planner over the call graph. Advisory:
+/// returns paths cheapest-first with a `fits` flag against the
+/// effective cap; the agent (or downstream policy) decides which
+/// path to apply.
+fn cmd_plan(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    let mut goal: Option<String> = None;
+    let mut max_cost: Option<u64> = None;
+    let mut intent: Option<String> = None;
+    let mut branch: Option<String> = None;
+    let mut root: Option<std::path::PathBuf> = None;
+    let mut it = args.iter();
+    while let Some(a) = it.next() {
+        match a.as_str() {
+            "--goal" => goal = it.next().cloned(),
+            "--max-cost" => {
+                max_cost = Some(
+                    it.next()
+                        .ok_or_else(|| anyhow!("--max-cost needs N"))?
+                        .parse()
+                        .map_err(|e| anyhow!("--max-cost: {e}"))?,
+                );
+            }
+            "--intent" => intent = it.next().cloned(),
+            "--branch" => branch = it.next().cloned(),
+            "--store" => root = Some(std::path::PathBuf::from(
+                it.next().ok_or_else(|| anyhow!("--store needs a path"))?,
+            )),
+            other => bail!("unexpected arg `{other}` for `lex plan`"),
+        }
+    }
+    let goal = goal.ok_or_else(|| anyhow!(
+        "usage: lex plan --goal <fn> [--max-cost N] [--intent <id>] [--branch B] [--store DIR]"))?;
+    let root = root.unwrap_or_else(default_store_root);
+    let store = Store::open(&root)
+        .with_context(|| format!("opening store at {}", root.display()))?;
+    let branch = branch.unwrap_or_else(|| store.current_branch());
+
+    // If `--intent` is supplied, resolve its session id via the
+    // IntentLog so the planner can consult `Store::session_budget`.
+    let session_id = if let Some(intent_id) = &intent {
+        let intent_log = lex_vcs::IntentLog::open(store.root())?;
+        intent_log.get(intent_id)?.map(|i| i.session_id)
+    } else {
+        None
+    };
+
+    let plan = store
+        .plan(&branch, &goal, max_cost, session_id.as_deref())
+        .with_context(|| format!("planning paths from `{goal}` on branch `{branch}`"))?;
+    let data = serde_json::to_value(&plan)?;
+    acli::emit_or_text("plan", data, fmt, || {
+        let cap = plan
+            .effective_cap
+            .map(|c| c.to_string())
+            .unwrap_or_else(|| "(uncapped)".into());
+        println!("plan from `{}` (effective cap: {}):", plan.goal, cap);
+        if let (Some(sid), Some(r)) = (&plan.session_id, plan.remaining_budget) {
+            println!("  session `{sid}`: remaining budget {r}");
+        }
+        if plan.paths.is_empty() {
+            println!("  (no paths — goal not in the branch head's active set)");
+        }
+        for p in &plan.paths {
+            let mark = if p.fits { "ok " } else { "no " };
+            let effs = if p.effects.is_empty() {
+                String::new()
+            } else {
+                format!(" [{}]", p.effects.iter().cloned().collect::<Vec<_>>().join(", "))
+            };
+            println!(
+                "  {mark} cost={} {}{}",
+                p.total_cost,
+                p.chain.join(" -> "),
+                effs,
+            );
+        }
+    });
+    Ok(())
 }
 
 /// `lex repair <op_id> [--apply --transform '<json>'] [--branch B] [--store DIR]`

--- a/crates/lex-store/src/lib.rs
+++ b/crates/lex-store/src/lib.rs
@@ -26,6 +26,7 @@
 //! to honor that is to keep the cache trivially derivable.
 
 mod budget;
+mod planner;
 mod store;
 mod model;
 mod branches;
@@ -35,6 +36,7 @@ pub mod users;
 pub mod policy;
 
 pub use budget::SessionBudget;
+pub use planner::{Plan, PlanPath};
 pub use delta::{StageDelta, DELTA_CHAIN_CAP, DELTA_RATIO_THRESHOLD};
 pub use gc::{GcPlan, RetentionReason};
 

--- a/crates/lex-store/src/planner.rs
+++ b/crates/lex-store/src/planner.rs
@@ -1,0 +1,267 @@
+//! `lex plan` — cost-aware path planner over the call graph (#307).
+//!
+//! Given a `goal` function and either an explicit `max_cost` or a
+//! session id whose remaining budget caps the spend, enumerate every
+//! linear call chain from `goal` to a leaf (a function that calls no
+//! other user-defined function on the branch head). Each chain is
+//! scored by the sum of `[budget(N)]` declarations along it, and the
+//! result is sorted cheapest-first.
+//!
+//! The planner is **advisory** — it doesn't execute anything. Agents
+//! consult it to pick the cheapest reachable path that fits in their
+//! remaining budget; downstream policy (`#292`'s gate) is what
+//! ultimately admits or refuses an op.
+
+use crate::{Store, StoreError};
+use lex_ast::{CExpr, Stage};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+
+/// One linear chain from `goal` to a leaf, with its total cost and
+/// the union of effects along it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PlanPath {
+    /// Functions in call order — `chain[0]` is always `goal`.
+    pub chain: Vec<String>,
+    /// Sum of declared `[budget(N)]` for every fn in `chain`.
+    /// Recursive self-calls are counted **once** (the cycle is broken
+    /// at the second visit) — see `expand_paths` for the visited-set.
+    pub total_cost: u64,
+    /// `true` iff `total_cost <= effective_cap` (whichever of
+    /// `max_cost` and the session-remaining is smaller). Always
+    /// `true` when no cap applies.
+    pub fits: bool,
+    /// Union of effect names declared on every fn in the chain
+    /// (excluding the `budget` pseudo-effect, which is the cost
+    /// dimension itself).
+    pub effects: BTreeSet<String>,
+}
+
+/// Result envelope returned by [`Store::plan`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Plan {
+    pub goal: String,
+    /// `Some(id)` when the planner was called with `--intent`/
+    /// `session_id`; `None` for the bare `--max-cost` flow.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    /// Budget remaining for `session_id`, when one was supplied
+    /// and a cap is configured. `None` otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remaining_budget: Option<i64>,
+    /// Whichever of `max_cost` and `remaining_budget` is smaller.
+    /// `None` when neither cap applies.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effective_cap: Option<u64>,
+    /// Paths sorted cheapest-first.
+    pub paths: Vec<PlanPath>,
+}
+
+/// Per-function summary extracted once per branch head.
+struct FnInfo {
+    budget_cost: u64,
+    effects: BTreeSet<String>,
+    calls: Vec<String>,
+}
+
+impl Store {
+    /// `lex plan` (#307). See module docs.
+    pub fn plan(
+        &self,
+        branch: &str,
+        goal: &str,
+        max_cost: Option<u64>,
+        session_id: Option<&str>,
+    ) -> Result<Plan, StoreError> {
+        // Build per-fn summaries from the branch head's active set.
+        let head = self
+            .branch_head(branch)
+            .map_err(|e| StoreError::Io(std::io::Error::other(format!("branch_head: {e}"))))?;
+        let mut fns: BTreeMap<String, FnInfo> = BTreeMap::new();
+        for stage_id in head.values() {
+            let Ok(Stage::FnDecl(fd)) = self.get_ast(stage_id) else { continue };
+            let mut effects = BTreeSet::new();
+            let mut budget_cost: u64 = 0;
+            for e in &fd.effects {
+                if e.name == "budget" {
+                    if let Some(lex_ast::EffectArg::Int { value }) = &e.arg {
+                        budget_cost = budget_cost.saturating_add(*value as u64);
+                    }
+                } else {
+                    effects.insert(e.name.clone());
+                }
+            }
+            let mut calls = Vec::new();
+            collect_call_targets(&fd.body, &mut calls);
+            fns.entry(fd.name.clone()).or_insert(FnInfo {
+                budget_cost,
+                effects,
+                calls,
+            });
+        }
+
+        // Resolve the session's remaining budget (if any).
+        let (remaining_budget, session_id_out) = if let Some(sid) = session_id {
+            let sb = self.session_budget(sid)?;
+            (sb.remaining, Some(sid.to_string()))
+        } else {
+            (None, None)
+        };
+
+        // Effective cap = min(max_cost, max(remaining, 0))
+        let effective_cap: Option<u64> = match (max_cost, remaining_budget) {
+            (Some(m), Some(r)) => Some(m.min(r.max(0) as u64)),
+            (Some(m), None) => Some(m),
+            (None, Some(r)) => Some(r.max(0) as u64),
+            (None, None) => None,
+        };
+
+        let mut paths: Vec<PlanPath> = Vec::new();
+        if fns.contains_key(goal) {
+            expand_paths(goal, &fns, &mut Vec::new(), &mut HashSet::new(), &mut paths);
+        }
+        // Cheapest-first, tie-break by chain length then alphabetical.
+        paths.sort_by(|a, b| {
+            a.total_cost
+                .cmp(&b.total_cost)
+                .then_with(|| a.chain.len().cmp(&b.chain.len()))
+                .then_with(|| a.chain.cmp(&b.chain))
+        });
+        // Stamp `fits` against the resolved cap.
+        for p in &mut paths {
+            p.fits = effective_cap.is_none_or(|cap| p.total_cost <= cap);
+        }
+
+        Ok(Plan {
+            goal: goal.to_string(),
+            session_id: session_id_out,
+            remaining_budget,
+            effective_cap,
+            paths,
+        })
+    }
+}
+
+/// Walk `expr` and append every direct call to a top-level fn (a
+/// `Call { callee = Var { name } }` shape) into `out`. Module-method
+/// calls (`io.print`) and closure calls are intentionally skipped —
+/// they don't reference user-defined fns by name in the call graph.
+fn collect_call_targets(expr: &CExpr, out: &mut Vec<String>) {
+    match expr {
+        CExpr::Call { callee, args } => {
+            if let CExpr::Var { name } = callee.as_ref() {
+                if !out.contains(name) {
+                    out.push(name.clone());
+                }
+            }
+            collect_call_targets(callee, out);
+            for a in args {
+                collect_call_targets(a, out);
+            }
+        }
+        CExpr::Let { value, body, .. } => {
+            collect_call_targets(value, out);
+            collect_call_targets(body, out);
+        }
+        CExpr::Match { scrutinee, arms } => {
+            collect_call_targets(scrutinee, out);
+            for arm in arms {
+                collect_call_targets(&arm.body, out);
+            }
+        }
+        CExpr::Block { statements, result } => {
+            for s in statements {
+                collect_call_targets(s, out);
+            }
+            collect_call_targets(result, out);
+        }
+        CExpr::Constructor { args, .. } => {
+            for a in args {
+                collect_call_targets(a, out);
+            }
+        }
+        CExpr::RecordLit { fields } => {
+            for f in fields {
+                collect_call_targets(&f.value, out);
+            }
+        }
+        CExpr::TupleLit { items } | CExpr::ListLit { items } => {
+            for i in items {
+                collect_call_targets(i, out);
+            }
+        }
+        CExpr::FieldAccess { value, .. } => collect_call_targets(value, out),
+        CExpr::Lambda { body, .. } => collect_call_targets(body, out),
+        CExpr::BinOp { lhs, rhs, .. } => {
+            collect_call_targets(lhs, out);
+            collect_call_targets(rhs, out);
+        }
+        CExpr::UnaryOp { expr, .. } => collect_call_targets(expr, out),
+        CExpr::Return { value } => collect_call_targets(value, out),
+        CExpr::Literal { .. } | CExpr::Var { .. } => {}
+    }
+}
+
+/// DFS enumeration of paths from `current` to every reachable leaf,
+/// breaking recursion at the second visit so a `recur` function's
+/// cost is counted once.
+fn expand_paths(
+    current: &str,
+    fns: &BTreeMap<String, FnInfo>,
+    chain: &mut Vec<String>,
+    visited: &mut HashSet<String>,
+    out: &mut Vec<PlanPath>,
+) {
+    chain.push(current.to_string());
+    let newly_inserted = visited.insert(current.to_string());
+
+    let Some(info) = fns.get(current) else {
+        // Unknown callee (stdlib or external) — terminate the chain
+        // here. The leaf itself contributes nothing to cost/effects.
+        emit_path(chain, fns, out);
+        chain.pop();
+        if newly_inserted {
+            visited.remove(current);
+        }
+        return;
+    };
+
+    // Pick the in-scope, not-yet-visited callees so we don't expand
+    // recursive cycles.
+    let next: Vec<&String> = info
+        .calls
+        .iter()
+        .filter(|c| !visited.contains(*c))
+        .collect();
+    if next.is_empty() {
+        emit_path(chain, fns, out);
+    } else {
+        for callee in next {
+            expand_paths(callee, fns, chain, visited, out);
+        }
+    }
+
+    chain.pop();
+    if newly_inserted {
+        visited.remove(current);
+    }
+}
+
+fn emit_path(chain: &[String], fns: &BTreeMap<String, FnInfo>, out: &mut Vec<PlanPath>) {
+    let mut total_cost: u64 = 0;
+    let mut effects: BTreeSet<String> = BTreeSet::new();
+    for name in chain {
+        if let Some(info) = fns.get(name) {
+            total_cost = total_cost.saturating_add(info.budget_cost);
+            for e in &info.effects {
+                effects.insert(e.clone());
+            }
+        }
+    }
+    out.push(PlanPath {
+        chain: chain.to_vec(),
+        total_cost,
+        fits: true, // patched by caller against effective_cap
+        effects,
+    });
+}

--- a/crates/lex-store/tests/planner.rs
+++ b/crates/lex-store/tests/planner.rs
@@ -1,0 +1,169 @@
+//! Conformance for `Store::plan` — the cost-aware planner (#307).
+
+use lex_ast::{canonicalize_program, sig_id, stage_id, Stage};
+use lex_store::{Store, DEFAULT_BRANCH};
+use lex_syntax::parse_source;
+use tempfile::TempDir;
+
+fn fresh() -> (Store, TempDir) {
+    let tmp = TempDir::new().unwrap();
+    let s = Store::open(tmp.path()).unwrap();
+    (s, tmp)
+}
+
+fn publish_fn(store: &Store, src: &str, name: &str) {
+    let prog = parse_source(src).unwrap();
+    let stages = canonicalize_program(&prog);
+    let stage = stages
+        .into_iter()
+        .find(|s| matches!(s, Stage::FnDecl(fd) if fd.name == name))
+        .expect("stage not found");
+    let sig = sig_id(&stage).unwrap();
+    let stg = stage_id(&stage).unwrap();
+    // The planner reads its budget data from the stage's AST, not
+    // the op record, so the precise op-effect set doesn't matter.
+    store.publish(&stage).unwrap();
+    let op = lex_vcs::Operation::new(
+        lex_vcs::OperationKind::AddFunction {
+            sig_id: sig.clone(),
+            stage_id: stg.clone(),
+            effects: Default::default(),
+            budget_cost: None,
+        },
+        [],
+    );
+    let t = lex_vcs::StageTransition::Create {
+        sig_id: sig,
+        stage_id: stg,
+    };
+    store.apply_operation(DEFAULT_BRANCH, op, t).unwrap();
+}
+
+const CHAIN_SRC: &str = r#"
+fn leaf() -> [budget(100)] Int { 7 }
+fn mid() -> [budget(200)] Int { leaf() }
+fn root() -> [budget(50)] Int { mid() }
+"#;
+
+#[test]
+fn three_fn_chain_sums_budget() {
+    // AC: a 3-fn chain with declared budgets produces the expected total.
+    let (store, _tmp) = fresh();
+    publish_fn(&store, CHAIN_SRC, "leaf");
+    publish_fn(&store, CHAIN_SRC, "mid");
+    publish_fn(&store, CHAIN_SRC, "root");
+
+    let plan = store.plan(DEFAULT_BRANCH, "root", None, None).unwrap();
+    assert_eq!(plan.goal, "root");
+    assert_eq!(plan.paths.len(), 1, "single linear chain: {:?}", plan.paths);
+    let path = &plan.paths[0];
+    assert_eq!(path.chain, vec!["root", "mid", "leaf"]);
+    assert_eq!(path.total_cost, 50 + 200 + 100);
+    assert!(path.fits, "no cap -> every path fits");
+}
+
+#[test]
+fn max_cost_marks_overflow_paths_as_would_exceed() {
+    let (store, _tmp) = fresh();
+    publish_fn(&store, CHAIN_SRC, "leaf");
+    publish_fn(&store, CHAIN_SRC, "mid");
+    publish_fn(&store, CHAIN_SRC, "root");
+
+    // Total cost is 350; cap of 200 doesn't fit.
+    let plan = store
+        .plan(DEFAULT_BRANCH, "root", Some(200), None)
+        .unwrap();
+    assert_eq!(plan.effective_cap, Some(200));
+    assert!(!plan.paths[0].fits);
+
+    // Cap of 1000 does fit.
+    let plan = store
+        .plan(DEFAULT_BRANCH, "root", Some(1000), None)
+        .unwrap();
+    assert!(plan.paths[0].fits);
+}
+
+const BRANCHING_SRC: &str = r#"
+fn cheap_leaf() -> [budget(10)] Int { 1 }
+fn expensive_leaf() -> [budget(900)] Int { 2 }
+fn branch_pick(n :: Int) -> [budget(5)] Int { match n { 0 => cheap_leaf(), _ => expensive_leaf() } }
+"#;
+
+#[test]
+fn branching_fn_emits_multiple_paths_sorted_cheapest_first() {
+    let (store, _tmp) = fresh();
+    publish_fn(&store, BRANCHING_SRC, "cheap_leaf");
+    publish_fn(&store, BRANCHING_SRC, "expensive_leaf");
+    publish_fn(&store, BRANCHING_SRC, "branch_pick");
+
+    let plan = store
+        .plan(DEFAULT_BRANCH, "branch_pick", Some(100), None)
+        .unwrap();
+    assert_eq!(plan.paths.len(), 2, "two match arms -> two paths");
+    // Cheapest first.
+    assert_eq!(plan.paths[0].chain, vec!["branch_pick", "cheap_leaf"]);
+    assert_eq!(plan.paths[0].total_cost, 5 + 10);
+    assert!(plan.paths[0].fits, "5+10=15 fits in cap=100");
+
+    assert_eq!(plan.paths[1].chain, vec!["branch_pick", "expensive_leaf"]);
+    assert_eq!(plan.paths[1].total_cost, 5 + 900);
+    assert!(!plan.paths[1].fits, "5+900=905 exceeds cap=100");
+}
+
+const RECURSIVE_SRC: &str = r#"
+fn recur(n :: Int) -> [budget(7)] Int { match n { 0 => 0, _ => recur(n) } }
+"#;
+
+#[test]
+fn recursive_self_call_is_budgeted_once() {
+    // AC: recursive functions are detected and budgeted with their
+    // declared self-cost (no infinite-loop expansion).
+    let (store, _tmp) = fresh();
+    publish_fn(&store, RECURSIVE_SRC, "recur");
+
+    let plan = store
+        .plan(DEFAULT_BRANCH, "recur", Some(1000), None)
+        .unwrap();
+    // The chain terminates at the second visit; cost is one
+    // self-budget (7), not infinite.
+    assert!(
+        plan.paths.iter().all(|p| p.total_cost == 7),
+        "recursive cost must be capped at one self-visit: {:?}",
+        plan.paths
+    );
+    assert!(plan.paths.iter().all(|p| p.chain == vec!["recur"]));
+}
+
+const EFFECT_SRC: &str = r#"
+import "std.io" as io
+fn echo(s :: Str) -> [io, budget(3)] Nil { io.print(s) }
+fn caller(s :: Str) -> [io, budget(1)] Nil { echo(s) }
+"#;
+
+#[test]
+fn path_effects_are_union_of_chain() {
+    // AC: effect-set on each path is reported so the agent can also
+    // gate by policy.
+    let (store, _tmp) = fresh();
+    publish_fn(&store, EFFECT_SRC, "echo");
+    publish_fn(&store, EFFECT_SRC, "caller");
+
+    let plan = store
+        .plan(DEFAULT_BRANCH, "caller", None, None)
+        .unwrap();
+    assert_eq!(plan.paths.len(), 1);
+    let p = &plan.paths[0];
+    assert_eq!(p.chain, vec!["caller", "echo"]);
+    // `io` flows through both. `budget` is the cost dimension, so
+    // it's intentionally excluded from the effects set.
+    assert!(p.effects.contains("io"));
+    assert!(!p.effects.contains("budget"));
+}
+
+#[test]
+fn unknown_goal_yields_empty_paths() {
+    let (store, _tmp) = fresh();
+    publish_fn(&store, CHAIN_SRC, "leaf");
+    let plan = store.plan(DEFAULT_BRANCH, "nonexistent", None, None).unwrap();
+    assert!(plan.paths.is_empty());
+}


### PR DESCRIPTION
## Summary

Closes #307. Cost-aware planner over the call graph. Closes the
loop opened by `[budget(N)]` declarations (#247) and the
session-budget gate (#292): given a `goal` function, enumerate
every linear call chain to a leaf, sum the declared budget, rank
cheapest-first.

Output is **advisory** — paths come back with `fits` against the
effective cap (`min(--max-cost, session-remaining)`); the agent
(or downstream policy) decides which path to apply.

## Wire

- New `lex_store::planner` module + `Store::plan(branch, goal, max_cost, session_id) -> Plan`.
- Recursive self-calls budgeted once via visited-set (no
  infinite-loop expansion).
- `effects` per-path is the union of declared effects along the
  chain, excluding the `budget` pseudo-effect.
- New CLI: `lex plan --goal <fn> [--max-cost N] [--intent <id>] [--branch B] [--store DIR]`.
  `--intent` resolves to a session id via the IntentLog so the
  planner consults `Store::session_budget`.

## Test plan

- [x] `cargo test -p lex-store --test planner` — 6/6 (linear-chain
  budget sum, max-cost would-exceed marking, branching sorted
  paths, recursive self-call budgeted once, effect-set union,
  unknown goal yields empty paths)
- [x] `cargo test -p lex-store -p lex-cli` — 390/390 regressions clean
- [x] `cargo clippy -p lex-store -p lex-cli --tests -- -D warnings` — clean

## Out of scope

- Auto-execution. Planner is advisory.
- Learning costs from runtime measurements (cost source is the
  `[budget(N)]` declarations).
- Time-budget planning. Only the cost dimension is optimized.
- Cross-store federated planning.

https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_