### PR TITLE
fix(#405): list.cons O(n²) → O(n) via VecDeque backing store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+### Performance
+
+- **#405: `list.cons` — O(n²) → O(n) for accumulation loops.** Changed
+  `Value::List` backing store from `Vec<Value>` to `VecDeque<Value>`.
+  `list.cons` now uses `VecDeque::push_front` (O(1) amortized) instead of
+  Vec element-shifting (O(n)). Programs that build lists by prepending in
+  a loop — e.g. CSV parsing, group-by aggregation, recursive folds — drop
+  from O(n²) to O(n). All other list operations (`list.append`, indexing,
+  iteration, `list.sort`) are unchanged in complexity; `list.sort`
+  round-trips through a temporary Vec for the sort step.
+
 ## [0.9.3] — 2026-05-14
 
 ### Performance

--- a/crates/core-compiler/tests/m9_phase2.rs
+++ b/crates/core-compiler/tests/m9_phase2.rs
@@ -265,8 +265,8 @@ fn native_matmul_perf_256() {
 #[test]
 fn native_dot_works() {
     let registry = NativeRegistry::with_defaults();
-    let a = Value::List(vec![Value::Float(1.0), Value::Float(2.0), Value::Float(3.0)]);
-    let b = Value::List(vec![Value::Float(4.0), Value::Float(5.0), Value::Float(6.0)]);
+    let a = Value::List(vec![Value::Float(1.0), Value::Float(2.0), Value::Float(3.0)].into());
+    let b = Value::List(vec![Value::Float(4.0), Value::Float(5.0), Value::Float(6.0)].into());
     let r = registry.dispatch("dot", &[a, b]).unwrap().unwrap();
     assert_eq!(r, Value::Float(32.0));
 }

--- a/crates/lex-bytecode/src/parser_runtime.rs
+++ b/crates/lex-bytecode/src/parser_runtime.rs
@@ -127,7 +127,7 @@ pub fn run_parser(
                     _ => break,
                 }
             }
-            Ok((Value::List(out), cur))
+            Ok((Value::List(out.into()), cur))
         }
         "Optional" => {
             let p = rec.get("p").ok_or((pos, "optional: missing p".to_string()))?;

--- a/crates/lex-bytecode/src/value.rs
+++ b/crates/lex-bytecode/src/value.rs
@@ -12,7 +12,7 @@ pub enum Value {
     Str(String),
     Bytes(Vec<u8>),
     Unit,
-    List(Vec<Value>),
+    List(VecDeque<Value>),
     Tuple(Vec<Value>),
     Record(IndexMap<String, Value>),
     Variant { name: String, args: Vec<Value> },
@@ -248,7 +248,7 @@ impl Value {
                 else { Value::Unit }
             }
             J::String(s) => Value::Str(s.clone()),
-            J::Array(items) => Value::List(items.iter().map(Value::from_json).collect()),
+            J::Array(items) => Value::List(items.iter().map(Value::from_json).collect::<VecDeque<_>>()),
             J::Object(map) => {
                 if let (Some(J::String(name)), Some(J::Array(args))) =
                     (map.get("$variant"), map.get("args"))

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -4,6 +4,7 @@ use crate::op::*;
 use crate::program::*;
 use crate::value::Value;
 use indexmap::IndexMap;
+use std::collections::VecDeque;
 
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum VmError {
@@ -639,7 +640,7 @@ impl<'a> Vm<'a> {
                 Op::MakeList(n) => {
                     let mut items: Vec<Value> = (0..n).map(|_| Value::Unit).collect();
                     for i in (0..n as usize).rev() { items[i] = self.pop()?; }
-                    self.stack.push(Value::List(items));
+                    self.stack.push(Value::List(items.into()));
                 }
                 Op::MakeVariant { name_idx, arity } => {
                     let mut args: Vec<Value> = (0..arity).map(|_| Value::Unit).collect();
@@ -751,7 +752,7 @@ impl<'a> Vm<'a> {
                     let list = self.pop()?;
                     match list {
                         Value::List(mut items) => {
-                            items.push(value);
+                            items.push_back(value);
                             self.stack.push(Value::List(items));
                         }
                         other => return Err(VmError::TypeMismatch(format!("ListAppend on non-list: {other:?}"))),
@@ -840,7 +841,7 @@ impl<'a> Vm<'a> {
                         keyed.push((key, item));
                     }
                     keyed.sort_by(|(ka, _), (kb, _)| compare_sort_keys(ka, kb));
-                    let sorted: Vec<Value> = keyed.into_iter().map(|(_, v)| v).collect();
+                    let sorted: VecDeque<Value> = keyed.into_iter().map(|(_, v)| v).collect();
                     self.stack.push(Value::List(sorted));
                 }
                 Op::ParallelMap { node_id_idx: _ } => {
@@ -881,8 +882,8 @@ impl<'a> Vm<'a> {
                                 .unwrap_or_else(|| Box::new(DenyAllEffects)),
                         );
                     }
-                    let results = par_map_run(self.program, f, items, worker_handlers)?;
-                    self.stack.push(Value::List(results));
+                    let results = par_map_run(self.program, f, items.into_iter().collect(), worker_handlers)?;
+                    self.stack.push(Value::List(results.into()));
                 }
                 Op::Call { fn_id, arity, node_id_idx } => {
                     let mut args: Vec<Value> = (0..arity).map(|_| Value::Unit).collect();

--- a/crates/lex-bytecode/tests/from_json.rs
+++ b/crates/lex-bytecode/tests/from_json.rs
@@ -125,7 +125,7 @@ fn list_round_trip() {
         Value::Int(1),
         Value::Int(2),
         Value::Int(3),
-    ]));
+    ].into()));
 }
 
 #[test]
@@ -139,7 +139,7 @@ fn list_of_variants_round_trips() {
             name: "Green".into(),
             args: vec![],
         },
-    ]));
+    ].into()));
 }
 
 #[test]

--- a/crates/lex-bytecode/tests/issue_339_lambda_capture.rs
+++ b/crates/lex-bytecode/tests/issue_339_lambda_capture.rs
@@ -98,6 +98,6 @@ fn run_it() -> List[Int] {
 "#;
     assert_eq!(
         run(src, "run_it", vec![]),
-        Value::List(vec![Value::Int(2), Value::Int(4), Value::Int(6)]),
+        Value::List(vec![Value::Int(2), Value::Int(4), Value::Int(6)].into()),
     );
 }

--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -32,15 +32,13 @@ pub fn call_pure_builtin(kind: &str, op: &str, args: Vec<Value>) -> Result<Value
     if (kind, op) == ("list", "cons") {
         let mut it = args.into_iter();
         let head = it.next().unwrap_or(Value::Unit);
-        let tail = match it.next() {
+        let mut tail = match it.next() {
             Some(Value::List(v)) => v,
             Some(other) => return Err(format!("list.cons: expected List, got {other:?}")),
-            None => vec![],
+            None => std::collections::VecDeque::new(),
         };
-        let mut out = Vec::with_capacity(1 + tail.len());
-        out.push(head);
-        out.extend(tail);
-        return Ok(Value::List(out));
+        tail.push_front(head);
+        return Ok(Value::List(tail));
     }
     dispatch(kind, op, &args)
 }
