### PR TITLE
feat(stdlib): std.time extensions — now_ms, now_str, mono_ns (#378)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+### Added
+
+- **#378: `std.time` extensions — `now_ms`, `now_str`, `mono_ns`.**
+  Three new ops on the existing `time` module: `time.now_ms()` (Unix
+  milliseconds, the natural resolution for request-latency and
+  rate-limiter windows), `time.now_str()` (ISO-8601 / RFC 3339 in UTC,
+  for `created_at` / `updated_at` timestamps and structured log
+  lines), and `time.mono_ns()` (monotonic nanoseconds since process
+  start, for duration measurement that's immune to NTP jitter). All
+  three carry the existing `[time]` effect. `time.now`, `time.now_ms`
+  and `time.now_str` all honor `LEX_TEST_NOW` (Unix seconds) for
+  deterministic tests, lifting the seconds value to the right
+  resolution per op; `time.mono_ns` deliberately doesn't pin since a
+  fixed monotonic clock defeats its purpose. `time.now` is now also
+  pinnable via `LEX_TEST_NOW`, closing a small consistency gap with
+  `datetime.now`.
+
 ### Changed
 
 - **#380: structured `SqlError` on the `Err` side of every `std.sql`

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -829,9 +829,55 @@ impl EffectHandler for DefaultHandler {
                 }
             }
             ("time", "now") => {
+                // LEX_TEST_NOW (Unix seconds) pins for deterministic tests.
+                if let Ok(s) = std::env::var("LEX_TEST_NOW") {
+                    if let Ok(secs) = s.trim().parse::<i64>() {
+                        return Ok(Value::Int(secs));
+                    }
+                }
                 let secs = SystemTime::now().duration_since(UNIX_EPOCH)
                     .map_err(|e| format!("time: {e}"))?.as_secs();
                 Ok(Value::Int(secs as i64))
+            }
+            ("time", "now_ms") => {
+                // Unix epoch in milliseconds (#378). `LEX_TEST_NOW` is
+                // documented in seconds, so we lift it to ms by *1000
+                // to keep the pinning story uniform across `time.now`
+                // and `time.now_ms`.
+                if let Ok(s) = std::env::var("LEX_TEST_NOW") {
+                    if let Ok(secs) = s.trim().parse::<i64>() {
+                        return Ok(Value::Int(secs.saturating_mul(1000)));
+                    }
+                }
+                let ms = SystemTime::now().duration_since(UNIX_EPOCH)
+                    .map_err(|e| format!("time: {e}"))?.as_millis();
+                Ok(Value::Int(ms as i64))
+            }
+            ("time", "now_str") => {
+                // ISO-8601 / RFC 3339 in UTC (#378). Format mirrors
+                // `chrono::Utc::now().to_rfc3339()` already used
+                // elsewhere in the handler.
+                if let Ok(s) = std::env::var("LEX_TEST_NOW") {
+                    if let Ok(secs) = s.trim().parse::<i64>() {
+                        let dt = chrono::DateTime::<chrono::Utc>::from_timestamp(secs, 0)
+                            .unwrap_or_else(chrono::Utc::now);
+                        return Ok(Value::Str(dt.to_rfc3339()));
+                    }
+                }
+                Ok(Value::Str(chrono::Utc::now().to_rfc3339()))
+            }
+            ("time", "mono_ns") => {
+                // Monotonic clock relative to process start. Cached
+                // `Instant::now()` anchor so successive `mono_ns`
+                // calls return strictly non-decreasing values without
+                // depending on the wall clock. Not affected by
+                // `LEX_TEST_NOW` — pinning a monotonic clock would
+                // defeat its purpose; tests needing a fake monotonic
+                // clock should swap in their own `EffectHandler`.
+                static MONO_START: OnceLock<std::time::Instant> = OnceLock::new();
+                let start = MONO_START.get_or_init(std::time::Instant::now);
+                let dur = std::time::Instant::now().duration_since(*start);
+                Ok(Value::Int(dur.as_nanos() as i64))
             }
             ("time", "sleep_ms") => {
                 // Block the current thread for `n` ms (#226). Used

--- a/crates/lex-runtime/tests/std_time_now.rs
+++ b/crates/lex-runtime/tests/std_time_now.rs
@@ -1,0 +1,172 @@
+//! Integration tests for `std.time` extensions in #378: `time.now_ms`,
+//! `time.now_str`, `time.mono_ns`. The existing `time.now` and
+//! `time.sleep_ms` are covered by their respective issue tests; this
+//! file only exercises the three new ops.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::collections::BTreeSet;
+use std::sync::Mutex;
+
+/// `LEX_TEST_NOW` is process-global state; the test cases that set it
+/// must serialize so two parallel tests don't race on the env var.
+/// Mirrors the env-lock pattern in `crates/lex-runtime/src/llm.rs`.
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: std::sync::OnceLock<Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn policy_with_time() -> Policy {
+    let mut p = Policy::pure();
+    p.allow_effects = ["time".to_string()].into_iter().collect::<BTreeSet<_>>();
+    p
+}
+
+fn run(src: &str, fn_name: &str) -> Value {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors:\n{errs:#?}");
+    }
+    let bc = compile_program(&stages);
+    let handler = DefaultHandler::new(policy_with_time());
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(fn_name, vec![]).unwrap_or_else(|e| panic!("call {fn_name}: {e}"))
+}
+
+const SRC: &str = r#"
+import "std.time" as time
+
+fn ms_now() -> [time] Int { time.now_ms() }
+fn str_now() -> [time] Str { time.now_str() }
+fn mono_now() -> [time] Int { time.mono_ns() }
+
+# Two reads of the monotonic clock back-to-back. The second one must
+# be >= the first.
+fn mono_pair() -> [time] (Int, Int) {
+  let a := time.mono_ns()
+  let b := time.mono_ns()
+  (a, b)
+}
+"#;
+
+#[test]
+fn now_ms_returns_positive_unix_millis() {
+    // Other tests in this file set LEX_TEST_NOW; serialize against
+    // them so this one always sees the real wall clock.
+    let _g = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let prior = std::env::var("LEX_TEST_NOW").ok();
+    std::env::remove_var("LEX_TEST_NOW");
+    let v = run(SRC, "ms_now");
+    if let Some(s) = prior { std::env::set_var("LEX_TEST_NOW", s); }
+    let ms = match v {
+        Value::Int(n) => n,
+        other => panic!("expected Int, got {other:?}"),
+    };
+    // A plausible-millis lower bound: any time after Jan 1 2020 UTC.
+    // 2020-01-01 00:00:00 UTC = 1_577_836_800 s = 1_577_836_800_000 ms.
+    assert!(
+        ms > 1_577_836_800_000,
+        "time.now_ms should return a recent Unix-millis value; got {ms}"
+    );
+}
+
+#[test]
+fn now_str_returns_iso8601_utc() {
+    let _g = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let prior = std::env::var("LEX_TEST_NOW").ok();
+    std::env::remove_var("LEX_TEST_NOW");
+    let v = run(SRC, "str_now");
+    if let Some(s) = prior { std::env::set_var("LEX_TEST_NOW", s); }
+    let s = match v {
+        Value::Str(s) => s,
+        other => panic!("expected Str, got {other:?}"),
+    };
+    // RFC 3339 / ISO 8601 in UTC: `YYYY-MM-DDTHH:MM:SS.frac+00:00` or `Z`.
+    // chrono::DateTime::to_rfc3339 emits `+00:00` for UTC; either form
+    // is acceptable per the spec.
+    assert!(
+        s.len() >= 20,
+        "time.now_str should look like an ISO-8601 string; got {s:?}"
+    );
+    assert!(
+        s.contains('T'),
+        "time.now_str output should have a 'T' separating date and time; got {s:?}"
+    );
+    assert!(
+        s.ends_with('Z') || s.ends_with("+00:00"),
+        "time.now_str should be in UTC (ending with 'Z' or '+00:00'); got {s:?}"
+    );
+    // Parses back through chrono to confirm well-formedness.
+    let _: chrono::DateTime<chrono::Utc> = s.parse().unwrap_or_else(|e| {
+        panic!("time.now_str output {s:?} is not a valid RFC 3339 timestamp: {e}")
+    });
+}
+
+#[test]
+fn mono_ns_is_non_decreasing_across_calls() {
+    // Two reads in a row must yield (a, b) with b >= a. We don't
+    // require strict monotonicity since two consecutive reads on a
+    // very fast machine could fall in the same tick; the contract is
+    // "monotonic", not "strictly monotonic".
+    let _g = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let v = run(SRC, "mono_pair");
+    let (a, b) = match v {
+        Value::Tuple(xs) if xs.len() == 2 => {
+            let a = match &xs[0] { Value::Int(n) => *n, other => panic!("got {other:?}") };
+            let b = match &xs[1] { Value::Int(n) => *n, other => panic!("got {other:?}") };
+            (a, b)
+        }
+        other => panic!("expected Tuple, got {other:?}"),
+    };
+    assert!(a >= 0, "first mono_ns reading must be non-negative; got {a}");
+    assert!(b >= a, "mono_ns must be non-decreasing; got first={a}, second={b}");
+}
+
+#[test]
+fn now_ms_respects_lex_test_now() {
+    // `LEX_TEST_NOW` documents seconds; the runtime lifts it to ms by
+    // *1000 so callers can pin both `time.now` and `time.now_ms`
+    // without setting two env vars.
+    let _g = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let prior = std::env::var("LEX_TEST_NOW").ok();
+    // 1700000000 s = Nov 14 2023; we expect exactly that *1000 = ms.
+    std::env::set_var("LEX_TEST_NOW", "1700000000");
+    let v = run(SRC, "ms_now");
+    match prior {
+        Some(s) => std::env::set_var("LEX_TEST_NOW", s),
+        None => std::env::remove_var("LEX_TEST_NOW"),
+    }
+    let ms = match v {
+        Value::Int(n) => n,
+        other => panic!("expected Int, got {other:?}"),
+    };
+    assert_eq!(
+        ms, 1_700_000_000_000,
+        "time.now_ms should lift LEX_TEST_NOW seconds to ms by ×1000"
+    );
+}
+
+#[test]
+fn now_str_respects_lex_test_now() {
+    // Pin to 2020-01-01 00:00:00 UTC = 1577836800 s; expect the
+    // formatted string to reflect that exact instant.
+    let _g = env_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let prior = std::env::var("LEX_TEST_NOW").ok();
+    std::env::set_var("LEX_TEST_NOW", "1577836800");
+    let v = run(SRC, "str_now");
+    match prior {
+        Some(s) => std::env::set_var("LEX_TEST_NOW", s),
+        None => std::env::remove_var("LEX_TEST_NOW"),
+    }
+    let s = match v {
+        Value::Str(s) => s,
+        other => panic!("expected Str, got {other:?}"),
+    };
+    assert!(
+        s.starts_with("2020-01-01T00:00:00"),
+        "expected pinned timestamp to render as 2020-01-01T00:00:00...; got {s:?}"
+    );
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -320,6 +320,37 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 EffectSet::singleton("time"),
                 Ty::int(),
             ));
+            // now_ms :: () -> [time] Int — unix milliseconds (#378).
+            // Resolution beyond what `time.now` (seconds) offers, for
+            // request-latency measurement / rate-limiter windows.
+            // Honors `LEX_TEST_NOW` for deterministic tests.
+            fields.insert("now_ms".into(), Ty::function(
+                vec![],
+                EffectSet::singleton("time"),
+                Ty::int(),
+            ));
+            // now_str :: () -> [time] Str — wall-clock instant rendered
+            // as an ISO-8601 / RFC 3339 string in UTC (#378). Suitable
+            // for auto-managed `created_at` / `updated_at` timestamps
+            // and structured log lines. Honors `LEX_TEST_NOW`.
+            fields.insert("now_str".into(), Ty::function(
+                vec![],
+                EffectSet::singleton("time"),
+                Ty::str(),
+            ));
+            // mono_ns :: () -> [time] Int — monotonic-clock nanoseconds
+            // since process start (#378). Use for *duration*
+            // measurement (`end - start`); the value carries no wall-
+            // clock meaning and the clock can never go backwards
+            // (unlike `time.now_ms` under NTP jitter). Not affected by
+            // `LEX_TEST_NOW` — pinning a monotonic clock would defeat
+            // its purpose; tests that need a fake monotonic clock
+            // should inject one through `EffectHandler`.
+            fields.insert("mono_ns".into(), Ty::function(
+                vec![],
+                EffectSet::singleton("time"),
+                Ty::int(),
+            ));
             // sleep_ms :: Int -> [time] Unit (#226).
             // Used internally by flow.retry_with_backoff for
             // exponential-backoff delays; also available to user


### PR DESCRIPTION
## Summary

Closes #378. Adds three ops to the existing `std.time` module:

```lex
fn time.now_ms()  -> [time] Int   # unix millis
fn time.now_str() -> [time] Str   # ISO-8601 / RFC 3339 in UTC
fn time.mono_ns() -> [time] Int   # monotonic ns since process start
```

All carry the existing `[time]` effect. `time.now`, `time.now_ms`, and `time.now_str` now honor `LEX_TEST_NOW` for deterministic tests; `time.mono_ns` deliberately doesn't (a fixed monotonic clock defeats its purpose).

## What this unblocks

| Consumer | Use |
|---|---|
| lex-orm | retry with exponential backoff timing (`mono_ns`); `created_at`/`updated_at` (`now_str`) |
| lex-web | request-latency measurement (`mono_ns`); rate-limiter windows (`now_ms`) |
| Any app | structured log timestamps without depending on `std.datetime` |

## Implementation

- `crates/lex-types/src/builtins.rs` — three new fields on the `time` module record. Doc comments call out what each op is for and the `LEX_TEST_NOW` behavior.
- `crates/lex-runtime/src/handler.rs` — three new dispatch arms. `now_ms` and `now_str` parse `LEX_TEST_NOW` seconds and lift to the right resolution. `mono_ns` caches the process-start `Instant` in a `OnceLock` so successive calls return a stable non-decreasing offset. `time.now` also gains `LEX_TEST_NOW` support (closing a small gap with `datetime.now`).

## Test plan

- [x] `cargo test -p lex-runtime --test std_time_now` — 5/5 pass
- [x] Tests cover: positive Unix millis, RFC 3339 shape (parses back via chrono), monotonic non-decreasing, and `LEX_TEST_NOW` pinning for both `now_ms` and `now_str`
- [x] Env-touching tests serialize via a module-local Mutex (same pattern as llm.rs after #377/#386)

## Risk / scope

- Touches: `lex-types` (3 field inserts), `lex-runtime` (one helper + 3 dispatch arms), 1 new test file, CHANGELOG
- Breaking change to wire format / SigId / StageId / canonical AST? **no**
- Adds a new effect kind? **no** — reuses the existing `[time]` effect
- Existing callers of `time.now` / `time.sleep_ms` unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_01RKGwSUUQoRH5zUDka5AL6f)_