### PR TITLE
chore(release): v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,74 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+## [0.9.1] — 2026-05-13
+
+### Added
+
+- **#369: signature-level `examples { ... }` block on `FnDecl`.** A pure
+  function can now carry an optional block between its return type and
+  body listing input/output examples that fold into the canonical AST. Two
+  signatures with different example sets hash to different SigIds —
+  examples are part of the contract, not an external test file. Slice 1
+  (PR #370) added the AST + parser + canonical-hash compat (regression
+  test pins `FnDecl { examples: vec![], .. }` to its pre-#369 hash) + the
+  type-level checks: argument arity, arg types against parameter types,
+  expected type against return type, and pure-only enforcement
+  (`ExamplesOnEffectfulFn` rule tag). Slice 2 (PR #373) added behavioral
+  evaluation: every example case runs through the bytecode VM at
+  `lex check` time and is compared to the declared expected value;
+  mismatches surface as `ExampleMismatch` with stable rule_tag
+  `example-mismatch` and a `suggested_transform` payload for the repair
+  flow. The `factorial`, `parse_int`, `double_input`, and `area` examples
+  carry working `examples` blocks as showcases. Closes #369.
+
+- **#363: record row spreads — `{ ...TypeName }` in type expressions.**
+  Type expressions accept the spread form so a record type can be defined
+  as the union of fields from one or more other record types. Unblocks
+  type-safe JOIN results in lex-orm — `Merge[A, B] = { ...A, ...B }` now
+  has a direct surface form. Closes #363.
+
+- **#364: `Iter[T]` lazy positional iterator stdlib.** New `std.iter`
+  module with `from_list / next / is_empty / count / take / skip /
+  to_list / map / filter / fold`. Backed at runtime by a
+  `(List[T], Int)` tuple with the Int as the cursor; all operations are
+  compiler-inlined as bytecode so no runtime effect dispatch is needed.
+  `Iter[T]` registered as an opaque type. Enables short-circuiting,
+  one-row-at-a-time consumption patterns over `std.list` and (in
+  combination with #362) over `std.sql` result sets. Closes #364.
+
+- **#362: Postgres support in `std.sql` + typed `SqlParam` ADT +
+  transactions + row decoders.** `sql.open` now dispatches on URL prefix:
+  `postgres://` / `postgresql://` connect via the sync `postgres` crate,
+  anything else opens SQLite as before. Parameters use the new
+  `SqlParam = PStr(Str) | PInt(Int) | PFloat(Float) | PBool(Bool) | PNull`
+  union instead of the v1 `List[Str]` workaround. New transaction surface:
+  `sql.begin(db) -> SqlTx`, `sql.commit / rollback(tx)`, and
+  `sql.exec_tx / query_tx(tx, ...)`. New row decoders
+  `sql.get_str / get_int / get_float / get_bool :: T, Str -> Option[X]`.
+  Effect annotations: `[sql]` for query/exec/begin/commit/rollback;
+  `[sql, fs_write]` for `open` (SQLite creates the file on first open).
+  Closes #362.
+
+- **#365: `lex fmt`, `lex init`, `lex ci` + `lex pkg install`.**
+  `lex init [<dir>]` scaffolds a new project with `lex.toml`,
+  `src/main.lex`, `tests/test_main.lex`, and a `.github/workflows/lex.yml`.
+  `lex fmt [--check] <file|dir>...` formats `.lex` files via the
+  canonical pretty-printer; `--check` exits 1 if any file needs
+  formatting (suitable for CI). `lex ci [--no-fmt] [--src <d>]
+  [--tests <d>]` runs the full local CI pipeline: `pkg install →
+  check --strict → fmt --check → test`. `lex pkg install` resolves and
+  installs all dependencies from `lex.toml`, cloning git dependencies
+  into the cache on first use. Closes #365.
+
+- **#347 A2 phase 3: bytecode stack-depth verifier as third
+  `--strict` check.** `lex check --strict` now runs a bytecode pass that
+  walks each function's instruction stream, tracks abstract stack depth
+  through opcodes and branches, and warns when two paths into the same
+  program counter carry different depths — catching `PConstructor` stack
+  leaks that the type checker cannot see. Surfaces as a `STACK_DEPTH`
+  lint warning (exit 1 in CI, non-fatal otherwise). Closes #347 (A2 phase).
+
 ## [0.9.0] — 2026-05-12
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 license = "EUPL-1.2"
 repository = "https://github.com/alpibrusl/lex-lang"

--- a/crates/lex-api/Cargo.toml
+++ b/crates/lex-api/Cargo.toml
@@ -16,14 +16,14 @@ serde_json.workspace = true
 anyhow.workspace = true
 indexmap.workspace = true
 tiny_http = "0.12"
-lex-syntax = { path = "../lex-syntax", version = "0.9.0" }
-lex-ast = { path = "../lex-ast", version = "0.9.0" }
-lex-types = { path = "../lex-types", version = "0.9.0" }
-lex-bytecode = { path = "../lex-bytecode", version = "0.9.0" }
-lex-runtime = { path = "../lex-runtime", version = "0.9.0" }
-lex-store = { path = "../lex-store", version = "0.9.0" }
-lex-trace = { path = "../lex-trace", version = "0.9.0" }
-lex-vcs = { path = "../lex-vcs", version = "0.9.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.1" }
+lex-ast = { path = "../lex-ast", version = "0.9.1" }
+lex-types = { path = "../lex-types", version = "0.9.1" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.9.1" }
+lex-runtime = { path = "../lex-runtime", version = "0.9.1" }
+lex-store = { path = "../lex-store", version = "0.9.1" }
+lex-trace = { path = "../lex-trace", version = "0.9.1" }
+lex-vcs = { path = "../lex-vcs", version = "0.9.1" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/lex-ast/Cargo.toml
+++ b/crates/lex-ast/Cargo.toml
@@ -16,4 +16,4 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-syntax = { path = "../lex-syntax", version = "0.9.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.1" }

--- a/crates/lex-bytecode/Cargo.toml
+++ b/crates/lex-bytecode/Cargo.toml
@@ -16,8 +16,8 @@ serde_json.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
 sha2.workspace = true
-lex-ast = { path = "../lex-ast", version = "0.9.0" }
-lex-types = { path = "../lex-types", version = "0.9.0" }
+lex-ast = { path = "../lex-ast", version = "0.9.1" }
+lex-types = { path = "../lex-types", version = "0.9.1" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.9.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.1" }

--- a/crates/lex-lsp/Cargo.toml
+++ b/crates/lex-lsp/Cargo.toml
@@ -25,12 +25,12 @@ serde_json.workspace = true
 # are rust-analyzer-team-maintained.
 lsp-server = "0.7"
 lsp-types = "0.97"
-lex-syntax = { path = "../lex-syntax", version = "0.9.0" }
-lex-ast = { path = "../lex-ast", version = "0.9.0" }
-lex-types = { path = "../lex-types", version = "0.9.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.1" }
+lex-ast = { path = "../lex-ast", version = "0.9.1" }
+lex-types = { path = "../lex-types", version = "0.9.1" }
 # Phase 4 of #304: surface RepairHint attestations from the store.
-lex-vcs = { path = "../lex-vcs", version = "0.9.0" }
-lex-store = { path = "../lex-store", version = "0.9.0" }
+lex-vcs = { path = "../lex-vcs", version = "0.9.1" }
+lex-store = { path = "../lex-store", version = "0.9.1" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -36,10 +36,10 @@ serde_yaml = "0.9"
 csv = "1"
 rusqlite = { version = "0.39", features = ["bundled"] }
 postgres = "0.19"
-lex-bytecode = { path = "../lex-bytecode", version = "0.9.0" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.9.1" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.9.0" }
-lex-ast = { path = "../lex-ast", version = "0.9.0" }
-lex-types = { path = "../lex-types", version = "0.9.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.1" }
+lex-ast = { path = "../lex-ast", version = "0.9.1" }
+lex-types = { path = "../lex-types", version = "0.9.1" }
 tempfile = "3"

--- a/crates/lex-search/Cargo.toml
+++ b/crates/lex-search/Cargo.toml
@@ -17,10 +17,10 @@ thiserror.workspace = true
 sha2.workspace = true
 hex.workspace = true
 ureq = { version = "3.3", default-features = false, features = ["rustls", "platform-verifier", "json"] }
-lex-ast = { path = "../lex-ast", version = "0.9.0" }
-lex-store = { path = "../lex-store", version = "0.9.0" }
+lex-ast = { path = "../lex-ast", version = "0.9.1" }
+lex-store = { path = "../lex-store", version = "0.9.1" }
 
 [dev-dependencies]
 tempfile = "3"
 tiny_http = "0.12"
-lex-syntax = { path = "../lex-syntax", version = "0.9.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.1" }

--- a/crates/lex-store/Cargo.toml
+++ b/crates/lex-store/Cargo.toml
@@ -21,11 +21,11 @@ hex.workspace = true
 # transitive dep via tempfile; promoting to direct so the lock
 # call sites compile.
 fs2 = "0.4"
-lex-ast = { path = "../lex-ast", version = "0.9.0" }
-lex-trace = { path = "../lex-trace", version = "0.9.0" }
-lex-types = { path = "../lex-types", version = "0.9.0" }
-lex-vcs = { path = "../lex-vcs", version = "0.9.0" }
+lex-ast = { path = "../lex-ast", version = "0.9.1" }
+lex-trace = { path = "../lex-trace", version = "0.9.1" }
+lex-types = { path = "../lex-types", version = "0.9.1" }
+lex-vcs = { path = "../lex-vcs", version = "0.9.1" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.9.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.1" }
 tempfile = "3"

--- a/crates/lex-trace/Cargo.toml
+++ b/crates/lex-trace/Cargo.toml
@@ -16,9 +16,9 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-bytecode = { path = "../lex-bytecode", version = "0.9.0" }
-lex-ast = { path = "../lex-ast", version = "0.9.0" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.9.1" }
+lex-ast = { path = "../lex-ast", version = "0.9.1" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.9.0" }
-lex-runtime = { path = "../lex-runtime", version = "0.9.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.1" }
+lex-runtime = { path = "../lex-runtime", version = "0.9.1" }

--- a/crates/lex-types/Cargo.toml
+++ b/crates/lex-types/Cargo.toml
@@ -15,7 +15,7 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-ast = { path = "../lex-ast", version = "0.9.0" }
+lex-ast = { path = "../lex-ast", version = "0.9.1" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.9.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.1" }

--- a/crates/lex-vcs/Cargo.toml
+++ b/crates/lex-vcs/Cargo.toml
@@ -11,8 +11,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-lex-ast = { path = "../lex-ast", version = "0.9.0" }
-lex-types = { path = "../lex-types", version = "0.9.0" }
+lex-ast = { path = "../lex-ast", version = "0.9.1" }
+lex-types = { path = "../lex-types", version = "0.9.1" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
@@ -24,4 +24,4 @@ hex.workspace = true
 
 [dev-dependencies]
 tempfile = "3"
-lex-syntax = { path = "../lex-syntax", version = "0.9.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.1" }

--- a/crates/spec-checker/Cargo.toml
+++ b/crates/spec-checker/Cargo.toml
@@ -16,11 +16,11 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-syntax = { path = "../lex-syntax", version = "0.9.0" }
-lex-ast = { path = "../lex-ast", version = "0.9.0" }
-lex-types = { path = "../lex-types", version = "0.9.0" }
-lex-bytecode = { path = "../lex-bytecode", version = "0.9.0" }
-lex-runtime = { path = "../lex-runtime", version = "0.9.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.1" }
+lex-ast = { path = "../lex-ast", version = "0.9.1" }
+lex-types = { path = "../lex-types", version = "0.9.1" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.9.1" }
+lex-runtime = { path = "../lex-runtime", version = "0.9.1" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.9.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.1" }


### PR DESCRIPTION
## Summary

Routine release: bumps the workspace version from 0.9.0 to 0.9.1 and adds the matching CHANGELOG entry. Lists everything that's landed on `main` since the v0.9.0 tag.

## What ships in 0.9.1

| # | Feature | PRs |
|---|---|---|
| #369 | signature-level `examples { ... }` block on `FnDecl` (AST + parse + type-level checks + **behavioral VM evaluation**) | #370, #373 |
| #363 | record row spreads `{ ...TypeName }` in type expressions | #371 |
| #364 | `Iter[T]` lazy positional iterator stdlib | #368 |
| #362 | `std.sql`: Postgres support, typed `SqlParam` ADT, transactions, row decoders | #367 |
| #365 | `lex fmt`, `lex init`, `lex ci`, `lex pkg install` | #365 |
| #347 A2 phase 3 | bytecode stack-depth verifier as third `--strict` check | #366 |

## Test plan

- [x] `cargo build --workspace` clean locally on the new version constraints
- [x] No Cargo.lock movement (workspace path deps don't pin to versions in the lock)
- [x] All 13 crate Cargo.toml dep constraints updated uniformly (grep for `version = "0.9.0"` returns empty)
- [ ] CI green here before tag push

## Tag + publish

Tagging `v0.9.1` triggers `.github/workflows/crates-io.yml`, which walks the 10 publishable crates in topological order and runs `cargo publish` for each (skipping crates already on crates.io for that version). The workflow derives the target version from `Cargo.toml`'s `[workspace.package]`, so it will publish 0.9.1 once this PR merges and the tag is pushed.

## Risk / scope

- Touches: 1 root Cargo.toml + 12 crate Cargo.tomls + CHANGELOG.md
- Breaking change to wire format / SigId / StageId / canonical AST? **no**
- Adds a new effect kind or runtime variant? **no**


---
_Generated by [Claude Code](https://claude.ai/code/session_01RKGwSUUQoRH5zUDka5AL6f)_