@@ -86,7 +84,7 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
         ("str", "split") => {
             let s = expect_str(args.first())?;
             let sep = expect_str(args.get(1))?;
-            let items: Vec<Value> = if sep.is_empty() {
+            let items: std::collections::VecDeque<Value> = if sep.is_empty() {
                 s.chars().map(|c| Value::Str(c.to_string())).collect()
             } else {
                 s.split(sep.as_str()).map(|p| Value::Str(p.to_string())).collect()
@@ -190,20 +188,20 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
         ("list", "is_empty") => Ok(Value::Bool(expect_list(args.first())?.is_empty())),
         ("list", "head") => {
             let xs = expect_list(args.first())?;
-            match xs.first() {
+            match xs.front() {
                 Some(v) => Ok(some(v.clone())),
                 None => Ok(none()),
             }
         }
         ("list", "tail") => {
             let xs = expect_list(args.first())?;
-            if xs.is_empty() { Ok(Value::List(Vec::new())) }
-            else { Ok(Value::List(xs[1..].to_vec())) }
+            if xs.is_empty() { Ok(Value::List(std::collections::VecDeque::new())) }
+            else { Ok(Value::List(xs.iter().skip(1).cloned().collect::<std::collections::VecDeque<_>>())) }
         }
         ("list", "range") => {
             let lo = expect_int(args.first())?;
             let hi = expect_int(args.get(1))?;
-            Ok(Value::List((lo..hi).map(Value::Int).collect()))
+            Ok(Value::List((lo..hi).map(Value::Int).collect::<std::collections::VecDeque<_>>()))
         }
         ("list", "concat") => {
             let mut out = expect_list(args.first())?.clone();
@@ -211,22 +209,25 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             Ok(Value::List(out))
         }
         ("list", "reverse") => {
-            let mut out = expect_list(args.first())?.clone();
-            out.reverse();
-            Ok(Value::List(out))
+            let out = expect_list(args.first())?.clone();
+            let rev: std::collections::VecDeque<Value> = out.into_iter().rev().collect();
+            Ok(Value::List(rev))
         }
         // #334: cons — prepend a single element to a list.
+        // (fast path via call_pure_builtin; this branch handles the
+        // borrow-based dispatch path which must clone)
         ("list", "cons") => {
             let head = args.first().cloned().unwrap_or(Value::Unit);
-            let mut out = vec![head];
-            out.extend(expect_list(args.get(1))?.iter().cloned());
+            let mut out: std::collections::VecDeque<Value> =
+                expect_list(args.get(1))?.iter().cloned().collect();
+            out.push_front(head);
             Ok(Value::List(out))
         }
         ("list", "enumerate") => {
             let xs = expect_list(args.first())?;
             let pairs = xs.iter().cloned().enumerate()
                 .map(|(i, v)| Value::Tuple(vec![Value::Int(i as i64), v]))
-                .collect::<Vec<_>>();
+                .collect::<std::collections::VecDeque<_>>();
             Ok(Value::List(pairs))
         }
 
@@ -506,14 +507,14 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
                 .has_headers(false)
                 .flexible(true)
                 .from_reader(s.as_bytes());
-            let mut rows: Vec<Value> = Vec::new();
+            let mut rows: std::collections::VecDeque<Value> = std::collections::VecDeque::new();
             for r in rdr.records() {
                 match r {
                     Ok(rec) => {
-                        let row: Vec<Value> = rec.iter()
+                        let row: std::collections::VecDeque<Value> = rec.iter()
                             .map(|f| Value::Str(f.to_string()))
                             .collect();
-                        rows.push(Value::List(row));
+                        rows.push_back(Value::List(row));
                     }
                     Err(e) => return Ok(err_v(Value::Str(format!("csv.parse: {e}")))),
                 }
@@ -1348,7 +1349,7 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             let pat = expect_str(args.first())?;
             let s = expect_str(args.get(1))?;
             let re = get_or_compile_regex(&pat).map_err(|e| format!("regex.find_all: {e}"))?;
-            let items: Vec<Value> = re.captures_iter(&s).map(|caps| match_value(&caps)).collect();
+            let items: std::collections::VecDeque<Value> = re.captures_iter(&s).map(|caps| match_value(&caps)).collect();
             Ok(Value::List(items))
         }
         ("regex", "replace") => {
@@ -1468,7 +1469,7 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             let pat = expect_str(args.first())?;
             let s = expect_str(args.get(1))?;
             let re = get_or_compile_regex(&pat).map_err(|e| format!("regex.split: {e}"))?;
-            let parts: Vec<Value> = re.split(&s).map(|p| Value::Str(p.to_string())).collect();
+            let parts: std::collections::VecDeque<Value> = re.split(&s).map(|p| Value::Str(p.to_string())).collect();
             Ok(Value::List(parts))
         }
 
@@ -1645,7 +1646,7 @@ fn match_value(caps: &regex::Captures) -> Value {
     rec.insert("text".into(), Value::Str(m0.as_str().to_string()));
     rec.insert("start".into(), Value::Int(m0.start() as i64));
     rec.insert("end".into(), Value::Int(m0.end() as i64));
-    let groups: Vec<Value> = (1..caps.len())
+    let groups: std::collections::VecDeque<Value> = (1..caps.len())
         .map(|i| {
             Value::Str(
                 caps.get(i)
@@ -1755,7 +1756,7 @@ fn expect_float(v: Option<&Value>) -> Result<f64, String> {
     }
 }
 
-fn expect_list(v: Option<&Value>) -> Result<&Vec<Value>, String> {
+fn expect_list(v: Option<&Value>) -> Result<&std::collections::VecDeque<Value>, String> {
     match v {
         Some(Value::List(xs)) => Ok(xs),
         Some(other) => Err(format!("expected List, got {other:?}")),

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -459,7 +459,7 @@ impl DefaultHandler {
                                 Err(e) => return Ok(err(Value::Str(format!("fs.list_dir: {e}")))),
                             }
                         }
-                        Ok(ok(Value::List(entries)))
+                        Ok(ok(Value::List(entries.into())))
                     }
                     Err(e) => Ok(err(Value::Str(format!("fs.list_dir `{path}`: {e}")))),
                 }
@@ -477,7 +477,7 @@ impl DefaultHandler {
                         Err(e) => return Ok(err(Value::Str(format!("fs.walk: {e}")))),
                     }
                 }
-                Ok(ok(Value::List(paths)))
+                Ok(ok(Value::List(paths.into())))
             }
             "glob" => {
                 let pattern = expect_str(args.first())?.to_string();
@@ -503,7 +503,7 @@ impl DefaultHandler {
                         Err(e) => return Ok(err(Value::Str(format!("fs.glob: {e}")))),
                     }
                 }
-                Ok(ok(Value::List(paths)))
+                Ok(ok(Value::List(paths.into())))
             }
             "mkdir_p" => {
                 let path = expect_str(args.first())?.to_string();
@@ -1135,7 +1135,7 @@ impl EffectHandler for DefaultHandler {
                     let s = String::from_utf8_lossy(&k).to_string();
                     keys.push(Value::Str(s));
                 }
-                Ok(Value::List(keys))
+                Ok(Value::List(keys.into()))
             }
             ("sql", "open") => {
                 let path = expect_str(args.first())?.to_string();
@@ -2475,21 +2475,21 @@ impl DefaultHandler {
     fn dispatch_stream_collect(&mut self, args: Vec<Value>) -> Value {
         let handle = match args.first().and_then(stream_handle_id) {
             Some(h) => h,
-            None => return Value::List(Vec::new()),
+            None => return Value::List(std::collections::VecDeque::new()),
         };
         let mut iter = {
             let mut streams = match self.streams.lock() {
                 Ok(g) => g,
-                Err(_) => return Value::List(Vec::new()),
+                Err(_) => return Value::List(std::collections::VecDeque::new()),
             };
             match streams.remove(&handle) {
                 Some(it) => it,
-                None => return Value::List(Vec::new()),
+                None => return Value::List(std::collections::VecDeque::new()),
             }
         };
-        let mut out: Vec<Value> = Vec::new();
+        let mut out: std::collections::VecDeque<Value> = std::collections::VecDeque::new();
         for chunk in iter.by_ref() {
-            out.push(Value::Str(chunk));
+            out.push_back(Value::Str(chunk));
         }
         Value::List(out)
     }
@@ -2713,7 +2713,7 @@ fn sql_run_query_sqlite(
         }
         out.push(Value::Record(rec));
     }
-    ok(Value::List(out))
+    ok(Value::List(out.into()))
 }
 
 /// Run a statement on Postgres and pack rows into `Value::List(Value::Record(...))`.
@@ -2729,7 +2729,7 @@ fn sql_run_query_pg(
         Ok(r)  => r,
         Err(e) => return err(pg_err_to_sql_error(e, "sql.query")),
     };
-    let out: Vec<Value> = rows.iter().map(|row| {
+    let out: std::collections::VecDeque<Value> = rows.iter().map(|row| {
         Value::Record(pg_row_to_lex_record(row))
     }).collect();
     ok(Value::List(out))

--- a/crates/lex-runtime/tests/closed_pydantic_issues.rs
+++ b/crates/lex-runtime/tests/closed_pydantic_issues.rs
@@ -108,7 +108,7 @@ fn r(xs :: List[Str]) -> List[(Int, Str)] { list.enumerate(xs) }
         Value::Str("a".into()),
         Value::Str("b".into()),
         Value::Str("c".into()),
-    ]);
+    ].into());
     let out = run(src, "r", vec![xs]);
     let Value::List(items) = out else { panic!() };
     assert_eq!(items.len(), 3);
@@ -231,7 +231,7 @@ fn count(xs :: List[Int]) -> Int {
   list.fold(xs, 0, fn(acc :: Int, _ :: Int) -> Int { acc + 1 })
 }
 "#;
-    let xs = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)]);
+    let xs = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)].into());
     assert_eq!(run(src, "count", vec![xs]), Value::Int(3));
 }
 
