### PR TITLE
lex-types+runtime: Stream[T] + agent.cloud_stream (#305 slice 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ bumps may carry breaking changes when justified).
 
 ### Added
 
+- **#305 slice 3: `Stream[T]` + `agent.cloud_stream`.** Closes
+  #305. Lex agents can now consume LLM completions chunk-by-chunk
+  instead of blocking on the full response. New nominal `Stream[T]`
+  opaque type registered in the type checker; new `stream` builtins
+  module with `stream.next(Stream[T]) -> [stream] Option[T]` and
+  `stream.collect(Stream[T]) -> [stream] List[T]`; new
+  `agent.cloud_stream(prompt) -> [llm_cloud] Result[Stream[Str], Str]`
+  producer. The runtime represents a Stream value as the opaque
+  variant `__StreamHandle(handle_id)` and holds an
+  `Arc<Mutex<HashMap<handle_id, Box<dyn Iterator + Send>>>>` on
+  `DefaultHandler`; the registry is shared across par_map workers
+  via slice 2's `spawn_for_worker`. The fixture path
+  (`LEX_LLM_STREAM_FIXTURE='chunk1|chunk2|…'`) is the test hook;
+  live HTTP chunked-response support is deferred. Coverage: 5
+  conformance tests in `crates/lex-runtime/tests/stream_basic.rs`
+  pin laziness (next + next + collect splits the stream at the
+  right boundary), the `None` past-end contract, and effect-gate
+  refusal. Tests serialise on a per-file mutex so cargo's parallel
+  scheduler can't race the process-global fixture env var.
+
+
 - **#307: cost-aware planner (`lex plan`).** Closes the loop opened
   by `[budget(N)]` declarations and the session-budget gate (#292):
   given a `goal` function, enumerate every linear call chain from

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -34,6 +34,11 @@ impl IoSink for CapturedSink {
     fn print_line(&mut self, s: &str) { self.lines.push(s.to_string()); }
 }
 
+/// `agent.cloud_stream` registry: per-handle producer iterators
+/// keyed by opaque handle id (#305 slice 3).
+pub type StreamRegistry =
+    std::collections::HashMap<String, Box<dyn Iterator<Item = String> + Send>>;
+
 pub struct DefaultHandler {
     policy: Policy,
     pub sink: Box<dyn IoSink>,
@@ -65,6 +70,15 @@ pub struct DefaultHandler {
     /// Capped — when the cache is full, the least-recently-used
     /// entry is dropped (its subprocess is reaped on Drop).
     pub mcp_clients: crate::mcp_client::McpClientCache,
+    /// Stream registry for `agent.cloud_stream` / `stream.next` /
+    /// `stream.collect` (#305 slice 3). Keyed by an opaque handle
+    /// id; values are the producer iterators. Wrapped in
+    /// `Arc<Mutex<…>>` so par_map workers can share the same
+    /// stream pool (when slice-2's per-worker handler split chains
+    /// the registry through).
+    pub streams: Arc<std::sync::Mutex<StreamRegistry>>,
+    /// Monotonic counter for handing out fresh stream handle ids.
+    pub next_stream_id: Arc<std::sync::atomic::AtomicU64>,
 }
 
 impl DefaultHandler {
@@ -83,6 +97,8 @@ impl DefaultHandler {
             program: None,
             chat_registry: None,
             mcp_clients: crate::mcp_client::McpClientCache::with_capacity(16),
+            streams: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            next_stream_id: Arc::new(std::sync::atomic::AtomicU64::new(0)),
         }
     }
 
@@ -708,6 +724,7 @@ impl EffectHandler for DefaultHandler {
             let effect_kind = match op {
                 "local_complete" => "llm_local",
                 "cloud_complete" => "llm_cloud",
+                "cloud_stream"   => "llm_cloud",
                 "send_a2a"       => "a2a",
                 "call_mcp"       => "mcp",
                 other => return Err(format!("unsupported agent.{other}")),
@@ -724,7 +741,22 @@ impl EffectHandler for DefaultHandler {
                 "call_mcp"       => Ok(self.dispatch_call_mcp(args)),
                 "local_complete" => Ok(dispatch_llm_local(args)),
                 "cloud_complete" => Ok(dispatch_llm_cloud(args)),
+                "cloud_stream"   => Ok(self.dispatch_cloud_stream(args)),
                 _ => Ok(ok(Value::Str(format!("<{effect_kind} stub>")))),
+            };
+        }
+        if kind == "stream" {
+            // #305 slice 3: consumer-side stream operations. Each
+            // op resolves the opaque handle in the parent handler's
+            // stream registry and pulls one or all items. The
+            // `stream` effect must be granted by policy; default
+            // policies for agent runs grant it alongside the
+            // producer effect (e.g. `llm_cloud`).
+            self.ensure_kind_allowed("stream")?;
+            return match op {
+                "next"    => Ok(self.dispatch_stream_next(args)),
+                "collect" => Ok(self.dispatch_stream_collect(args)),
+                other => Err(format!("unsupported stream.{other}")),
             };
         }
         if kind == "http" && matches!(op, "send" | "get" | "post") {
@@ -1142,6 +1174,12 @@ impl EffectHandler for DefaultHandler {
         fresh.read_root = self.read_root.clone();
         fresh.program = self.program.clone();
         fresh.chat_registry = self.chat_registry.clone();
+        // #305 slice 3: share the stream registry across workers so
+        // a stream produced on one thread (or the parent) is
+        // consumable on any other. The registry is already
+        // `Arc<Mutex<…>>` so concurrent access is safe.
+        fresh.streams = std::sync::Arc::clone(&self.streams);
+        fresh.next_stream_id = std::sync::Arc::clone(&self.next_stream_id);
         Some(Box::new(fresh))
     }
 }
@@ -1518,6 +1556,117 @@ impl DefaultHandler {
                 serde_json::to_string(&result).unwrap_or_else(|_| "null".into()))),
             Err(e) => err(Value::Str(e)),
         }
+    }
+
+    /// Implementation of `agent.cloud_stream(prompt) -> Result[Stream[Str], Str]`
+    /// (#305 slice 3). The fixture path (`LEX_LLM_STREAM_FIXTURE`)
+    /// splits the env-var value on `|` and yields each segment as
+    /// one chunk; it's the load-bearing test hook. Live HTTP
+    /// chunked-response support is deferred to a follow-up slice.
+    fn dispatch_cloud_stream(&mut self, args: Vec<Value>) -> Value {
+        let _prompt = match args.first() {
+            Some(Value::Str(s)) => s.clone(),
+            _ => return err(Value::Str(
+                "agent.cloud_stream(prompt): prompt must be Str".into())),
+        };
+        let chunks: Vec<String> = match std::env::var("LEX_LLM_STREAM_FIXTURE") {
+            Ok(v) => v.split('|').map(|s| s.to_string()).collect(),
+            Err(_) => return err(Value::Str(
+                "agent.cloud_stream: live streaming not yet implemented; \
+                 set LEX_LLM_STREAM_FIXTURE='chunk1|chunk2|…' for tests".into())),
+        };
+        let handle = self.register_stream(chunks.into_iter());
+        ok(stream_handle_value(handle))
+    }
+
+    /// Implementation of `stream.next(s) -> Option[T]` (#305 slice 3).
+    /// Returns `Some(chunk)` for each producer yield and `None` once
+    /// the producer is exhausted. Unknown handle ids return `None`
+    /// rather than erroring so streams can be safely consumed past
+    /// the end (matches the semantics of `Iterator::next`).
+    fn dispatch_stream_next(&mut self, args: Vec<Value>) -> Value {
+        let handle = match args.first().and_then(stream_handle_id) {
+            Some(h) => h,
+            None => return Value::Variant { name: "None".into(), args: vec![] },
+        };
+        let mut streams = match self.streams.lock() {
+            Ok(g) => g,
+            Err(_) => return Value::Variant { name: "None".into(), args: vec![] },
+        };
+        match streams.get_mut(&handle).and_then(|it| it.next()) {
+            Some(chunk) => some(Value::Str(chunk)),
+            None => {
+                streams.remove(&handle);
+                Value::Variant { name: "None".into(), args: vec![] }
+            }
+        }
+    }
+
+    /// Implementation of `stream.collect(s) -> List[T]` (#305 slice 3).
+    /// Drains the producer eagerly. Unknown handles drain to an
+    /// empty list so the contract is `collect ∘ collect = []`
+    /// (idempotent on a closed stream).
+    fn dispatch_stream_collect(&mut self, args: Vec<Value>) -> Value {
+        let handle = match args.first().and_then(stream_handle_id) {
+            Some(h) => h,
+            None => return Value::List(Vec::new()),
+        };
+        let mut iter = {
+            let mut streams = match self.streams.lock() {
+                Ok(g) => g,
+                Err(_) => return Value::List(Vec::new()),
+            };
+            match streams.remove(&handle) {
+                Some(it) => it,
+                None => return Value::List(Vec::new()),
+            }
+        };
+        let mut out: Vec<Value> = Vec::new();
+        for chunk in iter.by_ref() {
+            out.push(Value::Str(chunk));
+        }
+        Value::List(out)
+    }
+
+    /// Register a producer iterator and return its handle id. The
+    /// handle is monotonic-counter-based so two streams created in
+    /// quick succession get distinct ids.
+    fn register_stream<I>(&self, iter: I) -> String
+    where
+        I: Iterator<Item = String> + Send + 'static,
+    {
+        let id = self
+            .next_stream_id
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let handle = format!("stream_{id}");
+        if let Ok(mut streams) = self.streams.lock() {
+            streams.insert(handle.clone(), Box::new(iter));
+        }
+        handle
+    }
+}
+
+/// Build the runtime representation of a `Stream[T]` value:
+/// `Variant("__StreamHandle", [Str(handle_id)])`. The opaque tag is
+/// prefixed with `__` so it can't collide with a user-declared
+/// variant.
+fn stream_handle_value(handle: String) -> Value {
+    Value::Variant {
+        name: "__StreamHandle".into(),
+        args: vec![Value::Str(handle)],
+    }
+}
+
+/// Inverse of [`stream_handle_value`] — extract the handle id from
+/// a Stream value, or `None` if the input doesn't have the
+/// expected shape.
+fn stream_handle_id(v: &Value) -> Option<String> {
+    match v {
+        Value::Variant { name, args } if name == "__StreamHandle" => match args.first() {
+            Some(Value::Str(h)) => Some(h.clone()),
+            _ => None,
+        },
+        _ => None,
     }
 }
 

