### PR TITLE
chore(release): bump workspace version 0.9.2 → 0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+## [0.9.3] — 2026-05-14
+
 ### Performance
 
 - **#388: `net.serve` / `net.serve_fn` — replaced `tiny_http` with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ bumps may carry breaking changes when justified).
 
 ### Performance
 
+- **#405 (partial): eliminate redundant `args` clone on every `EffectCall`
+  dispatch and `list.cons` tail clone.** Two hot-path allocations removed:
+  (1) the VM's `EffectCall` handler previously cloned the entire args
+  `Vec<Value>` before passing it to the effect handler — now moved by
+  value (zero copy); (2) `list.cons` previously cloned every element of
+  the tail list because the pure-builtin dispatch accepted only `&[Value]`
+  — a new `call_pure_builtin(Vec<Value>)` owned entry-point lets `list.cons`
+  extend the output vec by moving elements from the tail instead of cloning
+  them. Combined impact: programs that accumulate results with `list.cons`
+  (e.g. CSV parsing, group-by aggregation) see substantially lower
+  allocation pressure; the algorithmic O(n²) from prepend-in-a-loop is
+  unchanged (tracked for 0.9.4).
+
 - **#388: `net.serve` / `net.serve_fn` — replaced `tiny_http` with
   hyper 1.x + tokio multi-thread runtime.** The blocking,
   one-thread-per-connection tiny_http server (p50 ≈ 28 ms for a

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 license = "EUPL-1.2"
 repository = "https://github.com/alpibrusl/lex-lang"

--- a/crates/lex-api/Cargo.toml
+++ b/crates/lex-api/Cargo.toml
@@ -16,14 +16,14 @@ serde_json.workspace = true
 anyhow.workspace = true
 indexmap.workspace = true
 tiny_http = "0.12"
-lex-syntax = { path = "../lex-syntax", version = "0.9.2" }
-lex-ast = { path = "../lex-ast", version = "0.9.2" }
-lex-types = { path = "../lex-types", version = "0.9.2" }
-lex-bytecode = { path = "../lex-bytecode", version = "0.9.2" }
-lex-runtime = { path = "../lex-runtime", version = "0.9.2" }
-lex-store = { path = "../lex-store", version = "0.9.2" }
-lex-trace = { path = "../lex-trace", version = "0.9.2" }
-lex-vcs = { path = "../lex-vcs", version = "0.9.2" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.3" }
+lex-ast = { path = "../lex-ast", version = "0.9.3" }
+lex-types = { path = "../lex-types", version = "0.9.3" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.9.3" }
+lex-runtime = { path = "../lex-runtime", version = "0.9.3" }
+lex-store = { path = "../lex-store", version = "0.9.3" }
+lex-trace = { path = "../lex-trace", version = "0.9.3" }
+lex-vcs = { path = "../lex-vcs", version = "0.9.3" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/lex-ast/Cargo.toml
+++ b/crates/lex-ast/Cargo.toml
@@ -16,4 +16,4 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-syntax = { path = "../lex-syntax", version = "0.9.2" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.3" }

--- a/crates/lex-bytecode/Cargo.toml
+++ b/crates/lex-bytecode/Cargo.toml
@@ -16,8 +16,8 @@ serde_json.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
 sha2.workspace = true
-lex-ast = { path = "../lex-ast", version = "0.9.2" }
-lex-types = { path = "../lex-types", version = "0.9.2" }
+lex-ast = { path = "../lex-ast", version = "0.9.3" }
+lex-types = { path = "../lex-types", version = "0.9.3" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.9.2" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.3" }

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -1030,8 +1030,8 @@ impl<'a> Vm<'a> {
                         // VM access to invoke `Value::Closure` values
                         // from `Map` / `AndThen` nodes.
                         None if (kind.as_str(), op_name.as_str()) == ("parser", "run")
-                            => self.run_parser_op(args.clone()),
-                        None => self.handler.dispatch(&kind, &op_name, args.clone()),
+                            => self.run_parser_op(args),
+                        None => self.handler.dispatch(&kind, &op_name, args),
                     };
                     match result {
                         Ok(v) => {

--- a/crates/lex-lsp/Cargo.toml
+++ b/crates/lex-lsp/Cargo.toml
@@ -25,12 +25,12 @@ serde_json.workspace = true
 # are rust-analyzer-team-maintained.
 lsp-server = "0.7"
 lsp-types = "0.97"
-lex-syntax = { path = "../lex-syntax", version = "0.9.2" }
-lex-ast = { path = "../lex-ast", version = "0.9.2" }
-lex-types = { path = "../lex-types", version = "0.9.2" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.3" }
+lex-ast = { path = "../lex-ast", version = "0.9.3" }
+lex-types = { path = "../lex-types", version = "0.9.3" }
 # Phase 4 of #304: surface RepairHint attestations from the store.
-lex-vcs = { path = "../lex-vcs", version = "0.9.2" }
-lex-store = { path = "../lex-store", version = "0.9.2" }
+lex-vcs = { path = "../lex-vcs", version = "0.9.3" }
+lex-store = { path = "../lex-store", version = "0.9.3" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -47,10 +47,10 @@ serde_yaml = "0.9"
 csv = "1"
 rusqlite = { version = "0.39", features = ["bundled"] }
 postgres = "0.19"
-lex-bytecode = { path = "../lex-bytecode", version = "0.9.2" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.9.3" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.9.2" }
-lex-ast = { path = "../lex-ast", version = "0.9.2" }
-lex-types = { path = "../lex-types", version = "0.9.2" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.3" }
+lex-ast = { path = "../lex-ast", version = "0.9.3" }
+lex-types = { path = "../lex-types", version = "0.9.3" }
 tempfile = "3"

--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -6,24 +6,53 @@ use lex_bytecode::{MapKey, Value};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::{Mutex, OnceLock};
 
+/// Returns `true` if `(kind, op)` will be handled by the pure-builtin
+/// path (no side effects, no policy gate needed). Used by the effect
+/// handler to decide whether to consume `args` by value.
+pub fn is_pure_call(kind: &str, op: &str) -> bool {
+    if !is_pure_module(kind) { return false; }
+    !matches!(
+        (kind, op),
+        ("crypto", "random")
+        | ("crypto", "random_str_hex")
+        | ("datetime", "now")
+        | ("http", "send")
+        | ("http", "get")
+        | ("http", "post")
+    )
+}
+
+/// Dispatch a pure-builtin call with owned args (no clone of arg values).
+/// Callers must first verify `is_pure_call(kind, op)` to ensure args
+/// ownership is only transferred for known-pure ops.
+///
+/// `list.cons` is handled here with move semantics so the tail `Vec<Value>`
+/// is extended without cloning each element (#405).
+pub fn call_pure_builtin(kind: &str, op: &str, args: Vec<Value>) -> Result<Value, String> {
+    if (kind, op) == ("list", "cons") {
+        let mut it = args.into_iter();
+        let head = it.next().unwrap_or(Value::Unit);
+        let tail = match it.next() {
+            Some(Value::List(v)) => v,
+            Some(other) => return Err(format!("list.cons: expected List, got {other:?}")),
+            None => vec![],
+        };
+        let mut out = Vec::with_capacity(1 + tail.len());
+        out.push(head);
+        out.extend(tail);
+        return Ok(Value::List(out));
+    }
+    dispatch(kind, op, &args)
+}
+
 /// Returns Some(...) if `(kind, op)` names a known pure builtin.
 /// `None` means "not handled here; fall through to effect dispatch".
+///
+/// Prefer `is_pure_call` + `call_pure_builtin` in hot paths — this
+/// variant takes `&[Value]` and must clone args for operations like
+/// `list.cons`; kept for external callers that already hold a slice.
 pub fn try_pure_builtin(kind: &str, op: &str, args: &[Value]) -> Option<Result<Value, String>> {
-    if !is_pure_module(kind) { return None; }
-    // `crypto.random` and `crypto.random_str_hex` (#382) are the
-    // effectful ops in an otherwise-pure module; let the handler
-    // dispatch them under the `[random]` effect kind instead of the
-    // pure-builtin bypass.
-    if (kind, op) == ("crypto", "random") { return None; }
-    if (kind, op) == ("crypto", "random_str_hex") { return None; }
-    // Same shape: `datetime.now` is the only effectful op in
-    // `std.datetime` (all the parse/format/arithmetic ops are pure).
-    if (kind, op) == ("datetime", "now") { return None; }
-    // `std.http` is mostly pure (builders + decoders); only the
-    // wire ops `send`/`get`/`post` need the [net] effect handler.
-    if (kind, "send") == (kind, op) && kind == "http" { return None; }
-    if (kind, "get")  == (kind, op) && kind == "http" { return None; }
-    if (kind, "post") == (kind, op) && kind == "http" { return None; }
+    if !is_pure_call(kind, op) { return None; }
     Some(dispatch(kind, op, args))
 }
 

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -12,7 +12,7 @@ use std::sync::{Mutex, OnceLock};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::builtins::try_pure_builtin;
+use crate::builtins::{call_pure_builtin, is_pure_call};
 use crate::policy::Policy;
 
 /// Output sink used by `io.print`. Tests inject a buffer; production prints
@@ -643,8 +643,8 @@ impl EffectHandler for DefaultHandler {
         // Pure stdlib builtins (str, list, json, ...) bypass the policy
         // gate — they have no observable side effects and aren't tracked
         // by the type system as effects.
-        if let Some(r) = try_pure_builtin(kind, op, &args) {
-            return r;
+        if is_pure_call(kind, op) {
+            return call_pure_builtin(kind, op, args);
         }
         // `std.fs` ops use the fine-grained `[fs_walk]` and `[fs_write]`
         // effect kinds (distinct from the module name `fs`); the

--- a/crates/lex-runtime/src/lib.rs
+++ b/crates/lex-runtime/src/lib.rs
@@ -21,6 +21,6 @@ pub mod ws;
 pub mod mcp_client;
 pub mod llm;
 
-pub use builtins::{is_pure_module, try_pure_builtin};
+pub use builtins::{call_pure_builtin, is_pure_call, is_pure_module, try_pure_builtin};
 pub use handler::{CapturedSink, DefaultHandler, IoSink, StdoutSink};
 pub use policy::{check_program, Policy, PolicyReport, PolicyViolation};

--- a/crates/lex-search/Cargo.toml
+++ b/crates/lex-search/Cargo.toml
@@ -17,10 +17,10 @@ thiserror.workspace = true
 sha2.workspace = true
 hex.workspace = true
 ureq = { version = "3.3", default-features = false, features = ["rustls", "platform-verifier", "json"] }
-lex-ast = { path = "../lex-ast", version = "0.9.2" }
-lex-store = { path = "../lex-store", version = "0.9.2" }
+lex-ast = { path = "../lex-ast", version = "0.9.3" }
+lex-store = { path = "../lex-store", version = "0.9.3" }
 
 [dev-dependencies]
 tempfile = "3"
 tiny_http = "0.12"
-lex-syntax = { path = "../lex-syntax", version = "0.9.2" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.3" }

--- a/crates/lex-store/Cargo.toml
+++ b/crates/lex-store/Cargo.toml
@@ -21,11 +21,11 @@ hex.workspace = true
 # transitive dep via tempfile; promoting to direct so the lock
 # call sites compile.
 fs2 = "0.4"
-lex-ast = { path = "../lex-ast", version = "0.9.2" }
-lex-trace = { path = "../lex-trace", version = "0.9.2" }
-lex-types = { path = "../lex-types", version = "0.9.2" }
-lex-vcs = { path = "../lex-vcs", version = "0.9.2" }
+lex-ast = { path = "../lex-ast", version = "0.9.3" }
+lex-trace = { path = "../lex-trace", version = "0.9.3" }
+lex-types = { path = "../lex-types", version = "0.9.3" }
+lex-vcs = { path = "../lex-vcs", version = "0.9.3" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.9.2" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.3" }
 tempfile = "3"

--- a/crates/lex-trace/Cargo.toml
+++ b/crates/lex-trace/Cargo.toml
@@ -16,9 +16,9 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-bytecode = { path = "../lex-bytecode", version = "0.9.2" }
-lex-ast = { path = "../lex-ast", version = "0.9.2" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.9.3" }
+lex-ast = { path = "../lex-ast", version = "0.9.3" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.9.2" }
-lex-runtime = { path = "../lex-runtime", version = "0.9.2" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.3" }
+lex-runtime = { path = "../lex-runtime", version = "0.9.3" }

--- a/crates/lex-types/Cargo.toml
+++ b/crates/lex-types/Cargo.toml
@@ -15,7 +15,7 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-ast = { path = "../lex-ast", version = "0.9.2" }
+lex-ast = { path = "../lex-ast", version = "0.9.3" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.9.2" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.3" }

--- a/crates/lex-vcs/Cargo.toml
+++ b/crates/lex-vcs/Cargo.toml
@@ -11,8 +11,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-lex-ast = { path = "../lex-ast", version = "0.9.2" }
-lex-types = { path = "../lex-types", version = "0.9.2" }
+lex-ast = { path = "../lex-ast", version = "0.9.3" }
+lex-types = { path = "../lex-types", version = "0.9.3" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
@@ -24,4 +24,4 @@ hex.workspace = true
 
 [dev-dependencies]
 tempfile = "3"
-lex-syntax = { path = "../lex-syntax", version = "0.9.2" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.3" }

--- a/crates/spec-checker/Cargo.toml
+++ b/crates/spec-checker/Cargo.toml
@@ -16,11 +16,11 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-syntax = { path = "../lex-syntax", version = "0.9.2" }
-lex-ast = { path = "../lex-ast", version = "0.9.2" }
-lex-types = { path = "../lex-types", version = "0.9.2" }
-lex-bytecode = { path = "../lex-bytecode", version = "0.9.2" }
-lex-runtime = { path = "../lex-runtime", version = "0.9.2" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.3" }
+lex-ast = { path = "../lex-ast", version = "0.9.3" }
+lex-types = { path = "../lex-types", version = "0.9.3" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.9.3" }
+lex-runtime = { path = "../lex-runtime", version = "0.9.3" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.9.2" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.3" }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Workspace version bumped `0.9.2` → `0.9.3` in root `Cargo.toml` and all crate cross-dependency version strings
- `CHANGELOG.md`: promoted `[Unreleased]` → `[0.9.3] — 2026-05-14`; empty `[Unreleased]` section added for future entries

## Included in this release

- **#388** `net.serve` / `net.serve_fn` — replaced `tiny_http` with hyper 1.x + tokio (5–8× throughput lift)
- **#389 slice 1** — VM dispatch: eliminate per-instruction `Op` clone (zero heap allocations in hot path)
- **#399** `Policy::permissive()` missing stdlib effect kinds fix + `lex test --allow-effects` flag
- **#390** `net.dial_ws` — WebSocket client primitive

## Test plan

- [ ] `cargo build --workspace` passes
- [ ] `cargo test --workspace` passes
- [ ] CHANGELOG entry date and version are correct (2026-05-14, 0.9.3)
- [ ] No remaining `0.9.2` version strings in any `Cargo.toml`
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01APBE4mmqZgBEsaB4pqDZ74)_