@@ -245,8 +245,8 @@ fn nest(xs :: List[Int], ys :: List[Int]) -> Int {
   })
 }
 "#;
-    let xs = Value::List(vec![Value::Int(0), Value::Int(0)]);
-    let ys = Value::List(vec![Value::Int(0), Value::Int(0), Value::Int(0)]);
+    let xs = Value::List(vec![Value::Int(0), Value::Int(0)].into());
+    let ys = Value::List(vec![Value::Int(0), Value::Int(0), Value::Int(0)].into());
     assert_eq!(run(src, "nest", vec![xs, ys]), Value::Int(6));
 }
 
@@ -374,10 +374,10 @@ fn issue_334_list_reverse_inverts_order() {
 import "std.list" as list
 fn r(xs :: List[Int]) -> List[Int] { list.reverse(xs) }
 "#;
-    let xs = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)]);
+    let xs = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)].into());
     assert_eq!(
         run(src, "r", vec![xs]),
-        Value::List(vec![Value::Int(3), Value::Int(2), Value::Int(1)]),
+        Value::List(vec![Value::Int(3), Value::Int(2), Value::Int(1)].into()),
     );
 }
 

--- a/crates/lex-runtime/tests/effect_polymorphism.rs
+++ b/crates/lex-runtime/tests/effect_polymorphism.rs
@@ -76,8 +76,8 @@ fn doubled(xs :: List[Int]) -> List[Int] {
 }
 "#;
     let r = run(src, "doubled",
-        vec![Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)])]);
-    assert_eq!(r, Value::List(vec![Value::Int(2), Value::Int(4), Value::Int(6)]));
+        vec![Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)].into())]);
+    assert_eq!(r, Value::List(vec![Value::Int(2), Value::Int(4), Value::Int(6)].into()));
 }
 
 // -- list.filter --------------------------------------------------
@@ -168,6 +168,6 @@ fn midpoints(xs :: List[Int]) -> [rand] List[Int] {
 "#;
     // rand.int_in(0, 10) → 5; rand.int_in(0, 100) → 50; rand.int_in(0, 6) → 3
     let r = run(src, "midpoints",
-        vec![Value::List(vec![Value::Int(10), Value::Int(100), Value::Int(6)])]);
-    assert_eq!(r, Value::List(vec![Value::Int(5), Value::Int(50), Value::Int(3)]));
+        vec![Value::List(vec![Value::Int(10), Value::Int(100), Value::Int(6)].into())]);
+    assert_eq!(r, Value::List(vec![Value::Int(5), Value::Int(50), Value::Int(3)].into()));
 }

--- a/crates/lex-runtime/tests/issue_345.rs
+++ b/crates/lex-runtime/tests/issue_345.rs
@@ -47,11 +47,11 @@ fn flatten(parts :: List[Errors]) -> Errors {
         "code".into() => Value::Str("e2".into())
     });
     let parts = Value::List(vec![
-        Value::List(vec![e1.clone()]),
-        Value::List(vec![e2.clone()]),
-    ]);
+        Value::List(vec![e1.clone()].into()),
+        Value::List(vec![e2.clone()].into()),
+    ].into());
     let result = run_one(src, "flatten", vec![parts]);
-    assert_eq!(result, Value::List(vec![e1, e2]));
+    assert_eq!(result, Value::List(vec![e1, e2].into()));
 }
 
 #[test]
@@ -65,11 +65,11 @@ fn names(xs :: List[Str]) -> List[Name] {
 }
 "#;
     let result = run_one(src, "names", vec![
-        Value::List(vec![Value::Str("alice".into()), Value::Str("bob".into())])
+        Value::List(vec![Value::Str("alice".into()), Value::Str("bob".into())].into())
     ]);
     assert_eq!(result, Value::List(vec![
         Value::Str("alice".into()), Value::Str("bob".into())
-    ]));
+    ].into()));
 }
 
 #[test]
@@ -82,9 +82,9 @@ fn high(scores :: List[Score]) -> List[Score] {
 }
 "#;
     let result = run_one(src, "high", vec![
-        Value::List(vec![Value::Int(30), Value::Int(70), Value::Int(90)])
+        Value::List(vec![Value::Int(30), Value::Int(70), Value::Int(90)].into())
     ]);
-    assert_eq!(result, Value::List(vec![Value::Int(70), Value::Int(90)]));
+    assert_eq!(result, Value::List(vec![Value::Int(70), Value::Int(90)].into()));
 }
 
 #[test]

--- a/crates/lex-runtime/tests/issues_331_332_334.rs
+++ b/crates/lex-runtime/tests/issues_331_332_334.rs
@@ -56,8 +56,8 @@ import "std.list" as list
 fn f(x :: Int, xs :: List[Int]) -> List[Int] { list.cons(x, xs) }
 "#;
     assert_eq!(
-        run_one(src, "f", vec![Value::Int(1), Value::List(vec![Value::Int(2), Value::Int(3)])]),
-        Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)])
+        run_one(src, "f", vec![Value::Int(1), Value::List(vec![Value::Int(2), Value::Int(3)].into())]),
+        Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)].into())
     );
 }
 
