### PR TITLE
feat(#381): conc.spawn / conc.ask / conc.tell — synchronous actor model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+### Added
+
+- **#381: `conc.spawn` / `conc.ask` / `conc.tell` — synchronous actor model.**
+  Programs can now create stateful actor handles with `conc.spawn(init_state,
+  handler_fn)` and send messages via `conc.ask` (returns the handler's reply)
+  or `conc.tell` (fire-and-forget, discards reply). Each actor wraps an
+  `Arc<Mutex<ActorCell>>` so message delivery is serialised at the call site —
+  no background OS thread is spawned. The handler closure runs on the calling
+  VM so it has full access to all effects (`sql`, `net`, `kv`, …). Requires
+  the `[concurrent]` effect on any function that spawns or messages an actor.
+  New import: `import "std.conc" as conc`.
+
 ### Performance
 
 - **#389 (slice 2): VM `GetField` — monomorphic inline cache.** Each

--- a/crates/lex-bytecode/src/value.rs
+++ b/crates/lex-bytecode/src/value.rs
@@ -3,6 +3,18 @@
 use crate::program::BodyHash;
 use indexmap::IndexMap;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::sync::{Arc, Mutex};
+
+/// Internal state of a `conc.Actor`. Protected by a `Mutex` so that
+/// concurrent callers serialise on message delivery (the actor processes
+/// one message at a time). The `handler` closure is called on the
+/// *calling* VM's thread — no extra OS thread required — which lets it
+/// invoke arbitrary effects (sql, net, …) through the same handler chain.
+#[derive(Debug, Clone)]
+pub struct ActorCell {
+    pub state: Value,
+    pub handler: Value,
+}
 
 #[derive(Debug, Clone)]
 pub enum Value {
@@ -49,6 +61,12 @@ pub enum Value {
     /// uses this dedicated variant rather than backing a deque on top
     /// of `Value::List` (which would make `push_front` O(n)).
     Deque(VecDeque<Value>),
+    /// A handle to a `conc.Actor`. The `Arc<Mutex<ActorCell>>` allows
+    /// cheap cloning and safe concurrent access — the mutex serialises
+    /// message delivery so the actor processes one message at a time.
+    /// Two actor handles compare equal iff they point to the same cell
+    /// (identity equality, not structural equality).
+    Actor(Arc<Mutex<ActorCell>>),
 }
 
 /// Manual `PartialEq` for `Value` (#222). Mirrors the auto-derived
@@ -81,6 +99,8 @@ impl PartialEq for Value {
             (Map(a), Map(b)) => a == b,
             (Set(a), Set(b)) => a == b,
             (Deque(a), Deque(b)) => a == b,
+            // Actor identity: same if both handles point to the same cell.
+            (Actor(a), Actor(b)) => Arc::ptr_eq(a, b),
             _ => false,
         }
     }
@@ -218,6 +238,7 @@ impl Value {
             Value::Set(s) => J::Array(
                 s.iter().map(|k| k.as_value().to_json()).collect()),
             Value::Deque(items) => J::Array(items.iter().map(Value::to_json).collect()),
+            Value::Actor(_) => J::String("<actor>".into()),
         }
     }
 

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -2,7 +2,8 @@
 
 use crate::op::*;
 use crate::program::*;
-use crate::value::Value;
+use crate::value::{ActorCell, Value};
+use std::sync::{Arc, Mutex};
 use indexmap::IndexMap;
 use std::collections::VecDeque;
 
@@ -498,6 +499,68 @@ impl<'a> Vm<'a> {
                     args: vec![Value::Record(e)],
                 })
             }
