### PR TITLE
list+bytecode: add list.sort_by[T, K] stable sort (#338)

### DIFF
--- a/crates/lex-bytecode/src/compiler.rs
+++ b/crates/lex-bytecode/src/compiler.rs
@@ -621,6 +621,7 @@ impl<'a> FnCompiler<'a> {
             ("option", "unwrap_or_else") => self.emit_option_unwrap_or_else(args),
             ("list", "map") => self.emit_list_map(args),
             ("list", "par_map") => self.emit_list_par_map(args),
+            ("list", "sort_by") => self.emit_list_sort_by(args),
             ("list", "filter") => self.emit_list_filter(args),
             ("list", "fold") => self.emit_list_fold(args),
             ("map", "fold") => self.emit_map_fold(args, node_id_idx),
@@ -707,6 +708,20 @@ impl<'a> FnCompiler<'a> {
         self.compile_expr(&args[1], false);
         let nid = self.pool.node_id("n_list_par_map");
         self.emit(Op::ParallelMap { node_id_idx: nid });
+    }
+
+    /// `list.sort_by(xs, f)` (#338). Pushes `xs` and the key-fn
+    /// `f`, then emits a single `Op::SortByKey` — the VM invokes
+    /// `f` on each element to derive a sortable key, stable-sorts
+    /// by key, and returns the values in sorted order. Keys must
+    /// resolve to `Int` / `Float` / `Str`; mixed-type pairs are
+    /// treated as equal by the comparator (preserving insertion
+    /// order via the stable sort).
+    fn emit_list_sort_by(&mut self, args: &[a::CExpr]) {
+        self.compile_expr(&args[0], false);
+        self.compile_expr(&args[1], false);
+        let nid = self.pool.node_id("n_list_sort_by");
+        self.emit(Op::SortByKey { node_id_idx: nid });
     }
 
     /// `list.filter(xs, pred)` — keep elements where pred returns true.

--- a/crates/lex-bytecode/src/op.rs
+++ b/crates/lex-bytecode/src/op.rs
@@ -65,6 +65,13 @@ pub enum Op {
     MakeClosure { fn_id: u32, capture_count: u16 },
     /// Call a closure: pop `arity` args + 1 closure (top of stack), invoke.
     CallClosure { arity: u16, node_id_idx: u32 },
+    /// Stable sort-by-key (#338). Stack: `[xs, f]` (xs underneath).
+    /// Pops the key-fn `f` and the list `xs`, applies `f` to each
+    /// element to derive a sortable key, returns the list reordered
+    /// so keys ascend. Keys must be one of `Int` / `Float` / `Str`;
+    /// other key types pair-wise compare as equal (preserving
+    /// insertion order). `node_id_idx` is the originating NodeId.
+    SortByKey { node_id_idx: u32 },
     /// Parallel map (#305 slice 1). Stack: `[xs, f]` (xs underneath).
     /// Pops the closure `f` and the list `xs`, applies `f` to each
     /// element in parallel via OS threads, pushes the result list

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -326,6 +326,22 @@ fn const_str(constants: &[Const], idx: u32) -> String {
 /// Read `LEX_PAR_MAX_CONCURRENCY` (default = available CPU cores,
 /// fallback 4). Capped at 64 so a malformed env var can't spawn an
 /// unreasonable number of OS threads.
+/// Order-defining comparator for `list.sort_by` keys (#338).
+/// Same-typed Int / Float / Str pairs compare via their native
+/// `Ord` / `PartialOrd`. Mixed-type or other key shapes compare
+/// as Equal; combined with `Vec::sort_by`'s stability that
+/// preserves the original element order — best-effort fallback
+/// that never panics.
+fn compare_sort_keys(a: &Value, b: &Value) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    match (a, b) {
+        (Value::Int(x), Value::Int(y)) => x.cmp(y),
+        (Value::Float(x), Value::Float(y)) => x.partial_cmp(y).unwrap_or(Ordering::Equal),
+        (Value::Str(x), Value::Str(y)) => x.cmp(y),
+        _ => Ordering::Equal,
+    }
+}
+
 fn par_max_concurrency() -> usize {
     let from_env = std::env::var("LEX_PAR_MAX_CONCURRENCY")
         .ok()
@@ -794,6 +810,34 @@ impl<'a> Vm<'a> {
                         // Direct Op::Call is the v1 surface.
                         memo_key: None,
                     })?;
+                }
+                Op::SortByKey { node_id_idx: _ } => {
+                    // #338: pop (xs, f). For each x in xs, invoke
+                    // f(x) to derive a sortable key. Stable-sort the
+                    // (key, value) pairs by key. Return the values
+                    // in sorted order. Keys must be Int / Float /
+                    // Str; mixed-type pairs and other types compare
+                    // as equal (preserving original order — stable
+                    // sort).
+                    let f = self.pop()?;
+                    let xs = self.pop()?;
+                    let items = match xs {
+                        Value::List(v) => v,
+                        other => return Err(VmError::TypeMismatch(
+                            format!("SortByKey requires a List, got: {other:?}"))),
+                    };
+                    if !matches!(f, Value::Closure { .. }) {
+                        return Err(VmError::TypeMismatch(
+                            format!("SortByKey requires a closure, got: {f:?}")));
+                    }
+                    let mut keyed: Vec<(Value, Value)> = Vec::with_capacity(items.len());
+                    for item in items {
+                        let key = self.invoke_closure_value(f.clone(), vec![item.clone()])?;
+                        keyed.push((key, item));
+                    }
+                    keyed.sort_by(|(ka, _), (kb, _)| compare_sort_keys(ka, kb));
+                    let sorted: Vec<Value> = keyed.into_iter().map(|(_, v)| v).collect();
+                    self.stack.push(Value::List(sorted));
                 }
                 Op::ParallelMap { node_id_idx: _ } => {
                     // #305 slice 1: pop (xs, f) and apply f to each

--- a/crates/lex-runtime/tests/list_sort_by.rs
+++ b/crates/lex-runtime/tests/list_sort_by.rs
@@ -1,0 +1,179 @@
+//! Conformance for `list.sort_by` (#338) — stable sort over a
+//! list by a closure-derived key. Keys can be `Int`, `Float`, or
+//! `Str`; mixed-type or otherwise unorderable pairs are treated
+//! as equal (the stable sort preserves their input order).
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::vm::Vm;
+use lex_bytecode::Value;
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+
+fn run(src: &str, entry: &str, args: Vec<Value>) -> Value {
+    let prog = parse_source(src).expect("parses");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors:\n{errs:#?}");
+    }
+    let bc = lex_bytecode::compile_program(&stages);
+    let handler = DefaultHandler::new(Policy::pure());
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(entry, args).unwrap_or_else(|e| panic!("call {entry}: {e:?}"))
+}
+
+#[test]
+fn sort_by_int_ascending() {
+    let src = r#"
+import "std.list" as list
+fn r(xs :: List[Int]) -> List[Int] {
+  list.sort_by(xs, fn(x :: Int) -> Int { x })
+}
+"#;
+    let xs = Value::List(vec![
+        Value::Int(3), Value::Int(1), Value::Int(4), Value::Int(1),
+        Value::Int(5), Value::Int(9), Value::Int(2), Value::Int(6),
+    ]);
+    let out = run(src, "r", vec![xs]);
+    assert_eq!(
+        out,
+        Value::List(vec![
+            Value::Int(1), Value::Int(1), Value::Int(2), Value::Int(3),
+            Value::Int(4), Value::Int(5), Value::Int(6), Value::Int(9),
+        ]),
+    );
+}
+
+#[test]
+fn sort_by_int_descending_via_negated_key() {
+    let src = r#"
+import "std.list" as list
+fn r(xs :: List[Int]) -> List[Int] {
+  list.sort_by(xs, fn(x :: Int) -> Int { 0 - x })
+}
+"#;
+    let xs = Value::List(vec![Value::Int(2), Value::Int(7), Value::Int(1), Value::Int(4)]);
+    assert_eq!(
+        run(src, "r", vec![xs]),
+        Value::List(vec![Value::Int(7), Value::Int(4), Value::Int(2), Value::Int(1)]),
+    );
+}
+
+#[test]
+fn sort_by_str_lexicographic() {
+    let src = r#"
+import "std.list" as list
+fn r(xs :: List[Str]) -> List[Str] {
+  list.sort_by(xs, fn(s :: Str) -> Str { s })
+}
+"#;
+    let xs = Value::List(vec![
+        Value::Str("banana".into()),
+        Value::Str("apple".into()),
+        Value::Str("cherry".into()),
+    ]);
+    assert_eq!(
+        run(src, "r", vec![xs]),
+        Value::List(vec![
+            Value::Str("apple".into()),
+            Value::Str("banana".into()),
+            Value::Str("cherry".into()),
+        ]),
+    );
+}
+
+#[test]
+fn sort_by_record_field() {
+    // The canonical use case: sort a list of records by one field.
+    let src = r#"
+import "std.list" as list
+type Order = { name :: Str, qty :: Int }
+fn r(xs :: List[Order]) -> List[Order] {
+  list.sort_by(xs, fn(o :: Order) -> Int { o.qty })
+}
+"#;
+    let mk = |name: &str, qty: i64| {
+        let mut fields = indexmap::IndexMap::new();
+        fields.insert("name".into(), Value::Str(name.into()));
+        fields.insert("qty".into(), Value::Int(qty));
+        Value::Record(fields)
+    };
+    let xs = Value::List(vec![mk("bob", 5), mk("alice", 2), mk("carl", 3)]);
+    let Value::List(out) = run(src, "r", vec![xs]) else { panic!() };
+    let qtys: Vec<i64> = out
+        .iter()
+        .map(|v| match v {
+            Value::Record(f) => match f.get("qty") {
+                Some(Value::Int(n)) => *n,
+                _ => panic!(),
+            },
+            _ => panic!(),
+        })
+        .collect();
+    assert_eq!(qtys, vec![2, 3, 5]);
+}
+
+#[test]
+fn sort_by_is_stable_for_equal_keys() {
+    // Stability: when two elements share a key, their relative
+    // order in the input must survive the sort.
+    let src = r#"
+import "std.list" as list
+type R = { k :: Int, tag :: Str }
+fn r(xs :: List[R]) -> List[R] {
+  list.sort_by(xs, fn(rec :: R) -> Int { rec.k })
+}
+"#;
+    let mk = |k: i64, tag: &str| {
+        let mut fields = indexmap::IndexMap::new();
+        fields.insert("k".into(), Value::Int(k));
+        fields.insert("tag".into(), Value::Str(tag.into()));
+        Value::Record(fields)
+    };
+    let xs = Value::List(vec![
+        mk(1, "a"), mk(2, "b"), mk(1, "c"), mk(2, "d"), mk(1, "e"),
+    ]);
+    let Value::List(out) = run(src, "r", vec![xs]) else { panic!() };
+    let tags: Vec<String> = out
+        .iter()
+        .map(|v| match v {
+            Value::Record(f) => match f.get("tag") {
+                Some(Value::Str(t)) => t.clone(),
+                _ => panic!(),
+            },
+            _ => panic!(),
+        })
+        .collect();
+    // Original order for k=1 was a→c→e; for k=2 was b→d. Both
+    // sub-orders must survive.
+    assert_eq!(tags, vec!["a", "c", "e", "b", "d"]);
+}
+
+#[test]
+fn sort_by_empty_and_singleton() {
+    let src = r#"
+import "std.list" as list
+fn r(xs :: List[Int]) -> List[Int] {
+  list.sort_by(xs, fn(x :: Int) -> Int { x })
+}
+"#;
+    assert_eq!(run(src, "r", vec![Value::List(vec![])]), Value::List(vec![]));
+    assert_eq!(
+        run(src, "r", vec![Value::List(vec![Value::Int(42)])]),
+        Value::List(vec![Value::Int(42)]),
+    );
+}
+
+#[test]
+fn sort_by_float_keys() {
+    let src = r#"
+import "std.list" as list
+fn r(xs :: List[Float]) -> List[Float] {
+  list.sort_by(xs, fn(x :: Float) -> Float { x })
+}
+"#;
+    let xs = Value::List(vec![Value::Float(3.5), Value::Float(1.25), Value::Float(2.75)]);
+    assert_eq!(
+        run(src, "r", vec![xs]),
+        Value::List(vec![Value::Float(1.25), Value::Float(2.75), Value::Float(3.5)]),
+    );
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -200,6 +200,22 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 EffectSet::open_var(7),
                 Ty::List(Box::new(Ty::Var(1))),
             ));
+            // #338: sort_by :: List[T], (T) -> [E] K -> [E] List[T]
+            // Stable sort by the key the closure derives from each
+            // element. K is intended to be one of Int / Float / Str
+            // (the runtime comparator falls back to equality for
+            // other shapes, preserving original order via the
+            // stable sort) but the type system doesn't enforce that
+            // — keep the signature minimal so callers can pass any
+            // K and trust the comparator.
+            fields.insert("sort_by".into(), Ty::function(
+                vec![
+                    Ty::List(Box::new(Ty::Var(0))),
+                    Ty::function(vec![Ty::Var(0)], EffectSet::open_var(8), Ty::Var(1)),
+                ],
+                EffectSet::open_var(8),
+                Ty::List(Box::new(Ty::Var(0))),
+            ));
             fields.insert("filter".into(), Ty::function(
                 vec![
                     Ty::List(Box::new(Ty::Var(0))),


### PR DESCRIPTION
## Summary

Closes #338. Canonicalisation / dedup / JSON-key normalisation /
content-addressed hashing pipelines all needed a sort-by-key
primitive; without one, callers were hand-rolling O(n²)
insertion sort with `list.concat` per insertion.

## Surface

```lex
list.sort_by :: List[T], (T) -> [E] K -> [E] List[T]
```

Stable sort. K is intended to be `Int` / `Float` / `Str`; the
runtime comparator falls back to equality for other shapes,
preserving original order via the stable sort.

## Implementation

- New `Op::SortByKey { node_id_idx }`. Pops closure + list,
  invokes closure on each element via `Vm::invoke_closure_value`
  to derive keys, stable-sorts the `(key, value)` pairs, pushes
  values in sorted order.
- New `compare_sort_keys` helper with arms for `Int` / `Float` /
  `Str`; non-matching pairs compare as `Equal`.
- Inline emitter `emit_list_sort_by` (mirrors `list.par_map`'s
  shape — push args, emit single op).
- `lex_types::builtins` registers the signature.

## Test plan

- [x] `cargo test -p lex-runtime --test list_sort_by` — 7/7
  - Int ascending, Int descending via negated key, Str
    lexicographic, record-field key.
  - Stability test (equal keys preserve insertion order).
  - Empty + singleton edge cases.
  - Float keys.
- [x] `cargo test --workspace` — 1399/1399
- [x] `cargo clippy -p lex-bytecode -p lex-types -p lex-runtime --tests -- -D warnings` — clean

https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDuDYwn9DRiP1eA2gf6jkW)_