### PR TITLE
Mangle identifiers in example expressions during import

### DIFF
--- a/crates/lex-syntax/src/loader.rs
+++ b/crates/lex-syntax/src/loader.rs
@@ -343,6 +343,24 @@ impl<'a> Mangler<'a> {
         for p in &fd.params {
             shadow.insert(p.name.clone());
         }
+        // Example args/expected sit outside the body's parameter scope:
+        // they're top-level expressions evaluated against the function
+        // signature, so the only names they can see are the file's
+        // top-level fns/types and any path-import aliases — i.e., an
+        // empty shadow set (#391).
+        let empty_shadow = HashSet::new();
+        let examples = fd
+            .examples
+            .into_iter()
+            .map(|ex| Example {
+                args: ex
+                    .args
+                    .into_iter()
+                    .map(|a| self.mangle_expr(a, &empty_shadow))
+                    .collect(),
+                expected: self.mangle_expr(ex.expected, &empty_shadow),
+            })
+            .collect();
         FnDecl {
             name: self.qualify(&fd.name),
             type_params: fd.type_params,
@@ -357,11 +375,7 @@ impl<'a> Mangler<'a> {
             effects: fd.effects,
             return_type: self.mangle_type_expr(fd.return_type),
             body: self.mangle_block(fd.body, &shadow),
-            // Examples (#369) ride through the loader unchanged. They
-            // are self-contained calls with pure args; cross-module
-            // identifier rewriting inside example expressions is a
-            // follow-up if it becomes a real need.
-            examples: fd.examples,
+            examples,
         }
     }
 

--- a/crates/lex-syntax/tests/loader_smoke.rs
+++ b/crates/lex-syntax/tests/loader_smoke.rs
@@ -520,3 +520,94 @@ fn string_source_rejects_package_imports() {
         .expect_err("expected rejection");
     matches!(err, LoadError::LocalImportInStringSource);
 }
+
+#[test]
+fn examples_in_imported_file_mangle_local_references() {
+    // Regression for #391: a fn whose `examples` block references
+    // another top-level fn in the same file must keep working when
+    // the file is imported from another package/file. The loader
+    // used to skip mangling inside examples, so a cross-file load
+    // produced an `unknown_identifier` at type-check time.
+    let dir = tempfile::tempdir().unwrap();
+    write(
+        dir.path(),
+        "widget.lex",
+        r#"fn helper(x :: Int) -> Int { x * 2 }
+
+fn use_helper(n :: Int) -> Int
+  examples {
+    use_helper(5) => helper(5),
+  }
+{
+  helper(n)
+}
+"#,
+    );
+    write(
+        dir.path(),
+        "main.lex",
+        r#"import "./widget" as w
+fn run() -> Int { w.use_helper(3) }
+"#,
+    );
+
+    let prog = load_program(&dir.path().join("main.lex")).expect("load");
+    let use_helper = unique_fn(&prog, "use_helper");
+    let helper = unique_fn(&prog, "helper");
+
+    assert_eq!(use_helper.examples.len(), 1, "expected one example case");
+    let ex = &use_helper.examples[0];
+    match &ex.expected {
+        Expr::Call { callee, .. } => match &**callee {
+            Expr::Var(name) => assert_eq!(
+                name, &helper.name,
+                "example's `expected` should reference helper via its mangled name",
+            ),
+            other => panic!("example expected callee not a Var: {other:?}"),
+        },
+        other => panic!("example expected not a Call: {other:?}"),
+    }
+}
+
+#[test]
+fn examples_in_imported_file_with_self_reference_mangles() {
+    // Variant of #391 where the example's `expected` calls the fn
+    // under definition itself (the schema.lex `join_path` /
+    // `elem_path` pattern). Self-references must resolve to the
+    // mangled name of the same fn.
+    let dir = tempfile::tempdir().unwrap();
+    write(
+        dir.path(),
+        "widget.lex",
+        r#"fn identity(n :: Int) -> Int
+  examples {
+    identity(7) => identity(7),
+  }
+{
+  n
+}
+"#,
+    );
+    write(
+        dir.path(),
+        "main.lex",
+        r#"import "./widget" as w
+fn run() -> Int { w.identity(1) }
+"#,
+    );
+
+    let prog = load_program(&dir.path().join("main.lex")).expect("load");
+    let identity = unique_fn(&prog, "identity");
+    assert_eq!(identity.examples.len(), 1);
+    let ex = &identity.examples[0];
+    match &ex.expected {
+        Expr::Call { callee, .. } => match &**callee {
+            Expr::Var(name) => assert_eq!(
+                name, &identity.name,
+                "self-reference in example should mangle to the fn's own mangled name",
+            ),
+            other => panic!("example expected callee not a Var: {other:?}"),
+        },
+        other => panic!("example expected not a Call: {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

Fix identifier mangling in `examples` blocks when functions are imported from other files. Previously, the loader skipped mangling inside examples, causing cross-file imports to fail type-checking when examples referenced other top-level functions or self-references.

## Why

Closes #391. When a function with an `examples` block is imported from another file, identifiers in the example expressions (both in `args` and `expected`) need to be mangled to match the qualified names of referenced functions. The loader was treating examples as "self-contained" and skipping mangling entirely, which caused `unknown_identifier` errors at type-check time for imported functions whose examples reference other functions in the same file.

## Test plan

- [x] Added two regression tests covering the main scenarios:
  - `examples_in_imported_file_mangle_local_references`: Examples referencing other top-level functions
  - `examples_in_imported_file_with_self_reference_mangles`: Examples with self-references
- [x] `cargo test --workspace` passes locally

## Risk / scope

- Touches: `crates/lex-syntax/src/loader.rs`, `crates/lex-syntax/tests/loader_smoke.rs`
- Breaking change to wire format / SigId / StageId / canonical AST? **no**
- Adds a new effect kind or runtime variant? **no**

https://claude.ai/code/session_01AYcNs2EQ8CVwLiiCRgsW8C