### PR TITLE
feat(crypto): blake2b + hex-string hashers + base64url + eq aliases + random_str_hex (#382 slice 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ bumps may carry breaking changes when justified).
 
 ### Added
 
+- **#382 (slice 1): `std.crypto` convenience adds.** Five new
+  primitives on top of the existing `std.crypto` surface, no new
+  effects required:
+  - **`blake2b(bytes)`** — 64-byte digest, BLAKE2b-512. Faster than
+    SHA-512 with the same security level. Backed by the `blake2` crate.
+  - **`sha256_str(s)` / `sha512_str(s)`** — hash a `Str` directly and
+    return the digest as a lowercase hex `Str`. Equivalent to
+    `crypto.hex_encode(crypto.shaN(bytes_of_str(s)))` for the common
+    case where the caller already has a string.
+  - **`base64url_encode` / `base64url_decode`** — URL-safe base64
+    (`-_` alphabet, no padding). Required for JWT segments, signed
+    cookies, and any token traveling in a URL.
+  - **`eq` / `eq_str`** — constant-time equality on `Bytes` and `Str`
+    respectively. `eq` is the recommended spelling; `constant_time_eq`
+    stays as an alias.
+  - **`random_str_hex(n)`** — N random bytes rendered as 2N hex chars,
+    gated by `[random]`. The canonical token-mint shape (session ids,
+    OAuth `state`, CSRF tokens, request ids).
+
+  AEAD primitives (`aes_gcm_seal/open`, `chacha20_poly1305_seal/open`)
+  and KDFs (`pbkdf2_sha256`, `hkdf_sha256`, `argon2id`) are the next
+  slices — each adds 2–3 new crypto crates and warrants its own
+  focused PR.
+
+
+### Added
+
 - **#378: `std.time` extensions — `now_ms`, `now_str`, `mono_ns`.**
   Three new ops on the existing `time` module: `time.now_ms()` (Unix
   milliseconds, the natural resolution for request-latency and

--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -17,6 +17,7 @@ thiserror.workspace = true
 indexmap.workspace = true
 sha2.workspace = true
 hmac = "0.13"
+blake2 = "0.10"
 regex = "1"
 sled = "0.34"
 walkdir = "2"

--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -10,10 +10,12 @@ use std::sync::{Mutex, OnceLock};
 /// `None` means "not handled here; fall through to effect dispatch".
 pub fn try_pure_builtin(kind: &str, op: &str, args: &[Value]) -> Option<Result<Value, String>> {
     if !is_pure_module(kind) { return None; }
-    // `crypto.random` is the lone effectful op in an otherwise-pure
-    // module; let the handler dispatch it under the `[random]` effect
-    // kind instead of the pure-builtin bypass.
+    // `crypto.random` and `crypto.random_str_hex` (#382) are the
+    // effectful ops in an otherwise-pure module; let the handler
+    // dispatch them under the `[random]` effect kind instead of the
+    // pure-builtin bypass.
     if (kind, op) == ("crypto", "random") { return None; }
+    if (kind, op) == ("crypto", "random_str_hex") { return None; }
     // Same shape: `datetime.now` is the only effectful op in
     // `std.datetime` (all the parse/format/arithmetic ops are pure).
     if (kind, op) == ("datetime", "now") { return None; }
@@ -1006,6 +1008,33 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             h.update(data);
             Ok(Value::Bytes(h.finalize().to_vec()))
         }
+        // BLAKE2b (#382) — 64-byte digest, faster than SHA-512 on most
+        // CPUs with the same security level. Backed by the `blake2`
+        // crate; uses `Blake2b512` (the standard 512-bit variant).
+        ("crypto", "blake2b") => {
+            use blake2::{Blake2b512, Digest};
+            let data = expect_bytes(args.first())?;
+            let mut h = Blake2b512::new();
+            h.update(data);
+            Ok(Value::Bytes(h.finalize().to_vec()))
+        }
+        // Hex-string convenience hashers (#382). Equivalent to
+        // `hex_encode(shaN(bytes_of_str(s)))` for the common case
+        // where the caller has a Str and wants a hex Str digest.
+        ("crypto", "sha256_str") => {
+            use sha2::{Digest, Sha256};
+            let s = expect_str(args.first())?;
+            let mut h = Sha256::new();
+            h.update(s.as_bytes());
+            Ok(Value::Str(hex::encode(h.finalize())))
+        }
+        ("crypto", "sha512_str") => {
+            use sha2::{Digest, Sha512};
+            let s = expect_str(args.first())?;
+            let mut h = Sha512::new();
+            h.update(s.as_bytes());
+            Ok(Value::Str(hex::encode(h.finalize())))
+        }
         ("crypto", "hmac_sha256") => {
             use hmac::{Hmac, KeyInit, Mac};
             type HmacSha256 = Hmac<sha2::Sha256>;
@@ -1039,6 +1068,22 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
                 Err(e) => Ok(err_v(Value::Str(format!("base64: {e}")))),
             }
         }
+        // URL-safe base64 (#382). Alphabet `-_` instead of `+/`,
+        // padding stripped. Use for JWT segments, signed cookies, any
+        // token that travels in a URL or path component.
+        ("crypto", "base64url_encode") => {
+            use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+            let data = expect_bytes(args.first())?;
+            Ok(Value::Str(URL_SAFE_NO_PAD.encode(data)))
+        }
+        ("crypto", "base64url_decode") => {
+            use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+            let s = expect_str(args.first())?;
+            match URL_SAFE_NO_PAD.decode(s) {
+                Ok(b)  => Ok(ok_v(Value::Bytes(b))),
+                Err(e) => Ok(err_v(Value::Str(format!("base64url: {e}")))),
+            }
+        }
         ("crypto", "hex_encode") => {
             let data = expect_bytes(args.first())?;
             Ok(Value::Str(hex::encode(data)))
@@ -1050,7 +1095,7 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
                 Err(e) => Ok(err_v(Value::Str(format!("hex: {e}")))),
             }
         }