@@ -69,7 +69,7 @@ fn f(x :: Int) -> List[Int] { list.cons(x, []) }
 "#;
     assert_eq!(
         run_one(src, "f", vec![Value::Int(42)]),
-        Value::List(vec![Value::Int(42)])
+        Value::List(vec![Value::Int(42)].into())
     );
 }
 
@@ -86,7 +86,7 @@ fn build_rev(n :: Int, acc :: List[Int]) -> List[Int] {
     // cons(4,[]) → cons(3,[4]) → cons(2,[3,4]) → cons(1,[2,3,4]) → reverse → [4,3,2,1]
     assert_eq!(
         run_one(src, "build", vec![Value::Int(4)]),
-        Value::List(vec![Value::Int(4), Value::Int(3), Value::Int(2), Value::Int(1)])
+        Value::List(vec![Value::Int(4), Value::Int(3), Value::Int(2), Value::Int(1)].into())
     );
 }
 

--- a/crates/lex-runtime/tests/iter_lazy.rs
+++ b/crates/lex-runtime/tests/iter_lazy.rs
@@ -105,7 +105,7 @@ fn unfold_empty() -> List[Int] {
 
 #[test]
 fn from_list_and_to_list_roundtrip() {
-    let xs = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)]);
+    let xs = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)].into());
     let got = run(SRC, "from_list_to_list", vec![xs.clone()]);
     assert_eq!(got, xs);
 }
@@ -118,70 +118,70 @@ fn next_on_empty_iter_is_none() {
 
 #[test]
 fn next_returns_first_element() {
-    let xs = Value::List(vec![Value::Int(10), Value::Int(20)]);
+    let xs = Value::List(vec![Value::Int(10), Value::Int(20)].into());
     let got = run(SRC, "next_first_elem", vec![xs]);
     assert_eq!(got, Value::Variant { name: "Some".into(), args: vec![Value::Int(10)] });
 }
 
 #[test]
 fn take_limits_to_n_elements() {
-    let xs = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3), Value::Int(4)]);
+    let xs = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3), Value::Int(4)].into());
     let got = run(SRC, "take_two", vec![xs]);
-    assert_eq!(got, Value::List(vec![Value::Int(1), Value::Int(2)]));
+    assert_eq!(got, Value::List(vec![Value::Int(1), Value::Int(2)].into()));
 }
 
 #[test]
 fn take_beyond_length_returns_all() {
-    let xs = Value::List(vec![Value::Int(1), Value::Int(2)]);
+    let xs = Value::List(vec![Value::Int(1), Value::Int(2)].into());
     let got = run(SRC, "take_two", vec![xs.clone()]);
     assert_eq!(got, xs);
 }
 
 #[test]
 fn skip_advances_cursor() {
-    let xs = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3), Value::Int(4)]);
+    let xs = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3), Value::Int(4)].into());
     let got = run(SRC, "skip_two", vec![xs]);
-    assert_eq!(got, Value::List(vec![Value::Int(3), Value::Int(4)]));
+    assert_eq!(got, Value::List(vec![Value::Int(3), Value::Int(4)].into()));
 }
 
 #[test]
 fn skip_beyond_length_gives_empty() {
-    let xs = Value::List(vec![Value::Int(1), Value::Int(2)]);
+    let xs = Value::List(vec![Value::Int(1), Value::Int(2)].into());
     let got = run(SRC, "skip_two", vec![xs]);
-    assert_eq!(got, Value::List(vec![]));
+    assert_eq!(got, Value::List(vec![].into()));
 }
 
 #[test]
 fn is_empty_after_exhaustion() {
-    let xs = Value::List(vec![Value::Int(1), Value::Int(2)]);
+    let xs = Value::List(vec![Value::Int(1), Value::Int(2)].into());
     let got = run(SRC, "is_empty_after_take_all", vec![xs]);
     assert_eq!(got, Value::Bool(true));
 }
 
 #[test]
 fn count_returns_remaining_size() {
-    let xs = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)]);
+    let xs = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)].into());
     let got = run(SRC, "count_remaining", vec![xs]);
     assert_eq!(got, Value::Int(3));
 }
 
 #[test]
 fn map_doubles_elements() {
-    let xs = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)]);
+    let xs = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)].into());
     let got = run(SRC, "map_double", vec![xs]);
-    assert_eq!(got, Value::List(vec![Value::Int(2), Value::Int(4), Value::Int(6)]));
+    assert_eq!(got, Value::List(vec![Value::Int(2), Value::Int(4), Value::Int(6)].into()));
 }
 
 #[test]
 fn filter_keeps_even_numbers() {
-    let xs = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3), Value::Int(4)]);
+    let xs = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3), Value::Int(4)].into());
     let got = run(SRC, "filter_even", vec![xs]);
-    assert_eq!(got, Value::List(vec![Value::Int(2), Value::Int(4)]));
+    assert_eq!(got, Value::List(vec![Value::Int(2), Value::Int(4)].into()));
 }
 
 #[test]
 fn fold_sums_elements() {
-    let xs = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3), Value::Int(4)]);
+    let xs = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3), Value::Int(4)].into());
     let got = run(SRC, "fold_sum", vec![xs]);
     assert_eq!(got, Value::Int(10));
 }
@@ -190,9 +190,9 @@ fn fold_sums_elements() {
 fn chained_skip_and_take() {
     let xs = Value::List(vec![
         Value::Int(1), Value::Int(2), Value::Int(3), Value::Int(4), Value::Int(5),
-    ]);
+    ].into());
     let got = run(SRC, "chained_skip_take", vec![xs]);
-    assert_eq!(got, Value::List(vec![Value::Int(2), Value::Int(3)]));
+    assert_eq!(got, Value::List(vec![Value::Int(2), Value::Int(3)].into()));
 }
 
 // --- #376: iter.unfold ----------------------------------------------
@@ -207,7 +207,7 @@ fn unfold_terminates_when_step_returns_none() {
     );
     assert_eq!(
         got,
-        Value::List(vec![Value::Int(0), Value::Int(1), Value::Int(2), Value::Int(3)])
+        Value::List(vec![Value::Int(0), Value::Int(1), Value::Int(2), Value::Int(3)].into())
     );
 }
 
@@ -218,7 +218,7 @@ fn unfold_zero_range_produces_empty_list() {
         "unfold_range_to_list",
         vec![Value::Int(5), Value::Int(5)],
     );
-    assert_eq!(got, Value::List(vec![]));
+    assert_eq!(got, Value::List(vec![].into()));
 }
 
 #[test]
@@ -228,12 +228,12 @@ fn unfold_next_advances_the_seed() {
     // distinct elements, not the same one. Catches a copy-paste bug
     // where the dispatch loops back on the same seed.
     let got = run(SRC, "unfold_first_two", vec![Value::Int(10)]);
-    assert_eq!(got, Value::List(vec![Value::Int(10), Value::Int(11)]));
+    assert_eq!(got, Value::List(vec![Value::Int(10), Value::Int(11)].into()));
 }
 
 #[test]
 fn unfold_empty_step_yields_empty_list() {
     // A step that returns None on its first call gives an empty iter.
     let got = run(SRC, "unfold_empty", vec![]);
-    assert_eq!(got, Value::List(vec![]));
+    assert_eq!(got, Value::List(vec![].into()));
 }

--- a/crates/lex-runtime/tests/list_higher_order.rs
+++ b/crates/lex-runtime/tests/list_higher_order.rs
@@ -104,7 +104,7 @@ fn join_with_dash(xs :: List[Str]) -> Str {
   list.fold(xs, "", fn (acc :: Str, x :: Str) -> Str { str.concat(acc, x) })
 }
 "#;
