### PR TITLE
feat(sql): Postgres support in std.sql — sync driver, tx helpers (#362)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.8.2"
+version = "0.9.0"
 edition = "2021"
 license = "EUPL-1.2"
 repository = "https://github.com/alpibrusl/lex-lang"

--- a/crates/lex-api/Cargo.toml
+++ b/crates/lex-api/Cargo.toml
@@ -16,14 +16,14 @@ serde_json.workspace = true
 anyhow.workspace = true
 indexmap.workspace = true
 tiny_http = "0.12"
-lex-syntax = { path = "../lex-syntax", version = "0.8.2" }
-lex-ast = { path = "../lex-ast", version = "0.8.2" }
-lex-types = { path = "../lex-types", version = "0.8.2" }
-lex-bytecode = { path = "../lex-bytecode", version = "0.8.2" }
-lex-runtime = { path = "../lex-runtime", version = "0.8.2" }
-lex-store = { path = "../lex-store", version = "0.8.2" }
-lex-trace = { path = "../lex-trace", version = "0.8.2" }
-lex-vcs = { path = "../lex-vcs", version = "0.8.2" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.0" }
+lex-ast = { path = "../lex-ast", version = "0.9.0" }
+lex-types = { path = "../lex-types", version = "0.9.0" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.9.0" }
+lex-runtime = { path = "../lex-runtime", version = "0.9.0" }
+lex-store = { path = "../lex-store", version = "0.9.0" }
+lex-trace = { path = "../lex-trace", version = "0.9.0" }
+lex-vcs = { path = "../lex-vcs", version = "0.9.0" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/lex-ast/Cargo.toml
+++ b/crates/lex-ast/Cargo.toml
@@ -16,4 +16,4 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-syntax = { path = "../lex-syntax", version = "0.8.2" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.0" }

--- a/crates/lex-bytecode/Cargo.toml
+++ b/crates/lex-bytecode/Cargo.toml
@@ -16,8 +16,8 @@ serde_json.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
 sha2.workspace = true
-lex-ast = { path = "../lex-ast", version = "0.8.2" }
-lex-types = { path = "../lex-types", version = "0.8.2" }
+lex-ast = { path = "../lex-ast", version = "0.9.0" }
+lex-types = { path = "../lex-types", version = "0.9.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.8.2" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.0" }

--- a/crates/lex-lsp/Cargo.toml
+++ b/crates/lex-lsp/Cargo.toml
@@ -25,12 +25,12 @@ serde_json.workspace = true
 # are rust-analyzer-team-maintained.
 lsp-server = "0.7"
 lsp-types = "0.97"
-lex-syntax = { path = "../lex-syntax", version = "0.8.2" }
-lex-ast = { path = "../lex-ast", version = "0.8.2" }
-lex-types = { path = "../lex-types", version = "0.8.2" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.0" }
+lex-ast = { path = "../lex-ast", version = "0.9.0" }
+lex-types = { path = "../lex-types", version = "0.9.0" }
 # Phase 4 of #304: surface RepairHint attestations from the store.
-lex-vcs = { path = "../lex-vcs", version = "0.8.2" }
-lex-store = { path = "../lex-store", version = "0.8.2" }
+lex-vcs = { path = "../lex-vcs", version = "0.9.0" }
+lex-store = { path = "../lex-store", version = "0.9.0" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -35,10 +35,10 @@ toml = "1.1"
 serde_yaml = "0.9"
 csv = "1"
 rusqlite = { version = "0.39", features = ["bundled"] }
-lex-bytecode = { path = "../lex-bytecode", version = "0.8.2" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.9.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.8.2" }
-lex-ast = { path = "../lex-ast", version = "0.8.2" }
-lex-types = { path = "../lex-types", version = "0.8.2" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.0" }
+lex-ast = { path = "../lex-ast", version = "0.9.0" }
+lex-types = { path = "../lex-types", version = "0.9.0" }
 tempfile = "3"

--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -35,6 +35,7 @@ toml = "1.1"
 serde_yaml = "0.9"
 csv = "1"
 rusqlite = { version = "0.39", features = ["bundled"] }
+postgres = "0.19"
 lex-bytecode = { path = "../lex-bytecode", version = "0.9.0" }
 
 [dev-dependencies]

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -1082,13 +1082,13 @@ impl EffectHandler for DefaultHandler {
             ("sql", "exec") => {
                 let h = expect_sql_handle(args.first())?;
                 let stmt = expect_str(args.get(1))?.to_string();
-                let params = expect_str_list(args.get(2))?;
+                let params = expect_sql_params(args.get(2))?;
                 let arc = sql_registry().lock().unwrap()
                     .touch_get(h)
                     .ok_or_else(|| "sql.exec: closed or unknown Db handle".to_string())?;
                 let conn = arc.lock().unwrap();
                 let bind: Vec<&dyn rusqlite::ToSql> = params.iter()
-                    .map(|s| s as &dyn rusqlite::ToSql)
+                    .map(|p| p as &dyn rusqlite::ToSql)
                     .collect();
                 match conn.execute(&stmt, rusqlite::params_from_iter(bind.iter())) {
                     Ok(n)  => Ok(ok(Value::Int(n as i64))),
@@ -1098,13 +1098,96 @@ impl EffectHandler for DefaultHandler {
             ("sql", "query") => {
                 let h = expect_sql_handle(args.first())?;
                 let stmt_str = expect_str(args.get(1))?.to_string();
-                let params = expect_str_list(args.get(2))?;
+                let params = expect_sql_params(args.get(2))?;
                 let arc = sql_registry().lock().unwrap()
                     .touch_get(h)
                     .ok_or_else(|| "sql.query: closed or unknown Db handle".to_string())?;
                 let conn = arc.lock().unwrap();
                 Ok(sql_run_query(&conn, &stmt_str, &params))
             }
+            // Transactions: begin issues BEGIN SQL on the connection;
+            // commit/rollback issue COMMIT/ROLLBACK. SqlTx reuses the
+            // same Int handle as Db — the type system enforces correct
+            // usage; the runtime treats both as the same registry key.
+            ("sql", "begin") => {
+                let h = expect_sql_handle(args.first())?;
+                let arc = sql_registry().lock().unwrap()
+                    .touch_get(h)
+                    .ok_or_else(|| "sql.begin: closed or unknown Db handle".to_string())?;
+                let conn = arc.lock().unwrap();
+                match conn.execute_batch("BEGIN") {
+                    Ok(()) => Ok(ok(Value::Int(h as i64))),
+                    Err(e) => Ok(err(Value::Str(format!("sql.begin: {e}")))),
+                }
+            }
+            ("sql", "commit") => {
+                let h = expect_sql_handle(args.first())?;
+                let arc = sql_registry().lock().unwrap()
+                    .touch_get(h)
+                    .ok_or_else(|| "sql.commit: closed or unknown SqlTx handle".to_string())?;
+                let conn = arc.lock().unwrap();
+                match conn.execute_batch("COMMIT") {
+                    Ok(()) => Ok(ok(Value::Unit)),
+                    Err(e) => Ok(err(Value::Str(format!("sql.commit: {e}")))),
+                }
+            }
+            ("sql", "rollback") => {
+                let h = expect_sql_handle(args.first())?;
+                let arc = sql_registry().lock().unwrap()
+                    .touch_get(h)
+                    .ok_or_else(|| "sql.rollback: closed or unknown SqlTx handle".to_string())?;
+                let conn = arc.lock().unwrap();
+                match conn.execute_batch("ROLLBACK") {
+                    Ok(()) => Ok(ok(Value::Unit)),
+                    Err(e) => Ok(err(Value::Str(format!("sql.rollback: {e}")))),
+                }
+            }
+            ("sql", "exec_tx") => {
+                let h = expect_sql_handle(args.first())?;
+                let stmt = expect_str(args.get(1))?.to_string();
+                let params = expect_sql_params(args.get(2))?;
+                let arc = sql_registry().lock().unwrap()
+                    .touch_get(h)
+                    .ok_or_else(|| "sql.exec_tx: closed or unknown SqlTx handle".to_string())?;
+                let conn = arc.lock().unwrap();
+                let bind: Vec<&dyn rusqlite::ToSql> = params.iter()
+                    .map(|p| p as &dyn rusqlite::ToSql)
+                    .collect();
+                match conn.execute(&stmt, rusqlite::params_from_iter(bind.iter())) {
+                    Ok(n)  => Ok(ok(Value::Int(n as i64))),
+                    Err(e) => Ok(err(Value::Str(format!("sql.exec_tx: {e}")))),
+                }
+            }
+            ("sql", "query_tx") => {
+                let h = expect_sql_handle(args.first())?;
+                let stmt_str = expect_str(args.get(1))?.to_string();
+                let params = expect_sql_params(args.get(2))?;
+                let arc = sql_registry().lock().unwrap()
+                    .touch_get(h)
+                    .ok_or_else(|| "sql.query_tx: closed or unknown SqlTx handle".to_string())?;
+                let conn = arc.lock().unwrap();
+                Ok(sql_run_query(&conn, &stmt_str, &params))
+            }
+            ("sql", "get_str") => Ok(sql_get_col(&args, |v| match v {
+                Value::Str(s) => Some(Value::Str(s.clone())),
+                Value::Int(n) => Some(Value::Str(n.to_string())),
+                _ => None,
+            })?),
+            ("sql", "get_int") => Ok(sql_get_col(&args, |v| match v {
+                Value::Int(n) => Some(Value::Int(*n)),
+                Value::Float(f) => Some(Value::Int(*f as i64)),
+                _ => None,
+            })?),
+            ("sql", "get_float") => Ok(sql_get_col(&args, |v| match v {
+                Value::Float(f) => Some(Value::Float(*f)),
+                Value::Int(n)   => Some(Value::Float(*n as f64)),
+                _ => None,
+            })?),
+            ("sql", "get_bool") => Ok(sql_get_col(&args, |v| match v {
+                Value::Bool(b)  => Some(Value::Bool(*b)),
+                Value::Int(n)   => Some(Value::Bool(*n != 0)),
+                _ => None,
+            })?),
             ("proc", "spawn") => {
                 // The escape hatch effect. Spawns a child process,
                 // collects its stdout/stderr, returns a structured
@@ -1848,15 +1931,49 @@ fn expect_str_list(v: Option<&Value>) -> Result<Vec<String>, String> {
     }
 }
 
-/// Run a `SELECT` (or any returning statement) and pack the rows
-/// into `Value::List(Value::Record(...))` shape — column-name keys,
-/// SQLite-typed values mapped one-for-one to Lex value variants
-/// (Null → Unit, Integer → Int, Real → Float, Text → Str, Blob →
-/// Bytes). Returns the standard `Result[List[T], Str]` Lex shape.
+/// Convert a `List[SqlParam]` value to rusqlite-boxed parameter values.
+/// SqlParam = PStr(Str) | PInt(Int) | PFloat(Float) | PBool(Bool) | PNull
+fn expect_sql_params(v: Option<&Value>) -> Result<Vec<rusqlite::types::Value>, String> {
+    let items = match v {
+        Some(Value::List(xs)) => xs,
+        Some(other) => return Err(format!("expected List[SqlParam], got {other:?}")),
+        None => return Err("missing params argument".into()),
+    };
+    items.iter().map(|item| {
+        match item {
+            Value::Variant { name, args } => match name.as_str() {
+                "PStr"   => match args.first() {
+                    Some(Value::Str(s)) => Ok(rusqlite::types::Value::Text(s.clone())),
+                    _ => Err("PStr requires a Str argument".into()),
+                },
+                "PInt"   => match args.first() {
+                    Some(Value::Int(n)) => Ok(rusqlite::types::Value::Integer(*n)),
+                    _ => Err("PInt requires an Int argument".into()),
+                },
+                "PFloat" => match args.first() {
+                    Some(Value::Float(f)) => Ok(rusqlite::types::Value::Real(*f)),
+                    _ => Err("PFloat requires a Float argument".into()),
+                },
+                "PBool"  => match args.first() {
+                    Some(Value::Bool(b)) => Ok(rusqlite::types::Value::Integer(*b as i64)),
+                    _ => Err("PBool requires a Bool argument".into()),
+                },
+                "PNull"  => Ok(rusqlite::types::Value::Null),
+                other    => Err(format!("unknown SqlParam constructor `{other}`")),
+            },
+            // Backward-compat: bare strings are accepted as PStr.
+            Value::Str(s) => Ok(rusqlite::types::Value::Text(s.clone())),
+            other => Err(format!("expected SqlParam variant, got {other:?}")),
+        }
+    }).collect()
+}
+
+/// Run a statement and pack the rows into `Value::List(Value::Record(...))`.
+/// Returns the standard `Result[List[T], Str]` Lex shape.
 fn sql_run_query(
     conn: &rusqlite::Connection,
     stmt_str: &str,
-    params: &[String],
+    params: &[rusqlite::types::Value],
 ) -> Value {
     let mut stmt = match conn.prepare(stmt_str) {
         Ok(s)  => s,
@@ -1867,7 +1984,7 @@ fn sql_run_query(
         .map(|i| stmt.column_name(i).unwrap_or("").to_string())
         .collect();
     let bind: Vec<&dyn rusqlite::ToSql> = params.iter()
-        .map(|s| s as &dyn rusqlite::ToSql)
+        .map(|p| p as &dyn rusqlite::ToSql)
         .collect();
     let mut rows = match stmt.query(rusqlite::params_from_iter(bind.iter())) {
         Ok(r)  => r,
@@ -1891,6 +2008,27 @@ fn sql_run_query(
         out.push(Value::Record(rec));
     }
     ok(Value::List(out))
+}
+
+/// Extract a column value from a row record by name, returning `Option[X]`.
+fn sql_get_col<F>(args: &[Value], convert: F) -> Result<Value, String>
+where
+    F: Fn(&Value) -> Option<Value>,
+{
+    let row = args.first().ok_or("sql.get_*: missing row argument")?;
+    let col = match args.get(1) {
+        Some(Value::Str(s)) => s.as_str(),
+        Some(other) => return Err(format!("sql.get_*: column name must be Str, got {other:?}")),
+        None => return Err("sql.get_*: missing column name argument".into()),
+    };
+    let cell = match row {
+        Value::Record(rec) => rec.get(col).cloned(),
+        other => return Err(format!("sql.get_*: row must be a Record, got {other:?}")),
+    };
+    Ok(match cell.and_then(|v| convert(&v)) {
+        Some(v) => Value::Variant { name: "Some".into(), args: vec![v] },
+        None    => Value::Variant { name: "None".into(), args: vec![] },
+    })
 }
 
 fn sql_value_ref_to_lex(v: rusqlite::types::ValueRef<'_>) -> Value {

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -1055,23 +1055,34 @@ impl EffectHandler for DefaultHandler {
             }
             ("sql", "open") => {
                 let path = expect_str(args.first())?.to_string();
-                // Same shape as `kv.open`: opening creates the
-                // SQLite file, so the fs-write allowlist applies
-                // (in-memory paths are exempt).
-                if path != ":memory:" && !self.policy.allow_fs_write.is_empty() {
-                    let p = std::path::Path::new(&path);
-                    if !self.policy.allow_fs_write.iter().any(|a| p.starts_with(a)) {
-                        return Ok(err(Value::Str(format!(
-                            "sql.open: `{path}` outside --allow-fs-write"))));
+                if path.starts_with("postgres://") || path.starts_with("postgresql://") {
+                    // Postgres: connect via sync driver; no fs-write policy applies.
+                    match postgres::Client::connect(&path, postgres::NoTls) {
+                        Ok(client) => {
+                            let handle = next_sql_handle();
+                            sql_registry().lock().unwrap().insert(handle, SqlConn::Postgres(client));
+                            Ok(ok(Value::Int(handle as i64)))
+                        }
+                        Err(e) => Ok(err(Value::Str(format!("sql.open: {e}")))),
                     }
-                }
-                match rusqlite::Connection::open(&path) {
-                    Ok(conn) => {
-                        let handle = next_sql_handle();
-                        sql_registry().lock().unwrap().insert(handle, conn);
-                        Ok(ok(Value::Int(handle as i64)))
+                } else {
+                    // SQLite: same shape as `kv.open`; fs-write allowlist applies
+                    // (in-memory paths are exempt).
+                    if path != ":memory:" && !self.policy.allow_fs_write.is_empty() {
+                        let p = std::path::Path::new(&path);
+                        if !self.policy.allow_fs_write.iter().any(|a| p.starts_with(a)) {
+                            return Ok(err(Value::Str(format!(
+                                "sql.open: `{path}` outside --allow-fs-write"))));
+                        }
                     }
-                    Err(e) => Ok(err(Value::Str(format!("sql.open: {e}")))),
+                    match rusqlite::Connection::open(&path) {
+                        Ok(conn) => {
+                            let handle = next_sql_handle();
+                            sql_registry().lock().unwrap().insert(handle, SqlConn::Sqlite(conn));
+                            Ok(ok(Value::Int(handle as i64)))
+                        }
+                        Err(e) => Ok(err(Value::Str(format!("sql.open: {e}")))),
+                    }
                 }
             }
             ("sql", "close") => {
@@ -1086,13 +1097,26 @@ impl EffectHandler for DefaultHandler {
                 let arc = sql_registry().lock().unwrap()
                     .touch_get(h)
                     .ok_or_else(|| "sql.exec: closed or unknown Db handle".to_string())?;
-                let conn = arc.lock().unwrap();
-                let bind: Vec<&dyn rusqlite::ToSql> = params.iter()
-                    .map(|p| p as &dyn rusqlite::ToSql)
-                    .collect();
-                match conn.execute(&stmt, rusqlite::params_from_iter(bind.iter())) {
-                    Ok(n)  => Ok(ok(Value::Int(n as i64))),
-                    Err(e) => Ok(err(Value::Str(format!("sql.exec: {e}")))),
+                let mut conn = arc.lock().unwrap();
+                match &mut *conn {
+                    SqlConn::Sqlite(c) => {
+                        let bound = sqlite_params(&params);
+                        let bind: Vec<&dyn rusqlite::ToSql> =
+                            bound.iter().map(|p| p as &dyn rusqlite::ToSql).collect();
+                        match c.execute(&stmt, rusqlite::params_from_iter(bind.iter())) {
+                            Ok(n)  => Ok(ok(Value::Int(n as i64))),
+                            Err(e) => Ok(err(Value::Str(format!("sql.exec: {e}")))),
+                        }
+                    }
+                    SqlConn::Postgres(c) => {
+                        let pg = pg_param_refs(&params);
+                        let refs: Vec<&(dyn postgres::types::ToSql + Sync)> =
+                            pg.iter().map(|b| b.as_ref()).collect();
+                        match c.execute(stmt.as_str(), &refs) {
+                            Ok(n)  => Ok(ok(Value::Int(n as i64))),
+                            Err(e) => Ok(err(Value::Str(format!("sql.exec: {e}")))),
+                        }
+                    }
                 }
             }
             ("sql", "query") => {
@@ -1102,8 +1126,11 @@ impl EffectHandler for DefaultHandler {
                 let arc = sql_registry().lock().unwrap()
                     .touch_get(h)
                     .ok_or_else(|| "sql.query: closed or unknown Db handle".to_string())?;
-                let conn = arc.lock().unwrap();
-                Ok(sql_run_query(&conn, &stmt_str, &params))
+                let mut conn = arc.lock().unwrap();
+                Ok(match &mut *conn {
+                    SqlConn::Sqlite(c)   => sql_run_query_sqlite(c, &stmt_str, &params),
+                    SqlConn::Postgres(c) => sql_run_query_pg(c, &stmt_str, &params),
+                })
             }
             // Transactions: begin issues BEGIN SQL on the connection;
             // commit/rollback issue COMMIT/ROLLBACK. SqlTx reuses the
@@ -1114,8 +1141,12 @@ impl EffectHandler for DefaultHandler {
                 let arc = sql_registry().lock().unwrap()
                     .touch_get(h)
                     .ok_or_else(|| "sql.begin: closed or unknown Db handle".to_string())?;
-                let conn = arc.lock().unwrap();
-                match conn.execute_batch("BEGIN") {
+                let mut conn = arc.lock().unwrap();
+                let res = match &mut *conn {
+                    SqlConn::Sqlite(c)   => c.execute_batch("BEGIN").map_err(|e| e.to_string()),
+                    SqlConn::Postgres(c) => c.batch_execute("BEGIN").map_err(|e| e.to_string()),
+                };
+                match res {
                     Ok(()) => Ok(ok(Value::Int(h as i64))),
                     Err(e) => Ok(err(Value::Str(format!("sql.begin: {e}")))),
                 }
@@ -1125,8 +1156,12 @@ impl EffectHandler for DefaultHandler {
                 let arc = sql_registry().lock().unwrap()
                     .touch_get(h)
                     .ok_or_else(|| "sql.commit: closed or unknown SqlTx handle".to_string())?;
-                let conn = arc.lock().unwrap();
-                match conn.execute_batch("COMMIT") {
+                let mut conn = arc.lock().unwrap();
+                let res = match &mut *conn {
+                    SqlConn::Sqlite(c)   => c.execute_batch("COMMIT").map_err(|e| e.to_string()),
+                    SqlConn::Postgres(c) => c.batch_execute("COMMIT").map_err(|e| e.to_string()),
+                };
+                match res {
                     Ok(()) => Ok(ok(Value::Unit)),
                     Err(e) => Ok(err(Value::Str(format!("sql.commit: {e}")))),
                 }
@@ -1136,8 +1171,12 @@ impl EffectHandler for DefaultHandler {
                 let arc = sql_registry().lock().unwrap()
                     .touch_get(h)
                     .ok_or_else(|| "sql.rollback: closed or unknown SqlTx handle".to_string())?;
-                let conn = arc.lock().unwrap();
-                match conn.execute_batch("ROLLBACK") {
+                let mut conn = arc.lock().unwrap();
+                let res = match &mut *conn {
+                    SqlConn::Sqlite(c)   => c.execute_batch("ROLLBACK").map_err(|e| e.to_string()),
+                    SqlConn::Postgres(c) => c.batch_execute("ROLLBACK").map_err(|e| e.to_string()),
+                };
+                match res {
                     Ok(()) => Ok(ok(Value::Unit)),
                     Err(e) => Ok(err(Value::Str(format!("sql.rollback: {e}")))),
                 }
@@ -1149,13 +1188,26 @@ impl EffectHandler for DefaultHandler {
                 let arc = sql_registry().lock().unwrap()
                     .touch_get(h)
                     .ok_or_else(|| "sql.exec_tx: closed or unknown SqlTx handle".to_string())?;
-                let conn = arc.lock().unwrap();
-                let bind: Vec<&dyn rusqlite::ToSql> = params.iter()
-                    .map(|p| p as &dyn rusqlite::ToSql)
-                    .collect();
-                match conn.execute(&stmt, rusqlite::params_from_iter(bind.iter())) {
-                    Ok(n)  => Ok(ok(Value::Int(n as i64))),
-                    Err(e) => Ok(err(Value::Str(format!("sql.exec_tx: {e}")))),
+                let mut conn = arc.lock().unwrap();
+                match &mut *conn {
+                    SqlConn::Sqlite(c) => {
+                        let bound = sqlite_params(&params);
+                        let bind: Vec<&dyn rusqlite::ToSql> =
+                            bound.iter().map(|p| p as &dyn rusqlite::ToSql).collect();
+                        match c.execute(&stmt, rusqlite::params_from_iter(bind.iter())) {
+                            Ok(n)  => Ok(ok(Value::Int(n as i64))),
+                            Err(e) => Ok(err(Value::Str(format!("sql.exec_tx: {e}")))),
+                        }
+                    }
+                    SqlConn::Postgres(c) => {
+                        let pg = pg_param_refs(&params);
+                        let refs: Vec<&(dyn postgres::types::ToSql + Sync)> =
+                            pg.iter().map(|b| b.as_ref()).collect();
+                        match c.execute(stmt.as_str(), &refs) {
+                            Ok(n)  => Ok(ok(Value::Int(n as i64))),
+                            Err(e) => Ok(err(Value::Str(format!("sql.exec_tx: {e}")))),
+                        }
+                    }
                 }
             }
             ("sql", "query_tx") => {
@@ -1165,8 +1217,11 @@ impl EffectHandler for DefaultHandler {
                 let arc = sql_registry().lock().unwrap()
                     .touch_get(h)
                     .ok_or_else(|| "sql.query_tx: closed or unknown SqlTx handle".to_string())?;
-                let conn = arc.lock().unwrap();
-                Ok(sql_run_query(&conn, &stmt_str, &params))
+                let mut conn = arc.lock().unwrap();
+                Ok(match &mut *conn {
+                    SqlConn::Sqlite(c)   => sql_run_query_sqlite(c, &stmt_str, &params),
+                    SqlConn::Postgres(c) => sql_run_query_pg(c, &stmt_str, &params),
+                })
             }
             ("sql", "get_str") => Ok(sql_get_col(&args, |v| match v {
                 Value::Str(s) => Some(Value::Str(s.clone())),
@@ -1920,6 +1975,7 @@ fn expect_sql_handle(v: Option<&Value>) -> Result<u64, String> {
     }
 }
 
+#[allow(dead_code)]
 fn expect_str_list(v: Option<&Value>) -> Result<Vec<String>, String> {
     match v {
         Some(Value::List(items)) => items.iter().map(|x| match x {
@@ -1931,9 +1987,9 @@ fn expect_str_list(v: Option<&Value>) -> Result<Vec<String>, String> {
     }
 }
 
-/// Convert a `List[SqlParam]` value to rusqlite-boxed parameter values.
+/// Convert a `List[SqlParam]` value to driver-neutral `SqlParamValue`s.
 /// SqlParam = PStr(Str) | PInt(Int) | PFloat(Float) | PBool(Bool) | PNull
-fn expect_sql_params(v: Option<&Value>) -> Result<Vec<rusqlite::types::Value>, String> {
+fn expect_sql_params(v: Option<&Value>) -> Result<Vec<SqlParamValue>, String> {
     let items = match v {
         Some(Value::List(xs)) => xs,
         Some(other) => return Err(format!("expected List[SqlParam], got {other:?}")),
@@ -1943,37 +1999,60 @@ fn expect_sql_params(v: Option<&Value>) -> Result<Vec<rusqlite::types::Value>, S
         match item {
             Value::Variant { name, args } => match name.as_str() {
                 "PStr"   => match args.first() {
-                    Some(Value::Str(s)) => Ok(rusqlite::types::Value::Text(s.clone())),
+                    Some(Value::Str(s)) => Ok(SqlParamValue::Text(s.clone())),
                     _ => Err("PStr requires a Str argument".into()),
                 },
                 "PInt"   => match args.first() {
-                    Some(Value::Int(n)) => Ok(rusqlite::types::Value::Integer(*n)),
+                    Some(Value::Int(n)) => Ok(SqlParamValue::Integer(*n)),
                     _ => Err("PInt requires an Int argument".into()),
                 },
                 "PFloat" => match args.first() {
-                    Some(Value::Float(f)) => Ok(rusqlite::types::Value::Real(*f)),
+                    Some(Value::Float(f)) => Ok(SqlParamValue::Real(*f)),
                     _ => Err("PFloat requires a Float argument".into()),
                 },
                 "PBool"  => match args.first() {
-                    Some(Value::Bool(b)) => Ok(rusqlite::types::Value::Integer(*b as i64)),
+                    Some(Value::Bool(b)) => Ok(SqlParamValue::Bool(*b)),
                     _ => Err("PBool requires a Bool argument".into()),
                 },
-                "PNull"  => Ok(rusqlite::types::Value::Null),
+                "PNull"  => Ok(SqlParamValue::Null),
                 other    => Err(format!("unknown SqlParam constructor `{other}`")),
             },
             // Backward-compat: bare strings are accepted as PStr.
-            Value::Str(s) => Ok(rusqlite::types::Value::Text(s.clone())),
+            Value::Str(s) => Ok(SqlParamValue::Text(s.clone())),
             other => Err(format!("expected SqlParam variant, got {other:?}")),
         }
     }).collect()
 }
 
-/// Run a statement and pack the rows into `Value::List(Value::Record(...))`.
-/// Returns the standard `Result[List[T], Str]` Lex shape.
-fn sql_run_query(
+/// Convert `SqlParamValue`s to rusqlite-typed values for SQLite binding.
+fn sqlite_params(params: &[SqlParamValue]) -> Vec<rusqlite::types::Value> {
+    params.iter().map(|p| match p {
+        SqlParamValue::Text(s)    => rusqlite::types::Value::Text(s.clone()),
+        SqlParamValue::Integer(n) => rusqlite::types::Value::Integer(*n),
+        SqlParamValue::Real(f)    => rusqlite::types::Value::Real(*f),
+        SqlParamValue::Bool(b)    => rusqlite::types::Value::Integer(*b as i64),
+        SqlParamValue::Null       => rusqlite::types::Value::Null,
+    }).collect()
+}
+
+/// Box `SqlParamValue`s as `dyn ToSql + Sync` for Postgres binding.
+fn pg_param_refs(params: &[SqlParamValue]) -> Vec<Box<dyn postgres::types::ToSql + Sync>> {
+    params.iter().map(|p| -> Box<dyn postgres::types::ToSql + Sync> {
+        match p {
+            SqlParamValue::Text(s)    => Box::new(s.clone()),
+            SqlParamValue::Integer(n) => Box::new(*n),
+            SqlParamValue::Real(f)    => Box::new(*f),
+            SqlParamValue::Bool(b)    => Box::new(*b),
+            SqlParamValue::Null       => Box::new(Option::<String>::None),
+        }
+    }).collect()
+}
+
+/// Run a statement on SQLite and pack rows into `Value::List(Value::Record(...))`.
+fn sql_run_query_sqlite(
     conn: &rusqlite::Connection,
     stmt_str: &str,
-    params: &[rusqlite::types::Value],
+    params: &[SqlParamValue],
 ) -> Value {
     let mut stmt = match conn.prepare(stmt_str) {
         Ok(s)  => s,
@@ -1983,7 +2062,8 @@ fn sql_run_query(
     let column_names: Vec<String> = (0..column_count)
         .map(|i| stmt.column_name(i).unwrap_or("").to_string())
         .collect();
-    let bind: Vec<&dyn rusqlite::ToSql> = params.iter()
+    let bound = sqlite_params(params);
+    let bind: Vec<&dyn rusqlite::ToSql> = bound.iter()
         .map(|p| p as &dyn rusqlite::ToSql)
         .collect();
     let mut rows = match stmt.query(rusqlite::params_from_iter(bind.iter())) {
@@ -2008,6 +2088,47 @@ fn sql_run_query(
         out.push(Value::Record(rec));
     }
     ok(Value::List(out))
+}
+
+/// Run a statement on Postgres and pack rows into `Value::List(Value::Record(...))`.
+fn sql_run_query_pg(
+    client: &mut postgres::Client,
+    stmt_str: &str,
+    params: &[SqlParamValue],
+) -> Value {
+    let pg = pg_param_refs(params);
+    let refs: Vec<&(dyn postgres::types::ToSql + Sync)> =
+        pg.iter().map(|b| b.as_ref()).collect();
+    let rows = match client.query(stmt_str, &refs) {
+        Ok(r)  => r,
+        Err(e) => return err(Value::Str(format!("sql.query: {e}"))),
+    };
+    let out: Vec<Value> = rows.iter().map(|row| {
+        Value::Record(pg_row_to_lex_record(row))
+    }).collect();
+    ok(Value::List(out))
+}
+
+/// Convert a Postgres row to a Lex record, mapping column types to Lex values.
+fn pg_row_to_lex_record(row: &postgres::Row) -> indexmap::IndexMap<String, Value> {
+    use postgres::types::Type;
+    let mut rec = indexmap::IndexMap::new();
+    for (i, col) in row.columns().iter().enumerate() {
+        let ty = col.type_();
+        let val = if *ty == Type::INT2 || *ty == Type::INT4 || *ty == Type::INT8 {
+            row.get::<_, Option<i64>>(i).map(Value::Int).unwrap_or(Value::Unit)
+        } else if *ty == Type::FLOAT4 || *ty == Type::FLOAT8 {
+            row.get::<_, Option<f64>>(i).map(Value::Float).unwrap_or(Value::Unit)
+        } else if *ty == Type::BOOL {
+            row.get::<_, Option<bool>>(i).map(Value::Bool).unwrap_or(Value::Unit)
+        } else if *ty == Type::BYTEA {
+            row.get::<_, Option<Vec<u8>>>(i).map(Value::Bytes).unwrap_or(Value::Unit)
+        } else {
+            row.get::<_, Option<String>>(i).map(Value::Str).unwrap_or(Value::Unit)
+        };
+        rec.insert(col.name().to_string(), val);
+    }
+    rec
 }
 
 /// Extract a column value from a row record by name, returning `Option[X]`.
@@ -2385,7 +2506,23 @@ fn sql_registry() -> &'static Mutex<SqlRegistry> {
 
 const MAX_SQL_HANDLES: usize = 256;
 
-type SharedConn = Arc<Mutex<rusqlite::Connection>>;
+/// Driver-neutral SQL parameter value shared between SQLite and Postgres paths.
+#[derive(Debug, Clone)]
+enum SqlParamValue {
+    Text(String),
+    Integer(i64),
+    Real(f64),
+    Bool(bool),
+    Null,
+}
+
+/// Abstraction over a SQLite connection or a Postgres client.
+pub(crate) enum SqlConn {
+    Sqlite(rusqlite::Connection),
+    Postgres(postgres::Client),
+}
+
+type SharedConn = Arc<Mutex<SqlConn>>;
 
 pub(crate) struct SqlRegistry {
     entries: indexmap::IndexMap<u64, SharedConn>,
@@ -2397,7 +2534,7 @@ impl SqlRegistry {
         Self { entries: indexmap::IndexMap::new(), cap }
     }
 
-    pub(crate) fn insert(&mut self, handle: u64, conn: rusqlite::Connection) {
+    pub(crate) fn insert(&mut self, handle: u64, conn: SqlConn) {
         if self.entries.len() >= self.cap {
             self.entries.shift_remove_index(0);
         }
@@ -2428,10 +2565,10 @@ fn next_sql_handle() -> u64 {
 
 #[cfg(test)]
 mod sql_registry_tests {
-    use super::SqlRegistry;
+    use super::{SqlConn, SqlRegistry};
 
-    fn fresh() -> rusqlite::Connection {
-        rusqlite::Connection::open_in_memory().expect("open in-memory sqlite")
+    fn fresh() -> SqlConn {
+        SqlConn::Sqlite(rusqlite::Connection::open_in_memory().expect("open in-memory sqlite"))
     }
 
     #[test]

--- a/crates/lex-runtime/tests/std_sql.rs
+++ b/crates/lex-runtime/tests/std_sql.rs
@@ -73,10 +73,10 @@ fn create_insert_query(path :: Str) -> [sql, fs_write] List[{ id :: Int, name ::
       let c := match sql.exec(db, "CREATE TABLE users(id INTEGER, name TEXT)", []) {
         Ok(_) => 0, Err(_) => 0 - 1,
       }
-      let i1 := match sql.exec(db, "INSERT INTO users VALUES (?1, ?2)", ["1", "alice"]) {
+      let i1 := match sql.exec(db, "INSERT INTO users VALUES (?1, ?2)", [PStr("1"), PStr("alice")]) {
         Ok(_) => 0, Err(_) => 0 - 1,
       }
-      let i2 := match sql.exec(db, "INSERT INTO users VALUES (?1, ?2)", ["2", "bob"]) {
+      let i2 := match sql.exec(db, "INSERT INTO users VALUES (?1, ?2)", [PStr("2"), PStr("bob")]) {
         Ok(_) => 0, Err(_) => 0 - 1,
       }
       let result :: Result[List[{ id :: Int, name :: Str }], Str] :=
@@ -115,7 +115,7 @@ fn pick_by_id(path :: Str, id :: Str) -> [sql, fs_write] Str {
   match sql.open(path) {
     Ok(db) => {
       let result :: Result[List[{ name :: Str }], Str] :=
-        sql.query(db, "SELECT name FROM users WHERE id = ?1", [id])
+        sql.query(db, "SELECT name FROM users WHERE id = ?1", [PStr(id)])
       match result {
         Ok(rows) => match list.head(rows) {
           Some(r) => r.name,
@@ -131,7 +131,7 @@ fn pick_by_id(path :: Str, id :: Str) -> [sql, fs_write] Str {
 # Confirm exec returns the row count.
 fn delete_count(path :: Str) -> [sql, fs_write] Int {
   match sql.open(path) {
-    Ok(db) => match sql.exec(db, "DELETE FROM users WHERE id = ?1", ["1"]) {
+    Ok(db) => match sql.exec(db, "DELETE FROM users WHERE id = ?1", [PStr("1")]) {
       Ok(n)  => n,
       Err(_) => 0 - 1,
     },

--- a/crates/lex-search/Cargo.toml
+++ b/crates/lex-search/Cargo.toml
@@ -17,10 +17,10 @@ thiserror.workspace = true
 sha2.workspace = true
 hex.workspace = true
 ureq = { version = "3.3", default-features = false, features = ["rustls", "platform-verifier", "json"] }
-lex-ast = { path = "../lex-ast", version = "0.8.2" }
-lex-store = { path = "../lex-store", version = "0.8.2" }
+lex-ast = { path = "../lex-ast", version = "0.9.0" }
+lex-store = { path = "../lex-store", version = "0.9.0" }
 
 [dev-dependencies]
 tempfile = "3"
 tiny_http = "0.12"
-lex-syntax = { path = "../lex-syntax", version = "0.8.2" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.0" }

--- a/crates/lex-store/Cargo.toml
+++ b/crates/lex-store/Cargo.toml
@@ -21,11 +21,11 @@ hex.workspace = true
 # transitive dep via tempfile; promoting to direct so the lock
 # call sites compile.
 fs2 = "0.4"
-lex-ast = { path = "../lex-ast", version = "0.8.2" }
-lex-trace = { path = "../lex-trace", version = "0.8.2" }
-lex-types = { path = "../lex-types", version = "0.8.2" }
-lex-vcs = { path = "../lex-vcs", version = "0.8.2" }
+lex-ast = { path = "../lex-ast", version = "0.9.0" }
+lex-trace = { path = "../lex-trace", version = "0.9.0" }
+lex-types = { path = "../lex-types", version = "0.9.0" }
+lex-vcs = { path = "../lex-vcs", version = "0.9.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.8.2" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.0" }
 tempfile = "3"

--- a/crates/lex-trace/Cargo.toml
+++ b/crates/lex-trace/Cargo.toml
@@ -16,9 +16,9 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-bytecode = { path = "../lex-bytecode", version = "0.8.2" }
-lex-ast = { path = "../lex-ast", version = "0.8.2" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.9.0" }
+lex-ast = { path = "../lex-ast", version = "0.9.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.8.2" }
-lex-runtime = { path = "../lex-runtime", version = "0.8.2" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.0" }
+lex-runtime = { path = "../lex-runtime", version = "0.9.0" }

--- a/crates/lex-types/Cargo.toml
+++ b/crates/lex-types/Cargo.toml
@@ -15,7 +15,7 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-ast = { path = "../lex-ast", version = "0.8.2" }
+lex-ast = { path = "../lex-ast", version = "0.9.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.8.2" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.0" }

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -1225,58 +1225,107 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
             Some(Ty::Record(fields))
         }
         "sql" => {
-            // Embedded SQL (SQLite). The opaque `Db` type is backed
-            // by an Int handle into a process-wide registry, same
-            // shape as `Kv`. v1 surface focuses on read-heavy and
-            // simple-write workloads — the kind that drove the
-            // requirement (audit history, "filter by verdict where
-            // score > 60", joins). Transactions, heterogeneous
-            // typed parameter binding, and named params are
-            // deferred to v1.5.
+            // Embedded SQL (SQLite via rusqlite). The opaque `Db` type is
+            // backed by an Int handle into a process-wide registry (#362).
             //
-            // Params are `List[Str]` for v1: callers stringify Int /
-            // Float values before binding, and SQLite's column type
-            // affinity coerces back at insert time. This is the one
-            // honest ergonomics caveat; the alternative (a tagged
-            // `SqlValue` variant) is forward-compatible but adds a
-            // type to the global scope that v1 doesn't need.
-            let db_t = || Ty::Con("Db".into(), vec![]);
+            // Params use the typed `SqlParam` ADT (PStr|PInt|PFloat|PBool|PNull)
+            // registered in env.rs, so callers don't have to stringify values.
+            //
+            // Transactions: sql.begin(db) → SqlTx; sql.commit/rollback(tx).
+            // exec_tx / query_tx mirror exec / query but operate on a SqlTx.
+            //
+            // Row decoders: get_str / get_int / get_float / get_bool extract
+            // typed columns from a row record by name.
+            let db_t  = || Ty::Con("Db".into(), vec![]);
+            let tx_t  = || Ty::Con("SqlTx".into(), vec![]);
+            let sp_t  = || Ty::Con("SqlParam".into(), vec![]);
+            let params_t = || Ty::List(Box::new(sp_t()));
             let mut fields = IndexMap::new();
+
             // open :: Str -> [sql, fs_write] Result[Db, Str]
-            // Path is the SQLite filename; ":memory:" works for
-            // ephemeral stores. fs_write is required because the
-            // DB file is created on first open.
             fields.insert("open".into(), Ty::function(
                 vec![Ty::str()],
                 EffectSet {
-                    concrete: [crate::types::EffectKind::bare("sql"), crate::types::EffectKind::bare("fs_write")].into_iter().collect(),
+                    concrete: [crate::types::EffectKind::bare("sql"),
+                               crate::types::EffectKind::bare("fs_write")]
+                        .into_iter().collect(),
                     var: None,
                 },
                 Ty::Con("Result".into(), vec![db_t(), Ty::str()])));
-            // close :: Db -> [sql] Nil
+
+            // close :: Db -> [sql] Unit
             fields.insert("close".into(), Ty::function(
                 vec![db_t()],
                 EffectSet::singleton("sql"),
                 Ty::Unit));
-            // exec :: Db, Str, List[Str] -> [sql] Result[Int, Str]
-            // Returns the affected row count (rusqlite's `execute`).
-            // Suitable for INSERT / UPDATE / DELETE / DDL.
+
+            // exec :: Db, Str, List[SqlParam] -> [sql] Result[Int, Str]
             fields.insert("exec".into(), Ty::function(
-                vec![db_t(), Ty::str(), Ty::List(Box::new(Ty::str()))],
+                vec![db_t(), Ty::str(), params_t()],
                 EffectSet::singleton("sql"),
                 Ty::Con("Result".into(), vec![Ty::int(), Ty::str()])));
-            // query[T] :: Db, Str, List[Str] -> [sql] Result[List[T], Str]
-            // Polymorphic on the row record shape. Each row is
-            // decoded into a record keyed by column name, with
-            // SQLite values mapped to the same Lex `Value` shape
-            // as `json.parse` and `toml.parse` produce.
+
+            // query[T] :: Db, Str, List[SqlParam] -> [sql] Result[List[T], Str]
             fields.insert("query".into(), Ty::function(
-                vec![db_t(), Ty::str(), Ty::List(Box::new(Ty::str()))],
+                vec![db_t(), Ty::str(), params_t()],
                 EffectSet::singleton("sql"),
                 Ty::Con("Result".into(), vec![
                     Ty::List(Box::new(Ty::Var(0))),
                     Ty::str(),
                 ])));
+
+            // begin :: Db -> [sql] Result[SqlTx, Str]
+            fields.insert("begin".into(), Ty::function(
+                vec![db_t()],
+                EffectSet::singleton("sql"),
+                Ty::Con("Result".into(), vec![tx_t(), Ty::str()])));
+
+            // commit :: SqlTx -> [sql] Result[Unit, Str]
+            fields.insert("commit".into(), Ty::function(
+                vec![tx_t()],
+                EffectSet::singleton("sql"),
+                Ty::Con("Result".into(), vec![Ty::Unit, Ty::str()])));
+
+            // rollback :: SqlTx -> [sql] Result[Unit, Str]
+            fields.insert("rollback".into(), Ty::function(
+                vec![tx_t()],
+                EffectSet::singleton("sql"),
+                Ty::Con("Result".into(), vec![Ty::Unit, Ty::str()])));
+
+            // exec_tx :: SqlTx, Str, List[SqlParam] -> [sql] Result[Int, Str]
+            fields.insert("exec_tx".into(), Ty::function(
+                vec![tx_t(), Ty::str(), params_t()],
+                EffectSet::singleton("sql"),
+                Ty::Con("Result".into(), vec![Ty::int(), Ty::str()])));
+
+            // query_tx[T] :: SqlTx, Str, List[SqlParam] -> [sql] Result[List[T], Str]
+            fields.insert("query_tx".into(), Ty::function(
+                vec![tx_t(), Ty::str(), params_t()],
+                EffectSet::singleton("sql"),
+                Ty::Con("Result".into(), vec![
+                    Ty::List(Box::new(Ty::Var(0))),
+                    Ty::str(),
+                ])));
+
+            // Row decoders: get_X[T] :: T, Str -> Option[X]
+            // T is polymorphic so these work on any row record shape.
+            fields.insert("get_str".into(), Ty::function(
+                vec![Ty::Var(0), Ty::str()],
+                EffectSet::empty(),
+                Ty::Con("Option".into(), vec![Ty::str()])));
+            fields.insert("get_int".into(), Ty::function(
+                vec![Ty::Var(0), Ty::str()],
+                EffectSet::empty(),
+                Ty::Con("Option".into(), vec![Ty::int()])));
+            fields.insert("get_float".into(), Ty::function(
+                vec![Ty::Var(0), Ty::str()],
+                EffectSet::empty(),
+                Ty::Con("Option".into(), vec![Ty::Con("Float".into(), vec![])])));
+            fields.insert("get_bool".into(), Ty::function(
+                vec![Ty::Var(0), Ty::str()],
+                EffectSet::empty(),
+                Ty::Con("Option".into(), vec![Ty::Con("Bool".into(), vec![])])));
+
             Some(Ty::Record(fields))
         }
         "parser" => {

--- a/crates/lex-types/src/env.rs
+++ b/crates/lex-types/src/env.rs
@@ -62,6 +62,29 @@ impl TypeEnv {
         e.types.insert("Map".into(), TypeDef { params: vec!["K".into(), "V".into()], kind: TypeDefKind::Opaque });
         e.types.insert("Set".into(), TypeDef { params: vec!["T".into()], kind: TypeDefKind::Opaque });
 
+        // SqlParam = PStr(Str) | PInt(Int) | PFloat(Float) | PBool(Bool) | PNull
+        // Typed parameter binding for std.sql (#362). Replaces the v1 List[Str]
+        // approach so callers don't have to stringify non-string values.
+        let mut sp_variants = IndexMap::new();
+        sp_variants.insert("PStr".into(),   Some(Ty::str()));
+        sp_variants.insert("PInt".into(),   Some(Ty::int()));
+        sp_variants.insert("PFloat".into(), Some(Ty::Con("Float".into(), vec![])));
+        sp_variants.insert("PBool".into(),  Some(Ty::Con("Bool".into(), vec![])));
+        sp_variants.insert("PNull".into(),  None);
+        e.types.insert("SqlParam".into(), TypeDef {
+            params: vec![],
+            kind: TypeDefKind::Union(sp_variants),
+        });
+        for ctor in &["PStr", "PInt", "PFloat", "PBool", "PNull"] {
+            e.ctor_to_type.insert((*ctor).into(), "SqlParam".into());
+        }
+
+        // SqlTx: opaque transaction handle (#362). Backed by the same
+        // Int registry key as Db; the type system enforces that commit/
+        // rollback can only be called on a value from sql.begin, not on
+        // a raw Db connection.
+        e.types.insert("SqlTx".into(), TypeDef { params: vec![], kind: TypeDefKind::Opaque });
+
         // Stream[T]: opaque streaming iterator (#305 slice 3).
         // Built and consumed exclusively through the `stream.*` and
         // `agent.cloud_stream` effect builtins; the runtime

--- a/crates/lex-vcs/Cargo.toml
+++ b/crates/lex-vcs/Cargo.toml
@@ -11,8 +11,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-lex-ast = { path = "../lex-ast", version = "0.8.2" }
-lex-types = { path = "../lex-types", version = "0.8.2" }
+lex-ast = { path = "../lex-ast", version = "0.9.0" }
+lex-types = { path = "../lex-types", version = "0.9.0" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
@@ -24,4 +24,4 @@ hex.workspace = true
 
 [dev-dependencies]
 tempfile = "3"
-lex-syntax = { path = "../lex-syntax", version = "0.8.2" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.0" }

--- a/crates/spec-checker/Cargo.toml
+++ b/crates/spec-checker/Cargo.toml
@@ -16,11 +16,11 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-syntax = { path = "../lex-syntax", version = "0.8.2" }
-lex-ast = { path = "../lex-ast", version = "0.8.2" }
-lex-types = { path = "../lex-types", version = "0.8.2" }
-lex-bytecode = { path = "../lex-bytecode", version = "0.8.2" }
-lex-runtime = { path = "../lex-runtime", version = "0.8.2" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.0" }
+lex-ast = { path = "../lex-ast", version = "0.9.0" }
+lex-types = { path = "../lex-types", version = "0.9.0" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.9.0" }
+lex-runtime = { path = "../lex-runtime", version = "0.9.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.8.2" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.0" }


### PR DESCRIPTION
PR #361 shipped the v0.9.0 feature set but the Cargo.toml version
was not updated. Bumps root workspace version and all hardcoded
internal dependency version constraints from 0.8.2 → 0.9.0.

https://claude.ai/code/session_01TN34hWDyCyB9WmUKVVacTQ