-        ("crypto", "constant_time_eq") => {
+        ("crypto", "constant_time_eq") | ("crypto", "eq") => {
             use subtle::ConstantTimeEq;
             let a = expect_bytes(args.first())?;
             let b = expect_bytes(args.get(1))?;
@@ -1058,8 +1103,25 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             // lengths match. For mismatched lengths return false in
             // constant time (length itself isn't secret, but we want
             // a single comparison shape).
+            //
+            // `eq` (#382) is the recommended spelling — same semantics,
+            // shorter name. `constant_time_eq` stays as an alias for
+            // existing callers.
             let eq = if a.len() == b.len() {
                 a.ct_eq(b).into()
+            } else {
+                false
+            };
+            Ok(Value::Bool(eq))
+        }
+        // Constant-time string equality (#382). Compares the bytes of
+        // both strings; semantics identical to `eq` after `.as_bytes()`.
+        ("crypto", "eq_str") => {
+            use subtle::ConstantTimeEq;
+            let a = expect_str(args.first())?;
+            let b = expect_str(args.get(1))?;
+            let eq = if a.len() == b.len() {
+                a.as_bytes().ct_eq(b.as_bytes()).into()
             } else {
                 false
             };

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -714,6 +714,22 @@ impl EffectHandler for DefaultHandler {
                 .map_err(|e| format!("crypto.random: OS RNG: {e}"))?;
             return Ok(Value::Bytes(buf));
         }
+        // crypto.random_str_hex(n) — N random bytes rendered as 2N
+        // lowercase hex chars (#382). The most common token-mint
+        // pattern (session ids, OAuth `state`, CSRF, request ids).
+        // Same `[random]` gate as `crypto.random`.
+        if kind == "crypto" && op == "random_str_hex" {
+            self.ensure_kind_allowed("random")?;
+            let n = expect_int(args.first())?;
+            if !(0..=1_048_576).contains(&n) {
+                return Err("crypto.random_str_hex: n must be in 0..=1048576".into());
+            }
+            use rand::{rngs::SysRng, TryRng};
+            let mut buf = vec![0u8; n as usize];
+            SysRng.try_fill_bytes(&mut buf)
+                .map_err(|e| format!("crypto.random_str_hex: OS RNG: {e}"))?;
+            return Ok(Value::Str(hex::encode(&buf)));
+        }
         // `std.http` wire ops (send/get/post) gate on the `net`
         // effect kind, not the module name. This matches the
         // declared signature (`http.get :: Str -> [net] ...`) and

--- a/crates/lex-runtime/tests/std_crypto_extras.rs
+++ b/crates/lex-runtime/tests/std_crypto_extras.rs
@@ -1,0 +1,209 @@
+//! Integration tests for the `std.crypto` extensions added in #382:
+//! `blake2b`, `sha256_str` / `sha512_str`, `base64url_encode` /
+//! `base64url_decode`, `eq` / `eq_str`, and `random_str_hex`. The
+//! pre-#382 hashes / HMAC / base64 / hex / `constant_time_eq` /
+//! `random` ops are covered by `std_crypto.rs`.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+fn policy_with(effects: &[&str]) -> Policy {
+    let mut p = Policy::pure();
+    p.allow_effects = effects
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<BTreeSet<_>>();
+    p
+}
+
+fn run(src: &str, fn_name: &str, args: Vec<Value>, policy: Policy) -> Value {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors:\n{errs:#?}");
+    }
+    let bc = Arc::new(compile_program(&stages));
+    let handler = DefaultHandler::new(policy).with_program(Arc::clone(&bc));
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(fn_name, args).unwrap_or_else(|e| panic!("call {fn_name}: {e}"))
+}
+
+fn bytes(v: Value) -> Vec<u8> {
+    match v { Value::Bytes(b) => b, other => panic!("expected Bytes, got {other:?}") }
+}
+fn s(v: Value) -> String {
+    match v { Value::Str(x) => x, other => panic!("expected Str, got {other:?}") }
+}
+fn b(v: Value) -> bool {
+    match v { Value::Bool(x) => x, other => panic!("expected Bool, got {other:?}") }
+}
+fn ok_b(v: Value) -> Vec<u8> {
+    match v {
+        Value::Variant { name, args } if name == "Ok" && args.len() == 1 => bytes(args.into_iter().next().unwrap()),
+        other => panic!("expected Ok(Bytes), got {other:?}"),
+    }
+}
+
+const SRC: &str = r#"
+import "std.crypto" as crypto
+import "std.bytes" as bytes
+
+fn blake2b_of(s :: Str) -> Bytes { crypto.blake2b(bytes.from_str(s)) }
+fn sha256_str_of(s :: Str) -> Str    { crypto.sha256_str(s) }
+fn sha512_str_of(s :: Str) -> Str    { crypto.sha512_str(s) }
+
+fn b64url_round(s :: Str) -> Result[Bytes, Str] {
+  crypto.base64url_decode(crypto.base64url_encode(bytes.from_str(s)))
+}
+fn b64url_encode(s :: Str) -> Str { crypto.base64url_encode(bytes.from_str(s)) }
+
+fn eq_self(s :: Str) -> Bool {
+  let bs := bytes.from_str(s)
+  crypto.eq(bs, bs)
+}
+fn eq_diff() -> Bool {
+  crypto.eq(bytes.from_str("alpha"), bytes.from_str("beta"))
+}
+fn eq_str_same(a :: Str, c :: Str) -> Bool { crypto.eq_str(a, c) }
+fn eq_str_len_mismatch() -> Bool { crypto.eq_str("foo", "fooo") }
+
+fn rand_hex(n :: Int) -> [random] Str { crypto.random_str_hex(n) }
+"#;
+
+// ── BLAKE2b ──────────────────────────────────────────────────────
+
+#[test]
+fn blake2b_returns_64_byte_digest() {
+    let v = run(SRC, "blake2b_of", vec![Value::Str("hello".into())], Policy::pure());
+    let digest = bytes(v);
+    assert_eq!(digest.len(), 64, "BLAKE2b-512 must return 64 bytes; got {} bytes", digest.len());
+}
+
+#[test]
+fn blake2b_is_deterministic() {
+    let a = bytes(run(SRC, "blake2b_of", vec![Value::Str("hello".into())], Policy::pure()));
+    let b = bytes(run(SRC, "blake2b_of", vec![Value::Str("hello".into())], Policy::pure()));
+    assert_eq!(a, b, "BLAKE2b must be deterministic across calls");
+}
+
+#[test]
+fn blake2b_distinguishes_inputs() {
+    let a = bytes(run(SRC, "blake2b_of", vec![Value::Str("hello".into())], Policy::pure()));
+    let b = bytes(run(SRC, "blake2b_of", vec![Value::Str("world".into())], Policy::pure()));
+    assert_ne!(a, b, "BLAKE2b of different inputs must produce different digests");
+}
+
+// ── sha256_str / sha512_str ──────────────────────────────────────
+
+#[test]
+fn sha256_str_known_vector() {
+    // RFC 6234 / Wikipedia test vector: SHA-256("") = e3b0c4...
+    let h = s(run(SRC, "sha256_str_of", vec![Value::Str("".into())], Policy::pure()));
+    assert_eq!(
+        h,
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "SHA-256 of empty string must match the standard test vector"
+    );
+}
+
+#[test]
+fn sha512_str_length_is_128_hex_chars() {
+    let h = s(run(SRC, "sha512_str_of", vec![Value::Str("hello".into())], Policy::pure()));
+    assert_eq!(h.len(), 128, "SHA-512 hex must be 128 chars; got {}", h.len());
+    assert!(h.chars().all(|c| c.is_ascii_hexdigit()), "all chars must be hex: {h}");
+}
+
+// ── base64url ────────────────────────────────────────────────────
+
+#[test]
+fn base64url_uses_urlsafe_alphabet_and_no_padding() {
+    // Plain `?` (0x3f) base64-encodes to `Pw==`; the URL-safe form
+    // both swaps no character here and strips the padding to `Pw`.
+    // Use a string that exercises the `+` / `/` → `-` / `_` swap:
+    // bytes `[0xfb, 0xff, 0xfe]` standard-encode to `+//+`, URL-safe
+    // to `-__-`. Pad would be `=`; URL_SAFE_NO_PAD omits it.
+    // We exercise via a round-trip + check the encoded shape.
+    let encoded = s(run(SRC, "b64url_encode", vec![Value::Str("hi".into())], Policy::pure()));
+    assert!(
+        !encoded.contains('+') && !encoded.contains('/') && !encoded.contains('='),
+        "URL-safe base64 must not contain +, /, or = padding: {encoded:?}"
+    );
+}
+
+#[test]
+fn base64url_round_trips() {
+    let v = run(SRC, "b64url_round", vec![Value::Str("any plaintext payload here".into())], Policy::pure());
+    let decoded = ok_b(v);
+    assert_eq!(decoded, b"any plaintext payload here".to_vec());
+}
+
+// ── eq / eq_str ──────────────────────────────────────────────────
+
+#[test]
+fn eq_returns_true_for_identical_bytes() {
+    assert!(b(run(SRC, "eq_self", vec![Value::Str("anything".into())], Policy::pure())));
+}
+
+#[test]
+fn eq_returns_false_for_distinct_bytes() {
+    assert!(!b(run(SRC, "eq_diff", vec![], Policy::pure())));
+}
+
+#[test]
+fn eq_str_returns_true_when_equal() {
+    let v = run(
+        SRC,
+        "eq_str_same",
+        vec![Value::Str("token".into()), Value::Str("token".into())],
+        Policy::pure(),
+    );
+    assert!(b(v));
+}
+
+#[test]
+fn eq_str_returns_false_when_different() {
+    let v = run(
+        SRC,
+        "eq_str_same",
+        vec![Value::Str("token".into()), Value::Str("toxen".into())],
+        Policy::pure(),
+    );
+    assert!(!b(v));
+}
+
+#[test]
+fn eq_str_returns_false_for_length_mismatch() {
+    // Length differences must return false (in constant time, though
+    // we can't really test the timing — just that the API doesn't
+    // panic and the result is false).
+    assert!(!b(run(SRC, "eq_str_len_mismatch", vec![], Policy::pure())));
+}
+
+// ── random_str_hex ───────────────────────────────────────────────
+
+#[test]
+fn random_str_hex_returns_2n_hex_chars() {
+    let v = run(SRC, "rand_hex", vec![Value::Int(16)], policy_with(&["random"]));
+    let hex = s(v);
+    assert_eq!(hex.len(), 32, "16 random bytes must render as 32 hex chars; got {} chars", hex.len());
+    assert!(hex.chars().all(|c| c.is_ascii_hexdigit()), "all chars must be hex: {hex}");
+}
+
+#[test]
+fn random_str_hex_zero_returns_empty_string() {
+    let v = run(SRC, "rand_hex", vec![Value::Int(0)], policy_with(&["random"]));
+    assert_eq!(s(v), "");
+}
+
+#[test]
+fn random_str_hex_produces_distinct_outputs_across_calls() {
+    // 32-byte tokens; two consecutive calls colliding has negligible
+    // probability (2^-256). If this ever fires, the RNG is broken.
+    let a = s(run(SRC, "rand_hex", vec![Value::Int(32)], policy_with(&["random"])));
+    let b = s(run(SRC, "rand_hex", vec![Value::Int(32)], policy_with(&["random"])));
+    assert_ne!(a, b, "two 32-byte random hex tokens must not collide");
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -981,12 +981,27 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
         }
         "crypto" => {
             let mut fields = IndexMap::new();
-            // Hashes: Bytes -> Bytes (digest as raw bytes)
-            for name in &["sha256", "sha512", "md5"] {
+            // Hashes: Bytes -> Bytes (digest as raw bytes).
+            // SHA-256 / SHA-512 are vetted. MD5 is retained only for
+            // interop with legacy systems — new code should not use it.
+            // BLAKE2b (#382) is included as a faster alternative to
+            // SHA-512 with the same security level.
+            for name in &["sha256", "sha512", "md5", "blake2b"] {
                 fields.insert((*name).into(), Ty::function(
                     vec![Ty::bytes()],
                     EffectSet::empty(),
                     Ty::bytes(),
+                ));
+            }
+            // Hex-string convenience hashers (#382): hash a Str directly,
+            // return the digest as a lowercase hex Str. Equivalent to
+            // `crypto.hex_encode(crypto.shaN(bytes_from_str(s)))` but
+            // saves the two-step incantation for the common case.
+            for name in &["sha256_str", "sha512_str"] {
+                fields.insert((*name).into(), Ty::function(
+                    vec![Ty::str()],
+                    EffectSet::empty(),
+                    Ty::str(),
                 ));
             }
             // HMAC: (key :: Bytes, data :: Bytes) -> Bytes
@@ -1003,14 +1018,28 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
             fields.insert("base64_decode".into(), Ty::function(
                 vec![Ty::str()], EffectSet::empty(),
                 Ty::Con("Result".into(), vec![Ty::bytes(), Ty::str()])));
+            // URL-safe base64 (#382): the alphabet swaps `+/` for `-_`
+            // and omits padding. Required by JWT, signed-cookie, and
+            // most token-bearing URL paths.
+            fields.insert("base64url_encode".into(), Ty::function(
+                vec![Ty::bytes()], EffectSet::empty(), Ty::str()));
+            fields.insert("base64url_decode".into(), Ty::function(
+                vec![Ty::str()], EffectSet::empty(),
+                Ty::Con("Result".into(), vec![Ty::bytes(), Ty::str()])));
             fields.insert("hex_encode".into(), Ty::function(
                 vec![Ty::bytes()], EffectSet::empty(), Ty::str()));
             fields.insert("hex_decode".into(), Ty::function(
                 vec![Ty::str()], EffectSet::empty(),
                 Ty::Con("Result".into(), vec![Ty::bytes(), Ty::str()])));
-            // constant-time equality (for HMAC verification etc.)
+            // Constant-time equality (for HMAC verification etc.).
+            // `eq` / `eq_str` (#382) are the recommended spelling;
+            // `constant_time_eq` stays as a deprecated alias.
             fields.insert("constant_time_eq".into(), Ty::function(
                 vec![Ty::bytes(), Ty::bytes()], EffectSet::empty(), Ty::bool()));
+            fields.insert("eq".into(), Ty::function(
+                vec![Ty::bytes(), Ty::bytes()], EffectSet::empty(), Ty::bool()));
+            fields.insert("eq_str".into(), Ty::function(
+                vec![Ty::str(), Ty::str()], EffectSet::empty(), Ty::bool()));
             // Cryptographically-secure random bytes — OS RNG, not the
             // deterministic `rand.int_in` stub. The new `[random]`
             // effect is fine-grained on purpose so reviewers can find
@@ -1020,6 +1049,16 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 vec![Ty::int()],
                 EffectSet::singleton("random"),
                 Ty::bytes(),
+            ));
+            // random_str_hex (#382): the most common token-mint pattern
+            // — N random bytes rendered as 2N lowercase hex chars.
+            // Suitable for session ids, request ids, OAuth `state`,
+            // CSRF tokens; not suitable as a JWT signing key (use raw
+            // `random` for that).
+            fields.insert("random_str_hex".into(), Ty::function(
+                vec![Ty::int()],
+                EffectSet::singleton("random"),
+                Ty::str(),
             ));
             Some(Ty::Record(fields))
         }


