### PR TITLE
lex-lsp: phase 4 — RepairHint surface from the store (#304 phase 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,26 @@ bumps may carry breaking changes when justified).
 
 ### Added
 
+- **#304 phase 4: `RepairHint` surface in `lex-lsp`.** Closes the
+  loop from typecheck failure → durable `RepairHint` attestation
+  (#281) → editor lightbulb. When the LSP is launched with
+  `LEX_STORE=<store-path>`, every fn in the open file whose
+  `stage_id` has an active `RepairHint` attestation surfaces as a
+  QuickFix code action titled
+  *"Lex: repair hint for `<fn>` (<rule_tag>) — <kind_hint>"*.
+  The `data` payload carries `failed_op_id`, `stage_id`, the
+  structured errors, the `suggested_transform`, and the
+  `attestation_id`, so a client extension (or phase 4b) can
+  invoke `lex repair --apply` and refresh the buffer. Hints are
+  resolved lazily per code-action request (no upfront index
+  build); the store is opened with `Store::open` on each request
+  and falls through silently when `LEX_STORE` is unset or the
+  path doesn't open — editors without a configured store see the
+  same surface as before. Coverage: 3 new lib unit tests
+  (round-trip through a real temp store; missing store → empty;
+  unparseable source → empty) + 1 e2e test through the protocol
+  with a real store that has a planted RepairHint.
+
 - **#304 phase 3b: applying `Inline let` refactor in `lex-lsp`.**
   First typed-transform (`InlineLet` from #280) that lands a real
   `WorkspaceEdit` instead of just a hint. The `textDocument/codeAction`

--- a/crates/lex-lsp/Cargo.toml
+++ b/crates/lex-lsp/Cargo.toml
@@ -28,6 +28,9 @@ lsp-types = "0.97"
 lex-syntax = { path = "../lex-syntax", version = "0.8.2" }
 lex-ast = { path = "../lex-ast", version = "0.8.2" }
 lex-types = { path = "../lex-types", version = "0.8.2" }
+# Phase 4 of #304: surface RepairHint attestations from the store.
+lex-vcs = { path = "../lex-vcs", version = "0.8.2" }
+lex-store = { path = "../lex-store", version = "0.8.2" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/lex-lsp/README.md
+++ b/crates/lex-lsp/README.md
@@ -4,7 +4,7 @@ Language Server Protocol bridge for Lex. Pipes
 `lex_types::check_program` errors to editor inline-error surfaces
 (VS Code, Cursor, Continue, Zed, JetBrains AI).
 
-## What's shipped (phases 1 + 2a + 3a + 3b of #304)
+## What's shipped (phases 1 + 2a + 3a + 3b + 4 of #304)
 
 **Phase 1** — read-only diagnostics:
 
@@ -50,6 +50,17 @@ Language Server Protocol bridge for Lex. Pipes
   (`RenameLocal`, `ReplaceMatchArm`, `ExtractFunction`) need
   cursor-to-NodeId mapping queued for a follow-up.
 
+**Phase 4** — `RepairHint` surface from the store:
+
+- Launch the LSP with `LEX_STORE=<path>` and every fn in the open
+  file whose `stage_id` has an active `RepairHint` attestation
+  (#281) surfaces as a QuickFix titled *"Lex: repair hint for
+  `<fn>` (<rule_tag>) — <kind_hint>"*. The action's `data`
+  carries `failed_op_id`, `stage_id`, structured errors,
+  `suggested_transform`, and `attestation_id` so a client
+  extension can pipe to `lex repair --apply`. Stores not
+  configured (no `LEX_STORE`) degrade silently.
+
 ## Build
 
 ```bash
@@ -94,12 +105,13 @@ A `.vscode/launch.json` snippet for debugging the LSP itself:
 }
 ```
 
-## What's queued (phases 2b / 3c / 4 of #304)
+## What's queued (phases 2b / 3c / 4b of #304)
 
 - Phase 2b: cross-file definition jumps, references, stdlib-module-
   member completion.
 - Phase 3c: applying refactors for the remaining #280 transforms
   (`RenameLocal`, `ReplaceMatchArm`, `ExtractFunction`). Needs
   cursor-to-NodeId mapping.
-- Phase 4: surface `RepairHint` attestations directly (one-click
-  `lex repair --apply` over the latest hint for a stage).
+- Phase 4b: invoking `lex repair --apply` directly from the LSP
+  command handler so the RepairHint action lands a real
+  `WorkspaceEdit` inline.

--- a/crates/lex-lsp/src/lib.rs
+++ b/crates/lex-lsp/src/lib.rs
@@ -557,6 +557,116 @@ pub fn inline_let_actions(src: &str, range: &Range) -> Vec<InlineLetAction> {
     out
 }
 
+// ---------------------------------------------------------------
+// #304 phase 4: surface RepairHint attestations from the store
+// ---------------------------------------------------------------
+
+/// A RepairHint attestation surfaced by the LSP as a clickable
+/// code action. Each instance corresponds to one previously-rejected
+/// op recorded in the store via `Store::apply_operation_checked`
+/// (#281): the LLM-driven repair flow's persistent breadcrumb.
+///
+/// Phase 4a (this slice) surfaces hints as **diagnostic-like
+/// markers** in the code-action lightbulb. The `data` payload
+/// carries `failed_op_id` and the structured suggestion so a
+/// client extension (or phase 4b) can invoke
+/// `lex repair --apply` and refresh the buffer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepairHintAction {
+    pub fn_name: String,
+    pub rule_tag: String,
+    pub kind_hint: String,
+    pub summary: String,
+    pub failed_op_id: String,
+    pub stage_id: String,
+    /// Full hint payload as serde JSON — `{rule_tag, errors,
+    /// suggested_transform, failed_op_id}` — for client-side
+    /// consumption.
+    pub data: serde_json::Value,
+}
+
+/// Surface every active RepairHint attestation that references a
+/// stage produced by an `fn` in `src`.
+///
+/// Lookup: for each `FnDecl` in the file, compute its
+/// `stage_id` from the canonical AST. The store's attestation
+/// log indexes attestations by `stage_id`; we filter to
+/// `RepairHint` kinds. When multiple hints exist for the same
+/// stage (e.g. multiple repair attempts), the most recent one
+/// wins by `timestamp`.
+///
+/// Returns an empty vec when `store_path` is missing or the
+/// store fails to open — the LSP degrades gracefully so editors
+/// without a configured store don't error out.
+pub fn repair_hint_actions_for_file(
+    store_path: &std::path::Path,
+    src: &str,
+) -> Vec<RepairHintAction> {
+    let Ok(store) = lex_store::Store::open(store_path) else { return Vec::new() };
+    let Ok(attlog) = store.attestation_log() else { return Vec::new() };
+    let Ok(program) = lex_syntax::parse_source(src) else { return Vec::new() };
+    let stages = lex_ast::canonicalize_program(&program);
+
+    let mut out: Vec<RepairHintAction> = Vec::new();
+    for stage in &stages {
+        let lex_ast::Stage::FnDecl(fd) = stage else { continue };
+        let Some(stage_id) = lex_ast::stage_id(stage) else { continue };
+        let Ok(atts) = attlog.list_for_stage(&stage_id) else { continue };
+        let latest = atts
+            .into_iter()
+            .filter(|a| matches!(&a.kind, lex_vcs::AttestationKind::RepairHint { .. }))
+            .max_by_key(|a| a.timestamp);
+        let Some(att) = latest else { continue };
+        let lex_vcs::AttestationKind::RepairHint {
+            failed_op_id,
+            errors,
+            suggested_transform,
+        } = &att.kind
+        else {
+            continue;
+        };
+        let (rule_tag, kind_hint, summary) = extract_hint_metadata(suggested_transform.as_ref());
+        let data = serde_json::json!({
+            "failed_op_id": failed_op_id,
+            "stage_id": stage_id,
+            "errors": errors,
+            "suggested_transform": suggested_transform,
+            "attestation_id": att.attestation_id,
+        });
+        out.push(RepairHintAction {
+            fn_name: fd.name.clone(),
+            rule_tag,
+            kind_hint,
+            summary,
+            failed_op_id: failed_op_id.clone(),
+            stage_id,
+            data,
+        });
+    }
+    out
+}
+
+fn extract_hint_metadata(suggestion: Option<&serde_json::Value>) -> (String, String, String) {
+    let s = match suggestion {
+        Some(v) if v.is_object() => v,
+        _ => {
+            return (
+                "unknown".into(),
+                "ModifyBody".into(),
+                "apply LLM-driven repair (no static hint)".into(),
+            );
+        }
+    };
+    let rule_tag = s.get("rule_tag").and_then(|v| v.as_str()).unwrap_or("unknown").to_string();
+    let kind_hint = s.get("kind_hint").and_then(|v| v.as_str()).unwrap_or("ModifyBody").to_string();
+    let summary = s
+        .get("summary")
+        .and_then(|v| v.as_str())
+        .unwrap_or("apply suggested transform")
+        .to_string();
+    (rule_tag, kind_hint, summary)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -814,6 +924,105 @@ fn second() -> Int {
             end: Position { line: 0, character: 0 },
         };
         assert!(inline_let_actions(src, &cursor).is_empty());
+    }
+
+    #[test]
+    fn repair_hint_action_surfaces_from_store() {
+        // Build a tiny store, publish a fn, push a typecheck-
+        // rejected variant so the gate auto-emits a RepairHint
+        // (#281), then ask the LSP for the action.
+        use lex_ast::{canonicalize_program, sig_id, stage_id, CExpr, CLit, NodeId, Stage};
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = lex_store::Store::open(tmp.path()).unwrap();
+
+        let src = "fn pick(n :: Int) -> Int { match n { 0 => 1, _ => 2 } }\n";
+        let prog = lex_syntax::parse_source(src).unwrap();
+        let stages = canonicalize_program(&prog);
+        let stage = stages
+            .into_iter()
+            .find(|s| matches!(s, Stage::FnDecl(fd) if fd.name == "pick"))
+            .unwrap();
+        let sig = sig_id(&stage).unwrap();
+        let stg = stage_id(&stage).unwrap();
+        store.publish(&stage).unwrap();
+        let op = lex_vcs::Operation::new(
+            lex_vcs::OperationKind::AddFunction {
+                sig_id: sig.clone(),
+                stage_id: stg.clone(),
+                effects: Default::default(),
+                budget_cost: None,
+            },
+            [],
+        );
+        let t = lex_vcs::StageTransition::Create {
+            sig_id: sig.clone(),
+            stage_id: stg.clone(),
+        };
+        store
+            .apply_operation(lex_store::DEFAULT_BRANCH, op, t)
+            .unwrap();
+
+        // Trigger a typecheck-rejected variant via apply_replace_match_arm:
+        // replace arm 0's body with a Str literal — type mismatch.
+        let ill = CExpr::Literal {
+            value: CLit::Str { value: "boom".into() },
+        };
+        let _ = store
+            .apply_replace_match_arm(
+                lex_store::DEFAULT_BRANCH,
+                &stg,
+                &NodeId("n_0.2".into()),
+                0,
+                ill,
+            )
+            .unwrap_err();
+        // The RepairHint is on the candidate stage that didn't
+        // typecheck, *not* on the original `pick`. We surface
+        // hints for any stage produced by any fn in the file —
+        // re-read the source so the LSP sees the candidate.
+        // For this test the original fn body is still in source.
+        // To exercise the lookup, derive the candidate stage_id by
+        // re-running the transform on the AST directly.
+        let cand = lex_ast::replace_match_arm(
+            &stage,
+            &NodeId("n_0.2".into()),
+            0,
+            CExpr::Literal { value: CLit::Str { value: "boom".into() } },
+        )
+        .unwrap();
+        let cand_stage_id = lex_ast::stage_id(&cand).unwrap();
+        // Source the LSP sees is the candidate's source, not pick's.
+        let cand_src = lex_ast::print_stages(&[cand]);
+
+        let actions = repair_hint_actions_for_file(tmp.path(), &cand_src);
+        assert_eq!(
+            actions.len(),
+            1,
+            "exactly one hint for the candidate stage: {actions:?}"
+        );
+        let a = &actions[0];
+        assert_eq!(a.fn_name, "pick");
+        assert_eq!(a.stage_id, cand_stage_id);
+        // Slice 3 of #306 wired type-mismatch → ReplaceMatchArm.
+        assert_eq!(a.rule_tag, "type-mismatch");
+        assert_eq!(a.kind_hint, "ReplaceMatchArm");
+        assert!(!a.summary.is_empty(), "summary populated: {a:?}");
+        assert_eq!(a.data["failed_op_id"], a.failed_op_id);
+    }
+
+    #[test]
+    fn repair_hint_action_returns_empty_when_no_store() {
+        let actions =
+            repair_hint_actions_for_file(std::path::Path::new("/nonexistent/path"), "fn x() -> Int { 1 }\n");
+        assert!(actions.is_empty(), "missing store → empty list");
+    }
+
+    #[test]
+    fn repair_hint_action_returns_empty_when_source_is_unparseable() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let _ = lex_store::Store::open(tmp.path()).unwrap();
+        let actions = repair_hint_actions_for_file(tmp.path(), "fn bad( :: Int { 1 }\n");
+        assert!(actions.is_empty());
     }
 
     #[test]

--- a/crates/lex-lsp/src/main.rs
+++ b/crates/lex-lsp/src/main.rs
@@ -8,7 +8,8 @@
 
 use lex_lsp::{
     analyze_source, code_actions_for_diagnostics, completions, definition_at,
-    diagnostics_for_source, hover_at, inline_let_actions, Documents,
+    diagnostics_for_source, hover_at, inline_let_actions, repair_hint_actions_for_file,
+    Documents,
 };
 use lsp_server::{Connection, Message, Notification, Request, Response};
 use lsp_types::notification::{
@@ -215,6 +216,33 @@ fn handle_request(
                         disabled: None,
                         data: None,
                     }));
+                }
+
+                // Phase 4a: RepairHint surface. When `LEX_STORE`
+                // points at a lex-store and a stage in this file
+                // has a `RepairHint` attestation (#281), surface
+                // the hint as a QuickFix. The data payload carries
+                // failed_op_id + the structured suggestion so a
+                // client extension (or phase 4b) can invoke
+                // `lex repair --apply` and refresh the buffer.
+                if let Ok(store_dir) = std::env::var("LEX_STORE") {
+                    let store_path = std::path::PathBuf::from(store_dir);
+                    for hint in repair_hint_actions_for_file(&store_path, src) {
+                        let title = format!(
+                            "Lex: repair hint for `{}` ({}) — {}",
+                            hint.fn_name, hint.rule_tag, hint.kind_hint
+                        );
+                        actions.push(CodeActionOrCommand::CodeAction(CodeAction {
+                            title,
+                            kind: Some(CodeActionKind::QUICKFIX),
+                            diagnostics: None,
+                            edit: None,
+                            command: None,
+                            is_preferred: None,
+                            disabled: None,
+                            data: Some(hint.data),
+                        }));
+                    }
                 }
             }
 