-    let xs = Value::List(vec![Value::Str("a".into()), Value::Str("b".into()), Value::Str("c".into())]);
+    let xs = Value::List(vec![Value::Str("a".into()), Value::Str("b".into()), Value::Str("c".into())].into());
     assert_eq!(run(src, "join_with_dash", vec![xs]), Value::Str("abc".into()));
 }
 

--- a/crates/lex-runtime/tests/list_par_map.rs
+++ b/crates/lex-runtime/tests/list_par_map.rs
@@ -45,9 +45,9 @@ fn doubled(xs :: List[Int]) -> List[Int] {
 "#;
     let bc = build(src);
     let xs: Vec<Value> = (0..8).map(Value::Int).collect();
-    let r = run(&bc, "doubled", vec![Value::List(xs)]);
+    let r = run(&bc, "doubled", vec![Value::List(xs.into())]);
     let expected: Vec<Value> = (0..8).map(|i: i64| Value::Int(i * 2)).collect();
-    assert_eq!(r, Value::List(expected));
+    assert_eq!(r, Value::List(expected.into()));
 }
 
 #[test]
@@ -59,8 +59,8 @@ fn run_(xs :: List[Int]) -> List[Int] {
 }
 "#;
     let bc = build(src);
-    let r = run(&bc, "run_", vec![Value::List(vec![])]);
-    assert_eq!(r, Value::List(vec![]));
+    let r = run(&bc, "run_", vec![Value::List(vec![].into())]);
+    assert_eq!(r, Value::List(vec![].into()));
 }
 
 /// Pure CPU spin: count list elements (via `list.fold`, which is
@@ -82,9 +82,9 @@ fn par_spins(buckets :: List[List[Int]]) -> List[Int] {
 fn measure_par_spin(n_workers: usize, items_per_bucket: usize) -> std::time::Duration {
     let bc = build(SPIN_SRC);
     let bucket: Vec<Value> = (0..items_per_bucket as i64).map(Value::Int).collect();
-    let buckets: Vec<Value> = (0..n_workers).map(|_| Value::List(bucket.clone())).collect();
+    let buckets: Vec<Value> = (0..n_workers).map(|_| Value::List(bucket.clone().into())).collect();
     let t0 = std::time::Instant::now();
-    let _ = run(&bc, "par_spins", vec![Value::List(buckets)]);
+    let _ = run(&bc, "par_spins", vec![Value::List(buckets.into())]);
     t0.elapsed()
 }
 
@@ -158,10 +158,10 @@ fn squared(xs :: List[Int]) -> List[Int] {
 "#;
     let bc = build(src);
     let xs: Vec<Value> = (0..16).map(Value::Int).collect();
-    let r = run(&bc, "squared", vec![Value::List(xs)]);
+    let r = run(&bc, "squared", vec![Value::List(xs.into())]);
     std::env::remove_var("LEX_PAR_MAX_CONCURRENCY");
     let expected: Vec<Value> = (0..16).map(|i: i64| Value::Int(i * i)).collect();
-    assert_eq!(r, Value::List(expected));
+    assert_eq!(r, Value::List(expected.into()));
 }
 
 #[test]
@@ -177,10 +177,10 @@ fn run_(xs :: List[Int]) -> List[Int] {
 "#;
     let bc = build(src);
     let xs: Vec<Value> = (0..32).map(Value::Int).collect();
-    let r = run(&bc, "run_", vec![Value::List(xs)]);
+    let r = run(&bc, "run_", vec![Value::List(xs.into())]);
     std::env::remove_var("LEX_PAR_MAX_CONCURRENCY");
     let expected: Vec<Value> = (0..32).map(|i: i64| Value::Int(i + 1000)).collect();
-    assert_eq!(r, Value::List(expected));
+    assert_eq!(r, Value::List(expected.into()));
 }
 
 #[test]
@@ -225,13 +225,13 @@ fn echo_par(xs :: List[Str]) -> [io] List[Unit] {
                 Value::Str("a".into()),
                 Value::Str("b".into()),
                 Value::Str("c".into()),
-            ])],
+            ].into())],
         )
         .expect("effectful par_map runs under DefaultHandler");
     // Result is a list of three Unit values — one per worker call.
     assert_eq!(
         r,
-        Value::List(vec![Value::Unit, Value::Unit, Value::Unit]),
+        Value::List(vec![Value::Unit, Value::Unit, Value::Unit].into()),
         "result list shape: one Unit per input"
     );
 }
@@ -263,7 +263,7 @@ fn par_steps(xs :: List[Int]) -> List[Int] {
     let mut vm = Vm::with_handler(&bc, Box::new(handler));
     let r = vm.call(
         "par_steps",
-        vec![Value::List(vec![Value::Int(0); 4])],
+        vec![Value::List(vec![Value::Int(0); 4].into())],
     );
     assert!(
         r.is_err(),

--- a/crates/lex-runtime/tests/list_sort_by.rs
+++ b/crates/lex-runtime/tests/list_sort_by.rs
@@ -32,14 +32,14 @@ fn r(xs :: List[Int]) -> List[Int] {
     let xs = Value::List(vec![
         Value::Int(3), Value::Int(1), Value::Int(4), Value::Int(1),
         Value::Int(5), Value::Int(9), Value::Int(2), Value::Int(6),
-    ]);
+    ].into());
     let out = run(src, "r", vec![xs]);
     assert_eq!(
         out,
         Value::List(vec![
             Value::Int(1), Value::Int(1), Value::Int(2), Value::Int(3),
             Value::Int(4), Value::Int(5), Value::Int(6), Value::Int(9),
-        ]),
+        ].into()),
     );
 }
 
@@ -51,10 +51,10 @@ fn r(xs :: List[Int]) -> List[Int] {
   list.sort_by(xs, fn(x :: Int) -> Int { 0 - x })
 }
 "#;
-    let xs = Value::List(vec![Value::Int(2), Value::Int(7), Value::Int(1), Value::Int(4)]);
+    let xs = Value::List(vec![Value::Int(2), Value::Int(7), Value::Int(1), Value::Int(4)].into());
     assert_eq!(
         run(src, "r", vec![xs]),
-        Value::List(vec![Value::Int(7), Value::Int(4), Value::Int(2), Value::Int(1)]),
+        Value::List(vec![Value::Int(7), Value::Int(4), Value::Int(2), Value::Int(1)].into()),
     );
 }
 
@@ -70,14 +70,14 @@ fn r(xs :: List[Str]) -> List[Str] {
         Value::Str("banana".into()),
         Value::Str("apple".into()),
         Value::Str("cherry".into()),
-    ]);
+    ].into());
     assert_eq!(
         run(src, "r", vec![xs]),
         Value::List(vec![
             Value::Str("apple".into()),
             Value::Str("banana".into()),
             Value::Str("cherry".into()),
-        ]),
+        ].into()),
     );
 }
 
@@ -97,7 +97,7 @@ fn r(xs :: List[Order]) -> List[Order] {
         fields.insert("qty".into(), Value::Int(qty));
         Value::Record(fields)
     };
-    let xs = Value::List(vec![mk("bob", 5), mk("alice", 2), mk("carl", 3)]);
+    let xs = Value::List(vec![mk("bob", 5), mk("alice", 2), mk("carl", 3)].into());
     let Value::List(out) = run(src, "r", vec![xs]) else { panic!() };
     let qtys: Vec<i64> = out
         .iter()
