### PR TITLE
feat(net): net.dial_ws — WebSocket client primitive (#390)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+### Added
+
+- **#390: `net.dial_ws` — WebSocket client primitive.** Inverse of
+  `net.serve_ws_fn` (server, shipped in 0.9.0): open an outbound
+  WebSocket connection, fire `on_open` once after the handshake,
+  then loop invoking `on_message` for every inbound frame.
+
+  ```lex
+  fn net.dial_ws[E](
+    url         :: Str,                    # ws:// or wss://
+    subprotocol :: Str,                    # e.g. "ocpp1.6", or "" for none
+    on_open     :: () -> [E] WsAction,
+    on_message  :: (WsMessage) -> [E] WsAction,
+  ) -> [net, E] Result[Unit, Str]
+  ```
+
+  Both callbacks return the same `WsAction` enum (`WsSend(Str)` /
+  `WsSendBinary(List[Int])` / `WsNoOp`) as the server-side
+  `serve_ws_fn` — the action is applied to the socket immediately
+  after the closure returns. `on_message` is also invoked once with
+  `WsClose` before the loop exits, so handlers can run cleanup. The
+  return type is `Result[Unit, Str]` (not bare `Unit` like the
+  server side) because a dial can fail on connect (DNS, refused,
+  bad TLS), bad URL, or mid-stream (read/write error), and the
+  caller usually wants to act on that.
+
+  TLS / `wss://` URLs are supported via tungstenite's
+  `rustls-tls-webpki-roots` feature — production OCPP / signed-WS
+  endpoints work out of the box, no extra config.
+
+  **v1 limitation.** The issue proposed a `send` closure threaded
+  through both handlers so users could push outbound frames from
+  arbitrary `[net]` code (e.g. a charger's heartbeat scheduler).
+  That requires representing Rust-native closures as Lex `Value`s,
+  which is a separate runtime change tracked for a follow-up
+  release. v1 covers the BootNotification + reactive-reply pattern
+  that motivates the issue: `on_open() => WsSend(boot_frame)` plus
+  `on_message(WsText(s)) => WsSend(handle(s))` is enough to write a
+  conforming OCPP charge-point client.
+
+  Closes #390.
+
 ## [0.9.2] — 2026-05-13
 
 ### Added

--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -35,7 +35,7 @@ hex = "0.4"
 subtle = "2.6"
 rand = { version = "0.10", features = ["sys_rng"] }
 tiny_http = { version = "0.12", features = ["ssl-rustls"] }
-tungstenite = "0.29"
+tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
 ureq = { version = "3.3", default-features = false, features = ["rustls", "platform-verifier"] }
 toml = "1.1"
 serde_yaml = "0.9"

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -1016,6 +1016,28 @@ impl EffectHandler for DefaultHandler {
                 let registry = Arc::new(crate::ws::ChatRegistry::default());
                 crate::ws::serve_ws_fn(port, subprotocol, closure, program, policy, registry)
             }
+            ("net", "dial_ws") => {
+                // dial_ws(url, subprotocol, on_open, on_message)
+                let url = expect_str(args.first())?.to_string();
+                let subprotocol = expect_str(args.get(1))?.to_string();
+                let on_open = match args.get(2).cloned() {
+                    Some(c @ Value::Closure { .. }) => c,
+                    _ => return Err(
+                        "net.dial_ws(url, subprotocol, on_open, on_message): on_open must be a closure".into(),
+                    ),
+                };
+                let on_message = match args.into_iter().nth(3) {
+                    Some(c @ Value::Closure { .. }) => c,
+                    _ => return Err(
+                        "net.dial_ws(url, subprotocol, on_open, on_message): on_message must be a closure".into(),
+                    ),
+                };
+                let program = self.program.clone().ok_or_else(|| {
+                    "net.dial_ws requires a Program reference; use DefaultHandler::with_program".to_string()
+                })?;
+                let policy = self.policy.clone();
+                crate::ws::dial_ws(url, subprotocol, on_open, on_message, program, policy)
+            }
             ("chat", "broadcast") => {
                 let registry = self.chat_registry.as_ref()
                     .ok_or_else(|| "chat.broadcast called outside a net.serve_ws handler".to_string())?;

--- a/crates/lex-runtime/src/ws.rs
+++ b/crates/lex-runtime/src/ws.rs
@@ -229,10 +229,18 @@ fn build_ws_message_ping() -> Value {
     Value::Variant { name: "WsPing".into(), args: vec![] }
 }
 
+fn build_ws_message_binary(payload: &[u8]) -> Value {
+    let bytes = payload.iter().map(|b| Value::Int(*b as i64)).collect();
+    Value::Variant { name: "WsBinary".into(), args: vec![Value::List(bytes)] }
+}
+
 /// Interpret a `WsAction` variant and send the appropriate frame.
-fn apply_ws_action(
+/// Generic over the stream so this serves both the plaintext-only
+/// server path (`TcpStream`) and the dial path that may sit on top
+/// of a TLS-wrapped stream (`MaybeTlsStream<TcpStream>`).
+fn apply_ws_action<S: std::io::Read + std::io::Write>(
     action: &Value,
-    ws: &mut tungstenite::WebSocket<std::net::TcpStream>,
+    ws: &mut tungstenite::WebSocket<S>,
 ) -> Result<(), String> {
     use tungstenite::Message;
     match action {
@@ -395,4 +403,193 @@ fn run_loop_fn(
         }
     }
     Ok(())
+}
+
+// ── Closure-based WebSocket client (#390) ────────────────────────────────────
+//
+// Inverse of `serve_ws_fn`: open a connection to a remote WS server and
+// run two Lex callbacks against it.
+//
+// - `on_open : () -> [E] WsAction` is invoked once after the handshake
+//   completes. The returned `WsAction` (typically `WsSend(boot_frame)`)
+//   is applied to the socket immediately. This is the hook for
+//   protocols like OCPP where the client sends a `BootNotification`
+//   the moment it connects.
+// - `on_message : (WsMessage) -> [E] WsAction` is invoked for every
+//   inbound frame. Same `WsAction` semantics as the server-side
+//   handler. A `WsClose` message is delivered once before the loop
+//   exits so handlers can run shutdown logic.
+//
+// Multi-frame sends from `on_open` (e.g. a charger that wants to
+// also kick off a heartbeat scheduler at connect-time) aren't
+// expressible in v1 — the issue's `send :: (Str) -> [net]
+// Result[Unit, Str]` closure would let users push outbound frames
+// from arbitrary `[net]` code, but that requires representing
+// Rust-native closures as Lex `Value`s, which is a separate
+// runtime change. v1 covers the BootNotification + reactive reply
+// pattern that motivates the issue.
+
+fn build_dial_result(ok: Result<(), String>) -> Value {
+    match ok {
+        Ok(()) => Value::Variant {
+            name: "Ok".into(),
+            args: vec![Value::Unit],
+        },
+        Err(msg) => Value::Variant {
+            name: "Err".into(),
+            args: vec![Value::Str(msg)],
+        },
+    }
+}
+
+/// `net.dial_ws(url, subprotocol, on_open, on_message) -> [net, E]
+/// Result[Unit, Str]`. Blocks for the lifetime of the connection;
+/// returns `Ok(())` on a clean close from the server, `Err(reason)`
+/// on dial failure, handshake failure, read error, or write error.
+pub fn dial_ws(
+    url: String,
+    subprotocol: String,
+    on_open: Value,
+    on_message: Value,
+    program: Arc<Program>,
+    policy: Policy,
+) -> Result<Value, String> {
+    use tungstenite::client::IntoClientRequest;
+    use tungstenite::http::HeaderValue;
+
+    // Build the request — when `subprotocol` is non-empty, attach the
+    // Sec-WebSocket-Protocol header so the server's accept-handler
+    // can match on it. Empty subprotocol → header omitted (the same
+    // contract as `serve_ws_fn`'s subprotocol arg).
+    //
+    // Caller-controlled inputs (URL syntax, subprotocol header value)
+    // surface as a Lex `Err(reason)`, not a Rust panic / handler
+    // error, so `match net.dial_ws(...) { Err(_) => ..., Ok(_) => ... }`
+    // works at the Lex level.
+    let mut req = match url.as_str().into_client_request() {
+        Ok(r) => r,
+        Err(e) => {
+            return Ok(build_dial_result(Err(format!(
+                "net.dial_ws: bad URL `{url}`: {e}"
+            ))));
+        }
+    };
+    if !subprotocol.is_empty() {
+        let header = match HeaderValue::from_str(&subprotocol) {
+            Ok(h) => h,
+            Err(e) => {
+                return Ok(build_dial_result(Err(format!(
+                    "net.dial_ws: invalid subprotocol `{subprotocol}`: {e}"
+                ))));
+            }
+        };
+        req.headers_mut().insert("Sec-WebSocket-Protocol", header);
+    }
+
+    let (mut ws, _resp) = match tungstenite::connect(req) {
+        Ok(pair) => pair,
+        Err(e) => {
+            return Ok(build_dial_result(Err(format!(
+                "net.dial_ws: connect to `{url}`: {e}"
+            ))));
+        }
+    };
+
+    // Non-blocking-ish reads so we don't tie up the thread on an idle
+    // socket, mirroring the server's read-timeout multiplexing.
+    if let Some(stream) = stream_for(&mut ws) {
+        let _ = stream.set_read_timeout(Some(Duration::from_millis(50)));
+    }
+
+    // 1. Fire on_open once and apply its action.
+    {
+        let handler = crate::handler::DefaultHandler::new(policy.clone())
+            .with_program(Arc::clone(&program));
+        let mut vm = Vm::with_handler(&program, Box::new(handler));
+        match vm.invoke_closure_value(on_open.clone(), vec![]) {
+            Ok(action) => {
+                if let Err(e) = apply_ws_action(&action, &mut ws) {
+                    return Ok(build_dial_result(Err(format!(
+                        "net.dial_ws: on_open action: {e}"
+                    ))));
+                }
+            }
+            Err(e) => {
+                return Ok(build_dial_result(Err(format!(
+                    "net.dial_ws: on_open: {e}"
+                ))));
+            }
+        }
+    }
+
+    // 2. Run the read loop, dispatching each inbound frame to on_message.
+    let loop_result = dial_run_loop(&mut ws, &on_message, &program, &policy);
+    let _ = ws.close(None);
+    Ok(build_dial_result(loop_result))
+}
+
+/// Pull the underlying TCP stream out of a `MaybeTlsStream` so we can
+/// set a read timeout. For plaintext connections this is the
+/// `TcpStream` directly; for `rustls`-wrapped streams it's the inner
+/// socket. Returns `None` if the wrapping is some other variant —
+/// in that case we just skip the timeout and rely on blocking reads.
+fn stream_for(
+    ws: &mut tungstenite::WebSocket<tungstenite::stream::MaybeTlsStream<std::net::TcpStream>>,
+) -> Option<&mut std::net::TcpStream> {
+    use tungstenite::stream::MaybeTlsStream;
+    match ws.get_mut() {
+        MaybeTlsStream::Plain(s) => Some(s),
+        MaybeTlsStream::Rustls(s) => Some(s.get_mut()),
+        _ => None,
+    }
+}
+
+fn dial_run_loop(
+    ws: &mut tungstenite::WebSocket<tungstenite::stream::MaybeTlsStream<std::net::TcpStream>>,
+    on_message: &Value,
+    program: &Arc<Program>,
+    policy: &Policy,
+) -> Result<(), String> {
+    use std::io::ErrorKind;
+    use tungstenite::Message;
+
+    loop {
+        let ws_msg = match ws.read() {
+            Ok(Message::Text(body)) => Some(build_ws_message_text(&body)),
+            Ok(Message::Binary(payload)) => Some(build_ws_message_binary(&payload)),
+            Ok(Message::Ping(_)) => Some(build_ws_message_ping()),
+            Ok(Message::Close(_)) | Err(tungstenite::Error::ConnectionClosed) => {
+                // Deliver WsClose so the handler can do shutdown work.
+                let handler = crate::handler::DefaultHandler::new(policy.clone())
+                    .with_program(Arc::clone(program));
+                let mut vm = Vm::with_handler(program, Box::new(handler));
+                let _ = vm.invoke_closure_value(
+                    on_message.clone(),
+                    vec![build_ws_message_close()],
+                );
+                return Ok(());
+            }
+            Ok(_) => None, // pong / raw frame
+            Err(tungstenite::Error::Io(ref e))
+                if e.kind() == ErrorKind::WouldBlock || e.kind() == ErrorKind::TimedOut =>
+            {
+                None
+            }
+            Err(e) => return Err(format!("net.dial_ws: read: {e}")),
+        };
+
+        if let Some(msg) = ws_msg {
+            let handler = crate::handler::DefaultHandler::new(policy.clone())
+                .with_program(Arc::clone(program));
+            let mut vm = Vm::with_handler(program, Box::new(handler));
+            match vm.invoke_closure_value(on_message.clone(), vec![msg]) {
+                Ok(action) => {
+                    if let Err(e) = apply_ws_action(&action, ws) {
+                        return Err(format!("net.dial_ws: action: {e}"));
+                    }
+                }
+                Err(e) => return Err(format!("net.dial_ws: on_message: {e}")),
+            }
+        }
+    }
 }

--- a/crates/lex-runtime/tests/net_dial_ws.rs
+++ b/crates/lex-runtime/tests/net_dial_ws.rs
@@ -1,0 +1,259 @@
+//! Wire-level integration tests for `net.dial_ws` — the WebSocket
+//! client primitive that mirrors `net.serve_ws_fn` (#390).
+//!
+//! Topology: a small Rust `tungstenite` server runs in a background
+//! thread, the test main thread drives a Lex program that uses
+//! `net.dial_ws` to connect, exchange a few frames, then exit when
+//! the server closes the connection.
+//!
+//! We use a Rust server rather than Lex `net.serve_ws_fn` for two
+//! reasons:
+//!  1. `serve_ws_fn` blocks forever — we'd need an out-of-band shutdown
+//!     hook to drive a single-test exchange, which the current API
+//!     doesn't expose.
+//!  2. Verifying the dial-side behaviour through what the server
+//!     *received* gives us an end-to-end correctness signal without
+//!     having to thread state out of the Lex VM.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::collections::BTreeSet;
+use std::net::TcpListener;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+use tungstenite::Message;
+
+/// Spin up a one-shot WS server bound to an OS-assigned port.
+///
+/// `setup` runs against the accepted WebSocket immediately after the
+/// handshake (server-initiated frames go here). The server then
+/// loops, recording every text frame it receives into `recv_log`,
+/// optionally responding via `on_each`, until `max_frames` have
+/// been consumed; then it closes.
+fn spawn_test_server(
+    setup: impl FnOnce(&mut tungstenite::WebSocket<std::net::TcpStream>) + Send + 'static,
+    on_each: impl Fn(&str, &mut tungstenite::WebSocket<std::net::TcpStream>) + Send + 'static,
+    max_frames: usize,
+) -> (u16, Arc<Mutex<Vec<String>>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    let recv_log: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let log_handle = Arc::clone(&recv_log);
+
+    thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("server accept");
+        // Read timeout so the server doesn't hang forever if the
+        // client misbehaves; the test as a whole still gets bounded
+        // by cargo test's own deadline.
+        let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
+        let mut ws = tungstenite::accept(stream).expect("ws handshake");
+        setup(&mut ws);
+
+        while log_handle.lock().unwrap().len() < max_frames {
+            match ws.read() {
+                Ok(Message::Text(body)) => {
+                    let s = body.to_string();
+                    log_handle.lock().unwrap().push(s.clone());
+                    on_each(&s, &mut ws);
+                }
+                Ok(Message::Close(_)) | Err(tungstenite::Error::ConnectionClosed) => break,
+                Ok(_) => {}
+                Err(_) => break,
+            }
+        }
+        let _ = ws.close(None);
+        // Drain a tail close frame.
+        let _ = ws.read();
+    });
+
+    // Give the listener a tick to be ready before the client dials.
+    thread::sleep(Duration::from_millis(50));
+    (port, recv_log)
+}
+
+fn run_lex(src: &str, fn_name: &str) -> Value {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors:\n{errs:#?}");
+    }
+    let bc = Arc::new(compile_program(&stages));
+    let mut policy = Policy::pure();
+    policy.allow_effects = ["net".to_string()]
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    let handler = DefaultHandler::new(policy).with_program(Arc::clone(&bc));
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(fn_name, vec![])
+        .unwrap_or_else(|e| panic!("call {fn_name}: {e}"))
+}
+
+fn assert_ok_unit(v: &Value) {
+    match v {
+        Value::Variant { name, args } if name == "Ok" && args.len() == 1 => {
+            assert!(matches!(args[0], Value::Unit), "Ok payload not Unit: {:?}", args[0]);
+        }
+        other => panic!("expected Ok(Unit), got {other:?}"),
+    }
+}
+
+fn assert_err_contains(v: &Value, needle: &str) {
+    match v {
+        Value::Variant { name, args } if name == "Err" && args.len() == 1 => match &args[0] {
+            Value::Str(s) => assert!(
+                s.contains(needle),
+                "expected Err containing `{needle}`, got `{s}`"
+            ),
+            other => panic!("Err payload not Str: {other:?}"),
+        },
+        other => panic!("expected Err(_), got {other:?}"),
+    }
+}
+
+#[test]
+fn dial_ws_runs_on_open_then_replies_to_inbound_text() {
+    // Server: after handshake, send "ping" once. Wait for the client's
+    // boot frame + its pong reply, then close.
+    let (port, log) = spawn_test_server(
+        |ws| {
+            ws.send(Message::Text("ping".into())).expect("server ping");
+        },
+        |_inbound, _ws| {},
+        2, // boot + pong
+    );
+
+    let src = format!(
+        r#"
+import "std.net" as net
+
+fn main() -> [net] Result[Unit, Str] {{
+  net.dial_ws(
+    "ws://127.0.0.1:{port}",
+    "",
+    fn () -> WsAction {{ WsSend("boot") }},
+    fn (msg :: WsMessage) -> WsAction {{
+      match msg {{
+        WsText(_)  => WsSend("pong"),
+        WsBinary(_) => WsNoOp,
+        WsPing     => WsNoOp,
+        WsClose    => WsNoOp,
+      }}
+    }},
+  )
+}}
+"#
+    );
+
+    let result = run_lex(&src, "main");
+    assert_ok_unit(&result);
+
+    let frames = log.lock().unwrap().clone();
+    assert_eq!(
+        frames,
+        vec!["boot".to_string(), "pong".to_string()],
+        "server should have seen boot frame from on_open and pong reply from on_message",
+    );
+}
+
+#[test]
+fn dial_ws_returns_err_on_connect_failure() {
+    // No server bound — picking a port that's almost certainly closed.
+    let src = r#"
+import "std.net" as net
+
+fn main() -> [net] Result[Unit, Str] {
+  net.dial_ws(
+    "ws://127.0.0.1:1",
+    "",
+    fn () -> WsAction { WsNoOp },
+    fn (_msg :: WsMessage) -> WsAction { WsNoOp },
+  )
+}
+"#;
+    let result = run_lex(src, "main");
+    assert_err_contains(&result, "connect");
+}
+
+#[test]
+fn dial_ws_returns_err_on_bad_url() {
+    let src = r#"
+import "std.net" as net
+
+fn main() -> [net] Result[Unit, Str] {
+  net.dial_ws(
+    "not a url",
+    "",
+    fn () -> WsAction { WsNoOp },
+    fn (_msg :: WsMessage) -> WsAction { WsNoOp },
+  )
+}
+"#;
+    let result = run_lex(src, "main");
+    // A `relative URL without a base` or `invalid scheme` style message —
+    // the exact wording is tungstenite's; we just need it to surface
+    // as a Lex `Err`.
+    match &result {
+        Value::Variant { name, .. } if name == "Err" => {}
+        other => panic!("expected Err(_), got {other:?}"),
+    }
+}
+
+#[test]
+fn dial_ws_subprotocol_header_is_sent_when_non_empty() {
+    // Bind a server that records the Sec-WebSocket-Protocol header
+    // out of the handshake request and then closes immediately.
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    let seen_subproto: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let seen_handle = Arc::clone(&seen_subproto);
+
+    thread::spawn(move || {
+        let (stream, _) = listener.accept().expect("accept");
+        let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
+        let mut ws = tungstenite::accept_hdr(stream, |req: &tungstenite::handshake::server::Request, mut resp: tungstenite::handshake::server::Response| {
+            if let Some(v) = req.headers().get("Sec-WebSocket-Protocol") {
+                if let Ok(s) = v.to_str() {
+                    *seen_handle.lock().unwrap() = Some(s.to_string());
+                    // Echo back so tungstenite considers the negotiation valid.
+                    resp.headers_mut().insert(
+                        "Sec-WebSocket-Protocol",
+                        tungstenite::http::HeaderValue::from_str(s).unwrap(),
+                    );
+                }
+            }
+            Ok(resp)
+        }).expect("handshake");
+        let _ = ws.close(None);
+        let _ = ws.read();
+    });
+
+    thread::sleep(Duration::from_millis(50));
+
+    let src = format!(
+        r#"
+import "std.net" as net
+
+fn main() -> [net] Result[Unit, Str] {{
+  net.dial_ws(
+    "ws://127.0.0.1:{port}",
+    "ocpp1.6",
+    fn () -> WsAction {{ WsNoOp }},
+    fn (_msg :: WsMessage) -> WsAction {{ WsNoOp }},
+  )
+}}
+"#
+    );
+
+    let result = run_lex(&src, "main");
+    assert_ok_unit(&result);
+
+    let seen = seen_subproto.lock().unwrap().clone();
+    assert_eq!(
+        seen.as_deref(),
+        Some("ocpp1.6"),
+        "server should have received Sec-WebSocket-Protocol: ocpp1.6"
+    );
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -486,6 +486,44 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 EffectSet::open_var(0).union(&EffectSet::singleton("net")),
                 Ty::Unit,
             ));
+            // dial_ws[Eff] :: (Str, Str, () -> [Eff] WsAction,
+            //                  (WsMessage) -> [Eff] WsAction)
+            //                  -> [net, Eff] Result[Unit, Str]
+            //
+            // WebSocket *client* — the inverse of serve_ws_fn (#390).
+            // Connects to `url` (ws:// or wss://) with the given
+            // subprotocol header, calls `on_open` once after the
+            // handshake completes, then loops invoking `on_message`
+            // for every inbound frame. Each callback returns a
+            // `WsAction` that gets applied to the socket — same enum
+            // as the server side, same semantics for `WsSend` /
+            // `WsSendBinary` / `WsNoOp`. open_var(0) propagates the
+            // handler effects so callers that touch [io], [time],
+            // [random] etc. inside their handlers see those propagate
+            // out of the dial_ws call.
+            //
+            // Returns `Result[Unit, Str]` rather than the bare `Unit`
+            // that serve_ws_fn returns: a dial can fail on connect
+            // (DNS, refused, bad TLS) or mid-stream (read error,
+            // unexpected close) and the caller usually wants to know.
+            fields.insert("dial_ws".into(), Ty::function(
+                vec![
+                    Ty::str(), // url (ws:// or wss://)
+                    Ty::str(), // subprotocol (Sec-WebSocket-Protocol)
+                    Ty::function(
+                        vec![],
+                        EffectSet::open_var(0),
+                        Ty::Con("WsAction".into(), vec![]),
+                    ),
+                    Ty::function(
+                        vec![Ty::Con("WsMessage".into(), vec![])],
+                        EffectSet::open_var(0),
+                        Ty::Con("WsAction".into(), vec![]),
+                    ),
+                ],
+                EffectSet::open_var(0).union(&EffectSet::singleton("net")),
+                Ty::Con("Result".into(), vec![Ty::Unit, Ty::str()]),
+            ));
             // serve_fn[Eff] :: (Int, (Request) -> [Eff] Response) -> [net, Eff] Unit
             // Effect-polymorphic variant of serve that accepts a first-class closure
             // instead of a handler name. open_var(0) captures the handler's effect row


### PR DESCRIPTION
Inverse of net.serve_ws_fn (shipped in 0.9.0). Opens an outbound
WebSocket connection, fires on_open once after the handshake, then
loops invoking on_message for every inbound frame. Both callbacks
return the same WsAction (WsSend / WsSendBinary / WsNoOp) the server
side uses — the action is applied to the socket synchronously.

## Surface

```
fn net.dial_ws[E](
  url         :: Str,                    # ws:// or wss://
  subprotocol :: Str,                    # e.g. "ocpp1.6"; "" omits the header
  on_open     :: () -> [E] WsAction,
  on_message  :: (WsMessage) -> [E] WsAction,
) -> [net, E] Result[Unit, Str]
```

Returns Result[Unit, Str] (not bare Unit like serve_ws_fn) — a dial
can fail on bad URL, connect (DNS / refused / bad TLS), or mid-stream
(read/write error), and callers usually want to discriminate. All
input-validation errors surface as a Lex `Err(reason)`, never a VM
panic. on_message is invoked once with `WsClose` before the loop
exits so handlers can run cleanup.

## What this unblocks

lex-ocpp's charge-point client (the issue's primary motivation):
- on_open() => WsSend(boot_notification_json)
- on_message(WsText(s)) => WsSend(handle_call(s))

