### PR TITLE
feat(types): run signature-level examples through the VM (#369 slice 2)

### DIFF
--- a/crates/lex-cli/src/examples_eval.rs
+++ b/crates/lex-cli/src/examples_eval.rs
@@ -1,0 +1,247 @@
+//! Behavioral evaluation of signature-level `examples { ... }` blocks (#369 slice 2).
+//!
+//! Slice 1 (PR #370) shipped the AST + parser + type-checking of example args
+//! and expected values against the function's signature. This pass takes the
+//! next step: it actually *runs* each example through the bytecode VM and
+//! compares the result to the declared `expected` value. A mismatch becomes
+//! a [`TypeError::ExampleMismatch`] with `rule_tag = "example-mismatch"`,
+//! surfaced through the same structured-JSON error envelope as every other
+//! `lex check` diagnostic.
+//!
+//! ## Implementation strategy
+//!
+//! For each pure function with non-empty examples, synthesize a small set of
+//! zero-argument helper functions and append them as new stages alongside
+//! the original program:
+//!
+//! - `__ex_<fn>_<K>_arg_<I>` returning the *I*th argument of case *K*.
+//! - `__ex_<fn>_<K>_expected` returning the declared expected value of case *K*.
+//!
+//! Compile the augmented program to bytecode (the user's program plus the
+//! helpers all see the same global scope), and for each case:
+//!
+//! 1. Call each `__ex_<fn>_<K>_arg_<I>` helper through the VM to get a
+//!    runtime `Value` for the argument.
+//! 2. Call the original function with those values to get the actual `Value`.
+//! 3. Call `__ex_<fn>_<K>_expected` to get the declared `Value`.
+//! 4. Compare the two via [`Value`]'s `PartialEq`. On mismatch, emit
+//!    `ExampleMismatch` with pretty-printed `expected` and `got`.
+//!
+//! ## v1 restrictions
+//!
+//! - Generic functions (with `type_params`) are skipped — the helper
+//!   synthesis would need to monomorphize. Examples on generic functions
+//!   still get the slice-1 *type-level* checks; they just don't get
+//!   *behavioral* checks. Worth a follow-up issue if examples on generics
+//!   become a real need.
+//! - Pure-only (already enforced by `ExamplesOnEffectfulFn` in slice 1).
+
+use lex_ast as a;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_types::TypeError;
+
+/// Run the behavioral-evaluation pass over `stages` and return any
+/// `ExampleMismatch` errors discovered. Returns the empty vec when every
+/// example case passes (or when there are no eligible cases).
+///
+/// Stages that fail VM execution (panics, step-limit, etc.) surface as
+/// `ExampleMismatch` with a synthetic "got" string describing the failure.
+/// We deliberately do not wrap them in a separate error variant so the
+/// downstream JSON envelope and repair-loop wiring stays uniform.
+pub fn evaluate_examples(stages: &[a::Stage]) -> Vec<TypeError> {
+    let helpers = synthesize_helpers(stages);
+    if helpers.cases.is_empty() {
+        return Vec::new();
+    }
+
+    let mut augmented: Vec<a::Stage> = stages.to_vec();
+    augmented.extend(helpers.helper_stages);
+
+    let bc = compile_program(&augmented);
+    let bc = std::sync::Arc::new(bc);
+
+    let mut out = Vec::new();
+    for case in &helpers.cases {
+        match run_case(&bc, case) {
+            CaseOutcome::Pass => {}
+            CaseOutcome::Mismatch { expected, got } => {
+                out.push(TypeError::ExampleMismatch {
+                    at_node: "n_0".into(),
+                    fn_name: case.fn_name.clone(),
+                    case_index: case.case_index,
+                    expected,
+                    got,
+                });
+            }
+            CaseOutcome::RuntimeError(msg) => {
+                // Surface VM panics as ExampleMismatch so the user sees a
+                // clear "this example failed" diagnostic with the panic
+                // message in the `got` slot. Keeps the error envelope uniform.
+                out.push(TypeError::ExampleMismatch {
+                    at_node: "n_0".into(),
+                    fn_name: case.fn_name.clone(),
+                    case_index: case.case_index,
+                    expected: "(declared value)".into(),
+                    got: format!("runtime error: {msg}"),
+                });
+            }
+        }
+    }
+    out
+}
+
+struct Helpers {
+    helper_stages: Vec<a::Stage>,
+    cases: Vec<Case>,
+}
+
+struct Case {
+    fn_name: String,
+    case_index: usize,
+    arg_helpers: Vec<String>,
+    expected_helper: String,
+}
+
+fn synthesize_helpers(stages: &[a::Stage]) -> Helpers {
+    let mut helper_stages = Vec::new();
+    let mut cases = Vec::new();
+
+    for stage in stages {
+        let a::Stage::FnDecl(fd) = stage else { continue };
+        if fd.examples.is_empty() {
+            continue;
+        }
+        // v1: skip generics. Helper synthesis would need to pick a
+        // concrete instantiation; defer until there's a real need.
+        if !fd.type_params.is_empty() {
+            continue;
+        }
+        // Pure-only is already enforced by ExamplesOnEffectfulFn in slice 1,
+        // but we double-check here so a future regression doesn't lead the
+        // VM to invoke a real effect handler during `lex check`.
+        if !fd.effects.is_empty() {
+            continue;
+        }
+        for (k, ex) in fd.examples.iter().enumerate() {
+            let mut arg_helpers = Vec::with_capacity(ex.args.len());
+            for (i, arg) in ex.args.iter().enumerate() {
+                let helper_name = format!("__ex_{}_{}_arg_{}", fd.name, k, i);
+                helper_stages.push(zero_arg_helper(&helper_name, fd.params[i].ty.clone(), arg.clone()));
+                arg_helpers.push(helper_name);
+            }
+            let expected_helper = format!("__ex_{}_{}_expected", fd.name, k);
+            helper_stages.push(zero_arg_helper(
+                &expected_helper,
+                fd.return_type.clone(),
+                ex.expected.clone(),
+            ));
+            cases.push(Case {
+                fn_name: fd.name.clone(),
+                case_index: k,
+                arg_helpers,
+                expected_helper,
+            });
+        }
+    }
+
+    Helpers { helper_stages, cases }
+}
+
+fn zero_arg_helper(name: &str, return_type: a::TypeExpr, body: a::CExpr) -> a::Stage {
+    a::Stage::FnDecl(a::FnDecl {
+        name: name.into(),
+        type_params: Vec::new(),
+        params: Vec::new(),
+        effects: Vec::new(),
+        return_type,
+        body,
+        examples: Vec::new(),
+    })
+}
+
+enum CaseOutcome {
+    Pass,
+    Mismatch { expected: String, got: String },
+    RuntimeError(String),
+}
+
+fn run_case(bc: &std::sync::Arc<lex_bytecode::Program>, case: &Case) -> CaseOutcome {
+    // Each VM invocation is a fresh instance — they share no state, and
+    // because we restrict to pure functions, there's nothing to share.
+    let mut arg_values: Vec<Value> = Vec::with_capacity(case.arg_helpers.len());
+    for helper in &case.arg_helpers {
+        match call_zero_arg(bc, helper) {
+            Ok(v) => arg_values.push(v),
+            Err(e) => return CaseOutcome::RuntimeError(format!("computing arg from `{helper}`: {e}")),
+        }
+    }
+    let expected = match call_zero_arg(bc, &case.expected_helper) {
+        Ok(v) => v,
+        Err(e) => return CaseOutcome::RuntimeError(format!("computing expected from `{}`: {e}", case.expected_helper)),
+    };
+    let got = match call_with_args(bc, &case.fn_name, arg_values) {
+        Ok(v) => v,
+        Err(e) => return CaseOutcome::RuntimeError(format!("calling `{}`: {e}", case.fn_name)),
+    };
+    if expected == got {
+        CaseOutcome::Pass
+    } else {
+        CaseOutcome::Mismatch {
+            expected: pretty_value(&expected),
+            got: pretty_value(&got),
+        }
+    }
+}
+
+fn call_zero_arg(bc: &std::sync::Arc<lex_bytecode::Program>, name: &str) -> Result<Value, String> {
+    call_with_args(bc, name, Vec::new())
+}
+
+fn call_with_args(
+    bc: &std::sync::Arc<lex_bytecode::Program>,
+    name: &str,
+    args: Vec<Value>,
+) -> Result<Value, String> {
+    let handler = DefaultHandler::new(Policy::pure()).with_program(std::sync::Arc::clone(bc));
+    let mut vm = Vm::with_handler(bc, Box::new(handler));
+    // Defensive: cap steps so a runaway example can't hang `lex check`.
+    vm.set_step_limit(1_000_000);
+    vm.call(name, args).map_err(|e| format!("{e:?}"))
+}
+
+/// Pretty-print a `Value` for inclusion in `ExampleMismatch` errors.
+/// We want the JSON envelope to carry something a human and an LLM can
+/// both read; `Debug` is verbose but unambiguous and matches the rest of
+/// Lex's diagnostic style.
+fn pretty_value(v: &Value) -> String {
+    match v {
+        Value::Int(n) => n.to_string(),
+        Value::Float(f) => f.to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Str(s) => format!("{s:?}"),
+        Value::Unit => "()".into(),
+        Value::List(xs) => format!(
+            "[{}]",
+            xs.iter().map(pretty_value).collect::<Vec<_>>().join(", ")
+        ),
+        Value::Tuple(xs) => format!(
+            "({})",
+            xs.iter().map(pretty_value).collect::<Vec<_>>().join(", ")
+        ),
+        Value::Variant { name, args } if args.is_empty() => name.clone(),
+        Value::Variant { name, args } => format!(
+            "{}({})",
+            name,
+            args.iter().map(pretty_value).collect::<Vec<_>>().join(", ")
+        ),
+        Value::Record(fs) => format!(
+            "{{ {} }}",
+            fs.iter()
+                .map(|(k, v)| format!("{k}: {}", pretty_value(v)))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        other => format!("{other:?}"),
+    }
+}

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -27,6 +27,7 @@ mod watch;
 mod fmt;
 mod init;
 mod ci;
+mod examples_eval;
 
 use ::acli::OutputFormat;
 use anyhow::{anyhow, bail, Context, Result};
@@ -375,6 +376,34 @@ fn cmd_check(fmt: &OutputFormat, args: &[String]) -> Result<()> {
 
     match check_result {
         Ok(_) => {
+            // #369 slice 2: behavioral evaluation of `examples { ... }` blocks.
+            // Type-level checks ran inside `check_program`; now we actually
+            // run each example case through the VM and compare to the
+            // declared expected value. Any mismatches surface through the
+            // same JSON envelope as type errors and exit 2 — they're hard
+            // errors, not lints, because the `examples` block is meant to
+            // be load-bearing contract, not a warning.
+            let example_errors = examples_eval::evaluate_examples(&stages);
+            if !example_errors.is_empty() {
+                let positioned: Vec<lex_types::PositionedError> = example_errors
+                    .into_iter()
+                    .map(lex_types::PositionedError::from)
+                    .collect();
+                let arr: Vec<serde_json::Value> = positioned
+                    .iter()
+                    .map(|e| serde_json::to_value(e).unwrap())
+                    .collect();
+                let data = serde_json::json!({ "ok": false, "errors": arr });
+                acli::emit_or_text("check", data, fmt, || {
+                    for e in &positioned {
+                        if let Ok(j) = serde_json::to_string(e) {
+                            println!("{j}");
+                        }
+                    }
+                });
+                std::process::exit(2);
+            }
+
             // --strict: run AST lint passes + bytecode stack verifier (#347 A2).
             // Warnings are non-fatal but exit 1 so CI can enforce them.
             let mut lint_warnings = if strict && !from_canonical && path != "-" {

--- a/crates/lex-cli/tests/example_eval.rs
+++ b/crates/lex-cli/tests/example_eval.rs
@@ -1,0 +1,141 @@
+//! `lex check` runs `examples { ... }` cases through the VM and emits a
+//! structured `example-mismatch` error when the body's actual output
+//! disagrees with the declared `expected` value (#369 slice 2).
+//!
+//! Slice 1 (PR #370) shipped the type-level checks. This suite covers the
+//! behavioral checks added in slice 2.
+
+use std::process::{Command, Stdio};
+
+fn lex_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_lex")
+}
+
+fn run(args: &[&str]) -> (i32, String) {
+    let out = Command::new(lex_bin())
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn lex");
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+    )
+}
+
+fn write_to_tempfile(name: &str, src: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("lex-example-eval-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(name);
+    std::fs::write(&path, src).unwrap();
+    path
+}
+
+#[test]
+fn passing_example_keeps_check_green() {
+    // The body genuinely produces `5` for `id(5)`, so `lex check` is happy.
+    let path = write_to_tempfile(
+        "ok.lex",
+        "fn id(x :: Int) -> Int\n  examples { id(5) => 5 }\n{ x }\n",
+    );
+    let (code, stdout) = run(&["check", path.to_str().unwrap()]);
+    assert_eq!(code, 0, "expected 0 (ok), got {code}: {stdout}");
+    assert!(stdout.contains("ok"), "stdout should say 'ok': {stdout}");
+}
+
+#[test]
+fn behavioral_mismatch_fires_example_mismatch() {
+    // Body returns x, but the example claims id(5) => 999. The type-level
+    // checks pass (both 5 and 999 are Int), so this case is the load-
+    // bearing one for slice 2 — it must fail at `lex check` time.
+    let path = write_to_tempfile(
+        "stale.lex",
+        "fn id(x :: Int) -> Int\n  examples { id(5) => 999 }\n{ x }\n",
+    );
+    let (code, stdout) = run(&["--output", "json", "check", path.to_str().unwrap()]);
+    assert_eq!(code, 2, "behavioral mismatch must exit nonzero: {stdout}");
+    let envelope: serde_json::Value = serde_json::from_str(&stdout)
+        .expect("output should be JSON when --output json is set");
+    let errors = envelope
+        .pointer("/data/errors")
+        .and_then(|v| v.as_array())
+        .expect("envelope must carry errors array at /data/errors");
+    assert_eq!(errors.len(), 1, "exactly one mismatch expected: {stdout}");
+    let err = &errors[0];
+    assert_eq!(err.get("kind").and_then(|v| v.as_str()), Some("example_mismatch"));
+    assert_eq!(err.get("rule_tag").and_then(|v| v.as_str()), Some("example-mismatch"));
+    assert_eq!(err.get("fn_name").and_then(|v| v.as_str()), Some("id"));
+    assert_eq!(err.get("case_index").and_then(|v| v.as_i64()), Some(0));
+    assert_eq!(err.get("expected").and_then(|v| v.as_str()), Some("999"));
+    assert_eq!(err.get("got").and_then(|v| v.as_str()), Some("5"));
+}
+
+#[test]
+fn recursive_function_with_passing_examples() {
+    // factorial is the canonical showcase. The body actually produces the
+    // declared values, so this should pass after slice 2.
+    let path = write_to_tempfile(
+        "factorial.lex",
+        "fn factorial(n :: Int) -> Int\n  \
+            examples {\n    \
+                factorial(0) => 1,\n    \
+                factorial(1) => 1,\n    \
+                factorial(5) => 120\n  \
+            }\n\
+         {\n  \
+           match n {\n    \
+             0 => 1,\n    \
+             _ => n * factorial(n - 1),\n  \
+           }\n\
+         }\n",
+    );
+    let (code, stdout) = run(&["check", path.to_str().unwrap()]);
+    assert_eq!(code, 0, "factorial examples must pass: {stdout}");
+}
+
+#[test]
+fn recursive_function_with_one_stale_case() {
+    // Three cases declared; only the middle one regressed. The error
+    // envelope must identify the offending case_index.
+    let path = write_to_tempfile(
+        "factorial_stale.lex",
+        "fn factorial(n :: Int) -> Int\n  \
+            examples {\n    \
+                factorial(0) => 1,\n    \
+                factorial(1) => 7,\n    \
+                factorial(5) => 120\n  \
+            }\n\
+         {\n  \
+           match n {\n    \
+             0 => 1,\n    \
+             _ => n * factorial(n - 1),\n  \
+           }\n\
+         }\n",
+    );
+    let (code, stdout) = run(&["--output", "json", "check", path.to_str().unwrap()]);
+    assert_eq!(code, 2, "stale middle example must surface: {stdout}");
+    let envelope: serde_json::Value = serde_json::from_str(&stdout).expect("json");
+    let errors = envelope
+        .pointer("/data/errors")
+        .and_then(|v| v.as_array())
+        .expect("errors array at /data/errors");
+    assert_eq!(errors.len(), 1);
+    assert_eq!(errors[0].get("case_index").and_then(|v| v.as_i64()), Some(1));
+    assert_eq!(errors[0].get("expected").and_then(|v| v.as_str()), Some("7"));
+    assert_eq!(errors[0].get("got").and_then(|v| v.as_str()), Some("1"));
+}
+
+#[test]
+fn variant_result_compares_structurally() {
+    // The expected value is a constructor call; the body produces the same
+    // shape. Demonstrates that PartialEq on Value covers variants.
+    let path = write_to_tempfile(
+        "wrap.lex",
+        "fn wrap(x :: Int) -> Option[Int]\n  \
+            examples { wrap(3) => Some(3) }\n\
+         { Some(x) }\n",
+    );
+    let (code, stdout) = run(&["check", path.to_str().unwrap()]);
+    assert_eq!(code, 0, "variant equality must work: {stdout}");
+}

--- a/crates/lex-types/src/error.rs
+++ b/crates/lex-types/src/error.rs
@@ -82,6 +82,19 @@ pub enum TypeError {
         expected: usize,
         got: usize,
     },
+    /// A signature-level example case (#369 slice 2) ran successfully
+    /// but the function's actual output disagrees with the declared
+    /// `expected` value. This is the load-bearing check that makes the
+    /// `examples` block enforce behavior, not just types.
+    ExampleMismatch {
+        at_node: String,
+        fn_name: String,
+        case_index: usize,
+        /// Pretty-printed expected value (LHS of the `=>` in the example).
+        expected: String,
+        /// Pretty-printed actual value the function body produced.
+        got: String,
+    },
 }
 
 impl TypeError {
@@ -100,7 +113,8 @@ impl TypeError {
             | TypeError::RecursiveTypeWithoutConstructor { at_node, .. }
             | TypeError::RefinementViolation { at_node, .. }
             | TypeError::ExamplesOnEffectfulFn { at_node, .. }
-            | TypeError::ExampleArityMismatch { at_node, .. } => at_node,
+            | TypeError::ExampleArityMismatch { at_node, .. }
+            | TypeError::ExampleMismatch { at_node, .. } => at_node,
         }
     }
 }
@@ -131,6 +145,9 @@ impl std::fmt::Display for TypeError {
                           v1 restricts examples to pure functions"),
             TypeError::ExampleArityMismatch { at_node, fn_name, case_index, expected, got } =>
                 write!(f, "example #{} of `{fn_name}` at {at_node}: expected {expected} argument(s), got {got}",
+                    case_index + 1),
+            TypeError::ExampleMismatch { at_node, fn_name, case_index, expected, got } =>
+                write!(f, "example #{} of `{fn_name}` at {at_node}: expected {expected}, got {got}",
                     case_index + 1),
         }
     }

--- a/crates/lex-types/src/rules.rs
+++ b/crates/lex-types/src/rules.rs
@@ -41,6 +41,7 @@ impl TypeError {
             TypeError::RefinementViolation { .. } => "refinement-violation",
             TypeError::ExamplesOnEffectfulFn { .. } => "examples-on-effectful-fn",
             TypeError::ExampleArityMismatch { .. } => "example-arity-mismatch",
+            TypeError::ExampleMismatch { .. } => "example-mismatch",
         }
     }
 
@@ -92,6 +93,9 @@ and rely on external tests.",
         "example-arity-mismatch" => "A case inside an `examples { ... }` block (#369) supplies a \
 different number of arguments than the function declares. Match the call's argument count to the \
 function's parameter count.",
+        "example-mismatch" => "A case inside an `examples { ... }` block (#369) ran successfully \
+but the function body's actual return value differs from the declared `expected` value. Either \
+update the example to match the new behavior, or fix the body to produce the declared value.",
         _ => "Unknown rule. The rule_tag may have been introduced after this Lex release.",
     }
 }
