### PR TITLE
lex-lsp: phase 3b — applying Inline let refactor with real WorkspaceEdit (#304 phase 3b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ bumps may carry breaking changes when justified).
 
 ### Added
 
+- **#304 phase 3b: applying `Inline let` refactor in `lex-lsp`.**
+  First typed-transform (`InlineLet` from #280) that lands a real
+  `WorkspaceEdit` instead of just a hint. The `textDocument/codeAction`
+  handler walks the file's canonical AST; for every fn whose body
+  is a top-level `let` and whose declaration falls inside the
+  requesting range, it emits a `Refactor.Inline` code action whose
+  `edit` is a full-document `TextEdit` replacing the source with
+  the canonical re-print after `inline_let`. Selecting the
+  lightbulb applies the refactor inline, no CLI round-trip. The
+  other three #280 transforms (`RenameLocal`, `ReplaceMatchArm`,
+  `ExtractFunction`) still need cursor-to-NodeId mapping that's
+  queued for a follow-up — top-level let is the case where the
+  target NodeId derives from fn structure alone
+  (`n_0.{params + 1}`). Coverage: 4 lib unit tests on
+  `inline_let_actions` + 2 e2e tests round-tripping the protocol
+  (action surfaces with a real `documentChanges` `edit`;
+  no-top-level-let → no action).
+
 - **#304 phase 3a: code-action surface in `lex-lsp`.** Editors
   now show a lightbulb on every type-error diagnostic that has a
   static `suggested_transform` (#306 slice 3): the action title is

--- a/crates/lex-lsp/README.md
+++ b/crates/lex-lsp/README.md
@@ -4,7 +4,7 @@ Language Server Protocol bridge for Lex. Pipes
 `lex_types::check_program` errors to editor inline-error surfaces
 (VS Code, Cursor, Continue, Zed, JetBrains AI).
 
-## What's shipped (phases 1 + 2a + 3a of #304)
+## What's shipped (phases 1 + 2a + 3a + 3b of #304)
 
 **Phase 1** — read-only diagnostics:
 
@@ -31,16 +31,24 @@ Language Server Protocol bridge for Lex. Pipes
   import aliases. Stdlib-module-member completion (`io.<TAB>`,
   `list.<TAB>`) is queued for phase 2b.
 
-**Phase 3a** — code-action surface:
+**Phase 3a** — code-action surface (QuickFix from diagnostics):
 
 - `textDocument/codeAction` returns one `QuickFix` action per
   diagnostic whose `data.suggested_transform` is populated (from
   #306 slice 3). The action's `data` carries the full suggestion
   so a client extension can pipe it to
-  `lex repair --apply --transform '<json>'`. Computing a real
-  `WorkspaceEdit` so the fix applies inline (no CLI round-trip)
-  is queued for phase 3b — that needs cursor-to-NodeId mapping +
-  AST-roundtrip pretty-printing.
+  `lex repair --apply --transform '<json>'`.
+
+**Phase 3b** — first applying refactor (Inline let):
+
+- `textDocument/codeAction` also returns a `Refactor.Inline` action
+  for every fn whose body is a top-level `let` and whose
+  declaration falls inside the requesting range. Selecting it
+  applies a real `WorkspaceEdit` that replaces the file with the
+  canonical re-print after `lex_ast::inline_let`, inline in the
+  editor — no CLI round-trip. The other three #280 transforms
+  (`RenameLocal`, `ReplaceMatchArm`, `ExtractFunction`) need
+  cursor-to-NodeId mapping queued for a follow-up.
 
 ## Build
 
@@ -86,11 +94,12 @@ A `.vscode/launch.json` snippet for debugging the LSP itself:
 }
 ```
 
-## What's queued (phases 2b / 3b / 4 of #304)
+## What's queued (phases 2b / 3c / 4 of #304)
 
 - Phase 2b: cross-file definition jumps, references, stdlib-module-
   member completion.
-- Phase 3b: real `WorkspaceEdit` from each code action so the
-  typed-transform fix applies inline without a CLI round-trip.
+- Phase 3c: applying refactors for the remaining #280 transforms
+  (`RenameLocal`, `ReplaceMatchArm`, `ExtractFunction`). Needs
+  cursor-to-NodeId mapping.
 - Phase 4: surface `RepairHint` attestations directly (one-click
   `lex repair --apply` over the latest hint for a stage).

--- a/crates/lex-lsp/src/lib.rs
+++ b/crates/lex-lsp/src/lib.rs
@@ -460,6 +460,103 @@ pub fn code_actions_for_diagnostics(diagnostics: &[lsp_types::Diagnostic]) -> Ve
     out
 }
 
+// ---------------------------------------------------------------
+// #304 phase 3b: refactor actions that apply real WorkspaceEdits
+// ---------------------------------------------------------------
+
+/// Refactor action surfaced when the cursor is on (or close to) a
+/// function whose body is a top-level `let` binding. Selecting
+/// the action replaces the file with the inlined-and-re-printed
+/// canonical source.
+///
+/// Phase 3b ships **`InlineLet`** for top-level let-bound fn
+/// bodies as the first applying refactor. The other three #280
+/// transforms (`RenameLocal`, `ReplaceMatchArm`, `ExtractFunction`)
+/// need cursor-to-NodeId mapping that this slice doesn't have
+/// yet — top-level let is the one case where the target NodeId
+/// is derivable from fn structure alone (`n_0.{n_params + 1}`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InlineLetAction {
+    /// `fn` whose body is a top-level let.
+    pub fn_name: String,
+    /// Binding name in the let — used to render the action title.
+    pub let_name: String,
+    /// New full-file source after applying `inline_let`. The
+    /// server wraps this in a `WorkspaceEdit` that replaces the
+    /// whole document.
+    pub new_text: String,
+}
+
+/// Find every applicable `InlineLet` refactor in `src`, scoped to
+/// fns whose declaration line falls inside the requesting LSP
+/// `range`. Returns `Vec` so multi-fn files surface multiple
+/// actions when a range spans them.
+///
+/// Phase 3b heuristic: the cursor is "on" a fn when the fn's
+/// declaration line is `<= range.end.line` and the next fn's
+/// declaration line is `> range.end.line` (or there is no next
+/// fn). This is coarse but correct for the dominant single-line-
+/// cursor case the lightbulb is built around.
+pub fn inline_let_actions(src: &str, range: &Range) -> Vec<InlineLetAction> {
+    let (program, fn_positions) = match lex_syntax::parse_source_with_positions(src) {
+        Ok(p) => p,
+        Err(_) => return Vec::new(),
+    };
+    let stages = lex_ast::canonicalize_program(&program);
+    let n_stages = stages.len();
+    let mut out: Vec<InlineLetAction> = Vec::new();
+
+    // Precompute each fn's declaration line so we can answer
+    // "is the cursor in this fn?" without re-tokenising.
+    let mut fn_lines: std::collections::BTreeMap<String, u32> = Default::default();
+    for (name, byte) in &fn_positions {
+        let (line, _col) = lex_types::byte_to_line_col(src, *byte);
+        fn_lines.insert(name.clone(), line.saturating_sub(1));
+    }
+
+    for (idx, stage) in stages.iter().enumerate() {
+        let lex_ast::Stage::FnDecl(fd) = stage else { continue };
+        // Bail when the fn body isn't a top-level `Let`.
+        let lex_ast::CExpr::Let { name: let_name, .. } = &fd.body else { continue };
+        let let_name = let_name.clone();
+
+        // Range scoping: cursor must fall on or past this fn's
+        // declaration line and before the next fn's.
+        let Some(&this_line) = fn_lines.get(&fd.name) else { continue };
+        let next_line = fn_lines
+            .values()
+            .filter(|&&l| l > this_line)
+            .min()
+            .copied();
+        let cursor = range.end.line;
+        if cursor < this_line {
+            continue;
+        }
+        if let Some(n) = next_line {
+            if cursor >= n { continue; }
+        }
+
+        // Apply the transform. NodeId for the body root is
+        // `n_0.{params + 1}`.
+        let node_id = lex_ast::NodeId(format!("n_0.{}", fd.params.len() + 1));
+        let new_stage = match lex_ast::inline_let(stage, &node_id) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        // Splice the new stage back in and re-print.
+        let mut new_stages: Vec<lex_ast::Stage> = stages.clone();
+        new_stages[idx] = new_stage;
+        let _ = n_stages; // tracking handle for diagnostics
+        let new_text = lex_ast::print_stages(&new_stages);
+        out.push(InlineLetAction {
+            fn_name: fd.name.clone(),
+            let_name,
+            new_text,
+        });
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -641,6 +738,82 @@ fn bar() -> Int { 2 }
         };
         let actions = code_actions_for_diagnostics(&[d]);
         assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn inline_let_action_round_trips() {
+        // Top-level let in the fn body is the slice-3b target.
+        // The action's `new_text` re-prints the canonical AST,
+        // which folds the let into the body.
+        let src = "\
+fn one() -> Int {
+    let x := 1
+    x + x
+}
+";
+        let cursor = Range {
+            start: Position { line: 1, character: 0 },
+            end: Position { line: 1, character: 0 },
+        };
+        let actions = inline_let_actions(src, &cursor);
+        assert_eq!(actions.len(), 1, "one inline-let action: {actions:?}");
+        let a = &actions[0];
+        assert_eq!(a.fn_name, "one");
+        assert_eq!(a.let_name, "x");
+        // The let is gone, replaced by the substituted body.
+        assert!(!a.new_text.contains("let x"), "let removed: {}", a.new_text);
+        assert!(
+            a.new_text.contains("1 + 1") || a.new_text.contains("1+1"),
+            "substituted body present: {}",
+            a.new_text
+        );
+    }
+
+    #[test]
+    fn inline_let_action_skips_fns_outside_cursor_range() {
+        // Two top-level lets in two separate fns. Cursor on the
+        // first fn should yield only the first action.
+        let src = "\
+fn first() -> Int {
+    let a := 10
+    a
+}
+
+fn second() -> Int {
+    let b := 20
+    b
+}
+";
+        let cursor = Range {
+            start: Position { line: 1, character: 0 },
+            end: Position { line: 1, character: 0 },
+        };
+        let actions = inline_let_actions(src, &cursor);
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].fn_name, "first");
+    }
+
+    #[test]
+    fn inline_let_action_skips_fn_without_top_level_let() {
+        // No top-level let -> no action surfaced.
+        let src = "fn plain(x :: Int) -> Int { x + 1 }\n";
+        let cursor = Range {
+            start: Position { line: 0, character: 5 },
+            end: Position { line: 0, character: 5 },
+        };
+        assert!(inline_let_actions(src, &cursor).is_empty());
+    }
+
+    #[test]
+    fn inline_let_action_handles_unparseable_source() {
+        // Parse failure must degrade silently (the diagnostics
+        // path already surfaces the parse error).
+        let src = "fn bad( :: Int { 1 }\n";
+        let cursor = Range {
+            start: Position { line: 0, character: 0 },
+            end: Position { line: 0, character: 0 },
+        };
+        assert!(inline_let_actions(src, &cursor).is_empty());
     }
 
     #[test]

--- a/crates/lex-lsp/src/main.rs
+++ b/crates/lex-lsp/src/main.rs
@@ -8,7 +8,7 @@
 
 use lex_lsp::{
     analyze_source, code_actions_for_diagnostics, completions, definition_at,
-    diagnostics_for_source, hover_at, Documents,
+    diagnostics_for_source, hover_at, inline_let_actions, Documents,
 };
 use lsp_server::{Connection, Message, Notification, Request, Response};
 use lsp_types::notification::{
@@ -25,8 +25,9 @@ use lsp_types::{
     DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams,
     GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverContents, HoverParams,
     HoverProviderCapability, InitializeParams, InitializeResult, Location, MarkupContent,
-    MarkupKind, OneOf, PublishDiagnosticsParams, Range, ServerCapabilities, ServerInfo,
-    TextDocumentSyncCapability, TextDocumentSyncKind, Uri,
+    MarkupKind, OneOf, Position, PublishDiagnosticsParams, Range, ServerCapabilities, ServerInfo,
+    TextDocumentEdit, TextDocumentSyncCapability, TextDocumentSyncKind, TextEdit, Uri,
+    OptionalVersionedTextDocumentIdentifier, WorkspaceEdit,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -171,30 +172,52 @@ fn handle_request(
         }
         m if m == CodeActionRequest::METHOD => {
             let params: CodeActionParams = serde_json::from_value(req.params)?;
-            // Phase 3a: every diagnostic in the request whose
+            let mut actions: Vec<CodeActionOrCommand> = Vec::new();
+
+            // Phase 3a: every diagnostic whose
             // `data.suggested_transform` is populated becomes one
-            // code-action stub. Selecting it (in slice 3b) will
-            // produce a `WorkspaceEdit`; for now the action carries
-            // the suggestion JSON in `data` for client extensions.
-            let actions: Vec<CodeActionOrCommand> =
-                code_actions_for_diagnostics(&params.context.diagnostics)
-                    .into_iter()
-                    .map(|stub| {
-                        CodeActionOrCommand::CodeAction(CodeAction {
-                            title: format!(
-                                "Lex: {} ({})",
-                                stub.title, stub.kind_hint
-                            ),
-                            kind: Some(CodeActionKind::QUICKFIX),
-                            diagnostics: Some(vec![stub.diagnostic]),
-                            edit: None,
-                            command: None,
-                            is_preferred: Some(true),
-                            disabled: None,
-                            data: Some(stub.data),
-                        })
-                    })
-                    .collect();
+            // QuickFix stub. The action carries the suggestion in
+            // `data` for client extensions that pipe to
+            // `lex repair --apply --transform '<json>'`.
+            for stub in code_actions_for_diagnostics(&params.context.diagnostics) {
+                actions.push(CodeActionOrCommand::CodeAction(CodeAction {
+                    title: format!("Lex: {} ({})", stub.title, stub.kind_hint),
+                    kind: Some(CodeActionKind::QUICKFIX),
+                    diagnostics: Some(vec![stub.diagnostic]),
+                    edit: None,
+                    command: None,
+                    is_preferred: Some(true),
+                    disabled: None,
+                    data: Some(stub.data),
+                }));
+            }
+
+            // Phase 3b: applying refactor — Inline let. For every
+            // fn whose body is a top-level `let` and whose
+            // declaration is in the requested range, emit a
+            // Refactor.Inline action carrying a real
+            // `WorkspaceEdit` that replaces the whole document
+            // with the canonical re-print after the transform.
+            let uri = params.text_document.uri.clone();
+            if let Some(src) = docs.get(&uri.to_string()) {
+                for action in inline_let_actions(src, &params.range) {
+                    let edit = full_document_replace(src, &uri, &action.new_text);
+                    actions.push(CodeActionOrCommand::CodeAction(CodeAction {
+                        title: format!(
+                            "Lex: inline let `{}` in `{}`",
+                            action.let_name, action.fn_name
+                        ),
+                        kind: Some(CodeActionKind::REFACTOR_INLINE),
+                        diagnostics: None,
+                        edit: Some(edit),
+                        command: None,
+                        is_preferred: None,
+                        disabled: None,
+                        data: None,
+                    }));
+                }
+            }
+
             Response {
                 id: req.id,
                 result: Some(serde_json::to_value(CodeActionResponse::from(actions))?),
@@ -306,4 +329,34 @@ where
 fn uri_to_path(uri: &Uri) -> Option<String> {
     let s = uri.to_string();
     s.strip_prefix("file://").map(|p| p.to_string())
+}
+
+/// Build a `WorkspaceEdit` that replaces the entirety of `uri`'s
+/// content with `new_text`. The end-of-document position is
+/// derived from the old `src` so the range covers every existing
+/// character — editors collapse the range to a single-edit
+/// replacement.
+fn full_document_replace(src: &str, uri: &Uri, new_text: &str) -> WorkspaceEdit {
+    let n_lines = src.lines().count() as u32;
+    let last_line_idx = n_lines.saturating_sub(1);
+    let last_line_chars = src
+        .lines()
+        .nth(last_line_idx as usize)
+        .map(|l| l.chars().count() as u32)
+        .unwrap_or(0);
+    let range = Range {
+        start: Position { line: 0, character: 0 },
+        end: Position { line: last_line_idx, character: last_line_chars },
+    };
+    let edit = TextDocumentEdit {
+        text_document: OptionalVersionedTextDocumentIdentifier {
+            uri: uri.clone(),
+            version: None,
+        },
+        edits: vec![OneOf::Left(TextEdit { range, new_text: new_text.to_string() })],
+    };
+    WorkspaceEdit {
+        document_changes: Some(lsp_types::DocumentChanges::Edits(vec![edit])),
+        ..Default::default()
+    }
 }

--- a/crates/lex-lsp/tests/end_to_end.rs
+++ b/crates/lex-lsp/tests/end_to_end.rs
@@ -408,6 +408,117 @@ fn code_action_returns_empty_when_no_diagnostics() {
 }
 
 #[test]
+fn inline_let_refactor_returns_real_workspace_edit() {
+    // Phase 3b: cursor inside a fn whose body is a top-level
+    // `let` produces a Refactor.Inline action with an applying
+    // WorkspaceEdit. The edit replaces the whole document; new
+    // text omits the let binding (substituted into the body).
+    let mut s = Server::spawn();
+    s.send(&json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": { "capabilities": {}, "processId": null, "rootUri": null }
+    }));
+    let _ = s.recv();
+    s.send(&json!({
+        "jsonrpc": "2.0",
+        "method": "initialized",
+        "params": {}
+    }));
+    let text = "\
+fn one() -> Int {
+    let x := 1
+    x + x
+}
+";
+    s.send(&json!({
+        "jsonrpc": "2.0",
+        "method": "textDocument/didOpen",
+        "params": {
+            "textDocument": {
+                "uri": "file:///tmp/lsp_inline.lex",
+                "languageId": "lex",
+                "version": 1,
+                "text": text,
+            }
+        }
+    }));
+    let _ = s.recv(); // empty diagnostics
+    s.send(&json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "textDocument/codeAction",
+        "params": {
+            "textDocument": { "uri": "file:///tmp/lsp_inline.lex" },
+            "range": { "start": { "line": 1, "character": 0 }, "end": { "line": 1, "character": 0 } },
+            "context": { "diagnostics": [] }
+        }
+    }));
+    let resp = s.recv();
+    let actions = resp["result"].as_array().expect("array of actions");
+    assert_eq!(actions.len(), 1, "one refactor action: {resp}");
+    let a = &actions[0];
+    let title = a["title"].as_str().unwrap_or("");
+    assert!(title.contains("inline let `x`"), "title carries name: {title}");
+    assert_eq!(a["kind"], "refactor.inline");
+    let edits = a["edit"]["documentChanges"][0]["edits"].as_array().expect("edits");
+    assert_eq!(edits.len(), 1, "one TextEdit replaces the whole doc");
+    let new_text = edits[0]["newText"].as_str().expect("newText");
+    assert!(
+        !new_text.contains("let x"),
+        "applied edit removes the let: {new_text}"
+    );
+    assert!(
+        new_text.contains("1 + 1") || new_text.contains("1+1"),
+        "applied edit substitutes the let value: {new_text}"
+    );
+}
+
+#[test]
+fn inline_let_refactor_silent_when_no_top_level_let() {
+    let mut s = Server::spawn();
+    s.send(&json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": { "capabilities": {}, "processId": null, "rootUri": null }
+    }));
+    let _ = s.recv();
+    s.send(&json!({
+        "jsonrpc": "2.0",
+        "method": "initialized",
+        "params": {}
+    }));
+    s.send(&json!({
+        "jsonrpc": "2.0",
+        "method": "textDocument/didOpen",
+        "params": {
+            "textDocument": {
+                "uri": "file:///tmp/lsp_no_inline.lex",
+                "languageId": "lex",
+                "version": 1,
+                "text": "fn plain(x :: Int) -> Int { x + 1 }\n",
+            }
+        }
+    }));
+    let _ = s.recv(); // empty diagnostics
+    s.send(&json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "textDocument/codeAction",
+        "params": {
+            "textDocument": { "uri": "file:///tmp/lsp_no_inline.lex" },
+            "range": { "start": { "line": 0, "character": 0 }, "end": { "line": 0, "character": 0 } },
+            "context": { "diagnostics": [] }
+        }
+    }));
+    let resp = s.recv();
+    let actions = resp["result"].as_array().expect("array");
+    assert!(actions.is_empty(), "no actions: {resp}");
+}
+
+#[test]
 fn clean_program_emits_empty_diagnostics() {
     let mut s = Server::spawn();
     s.send(&json!({


### PR DESCRIPTION
## Summary

Closes phase 3b of #304. First typed-transform from #280 that
lands a real `WorkspaceEdit` instead of a hint: selecting the
lightbulb applies `inline_let` inline in the editor — no CLI
round-trip.

## Wire

- `inline_let_actions(src, &range)` walks parsed + canonicalised
  stages. For every `Stage::FnDecl` whose body is a top-level
  `CExpr::Let` *and* whose declaration falls inside the requesting
  range, it applies `lex_ast::inline_let` and re-prints via
  `lex_ast::print_stages`.
- `textDocument/codeAction` handler emits `Refactor.Inline` actions
  alongside phase-3a's QuickFix stubs. Each carries a real
  `WorkspaceEdit` with a single full-document `TextEdit`.

## Why only Inline let

The other three #280 transforms (`RenameLocal`, `ReplaceMatchArm`,
`ExtractFunction`) need cursor-to-NodeId mapping — given a
byte/char position, which canonical AST node is "under" it. The
AST doesn't carry source spans today; deriving that mapping is
its own slice. Top-level let is the case where the target NodeId
derives from fn structure alone (always `n_0.{params + 1}`).

## Test plan

- [x] `cargo test -p lex-lsp` — 17 lib + 9 e2e = 26 pass
  - new lib tests: round-trip / range-scoping / non-let-skip /
    unparseable-source-silent
  - new e2e tests: full-document `documentChanges` edit removes
    the let + substitutes its value; no-let → no action
- [x] `cargo test --workspace` — 1399/1399 (+6 from main)
- [x] `cargo clippy -p lex-lsp --tests -- -D warnings` — clean

## Out of scope (queued)

- Phase 3c: applying refactors for the other three #280 transforms
  — needs cursor-to-NodeId mapping (its own slice).
- Phase 2b: cross-file definition + references + stdlib-member completion.
- Phase 4: surface `RepairHint` attestations directly (one-click
  `lex repair --apply` over the latest hint per stage).

https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_