### PR TITLE
lex init: scaffold AGENTS.md + pin CI to pre-built binary

### DIFF
--- a/crates/lex-cli/src/init.rs
+++ b/crates/lex-cli/src/init.rs
@@ -121,48 +121,63 @@ fn test_lex(_name: &str) -> String {
 }
 
 fn ci_yml(_name: &str) -> String {
-    // $GITHUB_PATH is a shell variable, not a Rust format specifier.
-    // We build the string without format! to avoid escaping every $.
-    [
-        "name: CI\n",
-        "\n",
-        "on:\n",
-        "  push:\n",
-        "    branches: [main]\n",
-        "  pull_request:\n",
-        "\n",
-        "jobs:\n",
-        "  build:\n",
-        "    runs-on: ubuntu-latest\n",
-        "    steps:\n",
-        "      - uses: actions/checkout@v4\n",
-        "\n",
-        "      - name: Install Lex toolchain\n",
-        "        run: |\n",
-        "          git clone --depth=1 https://github.com/alpibrusl/lex-lang /tmp/lex-lang\n",
-        "          cd /tmp/lex-lang && cargo build --release -p lex-cli\n",
-        "          echo \"/tmp/lex-lang/target/release\" >> $GITHUB_PATH\n",
-        "\n",
-        "      - name: Install package dependencies\n",
-        "        run: lex pkg install\n",
-        "\n",
-        "      - name: Type-check (strict)\n",
-        "        run: lex check --strict src/main.lex\n",
-        "\n",
-        "      - name: Format check\n",
-        "        run: lex fmt --check src/ tests/\n",
-        "\n",
-        "      - name: Test\n",
-        "        run: lex test\n",
-        "\n",
-        "      # Belt-and-braces: re-run the same checks via the `lex ci`\n",
-        "      # umbrella so this workflow stays in sync with whatever\n",
-        "      # `lex ci` runs locally (contributors run `lex ci` before\n",
-        "      # pushing). Remove if you find the duplication too noisy.\n",
-        "      - name: lex ci (full repro)\n",
-        "        run: lex ci\n",
-    ]
-    .concat()
+    // Pin to the lex version that scaffolded the project so CI is
+    // reproducible. Bump manually (`LEX_VERSION` env in the workflow)
+    // when you upgrade the toolchain.
+    //
+    // We download the pre-built binary from GitHub Releases instead of
+    // `cargo build`-ing — ~30s vs ~3min, no Rust required.
+    // `$GITHUB_PATH` is a shell variable, not a Rust format specifier;
+    // we build with `format!` and escape every `{`/`}` accordingly.
+    let version = env!("CARGO_PKG_VERSION");
+    format!(
+        r#"name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  # Pinned at scaffold time. Bump when you upgrade the toolchain.
+  LEX_VERSION: v{version}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Lex toolchain (pre-built binary)
+        run: |
+          set -euo pipefail
+          TARGET=x86_64-unknown-linux-gnu
+          URL="https://github.com/alpibrusl/lex-lang/releases/download/${{LEX_VERSION}}/lex-${{LEX_VERSION}}-${{TARGET}}.tar.gz"
+          curl -sSfL "$URL" | tar -xz
+          sudo install -m 0755 "lex-${{LEX_VERSION}}-${{TARGET}}/lex" /usr/local/bin/lex
+          lex --version
+
+      - name: Install package dependencies
+        run: lex pkg install
+
+      - name: Type-check (strict)
+        run: lex check --strict src/main.lex
+
+      - name: Format check
+        run: lex fmt --check src/ tests/
+
+      - name: Test
+        run: lex test
+
+      # Belt-and-braces: re-run the same checks via the `lex ci`
+      # umbrella so this workflow stays in sync with whatever
+      # `lex ci` runs locally (contributors run `lex ci` before
+      # pushing). Remove if you find the duplication too noisy.
+      - name: lex ci (full repro)
+        run: lex ci
+"#,
+        version = version,
+    )
 }
 
 /// AI-assistant cold-start guide dropped at the project root. Read by