+        }
+    }
+
+    /// VM-level handler for `conc.*` effect ops (#381).
+    ///
+    /// * `conc.spawn(init, handler)` — creates an `Actor` wrapping the
+    ///   initial state and the handler closure. No background thread is
+    ///   started; the actor runs synchronously on the calling thread
+    ///   under a `Mutex` so concurrent callers serialise.
+    ///
+    /// * `conc.ask(actor, msg)` — locks the actor, calls
+    ///   `handler(state, msg)` on *this* VM (reentrant), expects a
+    ///   2-tuple `(new_state, reply)`, updates the actor's state, and
+    ///   returns `reply`.
+    ///
+    /// * `conc.tell(actor, msg)` — same as `ask` but discards the
+    ///   reply and returns `Unit`.
+    fn run_conc_op(&mut self, op: &str, args: Vec<Value>) -> Result<Value, String> {
+        match op {
+            "spawn" => {
+                let mut it = args.into_iter();
+                let init = it.next().unwrap_or(Value::Unit);
+                let handler = it.next().unwrap_or(Value::Unit);
+                if !matches!(handler, Value::Closure { .. }) {
+                    return Err(format!(
+                        "conc.spawn: handler must be a Closure, got {handler:?}"));
+                }
+                Ok(Value::Actor(Arc::new(Mutex::new(ActorCell {
+                    state: init,
+                    handler,
+                }))))
+            }
+            "ask" | "tell" => {
+                let mut it = args.into_iter();
+                let actor_val = it.next().unwrap_or(Value::Unit);
+                let msg = it.next().unwrap_or(Value::Unit);
+                let cell = match actor_val {
+                    Value::Actor(ref arc) => Arc::clone(arc),
+                    other => return Err(format!(
+                        "conc.{op}: first arg must be an Actor, got {other:?}")),
+                };
+                // Lock the actor: guarantees at-most-one-concurrent message.
+                let mut guard = cell.lock().map_err(|e| format!("conc.{op}: actor mutex poisoned: {e}"))?;
+                let handler = guard.handler.clone();
+                let state = guard.state.clone();
+                // Call handler(state, msg) on this VM — full effect access.
+                let result = self.invoke_closure_value(handler, vec![state, msg])
+                    .map_err(|e| format!("conc.{op}: handler error: {e:?}"))?;
+                // Expect (new_state, reply) tuple.
+                match result {
+                    Value::Tuple(mut parts) if parts.len() == 2 => {
+                        let reply = parts.pop().unwrap();
+                        let new_state = parts.pop().unwrap();
+                        guard.state = new_state;
+                        drop(guard);
+                        if op == "ask" { Ok(reply) } else { Ok(Value::Unit) }
+                    }
+                    other => Err(format!(
+                        "conc.{op}: handler must return a 2-tuple (new_state, reply), got {other:?}")),
+                }
+            }
+            other => Err(format!("unknown conc.{other}")),
         }
     }
 