--- a/crates/lex-runtime/tests/stream_basic.rs
+++ b/crates/lex-runtime/tests/stream_basic.rs
@@ -1,0 +1,248 @@
+//! Conformance for `Stream[T]` + `agent.cloud_stream` (#305 slice 3).
+//!
+//! Asserts:
+//! - The `Stream[Str]` type parses and type-checks.
+//! - `agent.cloud_stream` populates a stream from the
+//!   `LEX_LLM_STREAM_FIXTURE` env var.
+//! - `stream.next` yields chunks lazily, one at a time, in order
+//!   (the load-bearing "token-by-token before full response"
+//!   property: each chunk is observable individually before the
+//!   next is consumed).
+//! - `stream.collect` drains the rest to a List[Str].
+//! - The producer chain is `Result[Stream[Str], Str]` so transport
+//!   errors surface synchronously at handshake.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::vm::Vm;
+use lex_bytecode::Value;
+use lex_runtime::{check_program, DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::collections::BTreeSet;
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+/// Every test in this file mutates `LEX_LLM_STREAM_FIXTURE`, which
+/// is process-global. Hold this mutex for the duration of each
+/// test so cargo's default parallel test runner doesn't race two
+/// fixture writers.
+fn env_lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(())).lock().unwrap_or_else(|e| e.into_inner())
+}
+
+fn build(src: &str) -> lex_bytecode::Program {
+    let prog = parse_source(src).unwrap();
+    let stages = canonicalize_program(&prog);
+    let bc = lex_bytecode::compile_program(&stages);
+    let mut policy = Policy::pure();
+    policy.allow_effects = ["llm_cloud", "stream"].into_iter().map(String::from).collect::<BTreeSet<_>>();
+    check_program(&bc, &policy).expect("program type-checks");
+    bc
+}
+
+fn run(bc: &lex_bytecode::Program, entry: &str, args: Vec<Value>) -> Value {
+    let mut policy = Policy::pure();
+    policy.allow_effects = ["llm_cloud", "stream"].into_iter().map(String::from).collect::<BTreeSet<_>>();
+    let handler = DefaultHandler::new(policy);
+    let mut vm = Vm::with_handler(bc, Box::new(handler));
+    vm.call(entry, args).unwrap()
+}
+
+#[test]
+fn stream_collect_yields_all_chunks_in_order() {
+    let src = r#"
+import "std.agent" as agent
+import "std.stream" as stream
+fn drain(prompt :: Str) -> [llm_cloud, stream] Result[List[Str], Str] {
+    match agent.cloud_stream(prompt) {
+        Ok(s) => Ok(stream.collect(s)),
+        Err(e) => Err(e),
+    }
+}
+"#;
+    let _lock = env_lock();
+    let bc = build(src);
+    std::env::set_var("LEX_LLM_STREAM_FIXTURE", "alpha|beta|gamma|delta");
+    let r = run(&bc, "drain", vec![Value::Str("ignored".into())]);
+    std::env::remove_var("LEX_LLM_STREAM_FIXTURE");
+
+    // Result[List[Str], Str] -> Ok([alpha, beta, gamma, delta]).
+    match r {
+        Value::Variant { name, args } => {
+            assert_eq!(name, "Ok", "expected Ok variant: {args:?}");
+            let inner = args.into_iter().next().expect("Ok payload");
+            assert_eq!(
+                inner,
+                Value::List(vec![
+                    Value::Str("alpha".into()),
+                    Value::Str("beta".into()),
+                    Value::Str("gamma".into()),
+                    Value::Str("delta".into()),
+                ]),
+            );
+        }
+        other => panic!("expected Variant, got {other:?}"),
+    }
+}
+
+#[test]
+fn stream_next_is_lazy_one_chunk_at_a_time() {
+    // The load-bearing AC: a chunk must be observable individually
+    // before its successor is consumed. We pull 2 of 4 chunks via
+    // stream.next, drain the rest with stream.collect, and assert
+    // the chunks split at the expected boundary.
+    //
+    // The pull chain runs in a helper so the `let`s are at function-
+    // body top level (which has well-supported `let` chains) instead
+    // of inside a match-arm block. A record literal would be
+    // canonicalized into alphabetical field order, which would
+    // change the effect schedule — use a tuple instead.
+    let src = r#"
+import "std.agent" as agent
+import "std.stream" as stream
+
+fn pull_three(s :: Stream[Str]) -> [stream] (Option[Str], Option[Str], List[Str]) {
+    let first := stream.next(s)
+    let second := stream.next(s)
+    let rest := stream.collect(s)
+    (first, second, rest)
+}
+
+fn pull2(prompt :: Str) -> [llm_cloud, stream] Result[(Option[Str], Option[Str], List[Str]), Str] {
+    match agent.cloud_stream(prompt) {
+        Ok(s) => Ok(pull_three(s)),
+        Err(e) => Err(e),
+    }
+}
+"#;
+    let _lock = env_lock();
+    let bc = build(src);
+    std::env::set_var("LEX_LLM_STREAM_FIXTURE", "one|two|three|four");
+    let r = run(&bc, "pull2", vec![Value::Str("ignored".into())]);
+    std::env::remove_var("LEX_LLM_STREAM_FIXTURE");
+
+    let Value::Variant { name, args } = r else {
+        panic!("expected Variant");
+    };
+    assert_eq!(name, "Ok");
+    let payload = args.into_iter().next().expect("Ok payload");
+    let Value::Tuple(items) = payload else {
+        panic!("expected Tuple payload");
+    };
+    let some = |s: &str| Value::Variant {
+        name: "Some".into(),
+        args: vec![Value::Str(s.into())],
+    };
+    assert_eq!(items.first().cloned(), Some(some("one")));
+    assert_eq!(items.get(1).cloned(), Some(some("two")));
+    assert_eq!(
+        items.get(2).cloned(),
+        Some(Value::List(vec![
+            Value::Str("three".into()),
+            Value::Str("four".into()),
+        ])),
+    );
+}
+
+#[test]
+fn stream_next_returns_none_past_end() {
+    // Pulling one more time than the producer has chunks must
+    // return None — matches Iterator::next semantics. We exhaust
+    // a 2-chunk stream with 3 stream.next calls and assert the
+    // third is None. Using `let` chain so the three pulls
+    // observably happen in source order.
+    let src = r#"
+import "std.agent" as agent
+import "std.stream" as stream
+
+fn three_pulls(s :: Stream[Str]) -> [stream] (Option[Str], Option[Str], Option[Str]) {
+    let a := stream.next(s)
+    let b := stream.next(s)
+    let c := stream.next(s)
+    (a, b, c)
+}
+
+fn pull3(prompt :: Str) -> [llm_cloud, stream] Result[(Option[Str], Option[Str], Option[Str]), Str] {
+    match agent.cloud_stream(prompt) {
+        Ok(s) => Ok(three_pulls(s)),
+        Err(e) => Err(e),
+    }
+}
+"#;
+    let _lock = env_lock();
+    let bc = build(src);
+    std::env::set_var("LEX_LLM_STREAM_FIXTURE", "x|y");
+    let r = run(&bc, "pull3", vec![Value::Str("p".into())]);
+    std::env::remove_var("LEX_LLM_STREAM_FIXTURE");
+
+    let Value::Variant { name: top, args } = r else { panic!() };
+    assert_eq!(top, "Ok");
+    let Value::Tuple(items) = args.into_iter().next().unwrap() else {
+        panic!()
+    };
+    let some = |s: &str| Value::Variant {
+        name: "Some".into(),
+        args: vec![Value::Str(s.into())],
+    };
+    let none = Value::Variant { name: "None".into(), args: vec![] };
+    assert_eq!(items.first().cloned(), Some(some("x")));
+    assert_eq!(items.get(1).cloned(), Some(some("y")));
+    assert_eq!(
+        items.get(2).cloned(),
+        Some(none),
+        "third pull past end must be None"
+    );
+}
+
+#[test]
+fn cloud_stream_without_fixture_returns_err() {
+    // Without LEX_LLM_STREAM_FIXTURE the producer surfaces an Err
+    // at handshake (Result[Stream[Str], Str]). Validates the
+    // synchronous-error path agents need to gate retries on.
+    let src = r#"
+import "std.agent" as agent
+fn handshake(prompt :: Str) -> [llm_cloud] Result[Str, Str] {
+    match agent.cloud_stream(prompt) {
+        Ok(_) => Ok("got_stream"),
+        Err(e) => Err(e),
+    }
+}
+"#;
+    let _lock = env_lock();
+    let bc = build(src);
+    std::env::remove_var("LEX_LLM_STREAM_FIXTURE");
+    let r = run(&bc, "handshake", vec![Value::Str("p".into())]);
+    let Value::Variant { name, args } = r else { panic!() };
+    assert_eq!(name, "Err", "no fixture must produce Err: {args:?}");
+    let Value::Str(msg) = args.into_iter().next().unwrap() else { panic!() };
+    assert!(
+        msg.contains("LEX_LLM_STREAM_FIXTURE"),
+        "Err message should mention the fixture env var so test setup is obvious: {msg}"
+    );
+}
+
+#[test]
+fn cloud_stream_without_effect_grant_is_refused() {
+    // Calling agent.cloud_stream when [llm_cloud] isn't allowed
+    // by policy must fail. Mirrors the existing gate for
+    // agent.cloud_complete.
+    let src = r#"
+import "std.agent" as agent
+fn no_grant() -> [llm_cloud] Result[Str, Str] {
+    match agent.cloud_stream("p") {
+        Ok(_) => Ok("got_stream"),
+        Err(e) => Err(e),
+    }
+}
+"#;
+    let prog = parse_source(src).unwrap();
+    let stages = canonicalize_program(&prog);
+    let bc = lex_bytecode::compile_program(&stages);
+    let policy = Policy::pure(); // no allow_effects
+    // The policy check refuses the program before run-time.
+    let err = check_program(&bc, &policy).expect_err("must reject");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("llm_cloud"),
+        "expected llm_cloud refusal, got: {msg}"
+    );
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -1617,6 +1617,44 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 EffectSet::singleton("mcp"),
                 Ty::Con("Result".into(), vec![Ty::str(), Ty::str()]),
             ));