@@ -131,7 +131,7 @@ fn r(xs :: List[R]) -> List[R] {
     };
     let xs = Value::List(vec![
         mk(1, "a"), mk(2, "b"), mk(1, "c"), mk(2, "d"), mk(1, "e"),
-    ]);
+    ].into());
     let Value::List(out) = run(src, "r", vec![xs]) else { panic!() };
     let tags: Vec<String> = out
         .iter()
@@ -156,10 +156,10 @@ fn r(xs :: List[Int]) -> List[Int] {
   list.sort_by(xs, fn(x :: Int) -> Int { x })
 }
 "#;
-    assert_eq!(run(src, "r", vec![Value::List(vec![])]), Value::List(vec![]));
+    assert_eq!(run(src, "r", vec![Value::List(vec![].into())]), Value::List(vec![].into()));
     assert_eq!(
-        run(src, "r", vec![Value::List(vec![Value::Int(42)])]),
-        Value::List(vec![Value::Int(42)]),
+        run(src, "r", vec![Value::List(vec![Value::Int(42)].into())]),
+        Value::List(vec![Value::Int(42)].into()),
     );
 }
 
@@ -171,9 +171,9 @@ fn r(xs :: List[Float]) -> List[Float] {
   list.sort_by(xs, fn(x :: Float) -> Float { x })
 }
 "#;
-    let xs = Value::List(vec![Value::Float(3.5), Value::Float(1.25), Value::Float(2.75)]);
+    let xs = Value::List(vec![Value::Float(3.5), Value::Float(1.25), Value::Float(2.75)].into());
     assert_eq!(
         run(src, "r", vec![xs]),
-        Value::List(vec![Value::Float(1.25), Value::Float(2.75), Value::Float(3.5)]),
+        Value::List(vec![Value::Float(1.25), Value::Float(2.75), Value::Float(3.5)].into()),
     );
 }

--- a/crates/lex-runtime/tests/m11.rs
+++ b/crates/lex-runtime/tests/m11.rs
@@ -60,7 +60,7 @@ fn list_basics() {
 import "std.list" as list
 fn count(xs :: List[Int]) -> Int { list.len(xs) }
 "#;
-    let xs = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)]);
+    let xs = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)].into());
     assert_eq!(run(src, "count", vec![xs]), Value::Int(3));
 }
 
@@ -71,7 +71,7 @@ import "std.list" as list
 fn r(lo :: Int, hi :: Int) -> List[Int] { list.range(lo, hi) }
 "#;
     let v = run(src, "r", vec![Value::Int(0), Value::Int(3)]);
-    assert_eq!(v, Value::List(vec![Value::Int(0), Value::Int(1), Value::Int(2)]));
+    assert_eq!(v, Value::List(vec![Value::Int(0), Value::Int(1), Value::Int(2)].into()));
 }
 
 #[test]

--- a/crates/lex-runtime/tests/map_set.rs
+++ b/crates/lex-runtime/tests/map_set.rs
@@ -242,7 +242,7 @@ fn keys_in_iter_order() -> List[Str] {
             Value::Str("a".into()),
             Value::Str("m".into()),
             Value::Str("z".into()),
-        ])
+        ].into())
     );
 }
 

--- a/crates/lex-runtime/tests/proc_effect.rs
+++ b/crates/lex-runtime/tests/proc_effect.rs
@@ -62,7 +62,7 @@ fn proc_spawn_runs_echo_and_returns_stdout() {
         vec![Value::List(vec![
             Value::Str("hello".into()),
             Value::Str("world".into()),
-        ])],
+        ].into())],
         policy_with(&["proc"], &["echo"])).expect("run");
     let inner = variant_args(&r, "Ok");
     let rec = unwrap_record(&inner[0]);
@@ -90,7 +90,7 @@ fn proc_spawn_with_empty_allow_proc_is_escape_hatch() {
     // Empty allow_proc list = any binary permitted (escape hatch).
     // Documented in SECURITY.md and in the policy field doc-comment.
     let r = run(SRC, "echo",
-        vec![Value::List(vec![Value::Str("x".into())])],
+        vec![Value::List(vec![Value::Str("x".into())].into())],
         policy_with(&["proc"], &[])).expect("run");
     let inner = variant_args(&r, "Ok");
     let rec = unwrap_record(&inner[0]);
@@ -117,7 +117,7 @@ fn proc_spawn_without_proc_in_allow_effects_is_runtime_rejected() {
     // bypass by not granting the effect kind. The handler errors
     // before running.
     let r = run(SRC, "echo",
-        vec![Value::List(vec![Value::Str("x".into())])],
+        vec![Value::List(vec![Value::Str("x".into())].into())],
         policy_with(&[], &[]));  // proc not granted
     let err = r.expect_err("proc.spawn without --allow-effects proc must error");
     assert!(err.contains("proc"), "err: {err}");

--- a/crates/lex-runtime/tests/sql_query_iter.rs
+++ b/crates/lex-runtime/tests/sql_query_iter.rs
@@ -273,5 +273,5 @@ fn empty_query_yields_empty_drain() {
         Value::Variant { name, args } if name == "Ok" && args.len() == 1 => args.into_iter().next().unwrap(),
         other => panic!("expected Ok([]), got {other:?}"),
     };
-    assert_eq!(names, Value::List(vec![]));
+    assert_eq!(names, Value::List(vec![].into()));
 }

--- a/crates/lex-runtime/tests/std_cli.rs
+++ b/crates/lex-runtime/tests/std_cli.rs
@@ -108,7 +108,7 @@ fn parse_argv(argv :: List[Str]) -> Result[Json, Str] {
   cli.parse(s, argv)
 }
 "#;
-    let v = run(src, "parse_argv", vec![Value::List(vec![])]).unwrap();
+    let v = run(src, "parse_argv", vec![Value::List(vec![].into())]).unwrap();
     let err = match v {
         Value::Variant { name, mut args } if name == "Err" => args.remove(0),
         other => panic!("expected Err, got: {other:?}"),
@@ -219,7 +219,7 @@ fn parse_argv(argv :: List[Str]) -> Result[Json, Str] {
   cli.parse(s, argv)
 }
 "#;
-    let v = run(src, "parse_argv", vec![Value::List(vec![])]).unwrap();
+    let v = run(src, "parse_argv", vec![Value::List(vec![].into())]).unwrap();
     let parsed = match v {
         Value::Variant { name, mut args } if name == "Ok" => args.remove(0).to_json(),
         other => panic!("expected Ok, got: {other:?}"),

--- a/crates/lex-runtime/tests/std_config.rs
+++ b/crates/lex-runtime/tests/std_config.rs
@@ -181,9 +181,9 @@ fn csv_parse_counts_rows() {
 #[test]
 fn csv_stringify_round_trips() {
     let rows = Value::List(vec![
-        Value::List(vec![Value::Str("a".into()), Value::Str("b".into())]),
-        Value::List(vec![Value::Str("1".into()), Value::Str("2".into())]),
-    ]);
+        Value::List(vec![Value::Str("a".into()), Value::Str("b".into())].into()),
+        Value::List(vec![Value::Str("1".into()), Value::Str("2".into())].into()),
+    ].into());
     let v = run(CSV_SRC, "round_trip", vec![rows]);
     match v {
         Value::Variant { name, args } if name == "Ok" => match &args[0] {

--- a/crates/lex-runtime/tests/std_flow_extensions.rs
+++ b/crates/lex-runtime/tests/std_flow_extensions.rs
@@ -34,7 +34,7 @@ fn run3() -> List[Int] {
     let r = run(src, "run3", vec![]);
     assert_eq!(
         r,
-        Value::List(vec![Value::Int(7), Value::Int(11), Value::Int(13)])
+        Value::List(vec![Value::Int(7), Value::Int(11), Value::Int(13)].into())
     );
 }
 
@@ -47,7 +47,7 @@ fn run0() -> List[Int] {
 }
 "#;
     let r = run(src, "run0", vec![]);
-    assert_eq!(r, Value::List(vec![]));
+    assert_eq!(r, Value::List(vec![].into()));
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn run1() -> List[Int] {
 }
 "#;
     let r = run(src, "run1", vec![]);
-    assert_eq!(r, Value::List(vec![Value::Int(42)]));
+    assert_eq!(r, Value::List(vec![Value::Int(42)].into()));
 }
 
 #[test]
@@ -82,7 +82,7 @@ fn run_caps() -> List[Int] {
     let r = run(src, "run_caps", vec![]);
     assert_eq!(
         r,
-        Value::List(vec![Value::Int(11), Value::Int(22), Value::Int(33)])
+        Value::List(vec![Value::Int(11), Value::Int(22), Value::Int(33)].into())
     );
 }
 
@@ -105,6 +105,6 @@ fn run_strs() -> List[Str] {
             Value::Str("alpha".into()),
             Value::Str("beta".into()),
             Value::Str("gamma".into()),
-        ])
+        ].into())
     );
 }