--- a/crates/lex-lsp/tests/end_to_end.rs
+++ b/crates/lex-lsp/tests/end_to_end.rs
@@ -23,12 +23,18 @@ struct Server {
 
 impl Server {
     fn spawn() -> Self {
-        let mut child = Command::new(lsp_bin())
-            .stdin(Stdio::piped())
+        Self::spawn_with_env(&[])
+    }
+
+    fn spawn_with_env(env: &[(&str, &str)]) -> Self {
+        let mut cmd = Command::new(lsp_bin());
+        cmd.stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .expect("spawn lex-lsp");
+            .stderr(Stdio::piped());
+        for (k, v) in env {
+            cmd.env(k, v);
+        }
+        let mut child = cmd.spawn().expect("spawn lex-lsp");
         let stdin = child.stdin.take().expect("stdin");
         let stdout = child.stdout.take().expect("stdout");
         Self { child, stdin, reader: BufReader::new(stdout) }
@@ -516,6 +522,125 @@ fn inline_let_refactor_silent_when_no_top_level_let() {
     let resp = s.recv();
     let actions = resp["result"].as_array().expect("array");
     assert!(actions.is_empty(), "no actions: {resp}");
+}
+
+#[test]
+fn repair_hint_surfaces_as_code_action_when_store_has_one() {
+    // Phase 4a end-to-end: build a real store + push a typecheck-
+    // rejected variant so the gate auto-emits a RepairHint
+    // attestation. Spawn the LSP with LEX_STORE pointing at it,
+    // open the file whose stage_id matches the candidate, and
+    // expect a QuickFix code action carrying the hint metadata.
+    use lex_ast::{canonicalize_program, sig_id, stage_id, CExpr, CLit, NodeId, Stage};
+    let tmp = tempfile::TempDir::new().unwrap();
+    let store_path = tmp.path().to_path_buf();
+    let store = lex_store::Store::open(&store_path).unwrap();
+
+    let original_src = "fn pick(n :: Int) -> Int { match n { 0 => 1, _ => 2 } }\n";
+    let prog = lex_syntax::parse_source(original_src).unwrap();
+    let stage = canonicalize_program(&prog)
+        .into_iter()
+        .find(|s| matches!(s, Stage::FnDecl(fd) if fd.name == "pick"))
+        .unwrap();
+    let sig = sig_id(&stage).unwrap();
+    let stg = stage_id(&stage).unwrap();
+    store.publish(&stage).unwrap();
+    let op = lex_vcs::Operation::new(
+        lex_vcs::OperationKind::AddFunction {
+            sig_id: sig.clone(),
+            stage_id: stg.clone(),
+            effects: Default::default(),
+            budget_cost: None,
+        },
+        [],
+    );
+    let t = lex_vcs::StageTransition::Create {
+        sig_id: sig.clone(),
+        stage_id: stg.clone(),
+    };
+    store
+        .apply_operation(lex_store::DEFAULT_BRANCH, op, t)
+        .unwrap();
+    // Push a typecheck-rejected variant to plant the RepairHint.
+    let ill = CExpr::Literal {
+        value: CLit::Str { value: "boom".into() },
+    };
+    let _ = store
+        .apply_replace_match_arm(
+            lex_store::DEFAULT_BRANCH,
+            &stg,
+            &NodeId("n_0.2".into()),
+            0,
+            ill,
+        )
+        .unwrap_err();
+    // The LSP looks up by stage_id of the fn in the open source.
+    // The hint is attached to the candidate stage, so re-derive
+    // the candidate and use its canonical source.
+    let cand = lex_ast::replace_match_arm(
+        &stage,
+        &NodeId("n_0.2".into()),
+        0,
+        CExpr::Literal { value: CLit::Str { value: "boom".into() } },
+    )
+    .unwrap();
+    let cand_src = lex_ast::print_stages(&[cand]);
+
+    let mut s = Server::spawn_with_env(&[("LEX_STORE", store_path.to_str().unwrap())]);
+    s.send(&json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": { "capabilities": {}, "processId": null, "rootUri": null }
+    }));
+    let _ = s.recv();
+    s.send(&json!({
+        "jsonrpc": "2.0",
+        "method": "initialized",
+        "params": {}
+    }));
+    s.send(&json!({
+        "jsonrpc": "2.0",
+        "method": "textDocument/didOpen",
+        "params": {
+            "textDocument": {
+                "uri": "file:///tmp/lsp_repair_hint.lex",
+                "languageId": "lex",
+                "version": 1,
+                "text": cand_src,
+            }
+        }
+    }));
+    let diag = s.recv(); // publishDiagnostics (the file has a type error)
+    let diagnostics = diag["params"]["diagnostics"].clone();
+
+    s.send(&json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "textDocument/codeAction",
+        "params": {
+            "textDocument": { "uri": "file:///tmp/lsp_repair_hint.lex" },
+            "range": { "start": { "line": 0, "character": 0 }, "end": { "line": 0, "character": 0 } },
+            "context": { "diagnostics": diagnostics }
+        }
+    }));
+    let resp = s.recv();
+    let actions = resp["result"].as_array().expect("array");
+    let titles: Vec<&str> = actions.iter().filter_map(|a| a["title"].as_str()).collect();
+    let hint_action = actions
+        .iter()
+        .find(|a| {
+            a["title"]
+                .as_str()
+                .is_some_and(|t| t.contains("repair hint"))
+        })
+        .unwrap_or_else(|| panic!("missing repair-hint action; saw: {titles:?}"));
+    let title = hint_action["title"].as_str().unwrap();
+    assert!(title.contains("pick"), "fn name in title: {title}");
+    assert!(title.contains("type-mismatch"), "rule_tag in title: {title}");
+    let data = &hint_action["data"];
+    assert!(data["failed_op_id"].as_str().is_some(), "failed_op_id present: {data}");
+    assert!(data["suggested_transform"].is_object());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes phase 4 of #304. Closes the loop from typecheck failure →
durable `RepairHint` attestation (#281) → editor lightbulb. When
the LSP is launched with `LEX_STORE=<path>`, every fn in the open
file whose `stage_id` has an active `RepairHint` surfaces as a
QuickFix titled *"Lex: repair hint for `<fn>` (<rule_tag>) —
<kind_hint>"*. The action's `data` carries `failed_op_id`,
`stage_id`, structured errors, `suggested_transform`, and
`attestation_id` so a client extension can invoke
`lex repair --apply` and refresh the buffer.

## Wire

- `lex-store` + `lex-vcs` added as `lex-lsp` deps.
- `repair_hint_actions_for_file(store_path, src)` walks the
  open file's canonical AST, computes each `FnDecl`'s
  `stage_id`, looks up `RepairHint` attestations via the store,
  returns the latest per stage by timestamp.
- `textDocument/codeAction` handler reads `LEX_STORE` from env
  and appends repair-hint QuickFixes alongside phase-3a stubs
  and phase-3b refactor edits. Stores not configured → empty;
  unparseable source → empty.

## Test plan

- [x] `cargo test -p lex-lsp` — 20 lib + 10 e2e = 30 pass
  - new lib tests: round-trip through real temp store + planted
    hint; missing store; unparseable source.
  - new e2e test: full protocol round-trip with `LEX_STORE`
    pointing at a temp store that has a real RepairHint.
- [x] `cargo test --workspace` — 1403/1403 (+4 from main)
- [x] `cargo clippy -p lex-lsp --tests -- -D warnings` — clean

## Out of scope

- **Phase 4b**: applying the hint inline. Slice 4a surfaces it;
  clicking carries the suggestion in `data`. 4b will wire the
  `command` field to invoke `lex repair --apply` and emit a
  `WorkspaceEdit`.
- Phase 2b: cross-file definition + references + stdlib-member
  completion.
- Phase 3c: applying refactors for the other three #280 typed
  transforms (`RenameLocal`, `ReplaceMatchArm`, `ExtractFunction`)
  — needs cursor-to-NodeId mapping.

https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_