+            // cloud_stream :: Str -> [llm_cloud] Result[Stream[Str], Str]
+            // (#305 slice 3). Streaming counterpart to cloud_complete.
+            // The result is `Result[Stream[Str], Str]` rather than a
+            // bare Stream so transport errors surface synchronously
+            // at handshake time; per-chunk errors collapse the
+            // stream to early termination.
+            fields.insert("cloud_stream".into(), Ty::function(
+                vec![Ty::str()],
+                EffectSet::singleton("llm_cloud"),
+                Ty::Con("Result".into(), vec![
+                    Ty::Con("Stream".into(), vec![Ty::str()]),
+                    Ty::str(),
+                ]),
+            ));
+            Some(Ty::Record(fields))
+        }
+        "stream" => {
+            // #305 slice 3: opaque consumer-side operations on
+            // `Stream[T]`. Producers live elsewhere (`agent.cloud_stream`
+            // for now); future producers (`http.get_stream`, etc.)
+            // will register the same Stream[T] surface.
+            let mut fields = IndexMap::new();
+            // next :: Stream[T] -> [stream] Option[T]
+            // One pull. `None` signals end-of-stream (consumed by
+            // the producer's lazy generator).
+            fields.insert("next".into(), Ty::function(
+                vec![Ty::Con("Stream".into(), vec![Ty::Var(0)])],
+                EffectSet::singleton("stream"),
+                Ty::Con("Option".into(), vec![Ty::Var(0)]),
+            ));
+            // collect :: Stream[T] -> [stream] List[T]
+            // Drain to a list. Eager; blocks until the producer
+            // signals end-of-stream.
+            fields.insert("collect".into(), Ty::function(
+                vec![Ty::Con("Stream".into(), vec![Ty::Var(0)])],
+                EffectSet::singleton("stream"),
+                Ty::List(Box::new(Ty::Var(0))),
+            ));
             Some(Ty::Record(fields))
         }
         _ => None,