--- a/crates/lex-runtime/tests/std_parse_strict.rs
+++ b/crates/lex-runtime/tests/std_parse_strict.rs
@@ -61,7 +61,7 @@ fn toml_parse_strict_passes_when_all_fields_present() {
     let src = "license = \"EUPL-1.2\"\nversion = \"0.1.0\"\n";
     let v = run(TOML_SRC, "strict", vec![
         Value::Str(src.into()),
-        Value::List(vec![Value::Str("license".into()), Value::Str("version".into())]),
+        Value::List(vec![Value::Str("license".into()), Value::Str("version".into())].into()),
     ]);
     let m = ok(&v);
     // Should be a Record with both fields.
@@ -82,7 +82,7 @@ fn toml_parse_strict_fails_when_required_field_missing() {
     let src = "version = \"0.1.0\"\n";
     let v = run(TOML_SRC, "strict", vec![
         Value::Str(src.into()),
-        Value::List(vec![Value::Str("license".into()), Value::Str("version".into())]),
+        Value::List(vec![Value::Str("license".into()), Value::Str("version".into())].into()),
     ]);
     let detail = err_msg(&v);
     assert!(detail.contains("missing required field"), "got: {detail}");
@@ -94,7 +94,7 @@ fn toml_parse_with_empty_required_degenerates_to_plain_parse() {
     let src = "version = \"0.1.0\"\n";
     let v = run(TOML_SRC, "strict", vec![
         Value::Str(src.into()),
-        Value::List(vec![]),
+        Value::List(vec![].into()),
     ]);
     // Empty required-list ⇒ no validation ⇒ behaves like plain parse.
     let _ = ok(&v);
@@ -129,7 +129,7 @@ fn yaml_parse_strict_fails_on_missing_field() {
     let src = "name: lex\n";
     let v = run(YAML_SRC, "strict", vec![
         Value::Str(src.into()),
-        Value::List(vec![Value::Str("name".into()), Value::Str("version".into())]),
+        Value::List(vec![Value::Str("name".into()), Value::Str("version".into())].into()),
     ]);
     let detail = err_msg(&v);
     assert!(detail.contains("version"), "should name missing field: {detail}");
@@ -140,7 +140,7 @@ fn yaml_parse_strict_passes_when_all_present() {
     let src = "name: lex\nversion: 0.1.0\n";
     let v = run(YAML_SRC, "strict", vec![
         Value::Str(src.into()),
-        Value::List(vec![Value::Str("name".into()), Value::Str("version".into())]),
+        Value::List(vec![Value::Str("name".into()), Value::Str("version".into())].into()),
     ]);
     let _ = ok(&v);
 }
@@ -162,7 +162,7 @@ fn json_parse_strict_fails_on_missing_field() {
     let src = r#"{"url": "https://example.com"}"#;
     let v = run(JSON_SRC, "strict", vec![
         Value::Str(src.into()),
-        Value::List(vec![Value::Str("url".into()), Value::Str("branch".into())]),
+        Value::List(vec![Value::Str("url".into()), Value::Str("branch".into())].into()),
     ]);
     let detail = err_msg(&v);
     assert!(detail.contains("branch"), "should name missing field: {detail}");
@@ -173,7 +173,7 @@ fn json_parse_strict_passes_when_all_present() {
     let src = r#"{"url": "https://example.com", "branch": "main"}"#;
     let v = run(JSON_SRC, "strict", vec![
         Value::Str(src.into()),
-        Value::List(vec![Value::Str("url".into()), Value::Str("branch".into())]),
+        Value::List(vec![Value::Str("url".into()), Value::Str("branch".into())].into()),
     ]);
     let _ = ok(&v);
 }
@@ -185,7 +185,7 @@ fn json_parse_strict_fails_when_top_level_is_not_an_object() {
     let src = "[1, 2, 3]";
     let v = run(JSON_SRC, "strict", vec![
         Value::Str(src.into()),
-        Value::List(vec![Value::Str("url".into())]),
+        Value::List(vec![Value::Str("url".into())].into()),
     ]);
     let _ = err_msg(&v);
 }

--- a/crates/lex-runtime/tests/std_process.rs
+++ b/crates/lex-runtime/tests/std_process.rs
@@ -103,7 +103,7 @@ fn streaming_spawn_and_read_lines() {
         "run_and_count_stdout",
         vec![
             Value::Str("printf".into()),
-            Value::List(vec![Value::Str("a\nb\nc\n".into())]),
+            Value::List(vec![Value::Str("a\nb\nc\n".into())].into()),
         ],
         policy_with_proc(),
     );
@@ -117,7 +117,7 @@ fn first_stdout_line_returns_first_line() {
         "first_stdout_line",
         vec![
             Value::Str("printf".into()),
-            Value::List(vec![Value::Str("alpha\nbeta\ngamma\n".into())]),
+            Value::List(vec![Value::Str("alpha\nbeta\ngamma\n".into())].into()),
         ],
         policy_with_proc(),
     );
@@ -131,7 +131,7 @@ fn run_capture_returns_full_stdout() {
         "run_capture_stdout",
         vec![
             Value::Str("printf".into()),
-            Value::List(vec![Value::Str("hello, world".into())]),
+            Value::List(vec![Value::Str("hello, world".into())].into()),
         ],
         policy_with_proc(),
     );
@@ -144,7 +144,7 @@ fn run_capture_exit_for_failing_command() {
     let v = run_with_policy(
         SRC,
         "run_capture_exit",
-        vec![Value::Str("false".into()), Value::List(vec![])],
+        vec![Value::Str("false".into()), Value::List(std::collections::VecDeque::new())],
         policy_with_proc(),
     );
     assert_eq!(v, Value::Int(1));
@@ -155,7 +155,7 @@ fn run_capture_exit_for_succeeding_command() {
     let v = run_with_policy(
         SRC,
         "run_capture_exit",
-        vec![Value::Str("true".into()), Value::List(vec![])],
+        vec![Value::Str("true".into()), Value::List(std::collections::VecDeque::new())],
         policy_with_proc(),
     );
     assert_eq!(v, Value::Int(0));
@@ -215,7 +215,7 @@ fn drain(h :: ProcessHandle) -> [proc] Int {
     let mut vm = Vm::with_handler(&bc, Box::new(handler));
     let r = vm.call("read_after_wait", vec![
         Value::Str("printf".into()),
-        Value::List(vec![Value::Str("a\n".into())]),
+        Value::List(vec![Value::Str("a\n".into())].into()),
     ]);
     let err = r.expect_err("post-wait read should hit closed-or-unknown");
     let msg = format!("{err:?}");
@@ -232,7 +232,7 @@ fn allow_proc_basename_blocks_unlisted() {
     let v = run_with_policy(
         SRC,
         "run_capture_stdout",
-        vec![Value::Str("printf".into()), Value::List(vec![Value::Str("x".into())])],
+        vec![Value::Str("printf".into()), Value::List(vec![Value::Str("x".into())].into())],
         p,
     );
     // The Err case in the Lex match returns "<run failed>".

--- a/crates/lex-runtime/tests/std_random.rs
+++ b/crates/lex-runtime/tests/std_random.rs
@@ -127,7 +127,7 @@ fn ranged_int_collapses_to_singleton_when_lo_eq_hi() {
 
 #[test]
 fn choose_returns_some_for_nonempty_list() {
-    let xs = Value::List(vec![Value::Int(10), Value::Int(20), Value::Int(30)]);
+    let xs = Value::List(vec![Value::Int(10), Value::Int(20), Value::Int(30)].into());
     let v = call("pick_from", vec![Value::Int(123), xs]);
     match v {
         Value::Variant { name, args } => {
@@ -143,7 +143,7 @@ fn choose_returns_some_for_nonempty_list() {
 
 #[test]
 fn choose_returns_none_for_empty_list() {
-    let v = call("pick_from", vec![Value::Int(7), Value::List(vec![])]);
+    let v = call("pick_from", vec![Value::Int(7), Value::List(vec![].into())]);
     match v {
         Value::Variant { name, .. } => assert_eq!(name, "None"),
         other => panic!("expected Variant, got {other:?}"),

--- a/crates/lex-runtime/tests/std_test.rs
+++ b/crates/lex-runtime/tests/std_test.rs
@@ -100,7 +100,7 @@ fn suite_runner_counts_failures() {
         err_msg("first failure"),               // fail
         ok_unit(),                              // pass
         err_msg("second failure"),              // fail
-    ]);
+    ].into());
     let v = run(SRC, "run_suite", vec![suite]);
     assert_eq!(v, Value::Int(2));
 }

--- a/crates/lex-runtime/tests/std_toml.rs
+++ b/crates/lex-runtime/tests/std_toml.rs
@@ -160,7 +160,7 @@ tags = ["alpha", "beta", "gamma"]
             Value::Str("alpha".into()),
             Value::Str("beta".into()),
             Value::Str("gamma".into()),
-        ])),
+        ].into())),
     );
 }
 

--- a/crates/lex-runtime/tests/stream_basic.rs
+++ b/crates/lex-runtime/tests/stream_basic.rs
@@ -77,7 +77,7 @@ fn drain(prompt :: Str) -> [llm_cloud, stream] Result[List[Str], Str] {
                     Value::Str("beta".into()),
                     Value::Str("gamma".into()),
                     Value::Str("delta".into()),
-                ]),
+                ].into()),
             );
         }
         other => panic!("expected Variant, got {other:?}"),
