### PR TITLE
lex-lsp: phase 1 — read-only diagnostics over LSP (#304 phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ bumps may carry breaking changes when justified).
 
 ### Added
 
+- **#304 phase 1: `lex-lsp` Language Server.** Editors that speak
+  LSP (VS Code, Cursor, Continue, Zed, JetBrains AI) now light up
+  Lex files with inline red squiggles for type errors instead of
+  needing a separate `lex check` pass. New `lex-lsp` crate ships
+  the JSON-RPC loop over stdin/stdout (`lsp-server` +
+  `lsp-types`); `initialize` / `initialized` / `shutdown`
+  lifecycle plus `textDocument/didOpen` / `didChange` / `didSave`
+  / `didClose` with full-document sync. Every type error becomes
+  a `Diagnostic` carrying severity ERROR, the stable
+  `rule_tag` (#306 slice 2) as `code`, source `"lex"`, and a
+  `data` payload with `rule_explanation`,
+  `suggested_transform` (#306 slice 3), and the `at_node` —
+  phase-3 code-action providers will read the suggestion from
+  there. Phase 2 (hover / definition / completion), phase 3
+  (typed-transform code actions), and phase 4 (RepairHint
+  surface) are queued as follow-up slices. Coverage: 5 lib unit
+  tests on the diagnostic-translation path + 2 e2e tests
+  spawning the compiled binary and round-tripping the protocol.
+
 - **#305 slice 3: `Stream[T]` + `agent.cloud_stream`.** Closes
   #305. Lex agents can now consume LLM completions chunk-by-chunk
   instead of blocking on the full response. New nominal `Stream[T]`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/lex-stdlib",
     "crates/lex-cli",
     "crates/lex-api",
+    "crates/lex-lsp",
     "crates/core-syntax",
     "crates/core-compiler",
     "crates/spec-checker",

--- a/crates/lex-lsp/Cargo.toml
+++ b/crates/lex-lsp/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "lex-lsp"
+description = "Language Server Protocol bridge for Lex — pipes lex-types' type-checker diagnostics to editor inline-error surfaces."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[[bin]]
+name = "lex-lsp"
+path = "src/main.rs"
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+# LSP protocol shim. `lsp-server` ships the JSON-RPC framing +
+# message dispatch over stdin/stdout (no async runtime —
+# it's a single-threaded sync loop, which matches LSP's
+# request/response shape and avoids pulling tokio into the
+# workspace). `lsp-types` is the protocol-message schema. Both
+# are rust-analyzer-team-maintained.
+lsp-server = "0.7"
+lsp-types = "0.97"
+lex-syntax = { path = "../lex-syntax", version = "0.7.1" }
+lex-ast = { path = "../lex-ast", version = "0.7.1" }
+lex-types = { path = "../lex-types", version = "0.7.1" }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/lex-lsp/README.md
+++ b/crates/lex-lsp/README.md
@@ -1,0 +1,71 @@
+# lex-lsp
+
+Language Server Protocol bridge for Lex. Pipes
+`lex_types::check_program` errors to editor inline-error surfaces
+(VS Code, Cursor, Continue, Zed, JetBrains AI).
+
+## Phase 1 (this slice — closes the first AC block of #304)
+
+- `initialize` / `initialized` / `shutdown` lifecycle.
+- `textDocument/didOpen` / `didChange` / `didSave` / `didClose`
+  with full-document sync.
+- `textDocument/publishDiagnostics` emitting
+  `lex_types::PositionedError` errors with:
+  - `severity = ERROR`
+  - `code = <rule_tag>` (e.g. `type-mismatch`, `unknown-identifier`)
+    — the stable identifier from #306 slice 2.
+  - `source = "lex"`
+  - `data = { rule_tag, rule_explanation, suggested_transform, at_node }`
+    — code-action providers in phase 3 read the
+    `suggested_transform` from here.
+
+## Build
+
+```bash
+cargo build --release -p lex-lsp
+# binary at: target/release/lex-lsp
+```
+
+## VS Code
+
+Add the following to your workspace's `.vscode/settings.json` and
+the language-extension config (e.g. via the
+[generic-lsp](https://marketplace.visualstudio.com/items?itemName=alefragnani.generic-language-server)
+extension or a custom contribution point):
+
+```jsonc
+{
+  "languageserver": {
+    "lex": {
+      "command": "/absolute/path/to/lex-lsp",
+      "args": [],
+      "filetypes": ["lex"],
+      "rootPatterns": ["lex.toml", ".git/"]
+    }
+  }
+}
+```
+
+A `.vscode/launch.json` snippet for debugging the LSP itself:
+
+```jsonc
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Attach to lex-lsp",
+      "type": "lldb",
+      "request": "attach",
+      "program": "${workspaceFolder}/target/debug/lex-lsp",
+      "pid": "${command:pickProcess}"
+    }
+  ]
+}
+```
+
+## What's queued (phases 2–4 of #304)
+
+- Phase 2: hover, definition, completion, references.
+- Phase 3: code actions backed by #280's typed transforms.
+- Phase 4: surface `RepairHint` attestations as code actions
+  (one-click `lex repair --apply`).

--- a/crates/lex-lsp/src/lib.rs
+++ b/crates/lex-lsp/src/lib.rs
@@ -1,0 +1,244 @@
+//! Language Server Protocol bridge for Lex (#304 phase 1).
+//!
+//! Pipes `lex_types::check_program` errors to editor inline-error
+//! surfaces (VS Code, Cursor, Continue, Zed, JetBrains AI). This
+//! crate ships **phase 1** of #304:
+//!
+//! - `initialize` / `initialized` / `shutdown` lifecycle
+//! - `textDocument/didOpen` / `didChange` / `didSave` / `didClose`
+//! - `textDocument/publishDiagnostics` with structured errors
+//!   carrying `rule_tag` (#306 slice 2) and source positions
+//!   (#306 slice 1).
+//!
+//! Subsequent phases (hover, definition, completion, code actions,
+//! repair-hint integration) are queued as follow-up slices.
+//!
+//! The diagnostic-translation logic in this module is pure
+//! (no I/O, no protocol surface), so it's covered by unit tests
+//! without needing to spawn a real LSP server.
+
+use lex_types::PositionedError;
+use lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
+use serde_json::json;
+
+/// Build LSP `Diagnostic`s for a single Lex source string.
+///
+/// Re-parses + canonicalises + runs `check_program_with_positions`,
+/// so callers don't need to know the type-check pipeline. Returns
+/// `Vec<Diagnostic>` — empty on a clean type-check.
+///
+/// `uri_path` is the file system path used when stamping source
+/// positions onto diagnostics; pass the URL-decoded path component
+/// of the document's `Uri`. Pass `None` if the document is
+/// in-memory and has no on-disk file.
+pub fn diagnostics_for_source(src: &str, uri_path: Option<&str>) -> Vec<Diagnostic> {
+    // Parse failures are surfaced as a single full-document
+    // diagnostic since the type checker hasn't run yet. Editor
+    // shows a red squiggle on line 1 col 1 with the parser's
+    // message; better than silent failure.
+    let (program, fn_positions) = match lex_syntax::parse_source_with_positions(src) {
+        Ok(pair) => pair,
+        Err(e) => {
+            return vec![Diagnostic {
+                range: full_range(src),
+                severity: Some(DiagnosticSeverity::ERROR),
+                code: Some(lsp_types::NumberOrString::String("parse-error".into())),
+                code_description: None,
+                source: Some("lex".into()),
+                message: format!("{e}"),
+                related_information: None,
+                tags: None,
+                data: None,
+            }];
+        }
+    };
+
+    let stages = lex_ast::canonicalize_program(&program);
+    let positions: std::collections::BTreeMap<String, lex_types::Position> = fn_positions
+        .into_iter()
+        .map(|(name, byte)| {
+            let (line, col) = lex_types::byte_to_line_col(src, byte);
+            let pos = lex_types::Position::new(uri_path.map(|s| s.to_string()), line, col);
+            (name, pos)
+        })
+        .collect();
+
+    match lex_types::check_program_with_positions(&stages, &positions) {
+        Ok(_) => Vec::new(),
+        Err(errs) => errs
+            .into_iter()
+            .map(|e| diagnostic_from_positioned_error(&e, src))
+            .collect(),
+    }
+}
+
+/// Translate one `PositionedError` into an LSP `Diagnostic`.
+///
+/// - Range: derived from the error's attached `Position` (line+col
+///   from #306 slice 1) when present; falls back to a zero-width
+///   point at the file start. The diagnostic spans from the
+///   reported start to the end of that line — the type checker
+///   currently stamps function-level positions, so this paints
+///   the whole `fn` line as the offending span. Future slices
+///   tighten this to per-expression precision.
+/// - Severity: always `ERROR` for type-check failures (Lex has no
+///   warning-level type errors today).
+/// - Code: the stable `rule_tag` from #306 slice 2 so editors can
+///   group / filter / annotate by rule.
+/// - Message: the `TypeError`'s `Display` rendering.
+/// - Data: serialised `rule_explanation` + `suggested_transform`
+///   payload so code-action providers in a future phase can read
+///   the hint without re-running the type checker.
+pub fn diagnostic_from_positioned_error(e: &PositionedError, src: &str) -> Diagnostic {
+    let range = range_from_position(e.position.as_ref(), src);
+    Diagnostic {
+        range,
+        severity: Some(DiagnosticSeverity::ERROR),
+        code: Some(lsp_types::NumberOrString::String(e.error.rule_tag().to_string())),
+        code_description: None,
+        source: Some("lex".into()),
+        message: format!("{}", e.error),
+        related_information: None,
+        tags: None,
+        data: Some(json!({
+            "rule_tag": e.error.rule_tag(),
+            "rule_explanation": e.error.rule_explanation(),
+            "suggested_transform": lex_types::suggested_transform_for(e.error.rule_tag()),
+            "at_node": e.error.node(),
+        })),
+    }
+}
+
+fn range_from_position(p: Option<&lex_types::Position>, src: &str) -> Range {
+    match p {
+        Some(pos) => {
+            // LSP `Position` is 0-based; our `Position` is 1-based.
+            let line0 = pos.line.saturating_sub(1);
+            let col0 = pos.col.saturating_sub(1);
+            let start = Position { line: line0, character: col0 };
+            // Paint to end-of-line so the squiggle is visible in
+            // editors that don't show zero-width markers.
+            let end_col = line_length_chars(src, line0);
+            let end = Position { line: line0, character: end_col };
+            Range { start, end }
+        }
+        None => Range {
+            start: Position { line: 0, character: 0 },
+            end: Position { line: 0, character: 0 },
+        },
+    }
+}
+
+fn line_length_chars(src: &str, line0: u32) -> u32 {
+    src.lines()
+        .nth(line0 as usize)
+        .map(|l| l.chars().count() as u32)
+        .unwrap_or(0)
+}
+
+fn full_range(src: &str) -> Range {
+    let n_lines = src.lines().count() as u32;
+    let last_line_idx = n_lines.saturating_sub(1);
+    let last_line_len = line_length_chars(src, last_line_idx);
+    Range {
+        start: Position { line: 0, character: 0 },
+        end: Position { line: last_line_idx, character: last_line_len },
+    }
+}
+
+/// Lightweight in-memory document registry used by the server
+/// loop. Maps `Uri` (as a String — `Uri` itself isn't `Hash`) to
+/// the latest known source text. `didOpen` inserts, `didChange`
+/// replaces (full-document sync only — incremental sync is queued),
+/// `didClose` removes.
+#[derive(Default)]
+pub struct Documents {
+    inner: std::collections::HashMap<String, String>,
+}
+
+impl Documents {
+    pub fn new() -> Self { Self::default() }
+
+    pub fn insert(&mut self, uri: String, text: String) {
+        self.inner.insert(uri, text);
+    }
+
+    pub fn get(&self, uri: &str) -> Option<&str> {
+        self.inner.get(uri).map(|s| s.as_str())
+    }
+
+    pub fn remove(&mut self, uri: &str) {
+        self.inner.remove(uri);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clean_program_yields_no_diagnostics() {
+        let src = "fn add(x :: Int, y :: Int) -> Int { x + y }\n";
+        let diags = diagnostics_for_source(src, Some("/tmp/clean.lex"));
+        assert!(diags.is_empty(), "expected no diagnostics: {diags:?}");
+    }
+
+    #[test]
+    fn type_mismatch_surfaces_with_rule_tag() {
+        let src = "fn bad(x :: Int) -> Int { \"oops\" }\n";
+        let diags = diagnostics_for_source(src, Some("/tmp/bad.lex"));
+        assert_eq!(diags.len(), 1, "one diagnostic expected: {diags:?}");
+        let d = &diags[0];
+        assert_eq!(d.severity, Some(DiagnosticSeverity::ERROR));
+        assert_eq!(d.source.as_deref(), Some("lex"));
+        match &d.code {
+            Some(lsp_types::NumberOrString::String(tag)) => {
+                assert_eq!(tag, "type-mismatch");
+            }
+            other => panic!("expected stable rule_tag code, got {other:?}"),
+        }
+        // Range: line 0 col 0 (1-based line 1 col 1 → 0-based 0,0).
+        assert_eq!(d.range.start.line, 0);
+        assert_eq!(d.range.start.character, 0);
+        // Message carries the type checker's prose.
+        assert!(d.message.contains("type mismatch"), "got: {}", d.message);
+        // Data carries the rule_explanation + suggested_transform.
+        let data = d.data.as_ref().expect("data present");
+        assert_eq!(data["rule_tag"], "type-mismatch");
+        assert!(data["rule_explanation"].as_str().is_some_and(|s| !s.is_empty()));
+        // Slice 3 of #306 wired a static suggestion for type-mismatch.
+        assert!(data["suggested_transform"].is_object());
+    }
+
+    #[test]
+    fn second_fn_diagnostic_lands_on_its_own_line() {
+        let src = "\
+fn first_ok(x :: Int) -> Int { x }
+fn broken(x :: Int) -> Str { x }
+";
+        let diags = diagnostics_for_source(src, Some("/tmp/two.lex"));
+        assert_eq!(diags.len(), 1, "one diag for `broken`: {diags:?}");
+        // `broken` is on line 2 (1-based) → line 1 in 0-based LSP coords.
+        assert_eq!(diags[0].range.start.line, 1);
+    }
+
+    #[test]
+    fn parse_failure_yields_a_single_full_document_diagnostic() {
+        let src = "fn bad( :: Int { 1 }\n"; // missing param name
+        let diags = diagnostics_for_source(src, None);
+        assert_eq!(diags.len(), 1);
+        assert_eq!(
+            diags[0].code,
+            Some(lsp_types::NumberOrString::String("parse-error".into()))
+        );
+    }
+
+    #[test]
+    fn documents_registry_round_trips() {
+        let mut docs = Documents::new();
+        docs.insert("file:///a.lex".into(), "fn f() -> Int { 1 }".into());
+        assert_eq!(docs.get("file:///a.lex"), Some("fn f() -> Int { 1 }"));
+        docs.remove("file:///a.lex");
+        assert!(docs.get("file:///a.lex").is_none());
+    }
+}

--- a/crates/lex-lsp/src/main.rs
+++ b/crates/lex-lsp/src/main.rs
@@ -1,0 +1,178 @@
+//! `lex-lsp` binary — LSP server over stdin/stdout (#304 phase 1).
+//!
+//! The minimum viable surface that turns a Lex file open in an
+//! LSP-capable editor (VS Code, Cursor, Continue, Zed, JetBrains AI)
+//! into a red-squiggle experience for type errors. Subsequent phases
+//! add hover, definition, completion, code actions, and repair-hint
+//! integration.
+
+use lex_lsp::{diagnostics_for_source, Documents};
+use lsp_server::{Connection, Message, Notification, Response};
+use lsp_types::notification::{
+    DidChangeTextDocument, DidCloseTextDocument, DidOpenTextDocument, DidSaveTextDocument,
+    Notification as NotificationTrait, PublishDiagnostics,
+};
+use lsp_types::{
+    DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
+    DidSaveTextDocumentParams, InitializeParams, InitializeResult, OneOf,
+    PublishDiagnosticsParams, ServerCapabilities, ServerInfo, TextDocumentSyncCapability,
+    TextDocumentSyncKind, Uri,
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // stderr is the standard LSP log channel — editors capture and
+    // surface it in their "Output" panes.
+    eprintln!("lex-lsp starting (phase 1: read-only diagnostics)");
+
+    let (connection, io_threads) = Connection::stdio();
+    let server_capabilities = ServerCapabilities {
+        // Full-document sync only for phase 1. Incremental sync is
+        // a follow-up; the type checker re-runs the whole program
+        // on every change anyway, so the marginal savings are
+        // ~zero today.
+        text_document_sync: Some(TextDocumentSyncCapability::Kind(TextDocumentSyncKind::FULL)),
+        definition_provider: Some(OneOf::Left(false)),
+        hover_provider: None,
+        completion_provider: None,
+        ..Default::default()
+    };
+    let server_capabilities_json = serde_json::to_value(&server_capabilities)?;
+
+    let initialization_params = connection.initialize(server_capabilities_json)?;
+    let _params: InitializeParams = serde_json::from_value(initialization_params)?;
+    let _info = InitializeResult {
+        capabilities: server_capabilities,
+        server_info: Some(ServerInfo {
+            name: "lex-lsp".into(),
+            version: Some(env!("CARGO_PKG_VERSION").into()),
+        }),
+    };
+
+    main_loop(connection)?;
+    io_threads.join()?;
+    eprintln!("lex-lsp shutting down");
+    Ok(())
+}
+
+fn main_loop(connection: Connection) -> Result<(), Box<dyn std::error::Error>> {
+    let mut docs = Documents::new();
+    for msg in &connection.receiver {
+        match msg {
+            Message::Request(req) => {
+                if connection.handle_shutdown(&req)? {
+                    return Ok(());
+                }
+                // Phase 2+ requests (hover, definition, completion,
+                // codeAction) reply with method-not-found so editors
+                // know the capability isn't supported yet.
+                let resp = Response {
+                    id: req.id,
+                    result: None,
+                    error: Some(lsp_server::ResponseError {
+                        code: lsp_server::ErrorCode::MethodNotFound as i32,
+                        message: format!("`{}` not supported by lex-lsp phase 1", req.method),
+                        data: None,
+                    }),
+                };
+                connection.sender.send(Message::Response(resp))?;
+            }
+            Message::Notification(note) => {
+                handle_notification(&connection, &mut docs, note)?;
+            }
+            Message::Response(_) => {
+                // We don't send any client → server requests yet.
+            }
+        }
+    }
+    Ok(())
+}
+
+fn handle_notification(
+    connection: &Connection,
+    docs: &mut Documents,
+    note: Notification,
+) -> Result<(), Box<dyn std::error::Error>> {
+    match note.method.as_str() {
+        m if m == DidOpenTextDocument::METHOD => {
+            let params: DidOpenTextDocumentParams = serde_json::from_value(note.params)?;
+            let uri = params.text_document.uri.to_string();
+            let text = params.text_document.text;
+            docs.insert(uri.clone(), text.clone());
+            publish(connection, &params.text_document.uri, &text)?;
+        }
+        m if m == DidChangeTextDocument::METHOD => {
+            let params: DidChangeTextDocumentParams = serde_json::from_value(note.params)?;
+            let uri = params.text_document.uri.to_string();
+            // Phase 1 uses FULL sync: the last content-change is
+            // the complete document text. Take the last one.
+            if let Some(change) = params.content_changes.into_iter().last() {
+                docs.insert(uri.clone(), change.text.clone());
+                publish(connection, &params.text_document.uri, &change.text)?;
+            }
+        }
+        m if m == DidSaveTextDocument::METHOD => {
+            let params: DidSaveTextDocumentParams = serde_json::from_value(note.params)?;
+            // Re-run diagnostics on save in case the editor's
+            // on-disk content differs from the in-memory copy
+            // (some editors batch saves).
+            let uri_str = params.text_document.uri.to_string();
+            if let Some(text) = docs.get(&uri_str) {
+                let text = text.to_string();
+                publish(connection, &params.text_document.uri, &text)?;
+            }
+        }
+        m if m == DidCloseTextDocument::METHOD => {
+            let params: DidCloseTextDocumentParams = serde_json::from_value(note.params)?;
+            docs.remove(&params.text_document.uri.to_string());
+            // Clear any pending diagnostics for the closed doc.
+            let empty = PublishDiagnosticsParams {
+                uri: params.text_document.uri,
+                diagnostics: Vec::new(),
+                version: None,
+            };
+            send_notification::<PublishDiagnostics>(connection, empty)?;
+        }
+        _ => {
+            // Silently ignore notifications we don't handle yet.
+            // Includes initialized, didChangeConfiguration, etc.
+        }
+    }
+    Ok(())
+}
+
+fn publish(
+    connection: &Connection,
+    uri: &Uri,
+    src: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let path = uri_to_path(uri);
+    let diagnostics = diagnostics_for_source(src, path.as_deref());
+    let params = PublishDiagnosticsParams {
+        uri: uri.clone(),
+        diagnostics,
+        version: None,
+    };
+    send_notification::<PublishDiagnostics>(connection, params)
+}
+
+fn send_notification<N: NotificationTrait>(
+    connection: &Connection,
+    params: N::Params,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    N::Params: serde::Serialize,
+{
+    let note = Notification {
+        method: N::METHOD.into(),
+        params: serde_json::to_value(params)?,
+    };
+    connection.sender.send(Message::Notification(note))?;
+    Ok(())
+}
+
+/// Extract the filesystem path from a `file://` URI. Returns `None`
+/// for non-file URIs (e.g. `untitled://` scratch buffers).
+fn uri_to_path(uri: &Uri) -> Option<String> {
+    let s = uri.to_string();
+    s.strip_prefix("file://").map(|p| p.to_string())
+}

--- a/crates/lex-lsp/tests/end_to_end.rs
+++ b/crates/lex-lsp/tests/end_to_end.rs
@@ -1,0 +1,178 @@
+//! End-to-end smoke test for `lex-lsp` phase 1 (#304).
+//!
+//! Spawns the compiled binary, drives it through `initialize` →
+//! `didOpen` → expects `publishDiagnostics`, asserting the JSON
+//! envelope the editor would receive. This is the minimum proof
+//! that the LSP loop actually works over stdio, beyond the unit
+//! tests that exercise `diagnostics_for_source` directly.
+
+use serde_json::{json, Value};
+use std::io::{BufRead, BufReader, Read, Write};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::time::Duration;
+
+fn lsp_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_lex-lsp")
+}
+
+struct Server {
+    child: Child,
+    stdin: ChildStdin,
+    reader: BufReader<std::process::ChildStdout>,
+}
+
+impl Server {
+    fn spawn() -> Self {
+        let mut child = Command::new(lsp_bin())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("spawn lex-lsp");
+        let stdin = child.stdin.take().expect("stdin");
+        let stdout = child.stdout.take().expect("stdout");
+        Self { child, stdin, reader: BufReader::new(stdout) }
+    }
+
+    fn send(&mut self, msg: &Value) {
+        let body = serde_json::to_string(msg).unwrap();
+        // LSP framing: Content-Length + CRLF + CRLF, then body.
+        write!(self.stdin, "Content-Length: {}\r\n\r\n{}", body.len(), body).unwrap();
+        self.stdin.flush().unwrap();
+    }
+
+    /// Read one LSP frame and parse it as JSON.
+    fn recv(&mut self) -> Value {
+        let mut content_length: Option<usize> = None;
+        loop {
+            let mut header = String::new();
+            self.reader.read_line(&mut header).expect("read header");
+            if header == "\r\n" || header.is_empty() {
+                break;
+            }
+            if let Some(rest) = header.strip_prefix("Content-Length:") {
+                content_length = Some(rest.trim().parse().unwrap());
+            }
+        }
+        let n = content_length.expect("Content-Length");
+        let mut body = vec![0u8; n];
+        self.reader.read_exact(&mut body).expect("read body");
+        serde_json::from_slice(&body).unwrap()
+    }
+}
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[test]
+fn type_error_round_trips_through_lsp_protocol() {
+    let mut s = Server::spawn();
+
+    // 1. Initialize.
+    s.send(&json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "capabilities": {},
+            "processId": null,
+            "rootUri": null,
+        }
+    }));
+    let init_resp = s.recv();
+    assert_eq!(init_resp["id"], 1, "initialize response correlation");
+    assert!(
+        init_resp["result"]["capabilities"]["textDocumentSync"].is_number()
+            || init_resp["result"]["capabilities"]["textDocumentSync"].is_object(),
+        "server declares textDocumentSync: {init_resp}"
+    );
+
+    // 2. Initialized notification (no response expected).
+    s.send(&json!({
+        "jsonrpc": "2.0",
+        "method": "initialized",
+        "params": {}
+    }));
+
+    // 3. didOpen a Lex doc with a type error.
+    s.send(&json!({
+        "jsonrpc": "2.0",
+        "method": "textDocument/didOpen",
+        "params": {
+            "textDocument": {
+                "uri": "file:///tmp/lsp_test.lex",
+                "languageId": "lex",
+                "version": 1,
+                "text": "fn bad(x :: Int) -> Int { \"oops\" }\n"
+            }
+        }
+    }));
+
+    // 4. Expect a publishDiagnostics notification.
+    let diag = s.recv();
+    assert_eq!(diag["method"], "textDocument/publishDiagnostics");
+    assert_eq!(diag["params"]["uri"], "file:///tmp/lsp_test.lex");
+    let diags = diag["params"]["diagnostics"].as_array().expect("array");
+    assert_eq!(diags.len(), 1, "exactly one diagnostic: {diag}");
+    let d = &diags[0];
+    assert_eq!(d["severity"], 1, "ERROR severity");
+    assert_eq!(d["source"], "lex");
+    assert_eq!(d["code"], "type-mismatch", "rule_tag as code");
+    assert_eq!(d["data"]["rule_tag"], "type-mismatch");
+    assert!(d["data"]["rule_explanation"].as_str().is_some());
+    assert!(d["data"]["suggested_transform"].is_object());
+
+    // 5. Shutdown + exit.
+    s.send(&json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "shutdown",
+        "params": null
+    }));
+    let _ = s.recv(); // shutdown response
+    s.send(&json!({
+        "jsonrpc": "2.0",
+        "method": "exit",
+        "params": null
+    }));
+
+    // Give the child a moment to exit cleanly.
+    std::thread::sleep(Duration::from_millis(200));
+}
+
+#[test]
+fn clean_program_emits_empty_diagnostics() {
+    let mut s = Server::spawn();
+    s.send(&json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": { "capabilities": {}, "processId": null, "rootUri": null }
+    }));
+    let _ = s.recv();
+    s.send(&json!({
+        "jsonrpc": "2.0",
+        "method": "initialized",
+        "params": {}
+    }));
+    s.send(&json!({
+        "jsonrpc": "2.0",
+        "method": "textDocument/didOpen",
+        "params": {
+            "textDocument": {
+                "uri": "file:///tmp/lsp_clean.lex",
+                "languageId": "lex",
+                "version": 1,
+                "text": "fn add(x :: Int, y :: Int) -> Int { x + y }\n"
+            }
+        }
+    }));
+    let diag = s.recv();
+    assert_eq!(diag["method"], "textDocument/publishDiagnostics");
+    let arr = diag["params"]["diagnostics"].as_array().unwrap();
+    assert!(arr.is_empty(), "clean program: no diagnostics, got {diag}");
+}


