### PR TITLE
lex-lsp: phase 3a — code-action surface for diagnostic suggestions (#304 phase 3a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ bumps may carry breaking changes when justified).
 
 ### Added
 
+- **#304 phase 3a: code-action surface in `lex-lsp`.** Editors
+  now show a lightbulb on every type-error diagnostic that has a
+  static `suggested_transform` (#306 slice 3): the action title is
+  the suggestion's `summary` plus the typed-transform `kind_hint`
+  (e.g. *"Lex: Replace the offending match arm... (ReplaceMatchArm)"*).
+  The full suggestion JSON is attached as `data` so a client
+  extension can pipe it to `lex repair --apply --transform '<json>'`.
+  Computing a real `WorkspaceEdit` (so the edit applies in the
+  editor without a CLI round-trip) is queued for phase 3b — that
+  needs cursor-to-NodeId mapping plus AST-roundtrip pretty-printing.
+  Coverage: 2 new lib unit tests on `code_actions_for_diagnostics`,
+  2 new e2e tests through the protocol (action surfaces with the
+  right title / kind / data; no diagnostics → no actions).
+
 - **#304 phase 2a: hover / definition / completion in `lex-lsp`.**
   Builds on phase 1's read-only diagnostics. Editors get three
   new request handlers:

--- a/crates/lex-lsp/README.md
+++ b/crates/lex-lsp/README.md
@@ -4,7 +4,7 @@ Language Server Protocol bridge for Lex. Pipes
 `lex_types::check_program` errors to editor inline-error surfaces
 (VS Code, Cursor, Continue, Zed, JetBrains AI).
 
-## What's shipped (phases 1 + 2a of #304)
+## What's shipped (phases 1 + 2a + 3a of #304)
 
 **Phase 1** — read-only diagnostics:
 
@@ -30,6 +30,17 @@ Language Server Protocol bridge for Lex. Pipes
 - `textDocument/completion` — proposes in-scope fn names and
   import aliases. Stdlib-module-member completion (`io.<TAB>`,
   `list.<TAB>`) is queued for phase 2b.
+
+**Phase 3a** — code-action surface:
+
+- `textDocument/codeAction` returns one `QuickFix` action per
+  diagnostic whose `data.suggested_transform` is populated (from
+  #306 slice 3). The action's `data` carries the full suggestion
+  so a client extension can pipe it to
+  `lex repair --apply --transform '<json>'`. Computing a real
+  `WorkspaceEdit` so the fix applies inline (no CLI round-trip)
+  is queued for phase 3b — that needs cursor-to-NodeId mapping +
+  AST-roundtrip pretty-printing.
 
 ## Build
 
@@ -75,10 +86,11 @@ A `.vscode/launch.json` snippet for debugging the LSP itself:
 }
 ```
 
-## What's queued (phases 2b–4 of #304)
+## What's queued (phases 2b / 3b / 4 of #304)
 
 - Phase 2b: cross-file definition jumps, references, stdlib-module-
   member completion.
-- Phase 3: code actions backed by #280's typed transforms.
-- Phase 4: surface `RepairHint` attestations as code actions
-  (one-click `lex repair --apply`).
+- Phase 3b: real `WorkspaceEdit` from each code action so the
+  typed-transform fix applies inline without a CLI round-trip.
+- Phase 4: surface `RepairHint` attestations directly (one-click
+  `lex repair --apply` over the latest hint for a stage).

--- a/crates/lex-lsp/src/lib.rs
+++ b/crates/lex-lsp/src/lib.rs
@@ -395,6 +395,71 @@ pub fn completions(file: &FileAnalysis) -> Vec<(String, String, u8)> {
     out
 }
 
+// ---------------------------------------------------------------
+// #304 phase 3a: code actions surfaced from diagnostic suggestions
+// ---------------------------------------------------------------
+
+/// One code action surfaced in the editor's lightbulb menu.
+///
+/// Slice-3a deliverable: the action carries the suggestion's
+/// `summary` as `title`, the diagnostic it addresses, and the
+/// full suggestion JSON in `data` so an editor extension (or a
+/// custom command handler in slice 3b) can pipe it to
+/// `lex repair --apply --transform '<json>'`. The actual
+/// `WorkspaceEdit` is **not** computed here — that's slice 3b,
+/// which needs cursor-to-NodeId mapping plus AST-roundtrip
+/// pretty-printing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodeActionStub {
+    pub title: String,
+    pub kind_hint: String,
+    pub rule_tag: String,
+    pub diagnostic: lsp_types::Diagnostic,
+    pub data: serde_json::Value,
+}
+
+/// Iterate `diagnostics` and produce a code-action stub for each
+/// one whose `data.suggested_transform` is populated. Diagnostics
+/// without a static suggestion (e.g. `infinite-type`,
+/// `refinement-violation`) yield no actions; the LLM-driven
+/// `lex repair --apply` path still works for those.
+pub fn code_actions_for_diagnostics(diagnostics: &[lsp_types::Diagnostic]) -> Vec<CodeActionStub> {
+    let mut out = Vec::new();
+    for d in diagnostics {
+        let data = match &d.data {
+            Some(v) => v,
+            None => continue,
+        };
+        let sug = match data.get("suggested_transform") {
+            Some(s) if s.is_object() => s,
+            _ => continue,
+        };
+        let title = sug
+            .get("summary")
+            .and_then(|v| v.as_str())
+            .unwrap_or("apply suggested transform")
+            .to_string();
+        let kind_hint = sug
+            .get("kind_hint")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let rule_tag = data
+            .get("rule_tag")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        out.push(CodeActionStub {
+            title,
+            kind_hint,
+            rule_tag,
+            diagnostic: d.clone(),
+            data: sug.clone(),
+        });
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -533,6 +598,49 @@ fn bar() -> Int { 2 }
         assert!(labels.contains(&"foo"));
         assert!(labels.contains(&"bar"));
         assert!(labels.contains(&"io"), "import alias must appear: {labels:?}");
+    }
+
+    #[test]
+    fn code_actions_surface_from_suggested_transform() {
+        // Build a real diagnostic via the standard pipeline so we
+        // exercise the data shape end-to-end (no mocking).
+        let src = "fn bad(x :: Int) -> Int { \"oops\" }\n";
+        let diags = diagnostics_for_source(src, Some("/tmp/qf.lex"));
+        let actions = code_actions_for_diagnostics(&diags);
+        assert_eq!(actions.len(), 1, "one action: {actions:?}");
+        let a = &actions[0];
+        assert_eq!(a.rule_tag, "type-mismatch");
+        // type-mismatch maps to ReplaceMatchArm in the static
+        // (rule_tag → kind_hint) table from #306 slice 3.
+        assert_eq!(a.kind_hint, "ReplaceMatchArm");
+        assert!(!a.title.is_empty(), "non-empty title for the action");
+    }
+
+    #[test]
+    fn diagnostics_without_suggestion_yield_no_action() {
+        // Hand-build a Diagnostic whose `data` has no
+        // `suggested_transform` field — simulates a rule without
+        // a static suggestion (e.g. infinite-type).
+        let d = Diagnostic {
+            range: Range {
+                start: Position { line: 0, character: 0 },
+                end: Position { line: 0, character: 0 },
+            },
+            severity: Some(DiagnosticSeverity::ERROR),
+            code: Some(lsp_types::NumberOrString::String("infinite-type".into())),
+            code_description: None,
+            source: Some("lex".into()),
+            message: "infinite type".into(),
+            related_information: None,
+            tags: None,
+            data: Some(serde_json::json!({
+                "rule_tag": "infinite-type",
+                "rule_explanation": "Inference would require...",
+                "suggested_transform": serde_json::Value::Null,
+            })),
+        };
+        let actions = code_actions_for_diagnostics(&[d]);
+        assert!(actions.is_empty());
     }
 
     #[test]

--- a/crates/lex-lsp/src/main.rs
+++ b/crates/lex-lsp/src/main.rs
@@ -7,21 +7,26 @@
 //! as follow-up slices.
 
 use lex_lsp::{
-    analyze_source, completions, definition_at, diagnostics_for_source, hover_at, Documents,
+    analyze_source, code_actions_for_diagnostics, completions, definition_at,
+    diagnostics_for_source, hover_at, Documents,
 };
 use lsp_server::{Connection, Message, Notification, Request, Response};
 use lsp_types::notification::{
     DidChangeTextDocument, DidCloseTextDocument, DidOpenTextDocument, DidSaveTextDocument,
     Notification as NotificationTrait, PublishDiagnostics,
 };
-use lsp_types::request::{Completion, GotoDefinition, HoverRequest, Request as RequestTrait};
+use lsp_types::request::{
+    CodeActionRequest, Completion, GotoDefinition, HoverRequest, Request as RequestTrait,
+};
 use lsp_types::{
-    CompletionItem, CompletionItemKind, CompletionOptions, CompletionParams, CompletionResponse,
-    DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
-    DidSaveTextDocumentParams, GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverContents,
-    HoverParams, HoverProviderCapability, InitializeParams, InitializeResult, Location,
-    MarkupContent, MarkupKind, OneOf, PublishDiagnosticsParams, Range, ServerCapabilities,
-    ServerInfo, TextDocumentSyncCapability, TextDocumentSyncKind, Uri,
+    CodeAction, CodeActionKind, CodeActionOrCommand, CodeActionParams,
+    CodeActionProviderCapability, CodeActionResponse, CompletionItem, CompletionItemKind,
+    CompletionOptions, CompletionParams, CompletionResponse, DidChangeTextDocumentParams,
+    DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams,
+    GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverContents, HoverParams,
+    HoverProviderCapability, InitializeParams, InitializeResult, Location, MarkupContent,
+    MarkupKind, OneOf, PublishDiagnosticsParams, Range, ServerCapabilities, ServerInfo,
+    TextDocumentSyncCapability, TextDocumentSyncKind, Uri,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -39,6 +44,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             trigger_characters: Some(vec![".".to_string()]),
             ..Default::default()
         }),
+        // Phase 3a: surface code actions derived from each
+        // diagnostic's `suggested_transform` (#306 slice 3).
+        // The action stub carries the suggestion in `data` so a
+        // client extension can pipe it to `lex repair --apply`;
+        // computing a full `WorkspaceEdit` is queued for phase 3b.
+        code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
         ..Default::default()
     };
     let server_capabilities_json = serde_json::to_value(&server_capabilities)?;
@@ -155,6 +166,38 @@ fn handle_request(
             Response {
                 id: req.id,
                 result: Some(serde_json::to_value(CompletionResponse::Array(items))?),
+                error: None,
+            }
+        }
+        m if m == CodeActionRequest::METHOD => {
+            let params: CodeActionParams = serde_json::from_value(req.params)?;
+            // Phase 3a: every diagnostic in the request whose
+            // `data.suggested_transform` is populated becomes one
+            // code-action stub. Selecting it (in slice 3b) will
+            // produce a `WorkspaceEdit`; for now the action carries
+            // the suggestion JSON in `data` for client extensions.
+            let actions: Vec<CodeActionOrCommand> =
+                code_actions_for_diagnostics(&params.context.diagnostics)
+                    .into_iter()
+                    .map(|stub| {
+                        CodeActionOrCommand::CodeAction(CodeAction {
+                            title: format!(
+                                "Lex: {} ({})",
+                                stub.title, stub.kind_hint
+                            ),
+                            kind: Some(CodeActionKind::QUICKFIX),
+                            diagnostics: Some(vec![stub.diagnostic]),
+                            edit: None,
+                            command: None,
+                            is_preferred: Some(true),
+                            disabled: None,
+                            data: Some(stub.data),
+                        })
+                    })
+                    .collect();
+            Response {
+                id: req.id,
+                result: Some(serde_json::to_value(CodeActionResponse::from(actions))?),
                 error: None,
             }
         }

--- a/crates/lex-lsp/tests/end_to_end.rs
+++ b/crates/lex-lsp/tests/end_to_end.rs
@@ -297,6 +297,117 @@ fn other() -> Int { 2 }
 }
 
 #[test]
+fn code_action_surfaces_suggested_transform() {
+    let mut s = Server::spawn();
+    s.send(&json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": { "capabilities": {}, "processId": null, "rootUri": null }
+    }));
+    let init = s.recv();
+    // Capability is advertised so editors enable the lightbulb.
+    assert!(
+        init["result"]["capabilities"]["codeActionProvider"] == json!(true)
+            || init["result"]["capabilities"]["codeActionProvider"].is_object(),
+        "codeActionProvider must be advertised: {init}"
+    );
+    s.send(&json!({
+        "jsonrpc": "2.0",
+        "method": "initialized",
+        "params": {}
+    }));
+    let text = "fn bad(x :: Int) -> Int { \"oops\" }\n";
+    s.send(&json!({
+        "jsonrpc": "2.0",
+        "method": "textDocument/didOpen",
+        "params": {
+            "textDocument": {
+                "uri": "file:///tmp/lsp_qf.lex",
+                "languageId": "lex",
+                "version": 1,
+                "text": text,
+            }
+        }
+    }));
+    // Pull the publishDiagnostics so we can echo its diagnostic
+    // back into the codeAction request — that's the realistic
+    // editor-side flow.
+    let diag = s.recv();
+    let diagnostics = diag["params"]["diagnostics"].clone();
+    assert!(diagnostics.as_array().is_some_and(|a| !a.is_empty()));
+
+    s.send(&json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "textDocument/codeAction",
+        "params": {
+            "textDocument": { "uri": "file:///tmp/lsp_qf.lex" },
+            "range": { "start": { "line": 0, "character": 0 }, "end": { "line": 0, "character": 0 } },
+            "context": { "diagnostics": diagnostics }
+        }
+    }));
+    let resp = s.recv();
+    let actions = resp["result"].as_array().expect("array of actions");
+    assert_eq!(actions.len(), 1, "one action for the type-mismatch: {resp}");
+    let a = &actions[0];
+    let title = a["title"].as_str().unwrap_or("");
+    assert!(title.starts_with("Lex:"), "title prefixed: {title}");
+    assert!(title.contains("ReplaceMatchArm"), "kind_hint in title: {title}");
+    assert_eq!(a["kind"], "quickfix");
+    assert_eq!(a["isPreferred"], true);
+    // The suggestion data round-trips so client extensions can
+    // pipe it to `lex repair --apply --transform '<json>'`.
+    let data = &a["data"];
+    assert_eq!(data["rule_tag"], "type-mismatch");
+    assert!(data["details"].as_str().is_some_and(|s| !s.is_empty()));
+}
+
+#[test]
+fn code_action_returns_empty_when_no_diagnostics() {
+    let mut s = Server::spawn();
+    s.send(&json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": { "capabilities": {}, "processId": null, "rootUri": null }
+    }));
+    let _ = s.recv();
+    s.send(&json!({
+        "jsonrpc": "2.0",
+        "method": "initialized",
+        "params": {}
+    }));
+    s.send(&json!({
+        "jsonrpc": "2.0",
+        "method": "textDocument/didOpen",
+        "params": {
+            "textDocument": {
+                "uri": "file:///tmp/lsp_no_qf.lex",
+                "languageId": "lex",
+                "version": 1,
+                "text": "fn ok_fn(x :: Int) -> Int { x + 1 }\n",
+            }
+        }
+    }));
+    let _ = s.recv(); // empty diagnostics
+
+    s.send(&json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "textDocument/codeAction",
+        "params": {
+            "textDocument": { "uri": "file:///tmp/lsp_no_qf.lex" },
+            "range": { "start": { "line": 0, "character": 0 }, "end": { "line": 0, "character": 0 } },
+            "context": { "diagnostics": [] }
+        }
+    }));
+    let resp = s.recv();
+    let actions = resp["result"].as_array().expect("array");
+    assert!(actions.is_empty(), "no diagnostics → no actions: {resp}");
+}
+
+#[test]
 fn clean_program_emits_empty_diagnostics() {
     let mut s = Server::spawn();
     s.send(&json!({


### PR DESCRIPTION
## Summary

Closes phase 3a of #304. Builds on phase 1's diagnostics and #306
slice 3's static `(rule_tag → suggested_transform)` table.
Editors now show a lightbulb on every type-error diagnostic that
has a static suggestion; the action carries the typed-transform
hint plus the full suggestion JSON in `data` for client extensions
that pipe to `lex repair --apply --transform '<json>'`.

## Wire

- `code_actions_for_diagnostics` library helper iterates
  diagnostics and yields one `CodeActionStub` per non-null
  `data.suggested_transform`.
- `textDocument/codeAction` handler emits a `CodeActionResponse`
  with `kind: QuickFix`, `isPreferred: true`, and the suggestion
  JSON in `data`.
- `code_action_provider` capability advertised so the lightbulb
  enables in editors.

## Test plan

- [x] `cargo test -p lex-lsp` — 13 lib + 7 e2e = 20 pass
  - new lib tests: action surfaces from real diagnostic;
    no-suggestion → no action.
  - new e2e tests: full protocol round-trip (capability +
    title + kind + isPreferred + data); no diagnostics → empty
    actions array.
- [x] `cargo test --workspace` — 1393/1393 (+4 from main)
- [x] `cargo clippy -p lex-lsp --tests -- -D warnings` — clean

## Out of scope (queued)

- Phase 3b: real `WorkspaceEdit` so the typed-transform fix
  applies inline without a CLI round-trip. Needs cursor-to-NodeId
  mapping plus AST-roundtrip pretty-printing.
- Phase 2b: cross-file definition / references / stdlib-member
  completion.
- Phase 4: surface `RepairHint` attestations directly (one-click
  `lex repair --apply` over the latest hint for a stage).

https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_