### PR DESCRIPTION
## Summary

First slice of #382 (`std.crypto` symmetric primitives). Adds five convenience primitives on top of the existing `std.crypto` surface — no new effects, one new dep (`blake2`), 15 integration tests.

## What this ships

- **`blake2b(bytes)`** → 64-byte digest (BLAKE2b-512). Faster than SHA-512 with the same security level.
- **`sha256_str(s)` / `sha512_str(s)`** → hash a `Str` directly, return the digest as a lowercase hex `Str`. Equivalent to `crypto.hex_encode(crypto.shaN(bytes_from_str(s)))` for the common case where the caller has a string.
- **`base64url_encode` / `base64url_decode`** → URL-safe alphabet (`-_` instead of `+/`), no padding. Required for JWT segments, signed cookies, OAuth `state`, and anything traveling in a URL.
- **`eq` / `eq_str`** → constant-time equality on `Bytes` and `Str`. `eq` is the recommended spelling; `constant_time_eq` stays as an alias for existing callers.
- **`random_str_hex(n)`** → N random bytes rendered as 2N lowercase hex chars, gated by `[random]`. The canonical token-mint shape (session ids, OAuth `state`, CSRF tokens, request ids).

## What's deferred to follow-ups

The issue's full surface also includes:
- **AEAD**: `aes_gcm_seal/open`, `chacha20_poly1305_seal/open` — adds 2 new crypto crates plus the `AeadResult` type and nonce/AAD handling. Worth its own focused PR.
- **KDFs**: `pbkdf2_sha256`, `hkdf_sha256`, `argon2id` — adds 3 new crates plus parameter-selection concerns (argon2id work factor, OWASP recommendations). Worth its own PR.

