### PR TITLE
fix(policy)+feat(cli): add `sql` (+ other stdlib effects) to permissive; lex test --allow-effects (#399)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,28 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+### Fixed
+
+- **#399: `Policy::permissive()` was missing several stdlib effect
+  kinds**, causing `lex test` (which uses the permissive policy by
+  default) to reject test files that touched stdlib modules whose
+  effects weren't in the runner's allow-list. Most painful case:
+  `[sql]` from `std.sql`, which broke any test that reached the SQL
+  surface — blocking lex-orm and lex-ocpp test suites under
+  `lex ci`. Added `sql`, `random` (`crypto.random` /
+  `crypto.random_str_hex`), `chat`, `log`, `kv`, `stream`, and
+  `fs_walk` to the permissive set; commented the rule that
+  `Policy::permissive()` tracks the stdlib effect catalog so future
+  effect additions get the same treatment.
+
 ### Added
+
+- **#399: `lex test --allow-effects k1,k2,...` flag.** Lets test
+  runs override the runner's permissive policy with an explicit
+  allow-list — covers vendor-extension effects we don't ship in the
+  stdlib catalog, and (in the other direction) lets contributors
+  verify effect-shape contracts by restricting a test run to a
+  tight allow-list. Mirrors `lex run --allow-effects` exactly.
 
 - **#390: `net.dial_ws` — WebSocket client primitive.** Inverse of
   `net.serve_ws_fn` (server, shipped in 0.9.0): open an outbound

--- a/crates/lex-cli/src/test_runner.rs
+++ b/crates/lex-cli/src/test_runner.rs
@@ -3,20 +3,51 @@
 //! Convention: each test file exports `fn run_all() -> ()`. The runner
 //! compiles the file, calls `run_all`, and reports pass/fail per file.
 //! Exit 0 iff every file passes.
+//!
+//! Flags:
+//!   --allow-effects k1,k2,...  override the runner's permissive
+//!                              policy with an explicit allow-list.
+//!                              Useful for tests that touch vendor-
+//!                              extension effects not in the stdlib
+//!                              catalog (#399).
 
 use anyhow::Result;
 use lex_ast::canonicalize_program;
 use lex_bytecode::{compile_program, vm::Vm};
 use lex_runtime::{check_program as check_policy, DefaultHandler, Policy};
 use lex_syntax::load_program;
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 pub fn cmd_test(_fmt: &::acli::OutputFormat, args: &[String]) -> Result<()> {
-    let dir: PathBuf = args
-        .iter()
-        .find(|a| !a.starts_with('-'))
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("tests"));
+    let mut dir: Option<PathBuf> = None;
+    let mut explicit_effects: Option<BTreeSet<String>> = None;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--allow-effects" => {
+                let val = args.get(i + 1).ok_or_else(|| {
+                    anyhow::anyhow!("--allow-effects requires a value")
+                })?;
+                explicit_effects = Some(
+                    val.split(',')
+                        .filter(|s| !s.is_empty())
+                        .map(|s| s.to_string())
+                        .collect(),
+                );
+                i += 2;
+            }
+            other if !other.starts_with('-') && dir.is_none() => {
+                dir = Some(PathBuf::from(other));
+                i += 1;
+            }
+            other => anyhow::bail!(
+                "unknown flag `{other}`; usage: lex test [--allow-effects k1,k2,...] [<dir>]"
+            ),
+        }
+    }
+    let dir = dir.unwrap_or_else(|| PathBuf::from("tests"));
 
     let entries = collect_test_files(&dir)?;
     if entries.is_empty() {
@@ -28,7 +59,7 @@ pub fn cmd_test(_fmt: &::acli::OutputFormat, args: &[String]) -> Result<()> {
     let mut fail = 0usize;
 
     for path in &entries {
-        match run_one(path) {
+        match run_one(path, explicit_effects.as_ref()) {
             Ok(()) => {
                 println!("ok   {}", path.display());
                 pass += 1;
@@ -69,7 +100,7 @@ fn collect_test_files(dir: &Path) -> Result<Vec<PathBuf>> {
     Ok(out)
 }
 
-fn run_one(path: &Path) -> Result<()> {
+fn run_one(path: &Path, explicit_effects: Option<&BTreeSet<String>>) -> Result<()> {
     // Route through the multi-file loader so `import "./foo" as f`,
     // `import "../src/lib" as lib`, and `import "pkg-name/mod" as p`
     // resolve and get mangled the same way `lex check` does. Without
@@ -86,7 +117,19 @@ fn run_one(path: &Path) -> Result<()> {
         anyhow::bail!("type error: {}", msgs.join("; "));
     }
     let bc = compile_program(&stages);
-    let policy = Policy::permissive();
+    // Permissive by default — covers every effect declared in the
+    // stdlib catalog (#399). `--allow-effects k1,k2,...` is the escape
+    // hatch for vendor-extension effects we don't know about, and also
+    // for restricting a test to a tight allow-list when verifying
+    // effect-shape contracts.
+    let policy = match explicit_effects {
+        Some(set) => {
+            let mut p = Policy::pure();
+            p.allow_effects = set.clone();
+            p
+        }
+        None => Policy::permissive(),
+    };
     check_policy(&bc, &policy).map_err(|v| anyhow::anyhow!("policy: {v:?}"))?;
     let bc = std::sync::Arc::new(bc);
     let handler = DefaultHandler::new(policy).with_program(std::sync::Arc::clone(&bc));

--- a/crates/lex-cli/tests/test_runner_effects.rs
+++ b/crates/lex-cli/tests/test_runner_effects.rs
@@ -1,0 +1,122 @@
+//! `lex test`'s permissive policy must include every effect declared
+//! in the stdlib catalog so test files that reach `[sql]` (or any
+//! other stdlib effect) don't fail at the runner-level policy gate
+//! (#399). The `--allow-effects` flag is the escape hatch for vendor-
+//! extension effects we don't ship and for tightening a test's
+//! allow-list to verify effect-shape contracts.
+
+use std::process::{Command, Stdio};
+
+fn lex_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_lex")
+}
+
+fn unique_dir(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "lex-test-effects-{}-{}-{tag}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn write(dir: &std::path::Path, name: &str, src: &str) {
+    let p = dir.join(name);
+    if let Some(parent) = p.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(&p, src).unwrap();
+}
+
+fn run_test_in(cwd: &std::path::Path, extra_args: &[&str]) -> (i32, String, String) {
+    let out = Command::new(lex_bin())
+        .arg("test")
+        .args(extra_args)
+        .current_dir(cwd)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn lex test");
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+fn write_sql_test(dir: &std::path::Path) {
+    write(
+        dir,
+        "lex.toml",
+        "[package]\nname = \"sql_repro\"\nversion = \"0.1.0\"\n",
+    );
+    // `sql.open(":memory:")` carries [sql, fs_write] in the stdlib
+    // signature (the SQLite driver creates a file on disk-backed
+    // opens; the in-memory case still types as fs_write for symmetry).
+    write(
+        dir,
+        "tests/test_with_sql.lex",
+        r#"import "std.sql" as sql
+
+fn run_all() -> [sql, fs_write] Int {
+  match sql.open(":memory:") {
+    Ok(_db) => 0,
+    Err(_e) => 1,
+  }
+}
+"#,
+    );
+}
+
+#[test]
+fn permissive_policy_allows_sql_effect_in_test_run() {
+    // Headline contract of #399: a test file that hits `[sql]`
+    // succeeds under the runner's default permissive policy.
+    let dir = unique_dir("sql-permissive");
+    write_sql_test(&dir);
+
+    let (code, stdout, stderr) = run_test_in(&dir, &[]);
+    assert_eq!(
+        code, 0,
+        "expected default permissive `lex test` to allow `[sql]`.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains("1 passed, 0 failed"),
+        "expected `1 passed, 0 failed`, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn explicit_allow_effects_flag_overrides_permissive() {
+    // --allow-effects sql,fs_write replaces the permissive default
+    // with a tight allow-list. Test still passes because both
+    // effects are listed.
+    let dir = unique_dir("sql-explicit-ok");
+    write_sql_test(&dir);
+
+    let (code, stdout, _) =
+        run_test_in(&dir, &["--allow-effects", "sql,fs_write"]);
+    assert_eq!(code, 0, "expected pass with explicit allow-list: {stdout}");
+    assert!(stdout.contains("1 passed"));
+}
+
+#[test]
+fn explicit_allow_effects_flag_rejects_missing_effect() {
+    // --allow-effects io alone is *not* enough to cover [sql,
+    // fs_write], so the runner must reject. This proves the flag
+    // actually narrows the policy — it doesn't just augment
+    // permissive.
+    let dir = unique_dir("sql-explicit-fail");
+    write_sql_test(&dir);
+
+    let (code, stdout, _) = run_test_in(&dir, &["--allow-effects", "io"]);
+    assert_ne!(code, 0, "expected non-zero exit; got 0 with stdout:\n{stdout}");
+    assert!(
+        stdout.contains("effect `sql` not in --allow-effects"),
+        "expected policy violation on `sql`, got:\n{stdout}"
+    );
+}

--- a/crates/lex-runtime/src/policy.rs
+++ b/crates/lex-runtime/src/policy.rs
@@ -51,6 +51,19 @@ impl Policy {
             // arrives with the per-capability effect parameterization
             // work (#207); the flat `[env]` is the v1 surface.
             "env",
+            // #399: keep this set in sync with every effect declared
+            // in `crates/lex-types/src/builtins.rs`. The "permissive"
+            // contract is "everything stdlib knows about"; missing
+            // entries here cause valid stdlib calls to fail under
+            // `lex test` / `lex repl` / any other consumer that opts
+            // into the permissive policy.
+            "sql",       // std.sql (#362, #379)
+            "random",    // crypto.random / crypto.random_str_hex (#382)
+            "chat",      // chat.broadcast / chat.send (#359)
+            "log",       // std.log structured logging
+            "kv",        // std.kv key-value store
+            "stream",    // std.stream
+            "fs_walk",   // std.fs directory traversal
         ] {
             s.insert(k.to_string());
         }


### PR DESCRIPTION
`Policy::permissive()` was missing several stdlib effect kinds that
got added after the initial list landed. `lex test` builds its
per-file policy from `permissive()` and so refused to run any test
file whose `run_all` reached one of those effects — most painfully
`[sql]`, which broke every test in lex-orm and lex-ocpp that touched
SQL through a library import.

## Fix 1: backfill `Policy::permissive()`

Added `sql`, `random` (separate from the older `rand`; used by
`crypto.random` / `crypto.random_str_hex`), `chat` (chat broadcast
/ send), `log`, `kv`, `stream`, and `fs_walk` to the permissive
allow-list. Audited against every `EffectSet::singleton(...)` site
in `crates/lex-types/src/builtins.rs`. Commented the invariant —
permissive must track the stdlib effect catalog; any new stdlib
effect that lands needs an entry here too.

## Fix 2: `lex test --allow-effects k1,k2,...`

For effects we *don't* ship in the stdlib (vendor extensions,
test-only fixtures) and for tightening a test run's allow-list
during contract verification, `lex test` now accepts
`--allow-effects` exactly like `lex run`. When set, the runner
switches from `Policy::permissive()` to `Policy::pure()` with the
caller's explicit allow-list — semantically a tight policy, not an
augmentation.

## Test plan

`crates/lex-cli/tests/test_runner_effects.rs` — 3 end-to-end tests
via `Command::new(lex_bin())`:

1. **`permissive_policy_allows_sql_effect_in_test_run`** — the
   issue's exact reproducer: `tests/test_with_sql.lex` calls
   `sql.open(":memory:")` and used to fail at the policy gate.
   Now exits 0 / "1 passed, 0 failed".
2. **`explicit_allow_effects_flag_overrides_permissive`** —
   `--allow-effects sql,fs_write` passes for the same SQL test
   because both effects are listed.
3. **`explicit_allow_effects_flag_rejects_missing_effect`** —
   `--allow-effects io` rejects (proves the flag *narrows* the
   policy, not just augments permissive). Asserts the exact
   `effect `sql` not in --allow-effects` violation surface.

Full workspace: 213 suites, 0 failures.

## Workaround removal

lex-ocpp's `.github/workflows/lex.yml` runs `test_route_io.lex` via
`lex run --allow-effects io,sql,time` as a separate step (the
README documents this). With this fix it should fold back into the
regular `lex ci` step.