### PR TITLE
feat(types): signature-level examples block on FnDecl (#369)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,32 @@ is a signed attestation that walks with the code.
 7. **Small total surface.** Grammar fits in ≤ 500 tokens; stdlib index ≤ 2000.
 8. **The AST is the interface.** Source text is a projection.
 
+### Signature-level examples
+
+A pure function can carry an optional `examples { ... }` block. Each case
+is folded into the canonical AST, so the **examples are part of the
+signature's identity** — two implementations with different example sets
+hash to different SigIds. The type checker validates every case before a
+byte runs.
+
+```lex
+fn factorial(n :: Int) -> Int
+  examples {
+    factorial(0) => 1,
+    factorial(5) => 120,
+  }
+{
+  match n {
+    0 => 1,
+    _ => n * factorial(n - 1),
+  }
+}
+```
+
+v1 restricts the block to functions with no declared effects (rule 5 —
+determinism). See [issue #369](https://github.com/alpibrusl/lex-lang/issues/369)
+for the design and follow-ups (behavioral evaluation, mocked effects).
+
 ## Quickstart
 
 ```bash

--- a/crates/lex-ast/src/canon_print.rs
+++ b/crates/lex-ast/src/canon_print.rs
@@ -57,6 +57,31 @@ impl Printer {
         write!(self.out, ") -> ").unwrap();
         self.effects(&fd.effects);
         self.ty(&fd.return_type);
+        if !fd.examples.is_empty() {
+            self.nl();
+            self.pad();
+            write!(self.out, "examples {{").unwrap();
+            self.indent += 1;
+            for (i, ex) in fd.examples.iter().enumerate() {
+                self.nl();
+                self.pad();
+                // Render as `name(args...) => expected`. Since canonical
+                // form doesn't carry the call expression, we synthesize
+                // a Call(Var name, args) for the printer.
+                write!(self.out, "{}(", fd.name).unwrap();
+                for (j, a) in ex.args.iter().enumerate() {
+                    if j > 0 { write!(self.out, ", ").unwrap(); }
+                    self.expr(a);
+                }
+                write!(self.out, ") => ").unwrap();
+                self.expr(&ex.expected);
+                if i + 1 < fd.examples.len() { write!(self.out, ",").unwrap(); }
+            }
+            self.indent -= 1;
+            self.nl();
+            self.pad();
+            write!(self.out, "}}").unwrap();
+        }
         write!(self.out, " ").unwrap();
         self.expr_as_block(&fd.body);
         self.nl();

--- a/crates/lex-ast/src/canonical.rs
+++ b/crates/lex-ast/src/canonical.rs
@@ -29,6 +29,18 @@ pub struct FnDecl {
     pub effects: Vec<Effect>,
     pub return_type: TypeExpr,
     pub body: CExpr,
+    /// Signature-level examples (#369). Empty when the source carried no
+    /// `examples { ... }` block; in that case the field is omitted from
+    /// the canonical-JSON encoding, so SigId / StageId are bit-identical
+    /// to pre-#369 stages.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub examples: Vec<Example>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Example {
+    pub args: Vec<CExpr>,
+    pub expected: CExpr,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/lex-ast/src/canonicalize.rs
+++ b/crates/lex-ast/src/canonicalize.rs
@@ -55,6 +55,14 @@ fn canonicalize_fn_decl(fd: &s::FnDecl) -> FnDecl {
         effects: fd.effects.iter().map(canonicalize_effect).collect(),
         return_type: canonicalize_type(&fd.return_type),
         body: canonicalize_block(&fd.body),
+        examples: fd.examples.iter().map(canonicalize_example).collect(),
+    }
+}
+
+fn canonicalize_example(ex: &s::Example) -> Example {
+    Example {
+        args: ex.args.iter().map(canonicalize_expr).collect(),
+        expected: canonicalize_expr(&ex.expected),
     }
 }
 

--- a/crates/lex-ast/src/lib.rs
+++ b/crates/lex-ast/src/lib.rs
@@ -54,6 +54,13 @@ fn sig_hash(stage: &Stage, include_name: bool) -> Option<[u8; 32]> {
                 fd.params.iter().map(|p| &p.ty).collect::<Vec<_>>()
             ).unwrap());
             v.insert("output_type".into(), serde_json::to_value(&fd.return_type).unwrap());
+            // Signature-level examples (#369) are part of the contract:
+            // two signatures with different example sets hash differently.
+            // Omitted entirely when there are no examples, preserving
+            // pre-#369 SigIds bit-for-bit.
+            if !fd.examples.is_empty() {
+                v.insert("examples".into(), serde_json::to_value(&fd.examples).unwrap());
+            }
             if include_name { v.insert("name".into(), serde_json::Value::String(fd.name.clone())); }
             serde_json::Value::Object(v)
         }

--- a/crates/lex-ast/src/transforms.rs
+++ b/crates/lex-ast/src/transforms.rs
@@ -648,6 +648,7 @@ pub fn extract_function(
         effects: spec.effects,
         return_type: spec.return_type,
         body: extracted_expr,
+        examples: Vec::new(),
     });
 
     Ok((modified, new_fn))
@@ -790,6 +791,7 @@ mod tests {
             effects: Vec::new(),
             return_type: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
             body,
+            examples: Vec::new(),
         })
     }
 
@@ -841,6 +843,7 @@ mod tests {
             effects: Vec::new(),
             return_type: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
             body,
+            examples: Vec::new(),
         });
         let out = rename_local(&stage, &NodeId("n_0.1".into()), "y").unwrap();
         let Stage::FnDecl(fd) = out else { panic!() };
@@ -882,6 +885,7 @@ mod tests {
                 ret: Box::new(TypeExpr::Named { name: "Int".into(), args: Vec::new() }),
             },
             body,
+            examples: Vec::new(),
         });
         let out = rename_local(&stage, &NodeId("n_0.1".into()), "y").unwrap();
         let Stage::FnDecl(fd) = out else { panic!() };
@@ -926,6 +930,7 @@ mod tests {
             effects: Vec::new(),
             return_type: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
             body,
+            examples: Vec::new(),
         });
         let out = rename_local(&stage, &NodeId("n_0.1".into()), "y").unwrap();
         let Stage::FnDecl(fd) = out else { panic!() };
@@ -971,6 +976,7 @@ mod tests {
             effects: Vec::new(),
             return_type: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
             body,
+            examples: Vec::new(),
         })
     }
 
@@ -1003,6 +1009,7 @@ mod tests {
             effects: Vec::new(),
             return_type: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
             body,
+            examples: Vec::new(),
         });
         let err = inline_let(&stage, &NodeId("n_0.1".into())).unwrap_err();
         assert!(matches!(err, TransformError::InlineLetRefused { .. }), "got {err:?}");
@@ -1038,6 +1045,7 @@ mod tests {
             effects: Vec::new(),
             return_type: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
             body,
+            examples: Vec::new(),
         });
         // Let `x` is at child index 2 (1 param + return + body slot).
         let err = inline_let(&stage, &NodeId("n_0.2".into())).unwrap_err();
@@ -1076,6 +1084,7 @@ mod tests {
             effects: Vec::new(),
             return_type: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
             body,
+            examples: Vec::new(),
         });
         let out = inline_let(&stage, &NodeId("n_0.2".into())).unwrap();
         let Stage::FnDecl(fd) = out else { panic!() };
@@ -1121,6 +1130,7 @@ mod tests {
             effects: Vec::new(),
             return_type: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
             body,
+            examples: Vec::new(),
         })
     }
 
@@ -1212,6 +1222,7 @@ mod tests {
             effects: Vec::new(),
             return_type: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
             body,
+            examples: Vec::new(),
         });
         let spec = ExtractFnSpec {
             name: "one".into(),
@@ -1272,6 +1283,7 @@ mod tests {
             effects: Vec::new(),
             return_type: TypeExpr::Named { name: "Int".into(), args: Vec::new() },
             body,
+            examples: Vec::new(),
         })
     }
 

--- a/crates/lex-ast/tests/canonical.rs
+++ b/crates/lex-ast/tests/canonical.rs
@@ -112,3 +112,44 @@ fn renaming_changes_sig_id() {
     // Per §4.6 default: name IS in SigId.
     assert_ne!(sig_id(&s1[0]), sig_id(&s2[0]));
 }
+
+// --- #369: signature-level examples ---
+
+#[test]
+fn empty_examples_does_not_perturb_sig_id() {
+    // A fn with no `examples` block (the entire existing corpus) must
+    // hash identically to its pre-#369 form. We enforce that by
+    // hashing the same source via two paths: source → canonicalize
+    // (the new code) and an explicitly-constructed FnDecl with the
+    // examples vec absent from the JSON. The canonical-JSON encoding
+    // skips the field when empty, so both paths produce the same hash.
+    let s = canon("fn id(x :: Int) -> Int { x }\n");
+    let Stage::FnDecl(fd) = &s[0] else { panic!() };
+    assert!(fd.examples.is_empty(), "no examples should be parsed");
+
+    // serde_json::to_value on the FnDecl must omit the `examples` key.
+    let v = serde_json::to_value(fd).unwrap();
+    assert!(
+        !v.as_object().unwrap().contains_key("examples"),
+        "examples must be omitted from canonical JSON when empty: {v:?}"
+    );
+}
+
+#[test]
+fn examples_are_part_of_sig_id() {
+    // Two functions with identical name/params/return/body but
+    // different example sets must have different SigIds — examples
+    // are part of the contract.
+    let s1 = canon("fn id(x :: Int) -> Int\nexamples { id(1) => 1 }\n{ x }\n");
+    let s2 = canon("fn id(x :: Int) -> Int\nexamples { id(2) => 2 }\n{ x }\n");
+    assert_ne!(sig_id(&s1[0]), sig_id(&s2[0]), "SigId must fold in examples");
+}
+
+#[test]
+fn examples_round_trip_through_canonicalize() {
+    let src = "fn id(x :: Int) -> Int\nexamples { id(7) => 7 }\n{ x }\n";
+    let s = canon(src);
+    let Stage::FnDecl(fd) = &s[0] else { panic!() };
+    assert_eq!(fd.examples.len(), 1);
+    assert_eq!(fd.examples[0].args.len(), 1);
+}

--- a/crates/lex-syntax/src/loader.rs
+++ b/crates/lex-syntax/src/loader.rs
@@ -357,6 +357,11 @@ impl<'a> Mangler<'a> {
             effects: fd.effects,
             return_type: self.mangle_type_expr(fd.return_type),
             body: self.mangle_block(fd.body, &shadow),
+            // Examples (#369) ride through the loader unchanged. They
+            // are self-contained calls with pure args; cross-module
+            // identifier rewriting inside example expressions is a
+            // follow-up if it becomes a real need.
+            examples: fd.examples,
         }
     }
 

--- a/crates/lex-syntax/src/parser.rs
+++ b/crates/lex-syntax/src/parser.rs
@@ -372,10 +372,10 @@ impl Parser {
     fn parse_examples_block(&mut self) -> Result<Vec<Example>, ParseError> {
         // Contextual: not a reserved keyword. Peek for the literal
         // identifier `examples` followed by `{`; otherwise no block.
-        let is_examples_kw = match self.peek_skip_newlines() {
-            Some(TokenKind::Ident(s)) if s == "examples" => true,
-            _ => false,
-        };
+        let is_examples_kw = matches!(
+            self.peek_skip_newlines(),
+            Some(TokenKind::Ident(s)) if s == "examples"
+        );
         if !is_examples_kw {
             return Ok(Vec::new());
         }

--- a/crates/lex-syntax/src/parser.rs
+++ b/crates/lex-syntax/src/parser.rs
@@ -361,8 +361,49 @@ impl Parser {
         self.expect(&TokenKind::Arrow, "before return type")?;
         let effects = self.parse_effects()?;
         let return_type = self.parse_type_expr()?;
+        let examples = self.parse_examples_block()?;
         let body = self.parse_block()?;
-        Ok(FnDecl { name, type_params, params, effects, return_type, body })
+        Ok(FnDecl { name, type_params, params, effects, return_type, body, examples })
+    }
+
+    /// Parse an optional `examples { call(a, b) => expected, ... }` block
+    /// sitting between the return type and the body (#369). Returns an
+    /// empty vec when no block is present.
+    fn parse_examples_block(&mut self) -> Result<Vec<Example>, ParseError> {
+        // Contextual: not a reserved keyword. Peek for the literal
+        // identifier `examples` followed by `{`; otherwise no block.
+        let is_examples_kw = match self.peek_skip_newlines() {
+            Some(TokenKind::Ident(s)) if s == "examples" => true,
+            _ => false,
+        };
+        if !is_examples_kw {
+            return Ok(Vec::new());
+        }
+        self.skip_newlines();
+        self.bump(); // consume `examples`
+        self.expect(&TokenKind::LBrace, "after `examples`")?;
+        let mut cases = Vec::new();
+        loop {
+            self.skip_newlines();
+            if matches!(self.peek(), Some(TokenKind::RBrace)) { break; }
+            let call = self.parse_expr()?;
+            self.expect(&TokenKind::FatArrow, "in example case (between call and expected)")?;
+            let expected = self.parse_expr()?;
+            let (args, _) = match call {
+                Expr::Call { callee: _, args } => (args, ()),
+                other => return Err(self.error(
+                    format!("example case must be a call to the function under definition; got {other:?}")
+                )),
+            };
+            cases.push(Example { args, expected });
+            self.skip_newlines();
+            if !self.eat(&TokenKind::Comma) {
+                self.skip_newlines();
+                break;
+            }
+        }
+        self.expect(&TokenKind::RBrace, "to close examples block")?;
+        Ok(cases)
     }
 
     fn parse_param(&mut self) -> Result<Param, ParseError> {

--- a/crates/lex-syntax/src/printer.rs
+++ b/crates/lex-syntax/src/printer.rs
@@ -72,9 +72,38 @@ impl Printer {
         write!(self.out, ") -> ").unwrap();
         self.effects(&fd.effects);
         self.type_expr(&fd.return_type);
-        write!(self.out, " ").unwrap();
+        if fd.examples.is_empty() {
+            write!(self.out, " ").unwrap();
+        } else {
+            self.examples(&fd.name, &fd.examples);
+            self.nl();
+        }
         self.block(&fd.body);
         self.nl();
+    }
+
+    fn examples(&mut self, fn_name: &str, examples: &[Example]) {
+        if examples.is_empty() { return; }
+        self.nl();
+        write!(self.out, "  examples {{").unwrap();
+        self.indent += 2;
+        for (i, ex) in examples.iter().enumerate() {
+            self.nl();
+            self.write_indent();
+            write!(self.out, "{}(", fn_name).unwrap();
+            for (j, a) in ex.args.iter().enumerate() {
+                if j > 0 { write!(self.out, ", ").unwrap(); }
+                self.expr(a);
+            }
+            write!(self.out, ") => ").unwrap();
+            self.expr(&ex.expected);
+            if i + 1 < examples.len() {
+                write!(self.out, ",").unwrap();
+            }
+        }
+        self.indent -= 2;
+        self.nl();
+        write!(self.out, "  }}").unwrap();
     }
 
     fn effects(&mut self, effects: &[Effect]) {

--- a/crates/lex-syntax/src/syntax.rs
+++ b/crates/lex-syntax/src/syntax.rs
@@ -38,6 +38,22 @@ pub struct FnDecl {
     pub effects: Vec<Effect>,
     pub return_type: TypeExpr,
     pub body: Block,
+    /// Optional `examples { call(a, b) => expected, ... }` block (#369).
+    /// Each case binds the function on literal-or-pure arguments and
+    /// declares the value the body is expected to produce. Pure-only in
+    /// v1: a function carrying examples must declare no effects.
+    /// Serialized as an empty `Vec` so the JSON shape stays compatible
+    /// with pre-#369 signatures when the block is absent.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub examples: Vec<Example>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Example {
+    /// Arguments passed to the function, in declaration order.
+    pub args: Vec<Expr>,
+    /// Value the body is expected to produce.
+    pub expected: Expr,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/lex-types/src/checker.rs
+++ b/crates/lex-types/src/checker.rs
@@ -723,14 +723,12 @@ impl Checker {
                 // The example's args/expected are expected to be pure
                 // by construction (literals in the common case); if
                 // they invoked effects, they'd break the pure-only
-                // discipline. Reject quietly via the same effect rule.
-                if !example_effects.concrete.is_empty() {
-                    for e in example_effects.concrete.iter() {
-                        return Err(vec![TypeError::EffectNotDeclared {
-                            at_node: "n_0".into(),
-                            effect: e.pretty(),
-                        }]);
-                    }
+                // discipline. Reject the first one via the same effect rule.
+                if let Some(e) = example_effects.concrete.iter().next() {
+                    return Err(vec![TypeError::EffectNotDeclared {
+                        at_node: "n_0".into(),
+                        effect: e.pretty(),
+                    }]);
                 }
             }
         }

--- a/crates/lex-types/src/checker.rs
+++ b/crates/lex-types/src/checker.rs
@@ -660,6 +660,81 @@ impl Checker {
             }
         }
 
+        // #369: signature-level examples. Pure-only in v1; arg arity
+        // must match params; each arg type-checks against its param,
+        // each expected type-checks against the return type. Behavioral
+        // equivalence (run the body, compare to expected) is a follow-up
+        // — this slice catches type-level drift, which is already a
+        // common source of stale examples.
+        if !fd.examples.is_empty() {
+            if !declared_effects.concrete.is_empty() {
+                return Err(vec![TypeError::ExamplesOnEffectfulFn {
+                    at_node: "n_0".into(),
+                    fn_name: fd.name.clone(),
+                }]);
+            }
+            for (case_index, ex) in fd.examples.iter().enumerate() {
+                if ex.args.len() != param_tys.len() {
+                    return Err(vec![TypeError::ExampleArityMismatch {
+                        at_node: "n_0".into(),
+                        fn_name: fd.name.clone(),
+                        case_index,
+                        expected: param_tys.len(),
+                        got: ex.args.len(),
+                    }]);
+                }
+                let mut example_locals: IndexMap<String, Ty> = IndexMap::new();
+                let mut example_effects = EffectSet::empty();
+                for (i, (arg, expected_ty)) in
+                    ex.args.iter().zip(param_tys.iter()).enumerate()
+                {
+                    let arg_ty = self
+                        .check_expr(arg, "n_0", &mut example_locals, &mut example_effects)
+                        .map_err(|e| vec![e])?;
+                    if let Err(e) = self.unify_with_record_coercion(&arg_ty, expected_ty) {
+                        return Err(vec![mismatch_err(
+                            "n_0",
+                            e,
+                            &self.u,
+                            vec![format!(
+                                "in example #{} for `{}`, argument {}",
+                                case_index + 1,
+                                fd.name,
+                                i + 1
+                            )],
+                        )]);
+                    }
+                }
+                let expected_ty = self
+                    .check_expr(&ex.expected, "n_0", &mut example_locals, &mut example_effects)
+                    .map_err(|e| vec![e])?;
+                if let Err(e) = self.unify_with_record_coercion(&expected_ty, &ret_ty) {
+                    return Err(vec![mismatch_err(
+                        "n_0",
+                        e,
+                        &self.u,
+                        vec![format!(
+                            "in example #{} for `{}`, expected value",
+                            case_index + 1,
+                            fd.name
+                        )],
+                    )]);
+                }
+                // The example's args/expected are expected to be pure
+                // by construction (literals in the common case); if
+                // they invoked effects, they'd break the pure-only
+                // discipline. Reject quietly via the same effect rule.
+                if !example_effects.concrete.is_empty() {
+                    for e in example_effects.concrete.iter() {
+                        return Err(vec![TypeError::EffectNotDeclared {
+                            at_node: "n_0".into(),
+                            effect: e.pretty(),
+                        }]);
+                    }
+                }
+            }
+        }
+
         Ok(scheme)
     }
 

--- a/crates/lex-types/src/error.rs
+++ b/crates/lex-types/src/error.rs
@@ -64,6 +64,24 @@ pub enum TypeError {
         binding: String,
         reason: String,
     },
+    /// A function carrying signature-level examples (#369) declares
+    /// at least one effect. v1 restricts examples to pure functions so
+    /// the "same inputs ⇒ same outputs" invariant (rule #5) holds
+    /// without modeling effect responses.
+    ExamplesOnEffectfulFn {
+        at_node: String,
+        fn_name: String,
+    },
+    /// A signature-level example case (#369) supplies the wrong number
+    /// of arguments for the function it documents.
+    ExampleArityMismatch {
+        at_node: String,
+        fn_name: String,
+        /// Zero-based index of the failing case in the `examples` block.
+        case_index: usize,
+        expected: usize,
+        got: usize,
+    },
 }
 
 impl TypeError {
@@ -80,7 +98,9 @@ impl TypeError {
             | TypeError::InfiniteType { at_node, .. }
             | TypeError::AmbiguousType { at_node, .. }
             | TypeError::RecursiveTypeWithoutConstructor { at_node, .. }
-            | TypeError::RefinementViolation { at_node, .. } => at_node,
+            | TypeError::RefinementViolation { at_node, .. }
+            | TypeError::ExamplesOnEffectfulFn { at_node, .. }
+            | TypeError::ExampleArityMismatch { at_node, .. } => at_node,
         }
     }
 }
@@ -106,6 +126,12 @@ impl std::fmt::Display for TypeError {
             TypeError::RefinementViolation { at_node, fn_name, param_index, binding, reason } =>
                 write!(f, "refinement violated at {at_node}: argument {} of `{fn_name}` (binding `{binding}`): {reason}",
                     param_index + 1),
+            TypeError::ExamplesOnEffectfulFn { at_node, fn_name } =>
+                write!(f, "function `{fn_name}` at {at_node} carries `examples` but declares effects; \
+                          v1 restricts examples to pure functions"),
+            TypeError::ExampleArityMismatch { at_node, fn_name, case_index, expected, got } =>
+                write!(f, "example #{} of `{fn_name}` at {at_node}: expected {expected} argument(s), got {got}",
+                    case_index + 1),
         }
     }
 }

--- a/crates/lex-types/src/rules.rs
+++ b/crates/lex-types/src/rules.rs
@@ -39,6 +39,8 @@ impl TypeError {
             TypeError::AmbiguousType { .. } => "ambiguous-type",
             TypeError::RecursiveTypeWithoutConstructor { .. } => "recursive-type-without-constructor",
             TypeError::RefinementViolation { .. } => "refinement-violation",
+            TypeError::ExamplesOnEffectfulFn { .. } => "examples-on-effectful-fn",
+            TypeError::ExampleArityMismatch { .. } => "example-arity-mismatch",
         }
     }
 
@@ -83,6 +85,13 @@ between, so no value of the type can ever be built. Make the recursive position 
         "refinement-violation" => "A literal argument provably violates a refinement-type predicate \
 (#209). Adjust the argument to satisfy the predicate, or relax the predicate at the function \
 signature.",
+        "examples-on-effectful-fn" => "A function with an `examples { ... }` block (#369) also \
+declares effects. Signature-level examples are pure-only in v1 — they must be deterministic so the \
+contract is reproducible. Either remove the effects from the signature, or remove the examples block \
+and rely on external tests.",
+        "example-arity-mismatch" => "A case inside an `examples { ... }` block (#369) supplies a \
+different number of arguments than the function declares. Match the call's argument count to the \
+function's parameter count.",
         _ => "Unknown rule. The rule_tag may have been introduced after this Lex release.",
     }
 }
@@ -104,6 +113,8 @@ pub fn all_rules() -> &'static [RuleInfo] {
         RuleInfo { tag: "ambiguous-type", explanation: AMBIGUOUS_TYPE },
         RuleInfo { tag: "recursive-type-without-constructor", explanation: RECURSIVE_NO_CTOR },
         RuleInfo { tag: "refinement-violation", explanation: REFINEMENT_VIOLATION },
+        RuleInfo { tag: "examples-on-effectful-fn", explanation: EXAMPLES_ON_EFFECTFUL_FN },
+        RuleInfo { tag: "example-arity-mismatch", explanation: EXAMPLE_ARITY_MISMATCH },
     ]
 }
 
@@ -222,6 +233,13 @@ between, so no value of the type can ever be built. Make the recursive position 
 const REFINEMENT_VIOLATION: &str = "A literal argument provably violates a refinement-type predicate \
 (#209). Adjust the argument to satisfy the predicate, or relax the predicate at the function \
 signature.";
+const EXAMPLES_ON_EFFECTFUL_FN: &str = "A function with an `examples { ... }` block (#369) also \
+declares effects. Signature-level examples are pure-only in v1 — they must be deterministic so the \
+contract is reproducible. Either remove the effects from the signature, or remove the examples block \
+and rely on external tests.";
+const EXAMPLE_ARITY_MISMATCH: &str = "A case inside an `examples { ... }` block (#369) supplies a \
+different number of arguments than the function declares. Match the call's argument count to the \
+function's parameter count.";
 
 #[cfg(test)]
 mod tests {
@@ -282,6 +300,17 @@ mod tests {
                 param_index: 0,
                 binding: "x".into(),
                 reason: "x > 0".into(),
+            },
+            TypeError::ExamplesOnEffectfulFn {
+                at_node: "n_0".into(),
+                fn_name: "f".into(),
+            },
+            TypeError::ExampleArityMismatch {
+                at_node: "n_0".into(),
+                fn_name: "f".into(),
+                case_index: 0,
+                expected: 2,
+                got: 1,
             },
         ];
         let catalog: std::collections::BTreeMap<&str, &str> =

--- a/crates/lex-types/tests/check.rs
+++ b/crates/lex-types/tests/check.rs
@@ -96,3 +96,74 @@ fn every_error_has_node_id() {
     let errs = check(src).unwrap_err();
     for e in &errs { assert!(!e.node().is_empty(), "missing node id: {e:?}"); }
 }
+
+// --- #369: signature-level examples ---
+
+#[test]
+fn examples_with_matching_types_check() {
+    let src = "fn id(x :: Int) -> Int\nexamples { id(7) => 7, id(0) => 0 }\n{ x }\n";
+    check(src).unwrap_or_else(|errs| panic!("type errors: {errs:#?}"));
+}
+
+#[test]
+fn example_arg_type_mismatch_is_caught() {
+    let src = "fn id(x :: Int) -> Int\nexamples { id(\"oops\") => 7 }\n{ x }\n";
+    let errs = check(src).unwrap_err();
+    assert!(
+        errs.iter().any(|e| matches!(e, TypeError::TypeMismatch { .. })),
+        "expected TypeMismatch, got {errs:#?}"
+    );
+}
+
+#[test]
+fn example_expected_type_mismatch_is_caught() {
+    let src = "fn id(x :: Int) -> Int\nexamples { id(7) => \"seven\" }\n{ x }\n";
+    let errs = check(src).unwrap_err();
+    assert!(
+        errs.iter().any(|e| matches!(e, TypeError::TypeMismatch { .. })),
+        "expected TypeMismatch, got {errs:#?}"
+    );
+}
+
+#[test]
+fn example_arity_mismatch_is_caught() {
+    let src = "fn add(x :: Int, y :: Int) -> Int\nexamples { add(1) => 1 }\n{ x + y }\n";
+    let errs = check(src).unwrap_err();
+    assert!(
+        errs.iter().any(|e| matches!(e, TypeError::ExampleArityMismatch { .. })),
+        "expected ExampleArityMismatch, got {errs:#?}"
+    );
+}
+
+#[test]
+fn examples_on_effectful_fn_are_rejected() {
+    let src = r#"
+import "std.io" as io
+fn echoes(s :: Str) -> [io] Str
+  examples { echoes("hi") => "hi" }
+{ s }
+"#;
+    let errs = check(src).unwrap_err();
+    assert!(
+        errs.iter().any(|e| matches!(e, TypeError::ExamplesOnEffectfulFn { .. })),
+        "expected ExamplesOnEffectfulFn, got {errs:#?}"
+    );
+}
+
+#[test]
+fn example_rule_tags_round_trip() {
+    // Both new rule tags must be reachable via `TypeError::rule_tag()`.
+    let arity = TypeError::ExampleArityMismatch {
+        at_node: "n_0".into(),
+        fn_name: "f".into(),
+        case_index: 0,
+        expected: 2,
+        got: 1,
+    };
+    let effectful = TypeError::ExamplesOnEffectfulFn {
+        at_node: "n_0".into(),
+        fn_name: "f".into(),
+    };
+    assert_eq!(arity.rule_tag(), "example-arity-mismatch");
+    assert_eq!(effectful.rule_tag(), "examples-on-effectful-fn");
+}

--- a/examples/a_factorial.lex
+++ b/examples/a_factorial.lex
@@ -1,6 +1,13 @@
-fn factorial(n :: Int) -> Int {
+fn factorial(n :: Int) -> Int
+  examples {
+    factorial(0) => 1,
+    factorial(1) => 1,
+    factorial(5) => 120
+  }
+{
   match n {
     0 => 1,
     _ => n * factorial(n - 1),
   }
 }
+

--- a/fuzz/corpus/parser/seed_examples.lex
+++ b/fuzz/corpus/parser/seed_examples.lex
@@ -1,0 +1,8 @@
+fn add(x :: Int, y :: Int) -> Int
+  examples {
+    add(1, 2) => 3,
+    add(0, 0) => 0,
+  }
+{
+  x + y
+}

--- a/fuzz/corpus/type_checker/seed_examples.lex
+++ b/fuzz/corpus/type_checker/seed_examples.lex
@@ -1,0 +1,8 @@
+fn double(n :: Int) -> Int
+  examples {
+    double(0) => 0,
+    double(3) => 6,
+  }
+{
+  n + n
+}


### PR DESCRIPTION
A pure function can now carry an optional `examples { call(args) =>
expected, ... }` block between its return type and body. Each case
folds into the canonical AST so two implementations with different
example sets hash to different SigIds — examples are part of the
contract, not a sibling test file.

What the type checker enforces in this slice:
- argument count matches the function's parameter arity
- each argument type-checks against its declared parameter type
- each expected value type-checks against the declared return type
- the function declares no effects (pure-only in v1, per rule #5)

Backwards-compat: an empty examples vec is omitted from the canonical
JSON, so pre-#369 signatures hash bit-identically. Regression test in
crates/lex-ast/tests/canonical.rs::empty_examples_does_not_perturb_sig_id.

New error variants ExamplesOnEffectfulFn and ExampleArityMismatch carry
stable rule_tags `examples-on-effectful-fn` and `example-arity-mismatch`.
Type-level mismatches on args/expected surface as the existing
TypeMismatch with a "in example #N for `fn`" context line.

Behavioral evaluation (run the body, compare to expected) is a planned
follow-up — this slice catches type-level drift, already a common
cause of stale examples.

The factorial example carries three cases as a showcase; lex fmt
round-trips the new block; fuzz seeds added under fuzz/corpus/.