### PR TITLE
lex-bytecode: pop dup'd scrutinee on PConstructor fail path (#337)

### DIFF
--- a/crates/lex-bytecode/src/compiler.rs
+++ b/crates/lex-bytecode/src/compiler.rs
@@ -465,8 +465,15 @@ impl<'a> FnCompiler<'a> {
 
             let fail_target = self.code.len() as i32;
             for j in fail_jumps {
-                if let Op::JumpIfNot(off) = &mut self.code[j] {
-                    *off = fail_target - (j as i32 + 1);
+                // #337: PConstructor patterns now register an
+                // unconditional `Op::Jump` for the failure path
+                // (alongside the existing `Op::JumpIfNot` from
+                // PLiteral / nested constructor tests). Patch
+                // either shape.
+                match &mut self.code[j] {
+                    Op::JumpIfNot(off) => *off = fail_target - (j as i32 + 1),
+                    Op::Jump(off)      => *off = fail_target - (j as i32 + 1),
+                    _ => {}
                 }
             }
             self.next_local = arm_start_locals;
@@ -505,11 +512,32 @@ impl<'a> FnCompiler<'a> {
             }
             a::Pattern::PConstructor { name, args } => {
                 let name_idx = self.pool.variant(name);
-                self.emit(Op::Dup);
-                self.emit(Op::TestVariant(name_idx));
-                let j = self.code.len();
-                self.emit(Op::JumpIfNot(0));
-                fails.push(j);
+                // #337: the failure path must drop the duplicated
+                // scrutinee so subsequent match arms see a clean
+                // stack. The previous shape
+                //   Dup; TestVariant; JumpIfNot(fail);
+                // left `[scrut]` on the stack at the fail target,
+                // poisoning later arms — e.g. a wildcard `_` arm
+                // whose body referenced an unrelated value would
+                // pop the leaked scrutinee instead of its own value.
+                //
+                // New shape: branch on success, fall through to a
+                // failure cleanup that pops the dup'd scrutinee
+                // before jumping. The registered fail-jump is an
+                // unconditional `Op::Jump`; `compile_match`'s patch
+                // loop accepts both `JumpIfNot` and `Jump`.
+                self.emit(Op::Dup);                   // [scrut, scrut]
+                self.emit(Op::TestVariant(name_idx)); // [scrut, Bool]
+                let j_success = self.code.len();
+                self.emit(Op::JumpIf(0));             // pop Bool. success → [scrut]
+                self.emit(Op::Pop);                   // failure cleanup: [scrut] → []
+                let j_fail = self.code.len();
+                self.emit(Op::Jump(0));               // → fail target with []
+                fails.push(j_fail);
+                let success_target = self.code.len() as i32;
+                if let Op::JumpIf(off) = &mut self.code[j_success] {
+                    *off = success_target - (j_success as i32 + 1);
+                }
                 if args.is_empty() {
                     self.emit(Op::Pop);
                 } else if args.len() == 1 {

--- a/crates/lex-bytecode/tests/issue_337_pattern_stack.rs
+++ b/crates/lex-bytecode/tests/issue_337_pattern_stack.rs
@@ -1,0 +1,96 @@
+//! Regression for #337 — constructor-pattern fail path used to leak
+//! the scrutinee onto the VM stack. A `match` against an ADT
+//! scrutinee whose pattern took the `_` arm would panic if any
+//! enclosing context expected a clean stack (e.g. `false or match
+//! …`, or any wildcard arm whose body referenced an unrelated
+//! value).
+//!
+//! Fix: the `PConstructor` branch in `compile_pattern_test` now
+//! routes failure through an explicit `Pop` + `Jump` so the dup'd
+//! scrutinee is dropped before jumping to the next arm.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, Value, Vm};
+use lex_syntax::parse_source;
+
+fn run(src: &str, fn_name: &str, args: Vec<Value>) -> Value {
+    let p = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&p);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors:\n{errs:#?}");
+    }
+    let prog = compile_program(&stages);
+    let mut vm = Vm::new(&prog);
+    vm.call(fn_name, args).unwrap_or_else(|e| panic!("call {fn_name}: {e}"))
+}
+
+const STR_CHECK: &str = r#"
+type StrCheck = StrEmail | StrMinLen(Int) | StrMaxLen(Int)
+
+fn test(chk :: StrCheck) -> Bool {
+  false or match chk { StrEmail => true, _ => false }
+}
+
+fn t_email() -> Bool      { test(StrEmail) }
+fn t_min_len() -> Bool    { test(StrMinLen(1)) }
+fn t_max_len() -> Bool    { test(StrMaxLen(99)) }
+"#;
+
+#[test]
+fn issue_337_match_in_or_with_zero_arg_variant_matches() {
+    assert_eq!(run(STR_CHECK, "t_email", vec![]), Value::Bool(true));
+}
+
+#[test]
+fn issue_337_match_in_or_with_payload_variant_falls_through() {
+    // The original panic. Previously: "expected Bool, got
+    // Variant { name: \"StrMinLen\", args: [Int(1)] }"
+    // because the failing TestVariant left the scrutinee on the
+    // stack and subsequent ops popped it instead of the wildcard's
+    // result.
+    assert_eq!(run(STR_CHECK, "t_min_len", vec![]), Value::Bool(false));
+    assert_eq!(run(STR_CHECK, "t_max_len", vec![]), Value::Bool(false));
+}
+
+#[test]
+fn issue_337_nested_constructor_pattern_round_trips() {
+    // Nested PConstructor: both outer and inner pattern tests use
+    // the new Pop-then-Jump shape on failure. Three branches:
+    // exact match, outer matches inner doesn't, neither matches.
+    let src = r#"
+fn cls(v :: Result[Option[Int], Str]) -> Int {
+  match v {
+    Ok(Some(n)) => n,
+    Ok(None)    => -1,
+    Err(_)      => -2,
+  }
+}
+fn a() -> Int { cls(Ok(Some(42))) }
+fn b() -> Int { cls(Ok(None)) }
+fn c() -> Int { cls(Err("oops")) }
+"#;
+    assert_eq!(run(src, "a", vec![]), Value::Int(42));
+    assert_eq!(run(src, "b", vec![]), Value::Int(-1));
+    assert_eq!(run(src, "c", vec![]), Value::Int(-2));
+}
+
+#[test]
+fn issue_337_wildcard_after_failed_constructor_returns_correct_value() {
+    // Direct test that the wildcard arm's body value isn't poisoned
+    // by a leaked scrutinee. Returning a fresh Int from the `_` arm
+    // would previously surface the variant value via the leak.
+    let src = r#"
+type Tag = TagA | TagB | TagC
+
+fn pick(t :: Tag) -> Int {
+  match t {
+    TagA => 1,
+    _    => 99,
+  }
+}
+fn a() -> Int { pick(TagA) }
+fn b() -> Int { pick(TagB) }
+"#;
+    assert_eq!(run(src, "a", vec![]), Value::Int(1));
+    assert_eq!(run(src, "b", vec![]), Value::Int(99));
+}


### PR DESCRIPTION
## Summary

Closes #337. Constructor-pattern matching used to leak the
scrutinee onto the VM stack when the variant test failed; later
ops popped the leak instead of the intended value, producing a
wrong-type panic far from the source.

## Bug

`compile_pattern_test`'s `PConstructor` branch emitted:

```
Dup                  # [scrut, scrut]
TestVariant(name)    # → [scrut, Bool]
JumpIfNot(fail)      # → [scrut]   ← fail-jump target retained scrut
Pop                  # success: cleanup → []
```

The success path cleans up; the **fail path** reached the
target with the dup still on the stack. The next arm's
`LoadLocal(scrut_slot)` pushed scrut *again*; the wildcard arm's
single `Pop` only dropped one copy, and the body either
returned the wrong value or panicked on a type-mismatch error
about a value it never produced.

## Fix

Branch on success, fall through to explicit cleanup:

```
Dup                  # [scrut, scrut]
TestVariant(name)    # [scrut, Bool]
JumpIf(success)      # pops Bool. success → [scrut]; fall → [scrut]
Pop                  # failure cleanup: → []
Jump(fail)           # unconditional, registered in fails list
success:
# [scrut], proceed
```

`compile_match`'s patch loop now accepts both `Op::JumpIfNot`
(existing fail-jump shape) and `Op::Jump` (new shape from
PConstructor). Stack-balance invariant restored: every fail-target
sees an empty test stack.

## Test plan

- [x] `cargo test -p lex-bytecode --test issue_337_pattern_stack` — 4/4
  - Exact `false or match …` repro from the issue.
  - Payload-bearing variants fall through to `_`.
  - Nested `Ok(Some(n))` / `Ok(None)` / `Err(_)` round-trips.
  - Wildcard arm returns a non-poisoned value.
- [x] `cargo test --workspace` — 1399/1399
- [x] `cargo clippy -p lex-bytecode --tests -- -D warnings` — clean

https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_