@@ -1666,6 +1704,7 @@ pub fn module_for_import(reference: &str) -> Option<&'static str> {
         "test" => "test",
         "agent" => "agent",
         "cli" => "cli",
+        "stream" => "stream",
         _ => return None,
     })
 }

--- a/crates/lex-types/src/env.rs
+++ b/crates/lex-types/src/env.rs
@@ -62,6 +62,14 @@ impl TypeEnv {
         e.types.insert("Map".into(), TypeDef { params: vec!["K".into(), "V".into()], kind: TypeDefKind::Opaque });
         e.types.insert("Set".into(), TypeDef { params: vec!["T".into()], kind: TypeDefKind::Opaque });
 
+        // Stream[T]: opaque streaming iterator (#305 slice 3).
+        // Built and consumed exclusively through the `stream.*` and
+        // `agent.cloud_stream` effect builtins; the runtime
+        // represents a Stream value as an opaque variant carrying a
+        // handle id. Registered as Opaque so type-checking knows
+        // `Stream[Str]` parses but doesn't unwrap it structurally.
+        e.types.insert("Stream".into(), TypeDef { params: vec!["T".into()], kind: TypeDefKind::Opaque });
+
         // Tz = Utc | Local | Offset(Int) | Iana(Str).
         // Used by std.datetime; the variant-typed alternative to the
         // pre-v1 stringly Tz ("UTC" / "Local" / "+05:30" / IANA name).


### PR DESCRIPTION
## Summary

Closes #305 — Lex agents can now consume LLM completions
chunk-by-chunk instead of blocking on the full response.

```lex
import "std.agent" as agent
import "std.stream" as stream

fn pulse(prompt :: Str) -> [llm_cloud, stream] List[Str] {
    match agent.cloud_stream(prompt) {
        Ok(s) => stream.collect(s),
        Err(_) => [],
    }
}
```

## Wire

- New nominal `Stream[T]` Opaque type in `lex_types::env`.
- New `stream` module:
  `stream.next(Stream[T]) -> [stream] Option[T]`,
  `stream.collect(Stream[T]) -> [stream] List[T]`.
- New `agent.cloud_stream(prompt) -> [llm_cloud] Result[Stream[Str], Str]`.
- Runtime representation: opaque variant `__StreamHandle(handle_id)`;
  registry on `DefaultHandler` is `Arc<Mutex<HashMap<id, Box<dyn Iterator + Send>>>>`
  shared across par_map workers via slice 2's `spawn_for_worker`.
- Fixture: `LEX_LLM_STREAM_FIXTURE='a|b|c|…'` for tests; live HTTP
  chunked-response producer deferred to a follow-up.

## Test plan

- [x] `cargo test -p lex-runtime --test stream_basic` — 5/5
  (collect drains in order; lazy chunk-by-chunk consumption pinned
  via `next + next + collect` split test; `None` past-end;
  synchronous Err on missing fixture; effect-gate refuses
  `llm_cloud` without grant).
- [x] `cargo test -p lex-runtime -p lex-types -p lex-bytecode -p lex-store -p lex-cli` — 933/933
- [x] `cargo clippy -p lex-types -p lex-runtime --tests -- -D warnings` — clean

Tests serialise on a per-file mutex so cargo's parallel scheduler
doesn't race the process-global fixture env var.

## Out of scope

- `stream.fold` (higher-order; needs reentrant closure dispatch
  from inside the effect handler).
- Live HTTP chunked-response producer for `agent.cloud_stream`.
- Backpressure / cancellation primitives.

https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_