### PR TITLE
dx: agent-experience improvements #348 #349 #350 #351 #352

### DIFF
--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -13,8 +13,8 @@ pub enum VmError {
     TypeMismatch(String),
     #[error("stack underflow")]
     StackUnderflow,
-    #[error("unknown function id: {0}")]
-    UnknownFunction(u32),
+    #[error("unknown function: {0}")]
+    UnknownFunction(String),
     #[error("effect handler error: {0}")]
     Effect(String),
     #[error("call stack overflow: recursion depth exceeded ({0})")]
@@ -577,8 +577,11 @@ impl<'a> Vm<'a> {
     fn run_to(&mut self, base_depth: usize) -> Result<Value, VmError> {
         loop {
             if self.steps > self.step_limit {
+                let frame_idx = self.frames.len() - 1;
+                let fn_id = self.frames[frame_idx].fn_id;
+                let fn_name = &self.program.functions[fn_id as usize].name;
                 return Err(VmError::Panic(format!(
-                    "step limit exceeded ({} > {})",
+                    "step limit exceeded in `{fn_name}` ({} > {})",
                     self.steps, self.step_limit,
                 )));
             }
@@ -588,7 +591,8 @@ impl<'a> Vm<'a> {
             let fn_id = self.frames[frame_idx].fn_id;
             let code = &self.program.functions[fn_id as usize].code;
             if pc >= code.len() {
-                return Err(VmError::Panic("ran past end of code".into()));
+                let fn_name = &self.program.functions[fn_id as usize].name;
+                return Err(VmError::Panic(format!("ran past end of code in `{fn_name}`")));
             }
             let op = code[pc].clone();
             self.frames[frame_idx].pc = pc + 1;

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -20,6 +20,7 @@ mod acli;
 mod docs;
 mod op;
 mod repl;
+mod test_runner;
 mod watch;
 
 use ::acli::OutputFormat;
@@ -112,6 +113,7 @@ fn run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         "canonical" => cmd_canonical(fmt, &args[1..]),
         "keygen" => cmd_keygen(fmt, &args[1..]),
         "repl" => repl::cmd_repl(&args[1..]),
+        "test" => test_runner::cmd_test(fmt, &args[1..]),
         "watch" => watch::cmd_watch(&args[1..]),
         "help" | "--help" | "-h" => { print_usage(); Ok(()) }
         other => bail!("unknown command `{other}`. try `lex help`"),
@@ -179,6 +181,8 @@ fn print_usage() {
     println!("                                     re-execute with effect overrides keyed by NodeId");
     println!("  diff <run_a> <run_b>               first NodeId where two traces diverge");
     println!("  serve [--port N] [--store DIR]     start the agent API HTTP server");
+    println!("  repl [--load <file>]...            interactive evaluator; --load pre-loads source");
+    println!("  test [<dir>]                       run tests/test_*.lex files (calls run_all in each)");
     println!("  conformance <dir>                  run all JSON test descriptors in <dir>");
     println!("  spec check <spec> --source <file> [--store DIR] [--trials N]");
     println!("                                     check a Spec against a Lex source");

--- a/crates/lex-cli/src/repl.rs
+++ b/crates/lex-cli/src/repl.rs
@@ -25,9 +25,31 @@ use std::io::{BufRead, Write};
 
 const BANNER: &str = "lex repl — type .help for commands, .quit to exit";
 
-pub fn cmd_repl(_args: &[String]) -> Result<()> {
+pub fn cmd_repl(args: &[String]) -> Result<()> {
     println!("{BANNER}");
     let mut session = Session::new();
+
+    // --load <file> (repeatable): pre-load Lex source files into the session.
+    let mut i = 0;
+    while i < args.len() {
+        if args[i] == "--load" {
+            let path = args.get(i + 1)
+                .ok_or_else(|| anyhow!("--load requires a file path"))?;
+            let src = std::fs::read_to_string(path)
+                .map_err(|e| anyhow!("--load {path}: {e}"))?;
+            session.add_stage(&src);
+            match session.check() {
+                Ok(_) => println!("loaded {path}"),
+                Err(e) => {
+                    session.rollback();
+                    return Err(anyhow!("--load {path}: type error: {e}"));
+                }
+            }
+            i += 2;
+        } else {
+            i += 1;
+        }
+    }
     let stdin = std::io::stdin();
     let mut stdin = stdin.lock();
     let mut buf = String::new();
@@ -95,6 +117,9 @@ fn print_help() {
     println!("  .quit       exit the REPL");
     println!("  .reset      drop all defined stages, start over");
     println!("  .list       print the current accumulated source");
+    println!();
+    println!("Flags (pass before entering the REPL):");
+    println!("  --load <file>   pre-load a .lex source file (repeatable)");
     println!();
     println!("Top-level inputs (`fn …`, `type …`, `import …`) are added");
     println!("to the session. Anything else is evaluated as an expression");

--- a/crates/lex-cli/src/test_runner.rs
+++ b/crates/lex-cli/src/test_runner.rs
@@ -1,0 +1,94 @@
+//! `lex test` — run test_*.lex files.
+//!
+//! Convention: each test file exports `fn run_all() -> ()`. The runner
+//! compiles the file, calls `run_all`, and reports pass/fail per file.
+//! Exit 0 iff every file passes.
+
+use anyhow::Result;
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm};
+use lex_runtime::{check_program as check_policy, DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::path::{Path, PathBuf};
+
+pub fn cmd_test(_fmt: &::acli::OutputFormat, args: &[String]) -> Result<()> {
+    let dir: PathBuf = args
+        .iter()
+        .find(|a| !a.starts_with('-'))
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("tests"));
+
+    let entries = collect_test_files(&dir)?;
+    if entries.is_empty() {
+        println!("no test_*.lex files found in {}", dir.display());
+        return Ok(());
+    }
+
+    let mut pass = 0usize;
+    let mut fail = 0usize;
+
+    for path in &entries {
+        match run_one(path) {
+            Ok(()) => {
+                println!("ok   {}", path.display());
+                pass += 1;
+            }
+            Err(e) => {
+                println!("FAIL {} — {e:#}", path.display());
+                fail += 1;
+            }
+        }
+    }
+
+    println!("\n{} passed, {} failed", pass, fail);
+    if fail > 0 {
+        anyhow::bail!("{fail} test file(s) failed");
+    }
+    Ok(())
+}
+
+fn collect_test_files(dir: &Path) -> Result<Vec<PathBuf>> {
+    if !dir.exists() {
+        return Ok(vec![]);
+    }
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir(dir)
+        .map_err(|e| anyhow::anyhow!("reading {}: {e}", dir.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) == Some("lex") {
+            if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                if name.starts_with("test_") {
+                    out.push(path);
+                }
+            }
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+fn run_one(path: &Path) -> Result<()> {
+    let src = std::fs::read_to_string(path)
+        .map_err(|e| anyhow::anyhow!("read: {e}"))?;
+    let prog = parse_source(&src)
+        .map_err(|e| anyhow::anyhow!("parse: {e}"))?;
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        let msgs: Vec<String> = errs
+            .iter()
+            .map(|e| serde_json::to_string(e).unwrap_or_else(|_| format!("{e:?}")))
+            .collect();
+        anyhow::bail!("type error: {}", msgs.join("; "));
+    }
+    let bc = compile_program(&stages);
+    let policy = Policy::permissive();
+    check_policy(&bc, &policy).map_err(|v| anyhow::anyhow!("policy: {v:?}"))?;
+    let bc = std::sync::Arc::new(bc);
+    let handler = DefaultHandler::new(policy).with_program(std::sync::Arc::clone(&bc));
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call("run_all", vec![])
+        .map_err(|e| anyhow::anyhow!("runtime: {e}"))?;
+    Ok(())
+}

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -692,6 +692,12 @@ impl EffectHandler for DefaultHandler {
         // declared kind is `time`, matching the existing `time.now`.
         if kind == "datetime" && op == "now" {
             self.ensure_kind_allowed("time")?;
+            // LEX_TEST_NOW (Unix seconds) pins the clock for deterministic tests (#350).
+            if let Ok(s) = std::env::var("LEX_TEST_NOW") {
+                if let Ok(secs) = s.trim().parse::<i64>() {
+                    return Ok(Value::Int(secs.saturating_mul(1_000_000_000)));
+                }
+            }
             let now = chrono::Utc::now();
             let nanos = now.timestamp_nanos_opt().unwrap_or(i64::MAX);
             return Ok(Value::Int(nanos));

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -1,0 +1,234 @@
+# Lex — Agent Cold-Start Guide
+
+This document is written for AI agents that are building or maintaining Lex programs.
+It covers the error envelope format, the iteration loop, effect annotations, stdlib surface,
+and known sharp edges — everything you need to be productive from a cold start.
+
+---
+
+## Project layout
+
+```
+crates/
+  lex-syntax/      parser
+  lex-ast/         canonical AST + canonicalizer
+  lex-types/       type checker + builtin signatures
+  lex-bytecode/    compiler + stack-machine VM
+  lex-runtime/     effect handler, DefaultHandler, Policy
+  lex-stdlib/      (reserved; builtins are currently inline in lex-types/lex-runtime)
+  lex-cli/         `lex` binary — all subcommands
+docs/              this file + design docs
+```
+
+Source files use the `.lex` extension. Entry points are named top-level functions.
+
+---
+
+## Iteration loop
+
+```
+write program.lex
+  → lex check program.lex --output json    # type-check; get structured errors
+  → lex run program.lex my_fn '"arg"'      # run one function
+  → lex test                               # run all tests/test_*.lex files
+```
+
+Always run `lex check` before `lex run`. The type checker catches most mistakes;
+the runtime only sees what the compiler emits.
+
+---
+
+## `lex check` error envelope
+
+Every error is a JSON object on stdout (one per line with `--output json`):
+
+```json
+{
+  "kind":             "type_error",
+  "expected":         "Int",
+  "got":              "Str",
+  "at_node":          "fn_body/call/arg[0]",
+  "position":         { "line": 12, "col": 5 },
+  "rule_tag":         "PARAM_TYPE_MISMATCH",
+  "rule_explanation": "argument 0 of `validate` expects Int, got Str"
+}
+```
+
+Fields:
+
+| field | meaning |
+|---|---|
+| `kind` | always `"type_error"` |
+| `expected` | the type the checker required |
+| `got` | the type it found |
+| `at_node` | AST path to the failing node |
+| `position` | source location |
+| `rule_tag` | machine-readable tag for filtering |
+| `rule_explanation` | human-readable sentence |
+
+Exit code is 0 on success, 1 on type errors.
+
+---
+
+## Effect system quick reference
+
+Functions declare effects in their signature:
+
+```lex
+fn fetch_data(url :: Str) -> Str [http.get] { ... }
+```
+
+The effect kind (`http`) and operation (`get`) must both be permitted by the
+active `Policy`. Effect kinds that exist:
+
+| kind | operations | notes |
+|---|---|---|
+| `http` | `get`, `post`, `put`, `delete`, `patch` | outbound HTTP |
+| `fs` | `read`, `write` | filesystem access |
+| `time` | `now` | `datetime.now` — non-deterministic |
+| `random` | `random` | `crypto.random` |
+| `llm` | `complete` | LLM inference |
+| `budget` | (N) | annotated cost; checked against `--budget` |
+
+Pure functions (no effect annotations) can run under `Policy::pure()`.
+
+---
+
+## Stdlib module summary
+
+Import modules with `import "std.X" as X`:
+
+### `std.str`
+`length`, `to_upper`, `to_lower`, `trim`, `split`, `contains`, `starts_with`,
+`ends_with`, `replace`, `concat`, `slice`, `index_of`
+
+String comparison operators (`<`, `<=`, `>`, `>=`, `==`, `!=`) work on `Str`
+via lexicographic order.
+
+`Str + Str` concatenates strings.
+
+### `std.int`
+`to_str`, `parse`, `abs`, `min`, `max`, `clamp`
+
+### `std.list`
+`map`, `filter`, `fold`, `length`, `head`, `tail`, `reverse`, `append`,
+`zip`, `flatten`, `any`, `all`, `find`, `cons`, `par_map`
+
+`list.cons(x, xs)` prepends `x` to `xs` — idiomatic O(n) builder with
+`list.cons` + `list.reverse`.
+
+### `std.json`
+`stringify`, `parse` — round-trips any Lex value through JSON.
+
+### `std.datetime`
+`now` [time], `parse_iso`, `format_iso`, `diff`, `before`, `after`, `compare`
+
+`datetime.now` returns nanoseconds since epoch as `Int`.
+`datetime.parse_iso` returns `Result[Instant, Str]`.
+`datetime.diff(later, earlier)` returns a `Duration`.
+`datetime.compare(a, b)` returns `-1`, `0`, or `1`.
+
+Set `LEX_TEST_NOW=<unix_seconds>` to pin the clock in tests (#350).
+
+### `std.duration`
+`seconds`, `minutes`, `hours`, `days`
+
+`duration.seconds(d)` extracts total whole seconds from a `Duration`.
+
+### `std.http`
+`get`, `post`, `put`, `delete`, `patch` — all require `[http.*]` effect.
+
+### `std.crypto`
+`hash`, `random` — `random` requires `[random]` effect.
+
+---
+
+## `lex test` — test runner
+
+Place test files in `tests/` named `test_*.lex`. Each file must export:
+
+```lex
+fn run_all() -> () { ... }
+```
+
+Use `assert` (or pattern-match + panic) inside `run_all`. The runner calls
+`run_all` with a permissive policy and reports pass/fail per file.
+
+```
+lex test            # runs tests/test_*.lex
+lex test my/dir     # runs my/dir/test_*.lex
+```
+
+Pin time-dependent tests with `LEX_TEST_NOW`:
+
+```bash
+LEX_TEST_NOW=1700000000 lex test
+```
+
+---
+
+## `lex repl` — interactive evaluator
+
+```
+lex repl                     # blank session
+lex repl --load src/rules.lex  # pre-load a file (repeatable)
+```
+
+Meta commands inside the REPL: `.help`, `.quit`, `.reset`, `.list`.
+
+Top-level inputs (`fn`, `type`, `import`) extend the session; anything else
+is evaluated as an expression and printed via `json.stringify`.
+
+---
+
+## Known sharp edges
+
+### Type-checker accepts, runtime rejects
+The type checker and the runtime builtin dispatch can drift. If a function
+signature is registered in `lex-types/src/builtins.rs` but its dispatch arm
+is missing in `lex-runtime/src/builtins.rs`, the type checker will accept the
+call but the runtime will error. When you see an unexpected runtime error on a
+stdlib call, check both files.
+
+### `datetime.now` is non-deterministic
+`datetime.now` has effect kind `time`. It returns nanoseconds since epoch.
+Pin it with `LEX_TEST_NOW=<unix_seconds>` for reproducible tests.
+
+### REPL policy is permissive
+The REPL runs under `Policy::permissive()` — all effects are allowed. Use
+`lex run --allow-effects ...` to test under a specific policy.
+
+### Recursive types not supported
+Type aliases cannot be recursive. Use a flat representation and recursion in
+functions instead.
+
+### Pattern match must be exhaustive
+The type checker requires exhaustive match arms for variants. Add a wildcard
+arm (`_ => ...`) if you don't handle every case.
+
+---
+
+## Useful commands
+
+```bash
+lex check --output json program.lex        # structured errors
+lex run program.lex fn_name '"arg"' 42     # args are JSON
+lex test                                   # run tests/test_*.lex
+lex repl --load src/rules.lex              # interactive with project loaded
+lex audit program.lex --effect http        # find all http effect calls
+lex hash program.lex                       # canonical content hashes
+lex publish --activate program.lex         # publish to local store
+LEX_TEST_NOW=1700000000 lex test           # deterministic time in tests
+```
+
+---
+
+## Filing issues
+
+Repository: https://github.com/alpibrusl/lex-lang
+
+Include:
+- The `.lex` source (or a minimal reproducer)
+- The `lex check --output json` output
+- The `lex run` error if it's a runtime issue
+- The version: `lex version`


### PR DESCRIPTION
## Summary

- **#348** VM runtime errors now name the function (`ran past end of code in \`build_rev\``) instead of showing a bare numeric fn_id.
- **#350** `datetime.now` respects `LEX_TEST_NOW=<unix_seconds>` env var — pins the clock for deterministic test runs.
- **#351** `lex repl --load <file>` (repeatable) pre-loads `.lex` source files before starting the interactive loop.
- **#349** New `lex test [dir]` subcommand — walks `tests/test_*.lex`, calls `run_all()` in each file, reports pass/fail, exits non-zero on failure.
- **#352** `docs/AGENT.md` — cold-start guide for AI agents: error envelope schema, effect system quick reference, stdlib surface, test runner, REPL flags, known sharp edges.

## Test plan

- [x] `cargo build -p lex-cli` — clean
- [x] `cargo clippy -p lex-cli -p lex-bytecode -p lex-runtime -- -D warnings` — clean
- [x] `LEX_TEST_NOW=1700000000 lex test` — pins clock correctly
- [x] `lex repl --load src/rules.lex` — loads file, functions available in session
- [x] `lex test tests/` — runs test_*.lex, reports ok/FAIL per file

https://claude.ai/code/session_01TN34hWDyCyB9WmUKVVacTQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TN34hWDyCyB9WmUKVVacTQ)_