### PR TITLE
Add fmt, init, and ci commands; implement pkg install

### DIFF
--- a/crates/lex-cli/src/ci.rs
+++ b/crates/lex-cli/src/ci.rs
@@ -1,0 +1,152 @@
+//! `lex ci` — run the full CI pipeline locally.
+//!
+//! Equivalent of what `.github/workflows/lex.yml` does:
+//!   1. lex pkg install           install / verify all declared dependencies
+//!   2. lex check --strict <src>  type-check with lint warnings
+//!   3. lex fmt --check <src>     verify formatting
+//!   4. lex test                  run the test suite
+//!
+//! Usage:
+//!   lex ci [--no-fmt] [--src <dir>] [--tests <dir>]
+//!
+//! Defaults: src=src/, tests=tests/. Pass --no-fmt to skip the format check
+//! (useful while actively editing).
+//!
+//! Exits 0 only if every step passes.
+
+use anyhow::Result;
+use std::path::Path;
+
+pub fn cmd_ci(args: &[String]) -> Result<()> {
+    let mut no_fmt    = false;
+    let mut src_dir   = "src".to_string();
+    let mut tests_dir = "tests".to_string();
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--no-fmt" => no_fmt = true,
+            "--src" => {
+                i += 1;
+                src_dir = args.get(i).cloned()
+                    .ok_or_else(|| anyhow::anyhow!("--src requires a value"))?;
+            }
+            "--tests" => {
+                i += 1;
+                tests_dir = args.get(i).cloned()
+                    .ok_or_else(|| anyhow::anyhow!("--tests requires a value"))?;
+            }
+            other => anyhow::bail!("unknown flag `{other}`; usage: lex ci [--no-fmt] [--src <dir>] [--tests <dir>]"),
+        }
+        i += 1;
+    }
+
+    let mut failures: Vec<&'static str> = Vec::new();
+
+    // ── Step 1: pkg install ───────────────────────────────────────────────────
+    println!("==> lex pkg install");
+    if let Err(e) = crate::pkg::cmd_pkg(&["install".to_string()]) {
+        eprintln!("  FAILED: {e:#}");
+        failures.push("pkg install");
+    }
+
+    // ── Step 2: check --strict ────────────────────────────────────────────────
+    println!("\n==> lex check --strict {src_dir}/");
+    let src_files = collect_lex_files(&src_dir);
+    if src_files.is_empty() {
+        println!("  no .lex files in {src_dir}/");
+    } else {
+        for file in &src_files {
+            print!("  checking {} ... ", file.display());
+            let check_args: Vec<String> = vec![
+                "--strict".to_string(),
+                file.display().to_string(),
+            ];
+            match run_check(&check_args) {
+                Ok(()) => println!("ok"),
+                Err(e) => {
+                    println!("FAILED");
+                    eprintln!("  {e:#}");
+                    failures.push("check");
+                }
+            }
+        }
+    }
+
+    // ── Step 3: fmt --check ───────────────────────────────────────────────────
+    if !no_fmt {
+        let dirs_to_fmt: Vec<String> = [src_dir.as_str(), tests_dir.as_str()]
+            .iter()
+            .filter(|d| Path::new(d).is_dir())
+            .map(|d| d.to_string())
+            .collect();
+
+        if !dirs_to_fmt.is_empty() {
+            println!("\n==> lex fmt --check {}", dirs_to_fmt.join(" "));
+            let mut fmt_args = vec!["--check".to_string()];
+            fmt_args.extend(dirs_to_fmt);
+            if let Err(e) = crate::fmt::cmd_fmt(&fmt_args) {
+                eprintln!("  FAILED: {e:#}");
+                failures.push("fmt --check");
+            }
+        }
+    }
+
+    // ── Step 4: test ─────────────────────────────────────────────────────────
+    println!("\n==> lex test");
+    let fmt = ::acli::OutputFormat::Text;
+    if let Err(e) = crate::test_runner::cmd_test(&fmt, &[]) {
+        eprintln!("  FAILED: {e:#}");
+        failures.push("test");
+    }
+
+    // ── Summary ───────────────────────────────────────────────────────────────
+    println!();
+    if failures.is_empty() {
+        println!("CI passed — all steps green");
+        Ok(())
+    } else {
+        anyhow::bail!("CI failed: {}", failures.join(", "))
+    }
+}
+
+fn collect_lex_files(dir: &str) -> Vec<std::path::PathBuf> {
+    let mut out = Vec::new();
+    collect_recursive(Path::new(dir), &mut out);
+    out.sort();
+    out
+}
+
+fn collect_recursive(dir: &Path, out: &mut Vec<std::path::PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else { return };
+    let mut entries: Vec<_> = entries.flatten().collect();
+    entries.sort_by_key(|e| e.path());
+    for entry in entries {
+        let p = entry.path();
+        if p.is_dir() {
+            collect_recursive(&p, out);
+        } else if p.extension().and_then(|e| e.to_str()) == Some("lex") {
+            out.push(p);
+        }
+    }
+}
+
+fn run_check(args: &[String]) -> Result<()> {
+    // Delegate to the check function in main by re-entrant call via
+    // the same process. We call cmd_check directly since it's in the
+    // same binary (not pub, so we route through main's run()).
+    //
+    // Simpler approach: shell out to ourselves.
+    let exe = std::env::current_exe()
+        .unwrap_or_else(|_| std::path::PathBuf::from("lex"));
+    let mut cmd = std::process::Command::new(&exe);
+    cmd.arg("check");
+    for a in args { cmd.arg(a); }
+    let status = cmd.status()
+        .map_err(|e| anyhow::anyhow!("could not run `lex check`: {e}"))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!("`lex check` exited with {}", status))
+    }
+}