@@ -170,6 +185,7 @@ fn ci_yml(_name: &str) -> String {
 /// agent tools that look for a project-conventions file. Deliberately
 /// short — points at the upstream `docs/AGENT.md` for the deep dive.
 fn agents_md(name: &str) -> String {
+    let version = env!("CARGO_PKG_VERSION");
     format!(
         r#"# AGENTS.md — {name}
 
@@ -179,18 +195,38 @@ read this **first**, then the upstream guide it points at.
 
 ## 1. Install the Lex toolchain
 
-If `lex --version` doesn't work, build it from source — there are no
-pre-built binaries yet:
+If `lex --version` doesn't work, download the pre-built binary for your
+platform. This project was scaffolded against **v{version}** — the CI
+workflow is pinned to that version, so use it locally too.
+
+```sh
+LEX_VERSION=v{version}
+case "$(uname -s)-$(uname -m)" in
+  Linux-x86_64)   TARGET=x86_64-unknown-linux-gnu  ;;
+  Linux-aarch64)  TARGET=aarch64-unknown-linux-gnu ;;
+  Darwin-x86_64)  TARGET=x86_64-apple-darwin       ;;
+  Darwin-arm64)   TARGET=aarch64-apple-darwin      ;;
+  *) echo "unsupported platform" >&2; exit 1 ;;
+esac
+curl -sSfL "https://github.com/alpibrusl/lex-lang/releases/download/${{LEX_VERSION}}/lex-${{LEX_VERSION}}-${{TARGET}}.tar.gz" | tar -xz
+sudo install -m 0755 "lex-${{LEX_VERSION}}-${{TARGET}}/lex" /usr/local/bin/lex
+lex --version
+```
+
+Windows: download `lex-v{version}-x86_64-pc-windows-msvc.zip` from
+<https://github.com/alpibrusl/lex-lang/releases/tag/v{version}> and put
+`lex.exe` on `PATH`.
+
+**Fallback (build from source).** Only needed if you want a version
+that has no published release yet (off-`main` fixes, custom branches):
 
 ```sh
 git clone --depth=1 https://github.com/alpibrusl/lex-lang /tmp/lex-lang
 cd /tmp/lex-lang && cargo build --release -p lex-cli
 export PATH="/tmp/lex-lang/target/release:$PATH"
-lex --version
 ```
 
-Requires Rust 1.80+. The CI workflow at `.github/workflows/lex.yml`
-does the same thing.
+Requires Rust 1.80+. Takes ~3 minutes the first time.
 
 ## 2. The loop
 

--- a/crates/lex-cli/src/init.rs
+++ b/crates/lex-cli/src/init.rs
@@ -2,9 +2,10 @@
 //!
 //! Creates in the current directory (or the given path):
 //!   lex.toml                   package manifest
-//!   src/main.lex               entry-point stub
-//!   tests/test_main.lex        test stub (run_all returns 0)
+//!   src/main.lex               entry-point stub (with an `examples { }` block)
+//!   tests/test_main.lex        test stub (`run_all` returns 0)
 //!   .github/workflows/lex.yml  GitHub Actions CI workflow
+//!   AGENTS.md                  cold-start guide for AI assistants
 //!
 //! Existing files are never overwritten.
 
@@ -35,6 +36,7 @@ pub fn cmd_init(args: &[String]) -> Result<()> {
         ("src/main.lex",                main_lex),
         ("tests/test_main.lex",         test_lex),
         (".github/workflows/lex.yml",   ci_yml),
+        ("AGENTS.md",                   agents_md),
     ];
 
     for (rel, gen) in files {
@@ -79,17 +81,39 @@ version = "0.1.0"
 }
 
 fn main_lex(_name: &str) -> String {
-    // Use the printer's canonical output so `lex fmt --check` passes immediately.
-    let src = "fn main() -> Str {\n  \"hello, world\"\n}\n";
+    // Includes an `examples { ... }` block so the convention is visible
+    // from line 1 of a fresh repo — agents pattern-match what they see,
+    // and these double as type-level + behavioural regression checks at
+    // `lex check` time.
+    //
+    // Run through the printer so `lex fmt --check` is green on a
+    // freshly-initialized project.
+    let src = concat!(
+        "fn main() -> Str\n",
+        "  examples {\n",
+        "    main() => \"hello, world\",\n",
+        "  }\n",
+        "{\n",
+        "  \"hello, world\"\n",
+        "}\n",
+    );
     let prog = lex_syntax::parse_source(src).expect("stub is valid lex");
     lex_syntax::print_program(&prog)
 }
 
 fn test_lex(_name: &str) -> String {
+    // `lex test` invokes `run_all` and treats a successful return as
+    // pass. Convention: return `0` for "no failures" and add real cases
+    // as you grow the suite. Keeping the stub trivially compiling means
+    // `lex ci` is green from minute one on a freshly-initialized
+    // project — agents reading AGENTS.md trust that as the baseline.
     let src = concat!(
-        "import \"std.list\" as list\n\n",
-        "fn run_all() -> () {\n",
-        "  list.fold([], (), fn (_ :: (), _ :: ()) -> () { () })\n",
+        "fn run_all() -> Int\n",
+        "  examples {\n",
+        "    run_all() => 0,\n",
+        "  }\n",
+        "{\n",
+        "  0\n",
         "}\n",
     );
     let prog = lex_syntax::parse_source(src).expect("stub is valid lex");
@@ -130,6 +154,130 @@ fn ci_yml(_name: &str) -> String {
         "\n",
         "      - name: Test\n",
         "        run: lex test\n",
+        "\n",
+        "      # Belt-and-braces: re-run the same checks via the `lex ci`\n",
+        "      # umbrella so this workflow stays in sync with whatever\n",
+        "      # `lex ci` runs locally (contributors run `lex ci` before\n",
+        "      # pushing). Remove if you find the duplication too noisy.\n",
+        "      - name: lex ci (full repro)\n",
+        "        run: lex ci\n",
     ]
     .concat()
+}
+
+/// AI-assistant cold-start guide dropped at the project root. Read by
+/// Claude Code (`CLAUDE.md`/`AGENTS.md`), Cursor, Aider, and most other
+/// agent tools that look for a project-conventions file. Deliberately
+/// short — points at the upstream `docs/AGENT.md` for the deep dive.
+fn agents_md(name: &str) -> String {
+    format!(
+        r#"# AGENTS.md — {name}
+
+This file is for AI assistants (Claude Code, Cursor, Aider, Copilot, …)
+working in this repo. Humans should read `README.md` first; agents should
+read this **first**, then the upstream guide it points at.
+
+## 1. Install the Lex toolchain
+
+If `lex --version` doesn't work, build it from source — there are no
+pre-built binaries yet:
+
+```sh
+git clone --depth=1 https://github.com/alpibrusl/lex-lang /tmp/lex-lang
+cd /tmp/lex-lang && cargo build --release -p lex-cli
+export PATH="/tmp/lex-lang/target/release:$PATH"
+lex --version
+```
+
+Requires Rust 1.80+. The CI workflow at `.github/workflows/lex.yml`
+does the same thing.
+
+## 2. The loop
+
+Every change goes through this loop. **Do not claim done before `lex ci`
+is green.**
+
+```sh
+lex check src/main.lex   # type-check (fast, catches most issues)
+lex test                 # run all tests/test_*.lex files
+lex fmt src/ tests/      # auto-format (or `lex fmt --check` to verify)
+lex ci                   # umbrella: pkg install + check --strict + fmt --check + test
+```
+
+`lex check --output json` emits structured errors with `rule_tag`,
+`position`, and `rule_explanation` fields — use these when iterating.
+
+## 3. Lex in 60 seconds (the bits most likely to trip you up)
+
+Coming from Rust / TypeScript / Python? These are the differences worth
+internalising before writing your first line:
+
+```lex
+import "std.list" as list           # stdlib import, alias is mandatory
+import "./helper" as h              # local import (path relative to this file)
+
+type Status = Healthy | Sick(Str)   # tagged union, no `enum` keyword
+
+fn parse(s :: Str) -> Result[Int, Str]   # `::` types params; `->` is the return arrow
+  examples {{                        # OPTIONAL: pure fns can carry test cases
+    parse("1") => Ok(1),
+    parse("x") => Err("not a number"),
+  }}
+{{
+  let n := str.length(s)            # `:=` for let-binding, NOT `=`
+  if n == 0 {{
+    Err("empty")
+  }} else {{
+    Ok(n)
+  }}
+}}
+
+fn save(path :: Str, body :: Str) -> [fs.write] Result[Unit, Str] {{
+  fs.write(path, body)              # `[effects]` between `->` and the type
+}}
+```
+
+Key rules:
+
+1. **Types use `::`, lets use `:=`, returns use `->`.** Easy to mix up; the
+   compiler error is clear when you do.
+2. **Effects are types.** Any function that does I/O, time, randomness,
+   network, LLM calls, etc. must declare them: `-> [io] Nil`,
+   `-> [http.get, fs.read] Result[Str, Str]`. Pure functions declare
+   nothing. The checker refuses bodies that reach outside their declaration.
+3. **No exceptions.** `Result[T, E]` and `Option[T]` are the only error /
+   absence channels. Idiom: `match res {{ Ok(x) => ..., Err(e) => ... }}`.
+4. **`examples {{ … }}` blocks are part of the signature.** They're
+   compiled into the canonical AST and run at `lex check` time. Use them
+   for every pure function — they're cheaper than a test and they survive
+   refactors.
+5. **No mutation in user code.** No `mut`, no `var`. Build new values.
+6. **One canonical AST per meaning.** `lex fmt` is deterministic; don't
+   fight it.
+
+## 4. This project
+
+- Source lives in `src/` — entry point is `src/main.lex`.
+- Tests live in `tests/` — files must start with `test_` and export
+  `fn run_all() -> ...`.
+- Dependencies go in `[dependencies]` of `lex.toml`; run `lex pkg install`
+  after editing.
+- Before pushing: `lex ci`. CI runs the same command.
+
+## 5. Need more?
+
+Deep references in the upstream repo:
+
+- **`docs/AGENT.md`** — full cold-start guide: error envelope schema,
+  effect kinds, stdlib module summary, every sharp edge.
+- **`docs/index.html`** — the design pitch (effects-as-types, content-
+  addressed AST, op log, attestations).
+- **`README.md`** in [alpibrusl/lex-lang](https://github.com/alpibrusl/lex-lang)
+  — design rules, stdlib index, examples.
+
+When a `lex check` error confuses you, search its `rule_tag` in
+`docs/AGENT.md` — most tags have an explanation and a fix template.
+"#,
+        name = name,
+    )
 }

--- a/crates/lex-cli/src/test_runner.rs
+++ b/crates/lex-cli/src/test_runner.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use lex_ast::canonicalize_program;
 use lex_bytecode::{compile_program, vm::Vm};
 use lex_runtime::{check_program as check_policy, DefaultHandler, Policy};
-use lex_syntax::parse_source;
+use lex_syntax::load_program;
 use std::path::{Path, PathBuf};
 
 pub fn cmd_test(_fmt: &::acli::OutputFormat, args: &[String]) -> Result<()> {
@@ -70,10 +70,13 @@ fn collect_test_files(dir: &Path) -> Result<Vec<PathBuf>> {
 }
 
 fn run_one(path: &Path) -> Result<()> {
-    let src = std::fs::read_to_string(path)
-        .map_err(|e| anyhow::anyhow!("read: {e}"))?;
-    let prog = parse_source(&src)
-        .map_err(|e| anyhow::anyhow!("parse: {e}"))?;
+    // Route through the multi-file loader so `import "./foo" as f`,
+    // `import "../src/lib" as lib`, and `import "pkg-name/mod" as p`
+    // resolve and get mangled the same way `lex check` does. Without
+    // this, every aliased import in a test file blows up with
+    // `unknown_identifier` at type-check time (#395).
+    let prog = load_program(path)
+        .map_err(|e| anyhow::anyhow!("load: {e}"))?;
     let stages = canonicalize_program(&prog);
     if let Err(errs) = lex_types::check_program(&stages) {
         let msgs: Vec<String> = errs

--- a/crates/lex-cli/tests/init_scaffold.rs
+++ b/crates/lex-cli/tests/init_scaffold.rs
@@ -80,6 +80,40 @@ fn init_workflow_runs_lex_ci_after_explicit_steps() {
 }
 
 #[test]
+fn init_workflow_downloads_pinned_binary_not_cargo_build() {
+    // Workflow should install lex by downloading the pre-built binary
+    // from the GitHub Release pinned to the toolchain version that
+    // scaffolded the project — not by cloning + `cargo build`. The
+    // binary path is ~30s; building was ~3min. Pinning keeps CI
+    // reproducible across toolchain bumps.
+    let dir = unique_dir("workflow-binary");
+    let (code, _, _) = run_in(&dir, &["init", "my-app"]);
+    assert_eq!(code, 0);
+
+    let yml = std::fs::read_to_string(dir.join("my-app/.github/workflows/lex.yml"))
+        .expect("read workflow");
+
+    let expected_version = env!("CARGO_PKG_VERSION");
+
+    assert!(
+        yml.contains(&format!("LEX_VERSION: v{expected_version}")),
+        "workflow should pin LEX_VERSION to the scaffolding toolchain version (v{expected_version}):\n{yml}"
+    );
+    assert!(
+        yml.contains("github.com/alpibrusl/lex-lang/releases/download"),
+        "workflow should download from GitHub Releases:\n{yml}"
+    );
+    assert!(
+        !yml.contains("cargo build"),
+        "workflow should NOT cargo-build the toolchain (slow + needs Rust):\n{yml}"
+    );
+    assert!(
+        !yml.contains("git clone"),
+        "workflow should NOT clone lex-lang at CI time:\n{yml}"
+    );
+}
+
+#[test]
 fn init_agents_md_points_at_install_loop_and_upstream() {
     let dir = unique_dir("agents");
     let (code, _, _) = run_in(&dir, &["init", "my-app"]);
@@ -88,20 +122,31 @@ fn init_agents_md_points_at_install_loop_and_upstream() {
     let agents = std::fs::read_to_string(dir.join("my-app/AGENTS.md"))
         .expect("read AGENTS.md");
 
-    // The three load-bearing sections an agent depends on.
-    for marker in [
+    // The load-bearing sections an agent depends on.
+    let expected_version = env!("CARGO_PKG_VERSION");
+    for marker in &[
         // Title personalised to the project name.
-        "AGENTS.md — my-app",
-        // Install instructions (so an agent on a fresh box can bootstrap).
-        "cargo build --release -p lex-cli",
+        "AGENTS.md — my-app".to_string(),
+        // Primary install path: pre-built binary download.
+        "github.com/alpibrusl/lex-lang/releases/download".to_string(),
+        // Pinned to the toolchain version that scaffolded the project.
+        format!("v{expected_version}"),
+        // Cross-platform target detection so the recipe works on
+        // Linux x86_64 / aarch64 and macOS Intel / Apple Silicon.
+        "uname -s".to_string(),
+        // Fallback `cargo build` still documented for off-release versions.
+        "cargo build --release -p lex-cli".to_string(),
         // The loop with `lex ci` as the gate.
-        "lex ci",
+        "lex ci".to_string(),
         // Reference to the upstream cold-start guide.
-        "docs/AGENT.md",
+        "docs/AGENT.md".to_string(),
         // Effects-as-types reminder — the single biggest Lex-ism.
-        "Effects are types",
+        "Effects are types".to_string(),
     ] {
-        assert!(agents.contains(marker), "AGENTS.md missing `{marker}`");
+        assert!(
+            agents.contains(marker.as_str()),
+            "AGENTS.md missing `{marker}`"
+        );
     }
 }
 

--- a/crates/lex-cli/tests/init_scaffold.rs
+++ b/crates/lex-cli/tests/init_scaffold.rs
@@ -1,0 +1,127 @@
+//! `lex init` must drop a project that's `lex ci`-green from minute one.
+//! The contract any agent reading the generated `AGENTS.md` relies on
+//! is "run `lex ci` and trust the exit code" — if init shipped a red
+//! baseline, that contract is broken before the agent writes a line.
+
+use std::process::{Command, Stdio};
+
+fn lex_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_lex")
+}
+
+fn unique_dir(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "lex-init-scaffold-{}-{}-{tag}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run_in(cwd: &std::path::Path, args: &[&str]) -> (i32, String, String) {
+    let out = Command::new(lex_bin())
+        .args(args)
+        .current_dir(cwd)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn lex");
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+#[test]
+fn init_produces_all_expected_files() {
+    let dir = unique_dir("files");
+    let (code, _, stderr) = run_in(&dir, &["init", "my-app"]);
+    assert_eq!(code, 0, "lex init exited {code}: {stderr}");
+
+    for rel in [
+        "lex.toml",
+        "src/main.lex",
+        "tests/test_main.lex",
+        ".github/workflows/lex.yml",
+        "AGENTS.md",
+    ] {
+        assert!(
+            dir.join("my-app").join(rel).is_file(),
+            "expected file not generated: {rel}"
+        );
+    }
+}
+
+#[test]
+fn init_workflow_runs_lex_ci_after_explicit_steps() {
+    // The generated workflow should keep the four named explicit steps
+    // *and* end with a `lex ci` step, so failures stay categorised in
+    // the GH Actions UI while the umbrella remains the source of truth.
+    let dir = unique_dir("workflow");
+    let (code, _, _) = run_in(&dir, &["init", "my-app"]);
+    assert_eq!(code, 0);
+
+    let yml = std::fs::read_to_string(dir.join("my-app/.github/workflows/lex.yml"))
+        .expect("read workflow");
+    for needle in [
+        "lex pkg install",
+        "lex check --strict src/main.lex",
+        "lex fmt --check src/ tests/",
+        "lex test",
+        "lex ci",
+    ] {
+        assert!(yml.contains(needle), "workflow missing `{needle}`:\n{yml}");
+    }
+}
+
+#[test]
+fn init_agents_md_points_at_install_loop_and_upstream() {
+    let dir = unique_dir("agents");
+    let (code, _, _) = run_in(&dir, &["init", "my-app"]);
+    assert_eq!(code, 0);
+
+    let agents = std::fs::read_to_string(dir.join("my-app/AGENTS.md"))
+        .expect("read AGENTS.md");
+
+    // The three load-bearing sections an agent depends on.
+    for marker in [
+        // Title personalised to the project name.
+        "AGENTS.md — my-app",
+        // Install instructions (so an agent on a fresh box can bootstrap).
+        "cargo build --release -p lex-cli",
+        // The loop with `lex ci` as the gate.
+        "lex ci",
+        // Reference to the upstream cold-start guide.
+        "docs/AGENT.md",
+        // Effects-as-types reminder — the single biggest Lex-ism.
+        "Effects are types",
+    ] {
+        assert!(agents.contains(marker), "AGENTS.md missing `{marker}`");
+    }
+}
+
+#[test]
+fn init_baseline_passes_lex_ci() {
+    // The headline contract: a freshly-initialised project is
+    // immediately green under `lex ci`. If this regresses, every
+    // agent's first iteration starts in a broken state.
+    let dir = unique_dir("ci-green");
+    let (code, _, stderr) = run_in(&dir, &["init", "my-app"]);
+    assert_eq!(code, 0, "lex init failed: {stderr}");
+
+    let app = dir.join("my-app");
+    let (code, stdout, stderr) = run_in(&app, &["ci"]);
+    assert_eq!(
+        code, 0,
+        "lex ci must be green on a fresh `lex init`.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains("CI passed"),
+        "expected `CI passed` line in lex ci output, got:\n{stdout}"
+    );
+}

--- a/crates/lex-cli/tests/test_runner_imports.rs
+++ b/crates/lex-cli/tests/test_runner_imports.rs
@@ -1,0 +1,126 @@
+//! `lex test` must resolve aliased path imports the same way `lex check`
+//! does — by routing the test file through the multi-file loader rather
+//! than parsing it in isolation (#395).
+//!
+//! Before the fix, `import "../src/lib" as lib` in a test file produced
+//! `unknown_identifier "lib"` because the runner used the bare parser
+//! and never expanded / mangled imports.
+
+use std::process::{Command, Stdio};
+
+fn lex_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_lex")
+}
+
+fn unique_dir(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "lex-test-runner-imports-{}-{}-{tag}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn write(dir: &std::path::Path, name: &str, src: &str) {
+    let p = dir.join(name);
+    if let Some(parent) = p.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(&p, src).unwrap();
+}
+
+fn run_test_in(cwd: &std::path::Path) -> (i32, String, String) {
+    let out = Command::new(lex_bin())
+        .arg("test")
+        .current_dir(cwd)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn lex test");
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+#[test]
+fn aliased_path_import_resolves_in_test_runner() {
+    // The exact reproducer from issue #395: a test file uses
+    // `import "../src/lib" as lib` plus a stdlib import, and exercises
+    // both aliases. Pre-fix this failed at type-check with
+    // `unknown_identifier "lib"`.
+    let dir = unique_dir("aliased-path");
+
+    write(
+        &dir,
+        "lex.toml",
+        "[package]\nname = \"alias_repro\"\nversion = \"0.1.0\"\n",
+    );
+    write(
+        &dir,
+        "src/lib.lex",
+        "fn greet(name :: Str) -> Str { \"hello, \" }\n",
+    );
+    write(
+        &dir,
+        "tests/test_lib.lex",
+        r#"import "../src/lib" as lib
+import "std.list"   as list
+
+fn one_test() -> Result[Unit, Str] {
+  let r := lib.greet("world")
+  if r == "hello, " { Ok(()) } else { Err("nope") }
+}
+
+fn suite() -> List[Result[Unit, Str]] { [one_test()] }
+fn run_all() -> Int {
+  list.fold(suite(), 0, fn (n :: Int, r :: Result[Unit, Str]) -> Int {
+    match r { Ok(_) => n, Err(_) => n + 1 }
+  })
+}
+"#,
+    );
+
+    let (code, stdout, stderr) = run_test_in(&dir);
+    assert_eq!(
+        code, 0,
+        "expected `lex test` to pass after #395 fix.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains("1 passed, 0 failed"),
+        "expected summary `1 passed, 0 failed`, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn helper_referenced_via_alias_from_test_file_runs() {
+    // The test file imports a sibling helper file and calls into it via
+    // the alias. The previous code path skipped the loader and so the
+    // alias never expanded — failing at type-check.
+    let dir = unique_dir("helper-alias");
+
+    write(
+        &dir,
+        "src/math.lex",
+        "fn double(x :: Int) -> Int { x + x }\n",
+    );
+    write(
+        &dir,
+        "tests/test_math.lex",
+        r#"import "../src/math" as m
+
+fn run_all() -> Int { m.double(21) }
+"#,
+    );
+
+    let (code, stdout, stderr) = run_test_in(&dir);
+    assert_eq!(
+        code, 0,
+        "expected `lex test` to pass.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,0 +1,144 @@
+# Quickstart for AI agents — bootstrap a new Lex project
+
+This doc is the **single URL** to point an AI assistant at when you
+want it to implement something in Lex. It covers the path from an
+empty directory to a green CI on GitHub. After step 2 the project
+itself contains an `AGENTS.md` with the language-specific guidance —
+this doc is intentionally only about getting there.
+
+**Prompt fragment you can paste to your agent:**
+
+> Implement \<project description\> in Lex. Bootstrap the project
+> following <https://github.com/alpibrusl/lex-lang/blob/main/docs/QUICKSTART.md>.
+> After running `lex init .`, follow the per-project `AGENTS.md` for
+> language conventions. Do not claim done before `lex ci` is green.
+
+---
+
+## Prerequisites
+
+- An empty directory under your control (typically a fresh `git init`).
+- `curl`, `tar`, `git`, and a writable `/usr/local/bin` (or any directory
+  on `PATH`).
+- Network access to `github.com`.
+- No Rust required.
+
+## 1. Install the `lex` binary
+
+Download the pre-built binary for your platform. There's no installer
+yet; the binary is self-contained and goes anywhere on `PATH`.
+
+```sh
+LEX_VERSION=v0.9.1   # latest at the time of writing; check the Releases page
+case "$(uname -s)-$(uname -m)" in
+  Linux-x86_64)   TARGET=x86_64-unknown-linux-gnu  ;;
+  Linux-aarch64)  TARGET=aarch64-unknown-linux-gnu ;;
+  Darwin-x86_64)  TARGET=x86_64-apple-darwin       ;;
+  Darwin-arm64)   TARGET=aarch64-apple-darwin      ;;
+  *) echo "unsupported platform" >&2; exit 1 ;;
+esac
+curl -sSfL "https://github.com/alpibrusl/lex-lang/releases/download/${LEX_VERSION}/lex-${LEX_VERSION}-${TARGET}.tar.gz" | tar -xz
+sudo install -m 0755 "lex-${LEX_VERSION}-${TARGET}/lex" /usr/local/bin/lex
+lex --version
+```
+
+Windows: grab `lex-v0.9.1-x86_64-pc-windows-msvc.zip` from
+<https://github.com/alpibrusl/lex-lang/releases> and put `lex.exe`
+on `PATH`.
+
+Fallback (build from source) — only when you need an unreleased fix:
+
+```sh
+git clone --depth=1 https://github.com/alpibrusl/lex-lang /tmp/lex-lang
+cd /tmp/lex-lang && cargo build --release -p lex-cli
+export PATH="/tmp/lex-lang/target/release:$PATH"
+```
+
+## 2. Scaffold the project
+
+From inside the empty directory:
+
+```sh
+git init                       # if you haven't already
+lex init .
+```
+
+This drops five files, none overwriting anything that exists:
+
+| File | Purpose |
+|---|---|
+| `lex.toml` | Package manifest (name, version, `[dependencies]`) |
+| `src/main.lex` | Entry-point stub with an `examples { }` block |
+| `tests/test_main.lex` | Test stub — `run_all` returns `0` for "all passed" |
+| `.github/workflows/lex.yml` | GitHub Actions CI: pkg install, check, fmt, test, `lex ci` |
+| `AGENTS.md` | Cold-start guide for AI assistants working in **this** project |
+
+The CI workflow is pinned to the lex version you installed; `lex --version`
+should match the `LEX_VERSION` env in the generated workflow.
+
+## 3. Verify the baseline is green
+
+```sh
+lex ci
+```
+
+You should see `CI passed — all steps green`. If not, that's a bug in
+the scaffold — file an issue on
+<https://github.com/alpibrusl/lex-lang/issues> before continuing.
+
+## 4. (Optional) Add dependencies
+
+```sh
+lex pkg add lex-schema --path ../lex-schema
+# or:
+lex pkg add lex-schema --git https://github.com/alpibrusl/lex-schema
+lex pkg install
+```
+
+## 5. Implement the project
+
+Open `src/main.lex` and `tests/test_main.lex` and start writing code.
+The project's own `AGENTS.md` covers the language-specific bits an agent
+needs to know — `::` for type annotations, effects-as-types, `Result`/
+`Option` over exceptions, `examples { }` blocks, the `lex check → lex
+test → lex fmt → lex ci` loop.
+
+Iterate with:
+
+```sh
+lex check src/main.lex --output json    # structured errors with rule_tag + position
+lex test                                # run tests/test_*.lex
+lex fmt src/ tests/                     # auto-format
+lex ci                                  # everything above, plus pkg install
+```
+
+`lex ci` is the gate — both contributors and CI run it, so a green
+local `lex ci` is the same green that CI will report.
+
+## 6. Commit and push
+
+```sh
+git add .
+git commit -m "scaffold via lex init"
+# Create the remote first (one-off):
+gh repo create <owner>/<name> --public --source=. --remote=origin --push
+# Or, if it already exists:
+git remote add origin git@github.com:<owner>/<name>.git
+git push -u origin main
+```
+
+GitHub Actions will pick up `.github/workflows/lex.yml` on the first
+push and run `lex ci` against the latest commit.
+
+## 7. Need more?
+
+- `AGENTS.md` (inside the project you just scaffolded) — language
+  cheat-sheet, project conventions.
+- [`docs/AGENT.md`](AGENT.md) (upstream) — the deep reference: error
+  envelope schema, every effect kind, stdlib module summary, sharp
+  edges, repair-loop semantics.
+- [`README.md`](../README.md) — design rules, contract-layer framing,
+  what makes Lex different.
+
+If something here is wrong or out of date, send a PR against this file:
+<https://github.com/alpibrusl/lex-lang/blob/main/docs/QUICKSTART.md>.


### PR DESCRIPTION
## Summary

Enhance `lex init` to generate an `AGENTS.md` cold-start guide for AI assistants, update the GitHub Actions workflow to download pre-built binaries pinned to the scaffolding toolchain version (instead of building from source), and improve the generated stub code with `examples { }` blocks. Add comprehensive tests to ensure freshly-initialized projects pass `lex ci` immediately.

## Why

**For AI agents:** The generated `AGENTS.md` provides a single entry point covering toolchain installation (with cross-platform binary download), the development loop (`lex check → lex test → lex fmt → lex ci`), a 60-second Lex cheat-sheet, and pointers to upstream documentation. This lets agents bootstrap and iterate without external guidance.

**For CI speed:** The workflow now downloads pre-built binaries (~30s) instead of cloning + `cargo build`-ing (~3min), and pins to the exact toolchain version that scaffolded the project. This keeps CI reproducible across toolchain bumps and removes the Rust build dependency from CI.

**For baseline quality:** The generated `main.lex` and `test_main.lex` now include `examples { }` blocks, making the convention visible from line 1 and serving as type-level + behavioural regression checks at `lex check` time. The test stub returns `Int` (0 for "all passed") instead of `()`, aligning with the actual test protocol.

**Contract enforcement:** Added `init_scaffold.rs` test suite to ensure the generated project is `lex ci`-green from minute one — the baseline contract that agents reading `AGENTS.md` depend on.

## Test plan

- [x] `cargo test --workspace` passes locally (new tests: `init_scaffold.rs`, `test_runner_imports.rs`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] New regression tests cover: generated files exist, workflow structure, binary pinning, `AGENTS.md` content, and `lex ci` passes on fresh scaffold
- [x] Existing `lex test` behavior verified with import resolution tests

## Risk / scope

- Touches: `lex-cli` (init, test_runner), docs (new QUICKSTART.md)
- Breaking change to wire format / SigId / StageId / canonical AST? **no**
- Adds a new effect kind or runtime variant? **no**
- The test_runner change routes test files through `load_program` instead of `parse_source` to properly resolve aliased imports — fixes #395 as a side effect

https://claude.ai/code/session_01AYcNs2EQ8CVwLiiCRgsW8C