OCPP runs over wss:// in production — tungstenite gains the
`rustls-tls-webpki-roots` feature so TLS works without extra config.

## v1 limitation

The issue proposed threading a `send :: (Str) -> [net]
Result[Unit, Str]` closure through both handlers so users could push
outbound frames from arbitrary `[net]` code (heartbeat schedulers,
multi-frame boot sequences). That requires representing Rust-native
closures as Lex `Value`s — a runtime change separate from this PR.
v1 covers BootNotification + reactive-reply (the load-bearing
half of OCPP); heartbeat-style outbound timers stay as a follow-up
once Native-Value closures land.

## Implementation

- `crates/lex-types/src/builtins.rs` — type signature in the `net`
  module record, mirroring serve_ws_fn's effect-polymorphic shape.
- `crates/lex-runtime/src/ws.rs` — `dial_ws()` impl built on
  tungstenite's `connect()`. `apply_ws_action` made generic over the
  stream type so the same Action interpretation handles both the
  server (`TcpStream`) and the client (`MaybeTlsStream<TcpStream>`).
  Read-loop multiplexes a 50ms socket read-timeout to keep the
  closure-dispatch cadence reasonable.
- `crates/lex-runtime/src/handler.rs` — dispatch arm validates the
  4-arg shape (url Str, subprotocol Str, on_open Closure, on_message
  Closure) and forwards to ws::dial_ws.
- `crates/lex-runtime/Cargo.toml` — `tungstenite` gains
  `rustls-tls-webpki-roots` so `wss://` works out of the box.

## Test plan

`crates/lex-runtime/tests/net_dial_ws.rs` — 4 wire-level tests
against a one-shot Rust tungstenite server bound to an OS-assigned
port. Coverage:

- **Loopback round-trip**: server sends "ping" right after
  handshake; Lex client's `on_open()` sends "boot", then
  `on_message(WsText(_))` replies with "pong". Server records the
  frames it received and we assert `["boot", "pong"]`.
- **Connect failure** (port 1, closed): returns a Lex
  `Err(reason)` mentioning "connect", not a VM panic.
- **Bad URL** ("not a url"): returns a Lex `Err(_)`.
- **Subprotocol negotiation**: server records the
  `Sec-WebSocket-Protocol` header; with subprotocol = "ocpp1.6"
  the server sees "ocpp1.6". Empty subprotocol omits the header
  (server doesn't see it; not asserted here, but follows from the
  branch in build-request code).

Full workspace: 212 suites, 0 failures.