--- a/crates/lex-cli/src/fmt.rs
+++ b/crates/lex-cli/src/fmt.rs
@@ -1,0 +1,135 @@
+//! `lex fmt` — format Lex source files using the canonical pretty-printer.
+//!
+//! Usage:
+//!   lex fmt [--check] <file|dir>...
+//!
+//! Without --check: rewrites each file in-place and prints the list of
+//! files that were changed.
+//!
+//! With --check: prints files that would change and exits 1 if any
+//! would (suitable for CI).
+//!
+//! Directories are expanded to all *.lex files found recursively.
+
+use anyhow::{Context, Result};
+use lex_syntax::{parse_source, print_program};
+use std::path::{Path, PathBuf};
+
+pub fn cmd_fmt(args: &[String]) -> Result<()> {
+    let mut check = false;
+    let mut paths: Vec<PathBuf> = Vec::new();
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--check" => check = true,
+            p => paths.push(PathBuf::from(p)),
+        }
+        i += 1;
+    }
+
+    if paths.is_empty() {
+        anyhow::bail!("usage: lex fmt [--check] <file|dir>...");
+    }
+
+    let files = collect_lex_files(&paths)?;
+    if files.is_empty() {
+        println!("no .lex files found");
+        return Ok(());
+    }
+
+    let mut changed = Vec::new();
+    let mut errors  = Vec::new();
+
+    for file in &files {
+        match fmt_file(file) {
+            Ok(Some(formatted)) => {
+                if check {
+                    changed.push(file.clone());
+                } else {
+                    std::fs::write(file, &formatted)
+                        .with_context(|| format!("writing {}", file.display()))?;
+                    changed.push(file.clone());
+                }
+            }
+            Ok(None) => {}
+            Err(e) => errors.push(format!("{}: {e}", file.display())),
+        }
+    }
+
+    for e in &errors {
+        eprintln!("error: {e}");
+    }
+
+    if check {
+        for f in &changed {
+            println!("would reformat {}", f.display());
+        }
+        if !changed.is_empty() {
+            anyhow::bail!("{} file(s) need formatting (run `lex fmt` to fix)", changed.len());
+        }
+        println!("all {} file(s) are formatted", files.len());
+    } else {
+        for f in &changed {
+            println!("reformatted {}", f.display());
+        }
+        let unchanged = files.len() - changed.len();
+        if unchanged > 0 || !changed.is_empty() {
+            println!(
+                "{} reformatted, {} unchanged",
+                changed.len(),
+                unchanged
+            );
+        }
+    }
+
+    if !errors.is_empty() {
+        anyhow::bail!("{} file(s) had parse errors", errors.len());
+    }
+    Ok(())
+}
+
+/// Returns `Some(formatted)` if the file needs reformatting, `None` if already canonical.
+fn fmt_file(path: &Path) -> Result<Option<String>> {
+    let src = std::fs::read_to_string(path)
+        .with_context(|| format!("reading {}", path.display()))?;
+    let prog = parse_source(&src)
+        .map_err(|e| anyhow::anyhow!("parse error: {e:?}"))?;
+    let formatted = print_program(&prog);
+    if formatted == src {
+        Ok(None)
+    } else {
+        Ok(Some(formatted))
+    }
+}
+
+/// Expand a list of file/directory paths to a sorted list of .lex files.
+fn collect_lex_files(paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
+    let mut files: Vec<PathBuf> = Vec::new();
+    for path in paths {
+        if path.is_dir() {
+            collect_recursive(path, &mut files);
+        } else if path.extension().and_then(|e| e.to_str()) == Some("lex") {
+            files.push(path.clone());
+        } else {
+            anyhow::bail!("{} is not a .lex file or directory", path.display());
+        }
+    }
+    files.sort();
+    files.dedup();
+    Ok(files)
+}
+
+fn collect_recursive(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else { return };
+    let mut entries: Vec<_> = entries.flatten().collect();
+    entries.sort_by_key(|e| e.path());
+    for entry in entries {
+        let p = entry.path();
+        if p.is_dir() {
+            collect_recursive(&p, out);
+        } else if p.extension().and_then(|e| e.to_str()) == Some("lex") {
+            out.push(p);
+        }
+    }
+}