Both follow-ups are pure, deterministic, no new effects — they slot in cleanly under the same `std.crypto` namespace once the slices land.

## Implementation

- `crates/lex-types/src/builtins.rs` — added the 5 new fields to the `"crypto"` module scope.
- `crates/lex-runtime/src/builtins.rs::try_pure_builtin` — added the pure ops (`blake2b`, `sha256_str`, `sha512_str`, `base64url_encode`, `base64url_decode`, `eq`, `eq_str`). `constant_time_eq` / `eq` share one match arm since the semantics are identical.
- `crates/lex-runtime/src/handler.rs` — added `crypto.random_str_hex` next to the existing `crypto.random` (both `[random]`-gated).
- New dep `blake2 = "0.10"` in `lex-runtime/Cargo.toml`. Everything else uses existing `sha2`, `hmac`, `base64`, `hex`, `subtle` deps.

## Test plan

- [x] 15 new tests in `crates/lex-runtime/tests/std_crypto_extras.rs`. Covers: BLAKE2b correctness (length, determinism, distinguishes inputs), SHA-256 known test vector (`""` → `e3b0c4...`), SHA-512 hex shape, base64url avoids `+/=` chars, base64url round-trip, `eq`/`eq_str` equal/unequal/length-mismatch paths, `random_str_hex` length / hex chars / non-collision.
- [x] Existing 14 tests in `std_crypto.rs` unaffected.

Closes the first slice of #382. AEAD + KDF follow-up issues to be filed (or carved off this issue).

https://claude.ai/code/session_01RKGwSUUQoRH5zUDka5AL6f


---
_Generated by [Claude Code](https://claude.ai/code/session_01RKGwSUUQoRH5zUDka5AL6f)_