@@ -139,7 +139,7 @@ fn pull2(prompt :: Str) -> [llm_cloud, stream] Result[(Option[Str], Option[Str],
         Some(Value::List(vec![
             Value::Str("three".into()),
             Value::Str("four".into()),
-        ])),
+        ].into())),
     );
 }
 

--- a/crates/spec-checker/src/checker.rs
+++ b/crates/spec-checker/src/checker.rs
@@ -199,9 +199,9 @@ fn sample(ty: &SpecType, rng: &mut DetRng) -> Value {
         // quickly, not stress-testing throughput.
         SpecType::List { element } => {
             let len = (rng.next_u64() % 9) as usize;
-            let mut out = Vec::with_capacity(len);
+            let mut out = std::collections::VecDeque::with_capacity(len);
             for _ in 0..len {
-                out.push(sample(element, rng));
+                out.push_back(sample(element, rng));
             }
             Value::List(out)
         }

--- a/crates/spec-checker/src/gate.rs
+++ b/crates/spec-checker/src/gate.rs
@@ -325,7 +325,7 @@ pub(crate) fn list_builtin(func: &str, args: &[Value]) -> Option<Result<Value, S
         "head" => {
             if args.len() != 1 { return None; }
             match &args[0] {
-                Value::List(xs) => Some(match xs.first() {
+                Value::List(xs) => Some(match xs.front() {
                     Some(v) => Ok(v.clone()),
                     None => Err("head: empty list".into()),
                 }),
@@ -335,9 +335,10 @@ pub(crate) fn list_builtin(func: &str, args: &[Value]) -> Option<Result<Value, S
         "tail" => {
             if args.len() != 1 { return None; }
             match &args[0] {
-                Value::List(xs) => Some(match xs.split_first() {
-                    Some((_, rest)) => Ok(Value::List(rest.to_vec())),
-                    None => Err("tail: empty list".into()),
+                Value::List(xs) => Some(if xs.is_empty() {
+                    Err("tail: empty list".into())
+                } else {
+                    Ok(Value::List(xs.iter().skip(1).cloned().collect::<std::collections::VecDeque<_>>()))
                 }),
                 _ => None,
             }
@@ -752,7 +753,7 @@ mod tests {
 
     /// Build a `Value::List` from a slice of values.
     fn lst(items: &[Value]) -> Value {
-        Value::List(items.to_vec())
+        Value::List(items.iter().cloned().collect::<std::collections::VecDeque<_>>())
     }
 
     #[test]
@@ -843,7 +844,7 @@ mod tests {
         session.insert("power".into(), Value::Int(50));
         session.insert("budget".into(), Value::Int(80));
         let allow = evaluate_gate(std::slice::from_ref(&spec), &b([
-            ("sessions", Value::List(vec![Value::Record(session.clone())])),
+            ("sessions", Value::List(vec![Value::Record(session.clone())].into())),
         ]), "");
         assert_eq!(allow, GateVerdict::Allow);
 
@@ -851,7 +852,7 @@ mod tests {
         over.insert("power".into(), Value::Int(120));
         over.insert("budget".into(), Value::Int(80));
         let deny = evaluate_gate(&[spec], &b([
-            ("sessions", Value::List(vec![Value::Record(over)])),
+            ("sessions", Value::List(vec![Value::Record(over)].into())),
         ]), "");
         assert!(matches!(deny, GateVerdict::Deny { .. }));
     }


### PR DESCRIPTION
## Summary

- Changes `Value::List` backing store from `Vec<Value>` to `VecDeque<Value>`
- `list.cons` now uses `VecDeque::push_front` — O(1) amortized vs O(n) Vec shift
- Fixes the O(n²) accumulation behaviour reported in #405 (CSV parsing, group-by, recursive folds)
- `list.sort` round-trips through a temporary Vec for the sort step (one-time O(n log n), correct)
- All other list operations unchanged in complexity

## Test plan

- [ ] `cargo build --workspace` passes
- [ ] `cargo test --workspace` passes (all green locally)
- [ ] Closes #405 (partial — step limit tracked separately)

---
_Generated by [Claude Code](https://claude.ai/code/session_01APBE4mmqZgBEsaB4pqDZ74)_