--- a/crates/lex-cli/src/init.rs
+++ b/crates/lex-cli/src/init.rs
@@ -1,0 +1,134 @@
+//! `lex init` — scaffold a new Lex project.
+//!
+//! Creates in the current directory (or the given path):
+//!   lex.toml                   package manifest
+//!   src/main.lex               entry-point stub
+//!   tests/test_main.lex        test stub (run_all returns 0)
+//!   .github/workflows/lex.yml  GitHub Actions CI workflow
+//!
+//! Existing files are never overwritten.
+
+use anyhow::{Context, Result};
+use std::path::Path;
+
+pub fn cmd_init(args: &[String]) -> Result<()> {
+    let root = args.first().map(|s| s.as_str()).unwrap_or(".");
+    let root = Path::new(root);
+
+    if !root.exists() {
+        std::fs::create_dir_all(root)
+            .with_context(|| format!("creating directory {}", root.display()))?;
+    }
+
+    let name = root.canonicalize()
+        .unwrap_or_else(|_| root.to_path_buf())
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "my-project".to_string());
+
+    let mut created = Vec::new();
+    let mut skipped = Vec::new();
+
+    let files: &[(&str, &dyn Fn(&str) -> String)] = &[
+        ("lex.toml",                    &lex_toml),
+        ("src/main.lex",                &main_lex),
+        ("tests/test_main.lex",         &test_lex),
+        (".github/workflows/lex.yml",   &ci_yml),
+    ];
+
+    for (rel, gen) in files {
+        let path = root.join(rel);
+        if path.exists() {
+            skipped.push(rel.to_string());
+            continue;
+        }
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating {}", parent.display()))?;
+        }
+        std::fs::write(&path, gen(&name))
+            .with_context(|| format!("writing {}", path.display()))?;
+        created.push(rel.to_string());
+    }
+
+    for f in &created { println!("  created  {f}"); }
+    for f in &skipped { println!("  skipped  {f}  (already exists)"); }
+
+    if !created.is_empty() {
+        println!("\nproject `{name}` initialized. next steps:");
+        println!("  lex check src/main.lex");
+        println!("  lex test");
+        println!("  lex fmt src/");
+    }
+
+    Ok(())
+}
+
+fn lex_toml(name: &str) -> String {
+    format!(
+        r#"[package]
+name = "{name}"
+version = "0.1.0"
+
+[dependencies]
+# lex-schema = {{ path = "../lex-schema" }}
+# lex-schema = {{ git = "https://github.com/alpibrusl/lex-schema" }}
+"#
+    )
+}
+
+fn main_lex(_name: &str) -> String {
+    // Use the printer's canonical output so `lex fmt --check` passes immediately.
+    let src = "fn main() -> Str {\n  \"hello, world\"\n}\n";
+    let prog = lex_syntax::parse_source(src).expect("stub is valid lex");
+    lex_syntax::print_program(&prog)
+}
+
+fn test_lex(_name: &str) -> String {
+    let src = concat!(
+        "import \"std.list\" as list\n\n",
+        "fn run_all() -> () {\n",
+        "  list.fold([], (), fn (_ :: (), _ :: ()) -> () { () })\n",
+        "}\n",
+    );
+    let prog = lex_syntax::parse_source(src).expect("stub is valid lex");
+    lex_syntax::print_program(&prog)
+}
+
+fn ci_yml(_name: &str) -> String {
+    // $GITHUB_PATH is a shell variable, not a Rust format specifier.
+    // We build the string without format! to avoid escaping every $.
+    [
+        "name: CI\n",
+        "\n",
+        "on:\n",
+        "  push:\n",
+        "    branches: [main]\n",
+        "  pull_request:\n",
+        "\n",
+        "jobs:\n",
+        "  build:\n",
+        "    runs-on: ubuntu-latest\n",
+        "    steps:\n",
+        "      - uses: actions/checkout@v4\n",
+        "\n",
+        "      - name: Install Lex toolchain\n",
+        "        run: |\n",
+        "          git clone --depth=1 https://github.com/alpibrusl/lex-lang /tmp/lex-lang\n",
+        "          cd /tmp/lex-lang && cargo build --release -p lex-cli\n",
+        "          echo \"/tmp/lex-lang/target/release\" >> $GITHUB_PATH\n",
+        "\n",
+        "      - name: Install package dependencies\n",
+        "        run: lex pkg install\n",
+        "\n",
+        "      - name: Type-check (strict)\n",
+        "        run: lex check --strict src/main.lex\n",
+        "\n",
+        "      - name: Format check\n",
+        "        run: lex fmt --check src/ tests/\n",
+        "\n",
+        "      - name: Test\n",
+        "        run: lex test\n",
+    ]
+    .concat()
+}

