### PR TITLE
feat(types): record row spreads — { ...TypeName } in type expressions (#363)

### DIFF
--- a/crates/lex-ast/src/canon_print.rs
+++ b/crates/lex-ast/src/canon_print.rs
@@ -126,6 +126,18 @@ impl Printer {
                 }
                 write!(self.out, " }}").unwrap();
             }
+            TypeExpr::RecordWithSpreads { spreads, fields } => {
+                write!(self.out, "{{ ").unwrap();
+                for (i, s) in spreads.iter().enumerate() {
+                    if i > 0 { write!(self.out, ", ").unwrap(); }
+                    write!(self.out, "...{}", s).unwrap();
+                }
+                for f in fields {
+                    write!(self.out, ", {} :: ", f.name).unwrap();
+                    self.ty(&f.ty);
+                }
+                write!(self.out, " }}").unwrap();
+            }
             TypeExpr::Tuple { items } => {
                 write!(self.out, "(").unwrap();
                 for (i, it) in items.iter().enumerate() {

--- a/crates/lex-ast/src/canonical.rs
+++ b/crates/lex-ast/src/canonical.rs
@@ -86,6 +86,13 @@ pub enum TypeExpr {
     Tuple { items: Vec<TypeExpr> },
     Function { params: Vec<TypeExpr>, effects: Vec<Effect>, ret: Box<TypeExpr> },
     Union { variants: Vec<UnionVariant> },
+    /// Record type with spread bases (#363): `{ ...TypeName, extra :: Type }`.
+    /// Kept in canonical form unresolved; type-checker expands to `Ty::Record`.
+    RecordWithSpreads {
+        spreads: Vec<String>,
+        #[serde(skip_serializing_if = "Vec::is_empty", default)]
+        fields: Vec<TypeField>,
+    },
     /// Refinement type (#209). Carries the predicate as a canonical
     /// expression so `lex-vcs` content-addressing picks up changes
     /// to the refinement just like changes to the base type. The

--- a/crates/lex-ast/src/canonicalize.rs
+++ b/crates/lex-ast/src/canonicalize.rs
@@ -103,6 +103,15 @@ fn canonicalize_type(t: &s::TypeExpr) -> TypeExpr {
             },
             ret: Box::new(canonicalize_type(ret)),
         },
+        s::TypeExpr::RecordWithSpreads { spreads, fields } => {
+            TypeExpr::RecordWithSpreads {
+                spreads: spreads.clone(),
+                fields: fields
+                    .iter()
+                    .map(|f| TypeField { name: f.name.clone(), ty: canonicalize_type(&f.ty) })
+                    .collect(),
+            }
+        }
         s::TypeExpr::Union(variants) => {
             let mut vs: Vec<UnionVariant> = variants
                 .iter()

--- a/crates/lex-ast/src/ids.rs
+++ b/crates/lex-ast/src/ids.rs
@@ -182,6 +182,14 @@ fn walk_type<'a>(t: &'a TypeExpr, parent: &NodeId, out: &mut Vec<(NodeId, NodeRe
                 idx += 1;
             }
         }
+        TypeExpr::RecordWithSpreads { fields, .. } => {
+            for f in fields {
+                let id = parent.child(idx);
+                out.push((id.clone(), NodeRef::TypeExpr(&f.ty)));
+                walk_type(&f.ty, &id, out);
+                idx += 1;
+            }
+        }
         TypeExpr::Tuple { items } => {
             for it in items {
                 let id = parent.child(idx);

--- a/crates/lex-cli/src/audit.rs
+++ b/crates/lex-cli/src/audit.rs
@@ -511,6 +511,11 @@ fn render_type(t: &TypeExpr) -> String {
                 .map(|f| format!("{} :: {}", f.name, render_type(&f.ty))).collect();
             format!("{{ {} }}", parts.join(", "))
         }
+        TypeExpr::RecordWithSpreads { spreads, fields } => {
+            let mut parts: Vec<String> = spreads.iter().map(|s| format!("...{}", s)).collect();
+            parts.extend(fields.iter().map(|f| format!("{} :: {}", f.name, render_type(&f.ty))));
+            format!("{{ {} }}", parts.join(", "))
+        }
         TypeExpr::Function { params, effects, ret } => {
             let parts: Vec<String> = params.iter().map(render_type).collect();
             let eff = if effects.is_empty() { String::new() } else {

--- a/crates/lex-cli/src/docs.rs
+++ b/crates/lex-cli/src/docs.rs
@@ -390,6 +390,11 @@ fn render_type(t: &lex_ast::TypeExpr) -> String {
             inner.join(" | ")
         }
         Refined { base, .. } => format!("{}{{…}}", render_type(base)),
+        RecordWithSpreads { spreads, fields } => {
+            let mut parts: Vec<String> = spreads.iter().map(|s| format!("...{}", s)).collect();
+            parts.extend(fields.iter().map(|f| format!("{}: {}", f.name, render_type(&f.ty))));
+            format!("{{{}}}", parts.join(", "))
+        }
     }
 }
 

--- a/crates/lex-lsp/src/lib.rs
+++ b/crates/lex-lsp/src/lib.rs
@@ -290,6 +290,11 @@ fn render_type(t: &lex_ast::TypeExpr) -> String {
             inner.join(" | ")
         }
         Refined { base, .. } => format!("{}{{...}}", render_type(base)),
+        RecordWithSpreads { spreads, fields } => {
+            let mut parts: Vec<String> = spreads.iter().map(|s| format!("...{}", s)).collect();
+            parts.extend(fields.iter().map(|f| format!("{}: {}", f.name, render_type(&f.ty))));
+            format!("{{{}}}", parts.join(", "))
+        }
     }
 }
 

--- a/crates/lex-search/src/index.rs
+++ b/crates/lex-search/src/index.rs
@@ -253,6 +253,11 @@ fn render_type(t: &TypeExpr) -> String {
                 .map(|f| format!("{} :: {}", f.name, render_type(&f.ty))).collect();
             format!("{{{}}}", parts.join(", "))
         }
+        TypeExpr::RecordWithSpreads { spreads, fields } => {
+            let mut parts: Vec<String> = spreads.iter().map(|s| format!("...{}", s)).collect();
+            parts.extend(fields.iter().map(|f| format!("{} :: {}", f.name, render_type(&f.ty))));
+            format!("{{{}}}", parts.join(", "))
+        }
         TypeExpr::Function { params, ret, .. } => {
             let parts: Vec<String> = params.iter().map(render_type).collect();
             format!("({}) -> {}", parts.join(", "), render_type(ret))

--- a/crates/lex-syntax/src/loader.rs
+++ b/crates/lex-syntax/src/loader.rs
@@ -380,6 +380,16 @@ impl<'a> Mangler<'a> {
                     })
                     .collect(),
             ),
+            TypeExpr::RecordWithSpreads { spreads, fields } => TypeExpr::RecordWithSpreads {
+                spreads: spreads.into_iter().map(|s| self.rewrite_type_name(&s)).collect(),
+                fields: fields
+                    .into_iter()
+                    .map(|f| TypeField {
+                        name: f.name,
+                        ty: self.mangle_type_expr(f.ty),
+                    })
+                    .collect(),
+            },
             TypeExpr::Tuple(items) => {
                 TypeExpr::Tuple(items.into_iter().map(|t| self.mangle_type_expr(t)).collect())
             }

--- a/crates/lex-syntax/src/parser.rs
+++ b/crates/lex-syntax/src/parser.rs
@@ -292,20 +292,31 @@ impl Parser {
     fn parse_record_type(&mut self) -> Result<TypeExpr, ParseError> {
         self.expect(&TokenKind::LBrace, "in record type")?;
         let mut fields = Vec::new();
+        let mut spreads = Vec::new();
         if !matches!(self.peek_skip_newlines(), Some(TokenKind::RBrace)) {
             loop {
                 self.skip_newlines();
-                let name = self.expect_ident("in record field")?;
-                self.expect(&TokenKind::ColonColon, "after record field name")?;
-                let ty = self.parse_type_expr()?;
-                fields.push(TypeField { name, ty });
+                if matches!(self.peek(), Some(TokenKind::DotDotDot)) {
+                    self.bump(); // consume `...`
+                    let name = self.expect_ident("after `...` in record type spread")?;
+                    spreads.push(name);
+                } else {
+                    let name = self.expect_ident("in record field")?;
+                    self.expect(&TokenKind::ColonColon, "after record field name")?;
+                    let ty = self.parse_type_expr()?;
+                    fields.push(TypeField { name, ty });
+                }
                 self.skip_newlines();
                 if !self.eat(&TokenKind::Comma) { break; }
                 if matches!(self.peek_skip_newlines(), Some(TokenKind::RBrace)) { break; }
             }
         }
         self.expect(&TokenKind::RBrace, "in record type")?;
-        Ok(TypeExpr::Record(fields))
+        if spreads.is_empty() {
+            Ok(TypeExpr::Record(fields))
+        } else {
+            Ok(TypeExpr::RecordWithSpreads { spreads, fields })
+        }
     }
 
     fn parse_paren_type_or_function(&mut self) -> Result<TypeExpr, ParseError> {

--- a/crates/lex-syntax/src/printer.rs
+++ b/crates/lex-syntax/src/printer.rs
@@ -145,6 +145,18 @@ impl Printer {
                 }
                 write!(self.out, " }}").unwrap();
             }
+            TypeExpr::RecordWithSpreads { spreads, fields } => {
+                write!(self.out, "{{ ").unwrap();
+                for (i, s) in spreads.iter().enumerate() {
+                    if i > 0 { write!(self.out, ", ").unwrap(); }
+                    write!(self.out, "...{}", s).unwrap();
+                }
+                for f in fields {
+                    write!(self.out, ", {} :: ", f.name).unwrap();
+                    self.type_expr(&f.ty);
+                }
+                write!(self.out, " }}").unwrap();
+            }
             TypeExpr::Tuple(items) => {
                 write!(self.out, "(").unwrap();
                 for (i, it) in items.iter().enumerate() {

--- a/crates/lex-syntax/src/syntax.rs
+++ b/crates/lex-syntax/src/syntax.rs
@@ -88,6 +88,12 @@ pub enum TypeExpr {
         ret: Box<TypeExpr>,
     },
     Union(Vec<UnionVariant>),
+    /// Record type with one or more spread bases (#363): `{ ...TypeName, field :: Type }`.
+    /// Resolved to a flat `Ty::Record` during type-checking.
+    RecordWithSpreads {
+        spreads: Vec<String>,
+        fields: Vec<TypeField>,
+    },
     /// Refinement type (#209): a base type plus a predicate the
     /// inhabitant must satisfy. `Int{x | x > 0 and x <= balance}`
     /// parses with `base = Named { name: "Int", args: [] }`,

--- a/crates/lex-syntax/src/token.rs
+++ b/crates/lex-syntax/src/token.rs
@@ -32,6 +32,9 @@ pub enum TokenKind {
     #[token("<=")] LtEq,
     #[token(">=")] GtEq,
 
+    // spread operator (record type spread `{ ...TypeName }`)
+    #[token("...")] DotDotDot,
+
     // single-char operators
     #[token("+")] Plus,
     #[token("-")] Minus,

--- a/crates/lex-types/src/checker.rs
+++ b/crates/lex-types/src/checker.rs
@@ -2,7 +2,7 @@
 //! and checks declared signatures and effects.
 
 use crate::builtins::{module_for_import, module_scope};
-use crate::env::{TypeDefKind, TypeEnv, ty_from_canon};
+use crate::env::{TypeDefKind, TypeEnv, ty_from_canon_env};
 use crate::error::{PositionedError, TypeError};
 use crate::position::Position;
 use crate::types::*;
@@ -107,7 +107,7 @@ fn check_program_inner(
     // Pass 3: register fn signatures (so mutual recursion works).
     for stage in stages {
         if let a::Stage::FnDecl(fd) = stage {
-            let scheme = function_scheme(fd);
+            let scheme = function_scheme(fd, &tcx.type_env);
             tcx.globals.insert(fd.name.clone(), scheme);
             // #209 slice 2: keep the original params so call-site
             // refinement discharge can see the predicate before it
@@ -396,10 +396,10 @@ fn collect_eff_vars(t: &Ty) -> Vec<u32> {
     out
 }
 
-fn function_scheme(fd: &a::FnDecl) -> Scheme {
+fn function_scheme(fd: &a::FnDecl, env: &TypeEnv) -> Scheme {
     // Collect type-param ids in order; map their names to fresh Var(idx).
-    let params: Vec<Ty> = fd.params.iter().map(|p| ty_from_canon(&p.ty, &fd.type_params)).collect();
-    let ret = ty_from_canon(&fd.return_type, &fd.type_params);
+    let params: Vec<Ty> = fd.params.iter().map(|p| ty_from_canon_env(&p.ty, &fd.type_params, env)).collect();
+    let ret = ty_from_canon_env(&fd.return_type, &fd.type_params, env);
     // Plumb effect args (#207). A canonical-AST `EffectDecl` already
     // carries `Option<EffectArg>`; map it into the type-system kind so
     // subsumption can honor parameterized effects.
@@ -624,7 +624,7 @@ impl Checker {
 
     fn check_fn(&mut self, fd: &a::FnDecl) -> Result<Scheme, Vec<TypeError>> {
         // Instantiate fn's signature with fresh vars for its type params.
-        let scheme = function_scheme(fd);
+        let scheme = function_scheme(fd, &self.type_env);
         let (param_tys, declared_effects, ret_ty) = match instantiate(&scheme, &mut self.u) {
             Ty::Function { params, effects, ret } => (params, effects, *ret),
             _ => unreachable!(),
@@ -759,7 +759,7 @@ impl Checker {
             a::CExpr::Let { name, ty, value, body } => {
                 let v_ty = self.check_expr(value, node_id, locals, effs)?;
                 if let Some(declared) = ty {
-                    let d = ty_from_canon(declared, &[]);
+                    let d = ty_from_canon_env(declared, &[], &self.type_env);
                     if let Err(err) = self.unify_with_record_coercion(&v_ty, &d) {
                         return Err(mismatch_err(node_id, err, &self.u, vec![format!("in let `{}`", name)]));
                     }
@@ -854,8 +854,8 @@ impl Checker {
                 }
             }
             a::CExpr::Lambda { params, return_type, effects: l_effects, body } => {
-                let param_tys: Vec<Ty> = params.iter().map(|p| ty_from_canon(&p.ty, &[])).collect();
-                let ret_ty = ty_from_canon(return_type, &[]);
+                let param_tys: Vec<Ty> = params.iter().map(|p| ty_from_canon_env(&p.ty, &[], &self.type_env)).collect();
+                let ret_ty = ty_from_canon_env(return_type, &[], &self.type_env);
                 let declared = EffectSet {
                     concrete: {
                         let mut s = std::collections::BTreeSet::new();

--- a/crates/lex-types/src/env.rs
+++ b/crates/lex-types/src/env.rs
@@ -264,7 +264,7 @@ impl TypeEnv {
                 });
             }
             other => {
-                let ty = ty_from_canon(other, &decl.params);
+                let ty = ty_from_canon_env(other, &decl.params, self);
                 self.types.insert(name.to_string(), TypeDef {
                     params: decl.params.clone(),
                     kind: TypeDefKind::Alias(ty),
@@ -353,5 +353,34 @@ pub fn ty_from_canon(t: &lex_ast::TypeExpr, params: &[String]) -> Ty {
             // wired up.
             ty_from_canon(base, params)
         }
+        lex_ast::TypeExpr::RecordWithSpreads { .. } => {
+            // Caller should use ty_from_canon_env for spread resolution.
+            Ty::Unit
+        }
+    }
+}
+
+/// Like `ty_from_canon` but resolves `RecordWithSpreads` by looking up base
+/// type names in `env`. Called from `add_user_type` and `function_scheme` so
+/// that `{ ...Post, extra :: Int }` expands to a flat `Ty::Record`.
+pub fn ty_from_canon_env(t: &lex_ast::TypeExpr, params: &[String], env: &TypeEnv) -> Ty {
+    match t {
+        lex_ast::TypeExpr::RecordWithSpreads { spreads, fields } => {
+            let mut m = IndexMap::new();
+            for spread_name in spreads {
+                if let Some(td) = env.types.get(spread_name.as_str()) {
+                    if let TypeDefKind::Alias(Ty::Record(spread_fields)) = &td.kind {
+                        for (k, v) in spread_fields {
+                            m.insert(k.clone(), v.clone());
+                        }
+                    }
+                }
+            }
+            for f in fields {
+                m.insert(f.name.clone(), ty_from_canon_env(&f.ty, params, env));
+            }
+            Ty::Record(m)
+        }
+        other => ty_from_canon(other, params),
     }
 }

--- a/crates/lex-types/tests/record_spreads.rs
+++ b/crates/lex-types/tests/record_spreads.rs
@@ -1,0 +1,85 @@
+//! Acceptance tests for #363 slice 1: `{ ...TypeName }` record spread syntax.
+//!
+//! Scope: spread type expressions parse, canonicalize, and are resolved to
+//! flat `Ty::Record` during type-checking. Functions accepting or returning
+//! spread types unify correctly with concrete record literals.
+
+use lex_ast::canonicalize_program;
+use lex_ast::TypeExpr;
+use lex_syntax::parse_source;
+use lex_types::check_program;
+
+fn canon_stages(src: &str) -> Vec<lex_ast::Stage> {
+    let p = parse_source(src).unwrap_or_else(|e| panic!("parse failed: {e}"));
+    canonicalize_program(&p)
+}
+
+#[test]
+fn spread_type_parses_and_canonicalizes() {
+    let src = r#"
+type Post = { title :: Str, body :: Str }
+type Tagged = { ...Post, tag :: Str }
+"#;
+    let stages = canon_stages(src);
+    let tagged_decl = stages.iter().find_map(|s| match s {
+        lex_ast::Stage::TypeDecl(td) if td.name == "Tagged" => Some(td),
+        _ => None,
+    }).expect("Tagged type decl");
+    match &tagged_decl.definition {
+        TypeExpr::RecordWithSpreads { spreads, fields } => {
+            assert_eq!(spreads, &["Post"]);
+            assert_eq!(fields.len(), 1);
+            assert_eq!(fields[0].name, "tag");
+        }
+        other => panic!("expected RecordWithSpreads, got {other:?}"),
+    }
+}
+
+#[test]
+fn spread_type_resolves_during_type_check() {
+    let src = r#"
+type Post = { title :: Str, body :: Str }
+type Tagged = { ...Post, tag :: Str }
+
+fn make_tagged(title :: Str, body :: Str, tag :: Str) -> Tagged {
+    { title: title, body: body, tag: tag }
+}
+"#;
+    let stages = canon_stages(src);
+    check_program(&stages).expect("type check should pass");
+}
+
+#[test]
+fn spread_type_with_multiple_spreads_parses() {
+    let src = r#"
+type HasName = { name :: Str }
+type HasAge = { age :: Int }
+type Person = { ...HasName, ...HasAge }
+"#;
+    let stages = canon_stages(src);
+    let person_decl = stages.iter().find_map(|s| match s {
+        lex_ast::Stage::TypeDecl(td) if td.name == "Person" => Some(td),
+        _ => None,
+    }).expect("Person type decl");
+    match &person_decl.definition {
+        TypeExpr::RecordWithSpreads { spreads, fields } => {
+            assert_eq!(spreads.len(), 2);
+            assert!(spreads.contains(&"HasName".to_string()));
+            assert!(spreads.contains(&"HasAge".to_string()));
+            assert!(fields.is_empty());
+        }
+        other => panic!("expected RecordWithSpreads, got {other:?}"),
+    }
+}
+
+#[test]
+fn spread_only_without_extra_fields_parses() {
+    let src = r#"
+type Base = { x :: Int, y :: Int }
+type Derived = { ...Base }
+
+fn use_derived(d :: Derived) -> Int { d.x }
+"#;
+    let stages = canon_stages(src);
+    check_program(&stages).expect("type check should pass");
+}

--- a/crates/lex-vcs/src/compute_diff.rs
+++ b/crates/lex-vcs/src/compute_diff.rs
@@ -311,6 +311,11 @@ fn render_type(t: &TypeExpr) -> String {
                 .map(|f| format!("{} :: {}", f.name, render_type(&f.ty))).collect();
             format!("{{ {} }}", parts.join(", "))
         }
+        TypeExpr::RecordWithSpreads { spreads, fields } => {
+            let mut parts: Vec<String> = spreads.iter().map(|s| format!("...{}", s)).collect();
+            parts.extend(fields.iter().map(|f| format!("{} :: {}", f.name, render_type(&f.ty))));
+            format!("{{ {} }}", parts.join(", "))
+        }
         TypeExpr::Function { params, effects, ret } => {
             let parts: Vec<String> = params.iter().map(render_type).collect();
             let eff = if effects.is_empty() { String::new() } else {


### PR DESCRIPTION
Adds `{ ...TypeName, extra :: T }` spread syntax so record types can
be composed from named bases without repeating every field.

- New `DotDotDot` (`...`) token in the lexer
- `TypeExpr::RecordWithSpreads { spreads, fields }` in syntax and
  canonical ASTs; kept unresolved in canonical form so SigId hashing
  picks up changes to the base type
- Parser handles `...Name` entries inside `{ }` type positions
- `ty_from_canon_env` resolves spreads by merging `Ty::Record` maps
  from the TypeEnv; `add_user_type` and `function_scheme` use it
- All `TypeExpr::Record` match sites updated across lex-ast, lex-cli,
  lex-lsp, lex-search, lex-syntax, lex-types, lex-vcs
- 4 new acceptance tests in `lex-types/tests/record_spreads.rs`

https://claude.ai/code/session_01TN34hWDyCyB9WmUKVVacTQ