### PR DESCRIPTION
## Summary

Closes phase 1 of #304. New `lex-lsp` crate ships an LSP server
that turns Lex files open in VS Code / Cursor / Continue / Zed /
JetBrains AI into a red-squiggle experience for type errors. The
single biggest reason agents don't reach for Lex today was that
their editor didn't speak it; this PR fixes the inline-diagnostic
half of that gap.

## Wire

- New `lex-lsp` crate + binary; JSON-RPC over stdin/stdout via
  `lsp-server` + `lsp-types` (rust-analyzer-team-maintained; no
  async runtime).
- Lifecycle: `initialize` / `initialized` / `shutdown` / `exit`.
- Sync: `textDocument/didOpen` / `didChange` / `didSave` /
  `didClose` (full-document sync — incremental is queued).
- Diagnostics: every `lex_types::PositionedError` becomes one
  LSP `Diagnostic` with:
  - `severity = ERROR`
  - `code = <rule_tag>` (stable from #306 slice 2)
  - `source = "lex"`
  - `data = { rule_tag, rule_explanation, suggested_transform,
    at_node }` — phase-3 code-action providers will read the
    `suggested_transform` from here.
- Parse errors surface as a single full-document diagnostic.
- Editor setup: VS Code settings snippet + launch.json in
  `crates/lex-lsp/README.md`.

## Test plan

- [x] `cargo test -p lex-lsp` — 5 unit tests on
  `diagnostics_for_source` (clean / type-mismatch / multi-fn /
  parse error / Documents round-trip)
- [x] `cargo test -p lex-lsp --test end_to_end` — 2 e2e tests
  spawning the compiled binary and round-tripping the protocol
  (clean program → empty diagnostics; type error → 1 diagnostic
  with `code: type-mismatch` and the full `data` payload)
- [x] `cargo test --workspace` — 1380/1380 pass (7 new)
- [x] `cargo clippy -p lex-lsp --tests -- -D warnings` — clean

## Out of scope (queued as phases 2–4)

- Phase 2: hover / definition / completion / references.
- Phase 3: code actions backed by #280's typed transforms
  (`ReplaceMatchArm` / `RenameLocal` / `InlineLet` /
  `ExtractFunction`).
- Phase 4: surface `RepairHint` attestations (#281) as code
  actions — one-click `lex repair --apply`.
- VS Code / JetBrains extension packaging — the LSP itself is
  editor-neutral.

https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_