@@ -1062,6 +1125,12 @@ impl<'a> Vm<'a> {
                         // from `Map` / `AndThen` nodes.
                         None if (kind.as_str(), op_name.as_str()) == ("parser", "run")
                             => self.run_parser_op(args),
+                        // VM-level intercept for `conc.*` (#381). The actor
+                        // handler closure must run on the calling VM so it can
+                        // dispatch arbitrary effects through the same handler
+                        // chain (e.g. sql queries inside an actor).
+                        None if kind.as_str() == "conc"
+                            => self.run_conc_op(op_name.as_str(), args),
                         None => self.handler.dispatch(&kind, &op_name, args),
                     };
                     match result {

--- a/crates/lex-runtime/src/policy.rs
+++ b/crates/lex-runtime/src/policy.rs
@@ -57,13 +57,14 @@ impl Policy {
             // entries here cause valid stdlib calls to fail under
             // `lex test` / `lex repl` / any other consumer that opts
             // into the permissive policy.
-            "sql",       // std.sql (#362, #379)
-            "random",    // crypto.random / crypto.random_str_hex (#382)
-            "chat",      // chat.broadcast / chat.send (#359)
-            "log",       // std.log structured logging
-            "kv",        // std.kv key-value store
-            "stream",    // std.stream
-            "fs_walk",   // std.fs directory traversal
+            "sql",         // std.sql (#362, #379)
+            "random",      // crypto.random / crypto.random_str_hex (#382)
+            "chat",        // chat.broadcast / chat.send (#359)
+            "log",         // std.log structured logging
+            "kv",          // std.kv key-value store
+            "stream",      // std.stream
+            "fs_walk",     // std.fs directory traversal
+            "concurrent",  // conc.spawn / conc.ask / conc.tell (#381)
         ] {
             s.insert(k.to_string());
         }

--- a/crates/lex-runtime/tests/concurrent_actor.rs
+++ b/crates/lex-runtime/tests/concurrent_actor.rs
@@ -1,0 +1,122 @@
+//! End-to-end tests for #381: conc.spawn / conc.ask / conc.tell.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::vm::Vm;
+use lex_bytecode::Value;
+use lex_runtime::{check_program, DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::collections::VecDeque;
+
+fn run(src: &str, entry: &str, args: Vec<Value>) -> Value {
+    let prog = parse_source(src).unwrap();
+    let stages = canonicalize_program(&prog);
+    let bc = lex_bytecode::compile_program(&stages);
+    let policy = Policy::permissive();
+    check_program(&bc, &policy).expect("policy check");
+    let handler = DefaultHandler::new(policy);
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(entry, args).unwrap()
+}
+
+// ── basic counter actor ──────────────────────────────────────────────────────
+
+#[test]
+fn actor_counter_ask_increments_state() {
+    let src = r#"
+import "std.conc" as conc
+
+fn counter_handler(state :: Int, msg :: Int) -> (Int, Int) {
+  let next := state + msg
+  (next, next)
+}
+
+fn make_and_use() -> Int {
+  let actor := conc.spawn(0, counter_handler)
+  let _     := conc.ask(actor, 5)
+  let r     := conc.ask(actor, 3)
+  r
+}
+"#;
+    assert_eq!(run(src, "make_and_use", vec![]), Value::Int(8));
+}
+
+// ── tell discards reply ──────────────────────────────────────────────────────
+
+#[test]
+fn actor_tell_returns_unit() {
+    let src = r#"
+import "std.conc" as conc
+
+fn acc_int_handler(state :: Int, msg :: Int) -> (Int, Int) {
+  let next := state + msg
+  (next, next)
+}
+
+fn test_tell() -> Int {
+  let actor := conc.spawn(0, acc_int_handler)
+  let _     := conc.tell(actor, 10)
+  let _     := conc.tell(actor, 10)
+  conc.ask(actor, 0)
+}
+"#;
+    // After two tell(10) calls state is 20; ask(0) → new state 20, reply 20.
+    assert_eq!(run(src, "test_tell", vec![]), Value::Int(20));
+}
+
+// ── actor state persists across calls ───────────────────────────────────────
+
+#[test]
+fn actor_state_accumulates() {
+    let src = r#"
+import "std.conc" as conc
+import "std.list" as list
+
+fn acc_handler(state :: List[Int], msg :: Int) -> (List[Int], List[Int]) {
+  let next := list.concat(state, list.cons(msg, []))
+  (next, next)
+}
+
+fn collect_items() -> List[Int] {
+  let actor := conc.spawn([], acc_handler)
+  let _ := conc.tell(actor, 1)
+  let _ := conc.tell(actor, 2)
+  let _ := conc.tell(actor, 3)
+  conc.ask(actor, 4)
+}
+"#;
+    let result = run(src, "collect_items", vec![]);
+    assert_eq!(
+        result,
+        Value::List(VecDeque::from(vec![
+            Value::Int(1),
+            Value::Int(2),
+            Value::Int(3),
+            Value::Int(4),
+        ]))
+    );
+}
+
+// ── multiple independent actors ──────────────────────────────────────────────
+
+#[test]
+fn two_independent_actors_have_separate_state() {
+    let src = r#"
+import "std.conc" as conc
+
+fn counter(state :: Int, msg :: Int) -> (Int, Int) {
+  (state + msg, state + msg)
+}
+
+fn test_two_actors() -> (Int, Int) {
+  let a := conc.spawn(0, counter)
+  let b := conc.spawn(100, counter)
+  let ra := conc.ask(a, 7)
+  let rb := conc.ask(b, 7)
+  (ra, rb)
+}
+"#;
+    assert_eq!(
+        run(src, "test_two_actors", vec![]),
+        Value::Tuple(vec![Value::Int(7), Value::Int(107)])
+    );
+}

--- a/crates/lex-trace/src/recorder.rs
+++ b/crates/lex-trace/src/recorder.rs
@@ -227,6 +227,7 @@ fn value_to_json(v: &Value) -> serde_json::Value {
                 items.iter().map(value_to_json).collect()));
             J::Object(o)
         }
+        Value::Actor(_) => J::String("<actor>".into()),
     }
 }
 

--- a/crates/lex-trace/tests/m7.rs
+++ b/crates/lex-trace/tests/m7.rs
@@ -82,7 +82,7 @@ fn value_to_json(v: &Value) -> serde_json::Value {
             m.insert("data".into(), J::Array(data.iter().map(|f| J::from(*f)).collect()));
             J::Object(m)
         }