@@ -115,6 +119,7 @@ pub fn all_rules() -> &'static [RuleInfo] {
         RuleInfo { tag: "refinement-violation", explanation: REFINEMENT_VIOLATION },
         RuleInfo { tag: "examples-on-effectful-fn", explanation: EXAMPLES_ON_EFFECTFUL_FN },
         RuleInfo { tag: "example-arity-mismatch", explanation: EXAMPLE_ARITY_MISMATCH },
+        RuleInfo { tag: "example-mismatch", explanation: EXAMPLE_MISMATCH },
     ]
 }
 
@@ -189,6 +194,14 @@ the missing field to the type declaration. Use the LLM-driven `lex repair --appl
 the offending `let` binding, function parameter, or function return type via `ModifyBody`. The \
 LLM-driven `lex repair --apply` flow can synthesize the annotation from the surrounding context.",
         ),
+        "example-mismatch" => (
+            "ModifyBody",
+            "Reconcile the body with its declared example — fix one or the other.",
+            "An `examples { ... }` case ran but produced a value different from the declared \
+`expected`. Either the example is stale (LLM should rewrite the case via `ReplaceMatchArm` against \
+the `examples` block) or the body regressed (LLM should rewrite the body via `ModifyBody` to make \
+the case pass). The `case_index` field in the error identifies which case to act on.",
+        ),
         _ => return None,
     };
     Some(serde_json::json!({
@@ -240,6 +253,9 @@ and rely on external tests.";
 const EXAMPLE_ARITY_MISMATCH: &str = "A case inside an `examples { ... }` block (#369) supplies a \
 different number of arguments than the function declares. Match the call's argument count to the \
 function's parameter count.";
+const EXAMPLE_MISMATCH: &str = "A case inside an `examples { ... }` block (#369) ran successfully \
+but the function body's actual return value differs from the declared `expected` value. Either \
+update the example to match the new behavior, or fix the body to produce the declared value.";
 
 #[cfg(test)]
 mod tests {
@@ -311,6 +327,13 @@ mod tests {
                 case_index: 0,
                 expected: 2,
                 got: 1,
+            },
+            TypeError::ExampleMismatch {
+                at_node: "n_0".into(),
+                fn_name: "f".into(),
+                case_index: 0,
+                expected: "1".into(),
+                got: "2".into(),
             },
         ];
         let catalog: std::collections::BTreeMap<&str, &str> =

--- a/examples/b_parse_int.lex
+++ b/examples/b_parse_int.lex
@@ -3,7 +3,13 @@ import "std.result" as result
 
 type ParseError = Empty | NotNumber
 
-fn parse_int(s :: Str) -> Result[Int, ParseError] {
+fn parse_int(s :: Str) -> Result[Int, ParseError]
+  examples {
+    parse_int("42") => Ok(42),
+    parse_int("") => Err(Empty),
+    parse_int("not a number") => Err(NotNumber),
+  }
+{
   if str.is_empty(s) {
     Err(Empty)
   } else {
@@ -14,6 +20,11 @@ fn parse_int(s :: Str) -> Result[Int, ParseError] {
   }
 }
 
-fn double_input(s :: Str) -> Result[Int, ParseError] {
+fn double_input(s :: Str) -> Result[Int, ParseError]
+  examples {
+    double_input("21") => Ok(42),
+    double_input("") => Err(Empty),
+  }
+{
   parse_int(s) |> result.map(fn (n :: Int) -> Int { n * 2 })
 }

--- a/examples/d_shape.lex
+++ b/examples/d_shape.lex
@@ -2,7 +2,12 @@ type Shape =
     Circle({ radius :: Float })
   | Rect({ width :: Float, height :: Float })
 
-fn area(s :: Shape) -> Float {
+fn area(s :: Shape) -> Float
+  examples {
+    area(Rect({ width: 3.0, height: 4.0 })) => 12.0,
+    area(Rect({ width: 0.0, height: 5.0 })) => 0.0,
+  }
+{
   match s {
     Circle({ radius }) => 3.14159 * radius * radius,
     Rect({ width, height }) => width * height,


### PR DESCRIPTION
## Summary

Slice 2 of #369 — `lex check` now actually **runs** each `examples { ... }` case through the bytecode VM and compares the result to the declared `expected` value. Slice 1 (PR #370) only validated types; an example like `factorial(5) => 999` would have passed because both sides are `Int`. That gap is closed here.

## What this adds

- **`TypeError::ExampleMismatch { at_node, fn_name, case_index, expected, got }`** with stable rule_tag `example-mismatch`. Carries pretty-printed expected/got values for the diagnostic. Wired into the existing rule catalog + `suggested_transform_for` so the LLM repair flow gets a `ModifyBody` hint pointing at the offending case_index.
- **`lex-cli/src/examples_eval.rs`** — the new pass. For every pure, non-generic function with examples, synthesizes zero-arg helper functions for each arg expression and the expected expression, compiles the augmented program once, and calls each helper plus the original function through `lex-bytecode::Vm`. Mismatches surface through the same `/data/errors` JSON envelope as type errors and exit 2.
- Hooked into `cmd_check` right after the type-check `Ok` arm, before the lint pass.

## v1 restrictions (documented in the module)

- **Pure-only.** Already enforced by `ExamplesOnEffectfulFn` in slice 1; we double-check here so a future regression doesn't lead the VM to invoke a real effect handler during `lex check`.
- **No generics.** Helper synthesis would need to monomorphize. Examples on generic functions still get the slice-1 type-level checks; behavioral eval is deferred. Worth a follow-up if it becomes a real need.

## Showcases applied

- `examples/b_parse_int.lex` — `parse_int` gets three cases (Ok + both error variants), `double_input` gets two. Exercises Result-variant structural equality.
- `examples/d_shape.lex` — `area` gets two `Rect` cases.

## Acceptance criteria (revising #369)

- [x] `lex check` evaluates examples and fails with structured-JSON error on mismatch.
- [x] New `example-mismatch` rule tag + `suggested_transform` payload in the repair flow.
- [x] At least three existing pure examples carry working `examples` blocks (factorial + parse_int + double_input + area = 4).

Together with slice 1 (PR #370), this closes #369.

## Test plan

- [x] 5 new behavioral tests in `crates/lex-cli/tests/example_eval.rs` — passing example, deliberate `id(5) => 999` mismatch, multi-case factorial with one stale case (verifies `case_index` is correct), variant equality.
- [x] Existing 17 tests in `crates/lex-types/tests/check.rs` unaffected.
- [x] Existing 3 tests in `crates/lex-ast/tests/canonical.rs` (slice 1 hash-compat) still pass.
- [x] `cargo test -p lex-api --test m8` passes under `--test-threads=1` (the workspace-wide flake on these 4 tests is pre-existing parallel-execution noise, not introduced by this PR).
- [x] `cargo +1.95 clippy --workspace --all-targets -- -D warnings` clean locally.

## Risk / scope

- Touches: `lex-cli` (new module + one hook in `cmd_check`), `lex-types/src/{error,rules}.rs` (additive error variant + catalog entries), 2 `.lex` example files.
- Breaking change to wire format / SigId / StageId / canonical AST? **no** — slice 1 already settled the hash-compat story; this slice doesn't touch the AST shape.
- Adds a new effect kind or runtime variant? **no** — uses `Policy::pure()` for the synthesized helpers.

Closes #369.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RKGwSUUQoRH5zUDka5AL6f)_