--- a/crates/lex-cli/src/init.rs
+++ b/crates/lex-cli/src/init.rs
@@ -29,11 +29,12 @@ pub fn cmd_init(args: &[String]) -> Result<()> {
     let mut created = Vec::new();
     let mut skipped = Vec::new();
 
-    let files: &[(&str, &dyn Fn(&str) -> String)] = &[
-        ("lex.toml",                    &lex_toml),
-        ("src/main.lex",                &main_lex),
-        ("tests/test_main.lex",         &test_lex),
-        (".github/workflows/lex.yml",   &ci_yml),
+    type Gen = fn(&str) -> String;
+    let files: &[(&str, Gen)] = &[
+        ("lex.toml",                    lex_toml),
+        ("src/main.lex",                main_lex),
+        ("tests/test_main.lex",         test_lex),
+        (".github/workflows/lex.yml",   ci_yml),
     ];
 
     for (rel, gen) in files {

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -24,6 +24,9 @@ mod lint;
 mod pkg;
 mod test_runner;
 mod watch;
+mod fmt;
+mod init;
+mod ci;
 
 use ::acli::OutputFormat;
 use anyhow::{anyhow, bail, Context, Result};
@@ -118,6 +121,9 @@ fn run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         "repl" => repl::cmd_repl(&args[1..]),
         "test" => test_runner::cmd_test(fmt, &args[1..]),
         "watch" => watch::cmd_watch(&args[1..]),
+        "fmt"  => fmt::cmd_fmt(&args[1..]),
+        "init" => init::cmd_init(&args[1..]),
+        "ci"   => ci::cmd_ci(&args[1..]),
         "help" | "--help" | "-h" => { print_usage(); Ok(()) }
         other => bail!("unknown command `{other}`. try `lex help`"),
     }
@@ -154,11 +160,17 @@ fn parse_output_format(args: &[String]) -> Result<(OutputFormat, Vec<String>)> {
 fn print_usage() {
     println!("lex — Lex toolchain\n");
     println!("commands:");
+    println!("  init [<dir>]                       scaffold a new project (lex.toml, src/, tests/, CI)");
     println!("  parse <file>                       print canonical AST as JSON");
     println!("  check [--strict] <file>            type-check; --strict adds lint warnings");
+    println!("  fmt [--check] <file|dir>...        format .lex files; --check exits 1 if any need it");
+    println!("  ci [--no-fmt] [--src <d>] [--tests <d>]");
+    println!("                                     run the full pipeline: pkg install, check --strict,");
+    println!("                                     fmt --check, test — same as CI in lex.yml");
     println!("  pkg init                           create lex.toml in current directory");
     println!("  pkg add <name> --path <p>          add a local path dependency");
     println!("  pkg add <name> --git <url>         add a git dependency");
+    println!("  pkg install                        install/verify all declared dependencies");
     println!("  pkg list                           list declared dependencies");
     println!("  run [policy] <file> <fn> [args]    execute fn (args parsed as JSON)");
     println!("  run --from-store STAGE_ID [--require-signed] [--trusted-key HEX] <fn> [args]");

--- a/crates/lex-cli/src/pkg.rs
+++ b/crates/lex-cli/src/pkg.rs
@@ -14,8 +14,9 @@ pub fn cmd_pkg(args: &[String]) -> Result<()> {
         Some("init")    => cmd_init(),
         Some("add")     => cmd_add(&args[1..]),
         Some("list")    => cmd_list(),
-        Some(other)     => bail!("unknown pkg subcommand `{other}`; try: init, add, list"),
-        None            => bail!("usage: lex pkg <init|add|list>"),
+        Some("install") => cmd_install(),
+        Some(other)     => bail!("unknown pkg subcommand `{other}`; try: init, add, install, list"),
+        None            => bail!("usage: lex pkg <init|add|install|list>"),
     }
 }
 
@@ -82,6 +83,67 @@ fn cmd_add(args: &[String]) -> Result<()> {
     };
 
     upsert_dependency(name, &dep_entry)
+}
+
+// ── lex pkg install ───────────────────────────────────────────────────────────
+
+/// Resolve and install all dependencies declared in the nearest lex.toml.
+///
+/// For path dependencies: verify the directory exists.
+/// For git dependencies: clone into the cache directory if not already present.
+fn cmd_install() -> Result<()> {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| ".".into());
+    let (toml_path, toml_dir) = lex_syntax::find_manifest(&cwd)
+        .ok_or_else(|| anyhow::anyhow!("no lex.toml found (run `lex pkg init` to create one)"))?;
+
+    let manifest = lex_syntax::Manifest::load(&toml_path)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    if manifest.dependencies.is_empty() {
+        println!("no dependencies declared in {}", toml_path.display());
+        return Ok(());
+    }
+
+    println!("installing dependencies from {}:", toml_path.display());
+    let mut errors = Vec::new();
+
+    for (name, dep) in &manifest.dependencies {
+        match dep {
+            lex_syntax::workspace::Dependency::Path { path } => {
+                let full = toml_dir.join(path);
+                if full.exists() {
+                    println!("  {} (path)  ok — {}", name, full.display());
+                } else {
+                    let msg = format!("  {} (path)  NOT FOUND: {}", name, full.display());
+                    eprintln!("{msg}");
+                    errors.push(msg);
+                }
+            }
+            lex_syntax::workspace::Dependency::Git { git } => {
+                print!("  {} (git)   {} ... ", name, git);
+                // resolve_package_import triggers git_ensure_cached internally.
+                // We use a dummy module name — we only care about the side-effect.
+                let dummy_file = toml_dir.join("__install_probe__.lex");
+                match lex_syntax::workspace::resolve_package_import(&dummy_file, name, "__probe__") {
+                    Ok(_) | Err(lex_syntax::PackageError::ModuleNotFound { .. }) => {
+                        println!("ok");
+                    }
+                    Err(e) => {
+                        println!("FAILED");
+                        eprintln!("    {e}");
+                        errors.push(format!("{name}: {e}"));
+                    }
+                }
+            }
+        }
+    }
+
+    if errors.is_empty() {
+        println!("all {} dependency/dependencies installed", manifest.dependencies.len());
+        Ok(())
+    } else {
+        bail!("{} dependency/dependencies failed to install", errors.len())
+    }
 }
 
 // ── lex pkg list ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

This PR adds three new CLI commands (`lex fmt`, `lex init`, `lex ci`) and implements the `lex pkg install` subcommand. These commands provide project scaffolding, code formatting, and a local CI pipeline runner that mirrors the GitHub Actions workflow.

## Why

Users need a way to:
1. **Initialize new projects** with boilerplate (manifest, source stubs, CI workflow)
2. **Format code** using a canonical pretty-printer with `--check` mode for CI
3. **Run the full CI pipeline locally** before pushing, matching what `.github/workflows/lex.yml` does
4. **Install and verify dependencies** declared in `lex.toml`

These are essential developer experience features for a language toolchain.

## Changes

- **`lex init [<dir>]`**: Scaffolds a new project with `lex.toml`, `src/main.lex`, `tests/test_main.lex`, and `.github/workflows/lex.yml`. Skips existing files.
- **`lex fmt [--check] <file|dir>...`**: Formats `.lex` files using the canonical printer. `--check` mode verifies formatting without writing (for CI).
- **`lex ci [--no-fmt] [--src <dir>] [--tests <dir>]`**: Runs the full CI pipeline locally:
  1. `lex pkg install` — verify dependencies
  2. `lex check --strict <src>` — type-check with lint warnings
  3. `lex fmt --check <src> <tests>` — verify formatting (skippable with `--no-fmt`)
  4. `lex test` — run test suite
- **`lex pkg install`**: Resolves and installs all dependencies from `lex.toml`. Verifies path dependencies exist and clones git dependencies into cache.

## Test plan

- `cargo test --workspace` passes locally
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- Manual verification: `lex init /tmp/test-proj` creates expected files; `lex fmt --check` correctly identifies unformatted files; `lex ci` runs all four steps in sequence

## Risk / scope

- Touches: `lex-cli` (new modules: `fmt.rs`, `init.rs`, `ci.rs`; modified: `pkg.rs`, `main.rs`)
- Breaking change: **no**
- New effect kind or runtime variant: **no**

https://claude.ai/code/session_01TN34hWDyCyB9WmUKVVacTQ