-        Value::Map(_) | Value::Set(_) | Value::Deque(_) => {
+        Value::Map(_) | Value::Set(_) | Value::Deque(_) | Value::Actor(_) => {
             // Tests in this file don't exercise these container values;
             // render as a placeholder so the match is exhaustive.
             J::String("<container>".into())

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -557,6 +557,44 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
             ));
             Some(Ty::Record(fields))
         }
+        "conc" => {
+            // Actor model (#381). Effect: [concurrent].
+            // spawn :: S, (S, M) -> [E] (S, R) -> [concurrent] Actor[S]
+            // ask   :: Actor[S], M -> [concurrent] R
+            // tell  :: Actor[S], M -> [concurrent] Unit
+            //
+            // The type variables used here are fresh placeholders;
+            // the checker instantiates them at each call site.
+            //   0 = S (state), 1 = M (message), 2 = R (reply), 3 = E (effect row)
+            let actor_t = |s: Ty| Ty::Con("Actor".into(), vec![s]);
+            let mut fields = IndexMap::new();
+            // spawn :: S, (S, M -> [E] (S, R)) -> [concurrent] Actor[S]
+            fields.insert("spawn".into(), Ty::function(
+                vec![
+                    Ty::Var(0),
+                    Ty::Function {
+                        params: vec![Ty::Var(0), Ty::Var(1)],
+                        effects: EffectSet::open_var(3),
+                        ret: Box::new(Ty::Tuple(vec![Ty::Var(0), Ty::Var(2)])),
+                    },
+                ],
+                EffectSet::singleton("concurrent"),
+                actor_t(Ty::Var(0)),
+            ));
+            // ask :: Actor[S], M -> [concurrent] R
+            fields.insert("ask".into(), Ty::function(
+                vec![actor_t(Ty::Var(0)), Ty::Var(1)],
+                EffectSet::singleton("concurrent"),
+                Ty::Var(2),
+            ));
+            // tell :: Actor[S], M -> [concurrent] Unit
+            fields.insert("tell".into(), Ty::function(
+                vec![actor_t(Ty::Var(0)), Ty::Var(1)],
+                EffectSet::singleton("concurrent"),
+                Ty::Unit,
+            ));
+            Some(Ty::Record(fields))
+        }
         "proc" => {
             // Subprocess dispatch. Effect: [proc]. Returns a Result
             // with a record on success carrying stdout / stderr /
@@ -2143,6 +2181,7 @@ pub fn module_for_import(reference: &str) -> Option<&'static str> {
         "agent" => "agent",
         "cli" => "cli",
         "stream" => "stream",
+        "conc" => "conc",
         _ => return None,
     })
 }


### PR DESCRIPTION
## Summary

- Adds `conc.spawn(init, handler)` to create a stateful actor handle (`Value::Actor`)
- Adds `conc.ask(actor, msg)` — sends a message and returns the handler's reply
- Adds `conc.tell(actor, msg)` — fire-and-forget, discards reply
- Each actor is an `Arc<Mutex<ActorCell>>`; message delivery is serialised on the calling thread (no background OS thread). The handler closure runs on the calling VM so it has full effect access (`sql`, `net`, `kv`, …)
- Requires the `[concurrent]` effect; new import: `import "std.conc" as conc`

## Files changed

| File | Change |
|------|--------|
| `lex-bytecode/src/value.rs` | `ActorCell` struct, `Value::Actor` variant, identity `PartialEq`, `to_json` arm |
| `lex-bytecode/src/vm.rs` | `run_conc_op` (spawn/ask/tell); VM-level intercept in `Op::EffectCall` |
| `lex-runtime/src/policy.rs` | Add `"concurrent"` to permissive effect set |
| `lex-trace/src/recorder.rs` | `Value::Actor` arm in `value_to_json` |
| `lex-trace/tests/m7.rs` | `Value::Actor` arm in local `value_to_json` |
| `lex-types/src/builtins.rs` | `"conc"` module type signatures + `module_for_import` entry |
| `lex-runtime/tests/concurrent_actor.rs` | 4 end-to-end tests |

## Test plan

- [x] `actor_counter_ask_increments_state` — `ask` accumulates state across calls
- [x] `actor_tell_returns_unit` — `tell` mutates state without returning a value
- [x] `actor_state_accumulates` — handler with list state (tests closure + list ops)
- [x] `two_independent_actors_have_separate_state` — two actors share no state
- [x] Full workspace `cargo test --workspace` passes (no regressions)

---
_Generated by [Claude Code](https://claude.ai/code/session_01APBE4mmqZgBEsaB4pqDZ74)_