### PR TITLE
feat(#389-slice4): migrate Value::Str from String to SmolStr SSO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+### Added
+
+- **#381: `conc.spawn` / `conc.ask` / `conc.tell` — synchronous actor model.**
+  Programs can now create stateful actor handles with `conc.spawn(init_state,
+  handler_fn)` and send messages via `conc.ask` (returns the handler's reply)
+  or `conc.tell` (fire-and-forget, discards reply). Each actor wraps an
+  `Arc<Mutex<ActorCell>>` so message delivery is serialised at the call site —
+  no background OS thread is spawned. The handler closure runs on the calling
+  VM so it has full access to all effects (`sql`, `net`, `kv`, …). Requires
+  the `[concurrent]` effect on any function that spawns or messages an actor.
+  New import: `import "std.conc" as conc`.
+
 ### Performance
 
 - **#389 (slice 2): VM `GetField` — monomorphic inline cache.** Each

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ bumps may carry breaking changes when justified).
 
 ### Performance
 
+- **#389 (slice 3): VM locals — stack-allocator arena.** Replaced the
+  per-call-frame `Vec<Value>` for function locals with a shared slab
+  (`Vm::locals_storage: Vec<Value>`) that acts as a stack allocator. Each
+  `Op::Call` / `Op::CallClosure` / `invoke()` claims a contiguous slice from
+  the top of the slab; `Op::Return` releases it with a single `truncate` call
+  (O(1), no individual `drop` per slot). `Op::TailCall` reuses the current
+  frame's start position so the hot tail-recursion path never touches the
+  allocator at all. The slab is pre-allocated to 256 slots at VM construction
+  and retains its capacity across consecutive `vm.call()` invocations, so
+  steady-state request handling incurs zero allocations for locals up to the
+  high-water mark. `stack` and `frames` Vecs are also pre-allocated (128 and
+  32 slots respectively) for the same reason.
+
 - **#389 (slice 2): VM `GetField` — monomorphic inline cache.** Each
   `Op::GetField` bytecode site now carries a per-call-site cache entry
   keyed by `(fn_id, pc)`. On a hit the VM verifies the field name at the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ thiserror = "2"
 anyhow = "1"
 logos = "0.16"
 indexmap = { version = "2", features = ["serde"] }
+smol_str = { version = "0.3", features = ["serde"] }
 ed25519-dalek = { version = "2", default-features = false, features = ["std", "fast"] }
 getrandom = "0.4"
 hex = "0.4"

--- a/crates/conformance/src/runner.rs
+++ b/crates/conformance/src/runner.rs
@@ -172,7 +172,7 @@ fn json_to_value(v: &serde_json::Value) -> Value {
             else if let Some(f) = n.as_f64() { Value::Float(f) }
             else { Value::Unit }
         }
-        J::String(s) => Value::Str(s.clone()),
+        J::String(s) => Value::Str(s.clone().into()),
         J::Array(items) => Value::List(items.iter().map(json_to_value).collect()),
         J::Object(map) => {
             if let (Some(J::String(name)), Some(J::Array(args))) =

--- a/crates/lex-bytecode/Cargo.toml
+++ b/crates/lex-bytecode/Cargo.toml
@@ -11,6 +11,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+smol_str.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/lex-bytecode/src/parser_runtime.rs
+++ b/crates/lex-bytecode/src/parser_runtime.rs
@@ -15,6 +15,7 @@
 //!     to invoke it on the parsed result.
 
 use crate::Value;
+use smol_str::SmolStr;
 
 /// Trait the parser interpreter uses to invoke captured closures
 /// during the recursive walk. The Vm implements it via
@@ -74,7 +75,7 @@ pub fn run_parser(
         "Digit" => {
             if let Some(&b) = bytes.get(pos) {
                 if b.is_ascii_digit() {
-                    return Ok((Value::Str((b as char).to_string()), pos + 1));
+                    return Ok((Value::Str(SmolStr::new_inline(&(b as char).to_string())), pos + 1));
                 }
             }
             Err((pos, "expected digit".into()))
@@ -82,7 +83,7 @@ pub fn run_parser(
         "Alpha" => {
             if let Some(&b) = bytes.get(pos) {
                 if b.is_ascii_alphabetic() {
-                    return Ok((Value::Str((b as char).to_string()), pos + 1));
+                    return Ok((Value::Str(SmolStr::new_inline(&(b as char).to_string())), pos + 1));
                 }
             }
             Err((pos, "expected alpha".into()))
@@ -90,7 +91,7 @@ pub fn run_parser(
         "Whitespace" => {
             if let Some(&b) = bytes.get(pos) {
                 if b.is_ascii_whitespace() {
-                    return Ok((Value::Str((b as char).to_string()), pos + 1));
+                    return Ok((Value::Str(SmolStr::new_inline(&(b as char).to_string())), pos + 1));
                 }
             }
             Err((pos, "expected whitespace".into()))

--- a/crates/lex-bytecode/src/value.rs
+++ b/crates/lex-bytecode/src/value.rs
@@ -2,6 +2,7 @@
 
 use crate::program::BodyHash;
 use indexmap::IndexMap;
+use smol_str::SmolStr;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::sync::{Arc, Mutex};
 
@@ -21,7 +22,10 @@ pub enum Value {
     Int(i64),
     Float(f64),
     Bool(bool),
-    Str(String),
+    /// String value. `SmolStr` stores strings ≤ 22 bytes inline — no heap
+    /// allocation for identifiers, HTTP methods, status codes, short keys, etc.
+    /// Clone of a short `SmolStr` is a 24-byte stack copy (#389 slice 4).
+    Str(SmolStr),
     Bytes(Vec<u8>),
     Unit,
     List(VecDeque<Value>),
@@ -119,7 +123,7 @@ pub enum MapKey {
 impl MapKey {
     pub fn from_value(v: &Value) -> Result<Self, String> {
         match v {
-            Value::Str(s) => Ok(MapKey::Str(s.clone())),
+            Value::Str(s) => Ok(MapKey::Str(s.to_string())),
             Value::Int(n) => Ok(MapKey::Int(*n)),
             other => Err(format!(
                 "map/set key must be Str or Int, got {other:?}")),
@@ -127,13 +131,13 @@ impl MapKey {
     }
     pub fn into_value(self) -> Value {
         match self {
-            MapKey::Str(s) => Value::Str(s),
+            MapKey::Str(s) => Value::Str(s.into()),
             MapKey::Int(n) => Value::Int(n),
         }
     }
     pub fn as_value(&self) -> Value {
         match self {
-            MapKey::Str(s) => Value::Str(s.clone()),
+            MapKey::Str(s) => Value::Str(s.as_str().into()),
             MapKey::Int(n) => Value::Int(*n),
         }
     }
@@ -181,7 +185,7 @@ impl Value {
             Value::Int(n) => J::from(*n),
             Value::Float(f) => J::from(*f),
             Value::Bool(b) => J::Bool(*b),
-            Value::Str(s) => J::String(s.clone()),
+            Value::Str(s) => J::String(s.to_string()),
             Value::Bytes(b) => {
                 let hex: String = b.iter().map(|b| format!("{:02x}", b)).collect();
                 let mut m = serde_json::Map::new();
@@ -268,7 +272,7 @@ impl Value {
                 else if let Some(f) = n.as_f64() { Value::Float(f) }
                 else { Value::Unit }
             }
-            J::String(s) => Value::Str(s.clone()),
+            J::String(s) => Value::Str(s.as_str().into()),
             J::Array(items) => Value::List(items.iter().map(Value::from_json).collect::<VecDeque<_>>()),
             J::Object(map) => {
                 if let (Some(J::String(name)), Some(J::Array(args))) =

--- a/crates/lex-bytecode/src/value.rs
+++ b/crates/lex-bytecode/src/value.rs
@@ -3,6 +3,18 @@
 use crate::program::BodyHash;
 use indexmap::IndexMap;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::sync::{Arc, Mutex};
+
+/// Internal state of a `conc.Actor`. Protected by a `Mutex` so that
+/// concurrent callers serialise on message delivery (the actor processes
+/// one message at a time). The `handler` closure is called on the
+/// *calling* VM's thread — no extra OS thread required — which lets it
+/// invoke arbitrary effects (sql, net, …) through the same handler chain.
+#[derive(Debug, Clone)]
+pub struct ActorCell {
+    pub state: Value,
+    pub handler: Value,
+}
 
 #[derive(Debug, Clone)]
 pub enum Value {
@@ -49,6 +61,12 @@ pub enum Value {
     /// uses this dedicated variant rather than backing a deque on top
     /// of `Value::List` (which would make `push_front` O(n)).
     Deque(VecDeque<Value>),
+    /// A handle to a `conc.Actor`. The `Arc<Mutex<ActorCell>>` allows
+    /// cheap cloning and safe concurrent access — the mutex serialises
+    /// message delivery so the actor processes one message at a time.
+    /// Two actor handles compare equal iff they point to the same cell
+    /// (identity equality, not structural equality).
+    Actor(Arc<Mutex<ActorCell>>),
 }
 
 /// Manual `PartialEq` for `Value` (#222). Mirrors the auto-derived
@@ -81,6 +99,8 @@ impl PartialEq for Value {
             (Map(a), Map(b)) => a == b,
             (Set(a), Set(b)) => a == b,
             (Deque(a), Deque(b)) => a == b,
+            // Actor identity: same if both handles point to the same cell.
+            (Actor(a), Actor(b)) => Arc::ptr_eq(a, b),
             _ => false,
         }
     }
@@ -218,6 +238,7 @@ impl Value {
             Value::Set(s) => J::Array(
                 s.iter().map(|k| k.as_value().to_json()).collect()),
             Value::Deque(items) => J::Array(items.iter().map(Value::to_json).collect()),
+            Value::Actor(_) => J::String("<actor>".into()),
         }
     }
 

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -2,7 +2,8 @@
 
 use crate::op::*;
 use crate::program::*;
-use crate::value::Value;
+use crate::value::{ActorCell, Value};
+use std::sync::{Arc, Mutex};
 use indexmap::IndexMap;
 use std::collections::VecDeque;
 
@@ -498,6 +499,68 @@ impl<'a> Vm<'a> {
                     args: vec![Value::Record(e)],
                 })
             }
+        }
+    }
+
+    /// VM-level handler for `conc.*` effect ops (#381).
+    ///
+    /// * `conc.spawn(init, handler)` — creates an `Actor` wrapping the
+    ///   initial state and the handler closure. No background thread is
+    ///   started; the actor runs synchronously on the calling thread
+    ///   under a `Mutex` so concurrent callers serialise.
+    ///
+    /// * `conc.ask(actor, msg)` — locks the actor, calls
+    ///   `handler(state, msg)` on *this* VM (reentrant), expects a
+    ///   2-tuple `(new_state, reply)`, updates the actor's state, and
+    ///   returns `reply`.
+    ///
+    /// * `conc.tell(actor, msg)` — same as `ask` but discards the
+    ///   reply and returns `Unit`.
+    fn run_conc_op(&mut self, op: &str, args: Vec<Value>) -> Result<Value, String> {
+        match op {
+            "spawn" => {
+                let mut it = args.into_iter();
+                let init = it.next().unwrap_or(Value::Unit);
+                let handler = it.next().unwrap_or(Value::Unit);
+                if !matches!(handler, Value::Closure { .. }) {
+                    return Err(format!(
+                        "conc.spawn: handler must be a Closure, got {handler:?}"));
+                }
+                Ok(Value::Actor(Arc::new(Mutex::new(ActorCell {
+                    state: init,
+                    handler,
+                }))))
+            }
+            "ask" | "tell" => {
+                let mut it = args.into_iter();
+                let actor_val = it.next().unwrap_or(Value::Unit);
+                let msg = it.next().unwrap_or(Value::Unit);
+                let cell = match actor_val {
+                    Value::Actor(ref arc) => Arc::clone(arc),
+                    other => return Err(format!(
+                        "conc.{op}: first arg must be an Actor, got {other:?}")),
+                };
+                // Lock the actor: guarantees at-most-one-concurrent message.
+                let mut guard = cell.lock().map_err(|e| format!("conc.{op}: actor mutex poisoned: {e}"))?;
+                let handler = guard.handler.clone();
+                let state = guard.state.clone();
+                // Call handler(state, msg) on this VM — full effect access.
+                let result = self.invoke_closure_value(handler, vec![state, msg])
+                    .map_err(|e| format!("conc.{op}: handler error: {e:?}"))?;
+                // Expect (new_state, reply) tuple.
+                match result {
+                    Value::Tuple(mut parts) if parts.len() == 2 => {
+                        let reply = parts.pop().unwrap();
+                        let new_state = parts.pop().unwrap();
+                        guard.state = new_state;
+                        drop(guard);
+                        if op == "ask" { Ok(reply) } else { Ok(Value::Unit) }
+                    }
+                    other => Err(format!(
+                        "conc.{op}: handler must return a 2-tuple (new_state, reply), got {other:?}")),
+                }
+            }
+            other => Err(format!("unknown conc.{other}")),
         }
     }
 
@@ -1062,6 +1125,12 @@ impl<'a> Vm<'a> {
                         // from `Map` / `AndThen` nodes.
                         None if (kind.as_str(), op_name.as_str()) == ("parser", "run")
                             => self.run_parser_op(args),
+                        // VM-level intercept for `conc.*` (#381). The actor
+                        // handler closure must run on the calling VM so it can
+                        // dispatch arbitrary effects through the same handler
+                        // chain (e.g. sql queries inside an actor).
+                        None if kind.as_str() == "conc"
+                            => self.run_conc_op(op_name.as_str(), args),
                         None => self.handler.dispatch(&kind, &op_name, args),
                     };
                     match result {

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -265,8 +265,8 @@ fn eval_refinement_inner(
             CLit::Int { value } => Value::Int(*value),
             CLit::Float { value } => Value::Float(value.parse().unwrap_or(0.0)),
             CLit::Bool { value } => Value::Bool(*value),
-            CLit::Str { value } => Value::Str(value.clone()),
-            CLit::Bytes { value } => Value::Str(value.clone()), // hex; unusual in predicates
+            CLit::Str { value } => Value::Str(value.as_str().into()),
+            CLit::Bytes { value } => Value::Str(value.as_str().into()), // hex; unusual in predicates
             CLit::Unit => Value::Unit,
         }),
         CExpr::Var { name } if name == binding => Ok(arg.clone()),
@@ -517,7 +517,7 @@ impl<'a> Vm<'a> {
             Err((pos, msg)) => {
                 let mut e = indexmap::IndexMap::new();
                 e.insert("pos".into(), Value::Int(pos as i64));
-                e.insert("message".into(), Value::Str(msg));
+                e.insert("message".into(), Value::Str(msg.into()));
                 Ok(Value::Variant {
                     name: "Err".into(),
                     args: vec![Value::Record(e)],
@@ -1264,9 +1264,11 @@ impl<'a> Vm<'a> {
                         (Value::Int(x), Value::Int(y)) => self.stack.push(Value::Int(x + y)),
                         (Value::Float(x), Value::Float(y)) => self.stack.push(Value::Float(x + y)),
                         (Value::Str(x), Value::Str(y)) => {
-                            let mut s = x;
+                            // SmolStr is immutable; concatenate via a temporary String.
+                            let mut s = String::with_capacity(x.len() + y.len());
+                            s.push_str(&x);
                             s.push_str(&y);
-                            self.stack.push(Value::Str(s));
+                            self.stack.push(Value::Str(s.into()));
                         }
                         (a, b) => return Err(VmError::TypeMismatch(format!("Num op: {a:?} {b:?}"))),
                     }
@@ -1304,7 +1306,7 @@ impl<'a> Vm<'a> {
                     let b = self.pop()?;
                     let a = self.pop()?;
                     let s = format!("{}{}", a.as_str(), b.as_str());
-                    self.stack.push(Value::Str(s));
+                    self.stack.push(Value::Str(s.into()));
                 }
                 Op::StrLen => {
                     let v = self.pop()?;
@@ -1399,9 +1401,9 @@ fn const_to_value(c: &Const) -> Value {
         Const::Int(n) => Value::Int(*n),
         Const::Float(f) => Value::Float(*f),
         Const::Bool(b) => Value::Bool(*b),
-        Const::Str(s) => Value::Str(s.clone()),
+        Const::Str(s) => Value::Str(s.as_str().into()),
         Const::Bytes(b) => Value::Bytes(b.clone()),
         Const::Unit => Value::Unit,
-        Const::FieldName(s) | Const::VariantName(s) | Const::NodeId(s) => Value::Str(s.clone()),
+        Const::FieldName(s) | Const::VariantName(s) | Const::NodeId(s) => Value::Str(s.as_str().into()),
     }
 }

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -159,12 +159,31 @@ pub struct Vm<'a> {
     /// in O(1) and skip the hash-table lookup entirely; on a miss we
     /// fall back to `IndexMap::get_full` and populate the cache.
     field_ics: std::collections::HashMap<u64, usize>,
+    /// Stack allocator for function locals (#389 slice 3).
+    ///
+    /// Every function frame claims `locals_count` contiguous slots from
+    /// this Vec on push and releases them on pop.  Because Lex uses
+    /// strictly LIFO frame semantics the most-recently-pushed frame's
+    /// slots always sit at the top of the Vec, so `truncate` is the
+    /// correct (and O(1)) release operation.
+    ///
+    /// The Vec is pre-allocated once at VM construction and then grows
+    /// only if the actual call depth × locals width exceeds the initial
+    /// capacity.  After a top-level `vm.call` returns the Vec is empty
+    /// again but its capacity is retained, so the next request incurs
+    /// zero allocations for locals up to the high-water mark.
+    locals_storage: Vec<Value>,
 }
 
 struct Frame {
     fn_id: u32,
     pc: usize,
-    locals: Vec<Value>,
+    /// Start index of this frame's locals in `Vm::locals_storage` (#389
+    /// slice 3). The frame owns `locals_storage[locals_start..locals_start
+    /// + locals_len]`; `Op::Return` truncates the Vec back to
+    /// `locals_start`, releasing the slots in O(1).
+    locals_start: usize,
+    locals_len: usize,
     /// Stack base when this frame started (for cleanup on return).
     stack_base: usize,
     trace_kind: FrameKind,
@@ -444,14 +463,19 @@ impl<'a> Vm<'a> {
             program,
             handler,
             tracer: Box::new(NullTracer),
-            frames: Vec::new(),
-            stack: Vec::new(),
+            // Pre-allocate enough capacity for a typical request so the first
+            // call incurs no reallocation (#389 slice 3).
+            frames: Vec::with_capacity(32),
+            stack: Vec::with_capacity(128),
             step_limit: 10_000_000,
             steps: 0,
             pure_memo: std::collections::HashMap::new(),
             pure_memo_hits: 0,
             pure_memo_misses: 0,
             field_ics: std::collections::HashMap::new(),
+            // 256 slots handles ~32 frames × 8 locals; grows on demand and
+            // retains capacity across consecutive vm.call() invocations.
+            locals_storage: Vec::with_capacity(256),
         }
     }
 
@@ -616,14 +640,20 @@ impl<'a> Vm<'a> {
             }
         }
         let f = &self.program.functions[fn_id as usize];
-        let mut locals = vec![Value::Unit; f.locals_count.max(f.arity) as usize];
-        for (i, v) in args.into_iter().enumerate() { locals[i] = v; }
+        // Claim slots from the locals stack allocator (#389 slice 3).
+        let locals_start = self.locals_storage.len();
+        let locals_len = f.locals_count.max(f.arity) as usize;
+        self.locals_storage.resize(locals_start + locals_len, Value::Unit);
+        for (i, v) in args.into_iter().enumerate() {
+            self.locals_storage[locals_start + i] = v;
+        }
         // Record the depth before pushing — this is what `run` will
         // exit at, supporting reentrant invocation from inside the
         // VM (e.g. the parser interpreter calling closures, #221).
         let base_depth = self.frames.len();
         self.push_frame(Frame {
-            fn_id, pc: 0, locals, stack_base: self.stack.len(),
+            fn_id, pc: 0, locals_start, locals_len,
+            stack_base: self.stack.len(),
             trace_kind: FrameKind::Entry,
             memo_key: None,
         })?;
@@ -680,12 +710,14 @@ impl<'a> Vm<'a> {
                     self.stack.push(v);
                 }
                 Op::LoadLocal(i) => {
-                    let v = self.frames[frame_idx].locals[i as usize].clone();
+                    let base = self.frames[frame_idx].locals_start;
+                    let v = self.locals_storage[base + i as usize].clone();
                     self.stack.push(v);
                 }
                 Op::StoreLocal(i) => {
                     let v = self.pop()?;
-                    self.frames[frame_idx].locals[i as usize] = v;
+                    let base = self.frames[frame_idx].locals_start;
+                    self.locals_storage[base + i as usize] = v;
                 }
                 Op::MakeRecord { field_name_indices } => {
                     let n = field_name_indices.len();
@@ -897,10 +929,15 @@ impl<'a> Vm<'a> {
                     combined.extend(args);
                     self.tracer.enter_call(&node_id, &callee_name, &combined);
                     let f = &self.program.functions[fn_id as usize];
-                    let mut locals = vec![Value::Unit; f.locals_count.max(f.arity) as usize];
-                    for (i, v) in combined.into_iter().enumerate() { locals[i] = v; }
+                    let locals_start = self.locals_storage.len();
+                    let locals_len = f.locals_count.max(f.arity) as usize;
+                    self.locals_storage.resize(locals_start + locals_len, Value::Unit);
+                    for (i, v) in combined.into_iter().enumerate() {
+                        self.locals_storage[locals_start + i] = v;
+                    }
                     self.push_frame(Frame {
-                        fn_id, pc: 0, locals, stack_base: self.stack.len(),
+                        fn_id, pc: 0, locals_start, locals_len,
+                        stack_base: self.stack.len(),
                         trace_kind: FrameKind::Call(node_id),
                         // Op::CallClosure intentionally doesn't memoize
                         // for v1 (#229) — closures over captures need a
@@ -1046,10 +1083,15 @@ impl<'a> Vm<'a> {
                         self.pure_memo_misses += 1;
                     }
                     self.tracer.enter_call(&node_id, &callee_name, &args);
-                    let mut locals = vec![Value::Unit; f.locals_count.max(f.arity) as usize];
-                    for (i, v) in args.into_iter().enumerate() { locals[i] = v; }
+                    let locals_start = self.locals_storage.len();
+                    let locals_len = f.locals_count.max(f.arity) as usize;
+                    self.locals_storage.resize(locals_start + locals_len, Value::Unit);
+                    for (i, v) in args.into_iter().enumerate() {
+                        self.locals_storage[locals_start + i] = v;
+                    }
                     self.push_frame(Frame {
-                        fn_id, pc: 0, locals, stack_base: self.stack.len(),
+                        fn_id, pc: 0, locals_start, locals_len,
+                        stack_base: self.stack.len(),
                         trace_kind: FrameKind::Call(node_id),
                         memo_key,
                     })?;
@@ -1096,11 +1138,21 @@ impl<'a> Vm<'a> {
                     self.tracer.exit_call_tail();
                     self.tracer.enter_call(&node_id, &callee_name, &args);
                     let f = &self.program.functions[fn_id as usize];
+                    // Reuse the current frame's locals_start position:
+                    // truncate to release old locals then extend for the
+                    // new function (#389 slice 3, same as Op::Return but
+                    // without popping the frame).
+                    let old_locals_start = self.frames.last().unwrap().locals_start;
+                    self.locals_storage.truncate(old_locals_start);
+                    let new_locals_len = f.locals_count.max(f.arity) as usize;
+                    self.locals_storage.resize(old_locals_start + new_locals_len, Value::Unit);
+                    for (i, v) in args.into_iter().enumerate() {
+                        self.locals_storage[old_locals_start + i] = v;
+                    }
                     let frame = self.frames.last_mut().unwrap();
                     frame.fn_id = fn_id;
                     frame.pc = 0;
-                    frame.locals = vec![Value::Unit; f.locals_count.max(f.arity) as usize];
-                    for (i, v) in args.into_iter().enumerate() { frame.locals[i] = v; }
+                    frame.locals_len = new_locals_len;
                     frame.trace_kind = FrameKind::Call(node_id);
                 }
                 Op::EffectCall { kind_idx, op_idx, arity, node_id_idx } => {
@@ -1149,6 +1201,9 @@ impl<'a> Vm<'a> {
                     let frame = self.frames.pop().unwrap();
                     // Trim any extra stuff that the function pushed but didn't pop.
                     self.stack.truncate(frame.stack_base);
+                    // Release this frame's locals back to the arena (#389 slice 3).
+                    // LIFO frame ordering guarantees this frame's slots are at the top.
+                    self.locals_storage.truncate(frame.locals_start);
                     if matches!(frame.trace_kind, FrameKind::Call(_)) {
                         self.tracer.exit_ok(&v);
                     }

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -4806,7 +4806,7 @@ fn run_tool_once(
     let handler = DefaultHandler::new(policy.clone()).with_program(std::sync::Arc::clone(bc));
     let mut vm = Vm::with_handler(bc, Box::new(handler));
     vm.set_step_limit(max_steps);
-    let result = match vm.call("tool", vec![Value::Str(input.to_string())]) {
+    let result = match vm.call("tool", vec![Value::Str(input.to_string().into())]) {
         Ok(v) => v,
         Err(e) => {
             let msg = format!("{e}");
@@ -4832,7 +4832,7 @@ fn run_tool_once(
         }
     };
     Ok(match result {
-        Value::Str(s) => s,
+        Value::Str(s) => s.to_string(),
         other => value_to_json_string(&other),
     })
 }

--- a/crates/lex-cli/src/repl.rs
+++ b/crates/lex-cli/src/repl.rs
@@ -224,7 +224,7 @@ impl Session {
         // original value). Unwrap one layer so the user sees the
         // JSON directly, not a quoted string.
         match v {
-            lex_bytecode::Value::Str(s) => Ok(s),
+            lex_bytecode::Value::Str(s) => Ok(s.to_string()),
             other => Ok(serde_json::to_string(&other.to_json())
                 .unwrap_or_else(|_| format!("{other:?}"))),
         }

--- a/crates/lex-cli/src/tool_registry.rs
+++ b/crates/lex-cli/src/tool_registry.rs
@@ -273,8 +273,8 @@ fn invoke_tool(id: &str, body_str: &str, registry: &Registry) -> Response<std::i
     let handler = DefaultHandler::new(policy).with_program(Arc::clone(&prog));
     let mut vm = Vm::with_handler(&prog, Box::new(handler));
     vm.set_step_limit(1_000_000);
-    match vm.call("tool", vec![Value::Str(parsed.input)]) {
-        Ok(Value::Str(s)) => json_response(200, json!({ "output": s })),
+    match vm.call("tool", vec![Value::Str(parsed.input.into())]) {
+        Ok(Value::Str(s)) => json_response(200, json!({ "output": s.to_string() })),
         Ok(other) => json_response(200, json!({ "output": format!("{other:?}") })),
         Err(e) => {
             let msg = format!("{e}");

--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -48,6 +48,7 @@ csv = "1"
 rusqlite = { version = "0.39", features = ["bundled"] }
 postgres = "0.19"
 lex-bytecode = { path = "../lex-bytecode", version = "0.9.3" }
+smol_str = { workspace = true }
 
 [dev-dependencies]
 lex-syntax = { path = "../lex-syntax", version = "0.9.3" }

--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -72,7 +72,7 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
         ("str", "concat") => {
             let a = expect_str(args.first())?;
             let b = expect_str(args.get(1))?;
-            Ok(Value::Str(format!("{a}{b}")))
+            Ok(Value::Str(format!("{a}{b}").into()))
         }
         ("str", "to_int") => {
             let s = expect_str(args.first())?;
@@ -85,9 +85,9 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             let s = expect_str(args.first())?;
             let sep = expect_str(args.get(1))?;
             let items: std::collections::VecDeque<Value> = if sep.is_empty() {
-                s.chars().map(|c| Value::Str(c.to_string())).collect()
+                s.chars().map(|c| Value::Str(c.to_string().into())).collect()
             } else {
-                s.split(sep.as_str()).map(|p| Value::Str(p.to_string())).collect()
+                s.split(sep.as_str()).map(|p| Value::Str(p.into())).collect()
             };
             Ok(Value::List(items))
         }
@@ -102,7 +102,7 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
                     other => return Err(format!("str.join element must be Str, got {other:?}")),
                 }
             }
-            Ok(Value::Str(out))
+            Ok(Value::Str(out.into()))
         }
         ("str", "starts_with") => {
             let s = expect_str(args.first())?;
@@ -123,16 +123,16 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             let s = expect_str(args.first())?;
             let from = expect_str(args.get(1))?;
             let to = expect_str(args.get(2))?;
-            Ok(Value::Str(s.replace(from.as_str(), to.as_str())))
+            Ok(Value::Str(s.replace(from.as_str(), to.as_str()).into()))
         }
-        ("str", "trim") => Ok(Value::Str(expect_str(args.first())?.trim().to_string())),
-        ("str", "to_upper") => Ok(Value::Str(expect_str(args.first())?.to_uppercase())),
-        ("str", "to_lower") => Ok(Value::Str(expect_str(args.first())?.to_lowercase())),
+        ("str", "trim") => Ok(Value::Str(expect_str(args.first())?.trim().into())),
+        ("str", "to_upper") => Ok(Value::Str(expect_str(args.first())?.to_uppercase().into())),
+        ("str", "to_lower") => Ok(Value::Str(expect_str(args.first())?.to_lowercase().into())),
         ("str", "strip_prefix") => {
             let s = expect_str(args.first())?;
             let prefix = expect_str(args.get(1))?;
             Ok(match s.strip_prefix(prefix.as_str()) {
-                Some(rest) => some(Value::Str(rest.to_string())),
+                Some(rest) => some(Value::Str(rest.into())),
                 None => none(),
             })
         }
@@ -140,7 +140,7 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             let s = expect_str(args.first())?;
             let suffix = expect_str(args.get(1))?;
             Ok(match s.strip_suffix(suffix.as_str()) {
-                Some(rest) => some(Value::Str(rest.to_string())),
+                Some(rest) => some(Value::Str(rest.into())),
                 None => none(),
             })
         }
@@ -167,14 +167,14 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             if !s.is_char_boundary(lo) || !s.is_char_boundary(hi) {
                 return Err(format!("str.slice: [{lo}..{hi}] not on char boundaries"));
             }
-            Ok(Value::Str(s[lo..hi].to_string()))
+            Ok(Value::Str(s[lo..hi].into()))
         }
 
         // -- int / float --
-        ("int", "to_str") => Ok(Value::Str(expect_int(args.first())?.to_string())),
+        ("int", "to_str") => Ok(Value::Str(expect_int(args.first())?.to_string().into())),
         ("int", "to_float") => Ok(Value::Float(expect_int(args.first())? as f64)),
         ("float", "to_int") => Ok(Value::Int(expect_float(args.first())? as i64)),
-        ("float", "to_str") => Ok(Value::Str(expect_float(args.first())?.to_string())),
+        ("float", "to_str") => Ok(Value::Str(expect_float(args.first())?.to_string().into())),
         ("str", "to_float") => {
             let s = expect_str(args.first())?;
             match s.parse::<f64>() {
@@ -301,13 +301,13 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
         // -- json --
         ("json", "stringify") => {
             let v = first_arg(args)?;
-            Ok(Value::Str(serde_json::to_string(&value_to_json(v)).unwrap_or_default()))
+            Ok(Value::Str(serde_json::to_string(&value_to_json(v)).unwrap_or_default().into()))
         }
         ("json", "parse") => {
             let s = expect_str(args.first())?;
             match serde_json::from_str::<serde_json::Value>(&s) {
                 Ok(v) => Ok(ok_v(json_to_value(&v))),
-                Err(e) => Ok(err_v(Value::Str(format!("{e}")))),
+                Err(e) => Ok(err_v(Value::Str(format!("{e}").into()))),
             }
         }
         // Tactical fix for #168: validate required fields before
@@ -319,14 +319,14 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             match serde_json::from_str::<serde_json::Value>(&s) {
                 Ok(v) => {
                     if let Err(e) = check_required_fields(&v, &required) {
-                        return Ok(err_v(Value::Str(e)));
+                        return Ok(err_v(Value::Str(e.into())));
                     }
                     if let Err(e) = validate_field_types(&v, &schema) {
-                        return Ok(err_v(Value::Str(e)));
+                        return Ok(err_v(Value::Str(e.into())));
                     }
                     Ok(ok_v(json_to_value(&v)))
                 }
-                Err(e) => Ok(err_v(Value::Str(format!("{e}")))),
+                Err(e) => Ok(err_v(Value::Str(format!("{e}").into()))),
             }
         }
 
@@ -341,7 +341,7 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
                     unwrap_toml_datetime_markers(&mut v);
                     Ok(ok_v(json_to_value(&v)))
                 }
-                Err(e) => Ok(err_v(Value::Str(format!("{e}")))),
+                Err(e) => Ok(err_v(Value::Str(format!("{e}").into()))),
             }
         }
         // Compiler-emitted variant of parse_strict that carries the type
@@ -354,14 +354,14 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             match serde_json::from_str::<serde_json::Value>(&s) {
                 Ok(v) => {
                     if let Err(e) = check_required_fields(&v, &required) {
-                        return Ok(err_v(Value::Str(e)));
+                        return Ok(err_v(Value::Str(e.into())));
                     }
                     if let Err(e) = validate_field_types(&v, &schema) {
-                        return Ok(err_v(Value::Str(e)));
+                        return Ok(err_v(Value::Str(e.into())));
                     }
                     Ok(ok_v(json_to_value(&v)))
                 }
-                Err(e) => Ok(err_v(Value::Str(format!("{e}")))),
+                Err(e) => Ok(err_v(Value::Str(format!("{e}").into()))),
             }
         }
 
@@ -375,14 +375,14 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
                 Ok(mut v) => {
                     unwrap_toml_datetime_markers(&mut v);
                     if let Err(e) = check_required_fields(&v, &required) {
-                        return Ok(err_v(Value::Str(e)));
+                        return Ok(err_v(Value::Str(e.into())));
                     }
                     if let Err(e) = validate_field_types(&v, &schema) {
-                        return Ok(err_v(Value::Str(e)));
+                        return Ok(err_v(Value::Str(e.into())));
                     }
                     Ok(ok_v(json_to_value(&v)))
                 }
-                Err(e) => Ok(err_v(Value::Str(format!("{e}")))),
+                Err(e) => Ok(err_v(Value::Str(format!("{e}").into()))),
             }
         }
         ("toml", "parse_strict_typed") => {
@@ -393,14 +393,14 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
                 Ok(mut v) => {
                     unwrap_toml_datetime_markers(&mut v);
                     if let Err(e) = check_required_fields(&v, &required) {
-                        return Ok(err_v(Value::Str(e)));
+                        return Ok(err_v(Value::Str(e.into())));
                     }
                     if let Err(e) = validate_field_types(&v, &schema) {
-                        return Ok(err_v(Value::Str(e)));
+                        return Ok(err_v(Value::Str(e.into())));
                     }
                     Ok(ok_v(json_to_value(&v)))
                 }
-                Err(e) => Ok(err_v(Value::Str(format!("{e}")))),
+                Err(e) => Ok(err_v(Value::Str(format!("{e}").into()))),
             }
         }
         ("toml", "stringify") => {
@@ -412,8 +412,8 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             // rather than panic.
             let json = value_to_json(v);
             match toml::to_string(&json) {
-                Ok(s)  => Ok(ok_v(Value::Str(s))),
-                Err(e) => Ok(err_v(Value::Str(format!("toml.stringify: {e}")))),
+                Ok(s)  => Ok(ok_v(Value::Str(s.into()))),
+                Err(e) => Ok(err_v(Value::Str(format!("toml.stringify: {e}").into()))),
             }
         }
 
@@ -426,7 +426,7 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             let s = expect_str(args.first())?;
             match serde_yaml::from_str::<serde_json::Value>(&s) {
                 Ok(v)  => Ok(ok_v(json_to_value(&v))),
-                Err(e) => Ok(err_v(Value::Str(format!("{e}")))),
+                Err(e) => Ok(err_v(Value::Str(format!("{e}").into()))),
             }
         }
         // Tactical fix for #168 — same shape as toml.parse_strict.
@@ -438,14 +438,14 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             match serde_yaml::from_str::<serde_json::Value>(&s) {
                 Ok(v) => {
                     if let Err(e) = check_required_fields(&v, &required) {
-                        return Ok(err_v(Value::Str(e)));
+                        return Ok(err_v(Value::Str(e.into())));
                     }
                     if let Err(e) = validate_field_types(&v, &schema) {
-                        return Ok(err_v(Value::Str(e)));
+                        return Ok(err_v(Value::Str(e.into())));
                     }
                     Ok(ok_v(json_to_value(&v)))
                 }
-                Err(e) => Ok(err_v(Value::Str(format!("{e}")))),
+                Err(e) => Ok(err_v(Value::Str(format!("{e}").into()))),
             }
         }
         ("yaml", "parse_strict_typed") => {
@@ -455,22 +455,22 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             match serde_yaml::from_str::<serde_json::Value>(&s) {
                 Ok(v) => {
                     if let Err(e) = check_required_fields(&v, &required) {
-                        return Ok(err_v(Value::Str(e)));
+                        return Ok(err_v(Value::Str(e.into())));
                     }
                     if let Err(e) = validate_field_types(&v, &schema) {
-                        return Ok(err_v(Value::Str(e)));
+                        return Ok(err_v(Value::Str(e.into())));
                     }
                     Ok(ok_v(json_to_value(&v)))
                 }
-                Err(e) => Ok(err_v(Value::Str(format!("{e}")))),
+                Err(e) => Ok(err_v(Value::Str(format!("{e}").into()))),
             }
         }
         ("yaml", "stringify") => {
             let v = first_arg(args)?;
             let json = value_to_json(v);
             match serde_yaml::to_string(&json) {
-                Ok(s)  => Ok(ok_v(Value::Str(s))),
-                Err(e) => Ok(err_v(Value::Str(format!("yaml.stringify: {e}")))),
+                Ok(s)  => Ok(ok_v(Value::Str(s.into()))),
+                Err(e) => Ok(err_v(Value::Str(format!("yaml.stringify: {e}").into()))),
             }
         }
 
@@ -489,11 +489,11 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
                 Ok(map) => {
                     let mut bt: BTreeMap<MapKey, Value> = BTreeMap::new();
                     for (k, v) in map {
-                        bt.insert(MapKey::Str(k), Value::Str(v));
+                        bt.insert(MapKey::Str(k), Value::Str(v.into()));
                     }
                     Ok(ok_v(Value::Map(bt)))
                 }
-                Err(e) => Ok(err_v(Value::Str(e))),
+                Err(e) => Ok(err_v(Value::Str(e.into()))),
             }
         }
 
@@ -512,11 +512,11 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
                 match r {
                     Ok(rec) => {
                         let row: std::collections::VecDeque<Value> = rec.iter()
-                            .map(|f| Value::Str(f.to_string()))
+                            .map(|f| Value::Str(f.into()))
                             .collect();
                         rows.push_back(Value::List(row));
                     }
-                    Err(e) => return Ok(err_v(Value::Str(format!("csv.parse: {e}")))),
+                    Err(e) => return Ok(err_v(Value::Str(format!("csv.parse: {e}").into()))),
                 }
             }
             Ok(ok_v(Value::List(rows)))
@@ -542,21 +542,21 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
                         _ => return Ok(err_v(Value::Str("csv.stringify row must be List[Str]".into()))),
                     };
                     let strs: Vec<String> = cells.iter().map(|c| match c {
-                        Value::Str(s) => s.clone(),
+                        Value::Str(s) => s.to_string(),
                         other => serde_json::to_string(&other.to_json())
                             .unwrap_or_else(|_| String::new()),
                     }).collect();
                     if let Err(e) = wtr.write_record(&strs) {
-                        return Ok(err_v(Value::Str(format!("csv.stringify: {e}"))));
+                        return Ok(err_v(Value::Str(format!("csv.stringify: {e}").into())));
                     }
                 }
                 if let Err(e) = wtr.flush() {
-                    return Ok(err_v(Value::Str(format!("csv.stringify flush: {e}"))));
+                    return Ok(err_v(Value::Str(format!("csv.stringify flush: {e}").into())));
                 }
             }
             match String::from_utf8(out) {
-                Ok(s) => Ok(ok_v(Value::Str(s))),
-                Err(e) => Ok(err_v(Value::Str(format!("csv.stringify utf8: {e}")))),
+                Ok(s) => Ok(ok_v(Value::Str(s.into()))),
+                Err(e) => Ok(err_v(Value::Str(format!("csv.stringify utf8: {e}").into()))),
             }
         }
 
@@ -573,7 +573,7 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
                 Ok(ok_v(Value::Unit))
             } else {
                 Ok(err_v(Value::Str(format!("assert_eq: lhs {} != rhs {}",
-                    value_to_json(a), value_to_json(b)))))
+                    value_to_json(a), value_to_json(b)).into())))
             }
         }
         ("test", "assert_ne") => {
@@ -583,7 +583,7 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
                 Ok(ok_v(Value::Unit))
             } else {
                 Ok(err_v(Value::Str(format!("assert_ne: both sides are {}",
-                    value_to_json(a)))))
+                    value_to_json(a)).into())))
             }
         }
         ("test", "assert_true") => {
@@ -618,8 +618,8 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
         ("bytes", "to_str") => {
             let b = expect_bytes(args.first())?;
             match String::from_utf8(b.to_vec()) {
-                Ok(s) => Ok(ok_v(Value::Str(s))),
-                Err(e) => Ok(err_v(Value::Str(format!("{e}")))),
+                Ok(s) => Ok(ok_v(Value::Str(s.into()))),
+                Err(e) => Ok(err_v(Value::Str(format!("{e}").into()))),
             }
         }
         ("bytes", "slice") => {
@@ -1056,14 +1056,14 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             let s = expect_str(args.first())?;
             let mut h = Sha256::new();
             h.update(s.as_bytes());
-            Ok(Value::Str(hex::encode(h.finalize())))
+            Ok(Value::Str(hex::encode(h.finalize()).into()))
         }
         ("crypto", "sha512_str") => {
             use sha2::{Digest, Sha512};
             let s = expect_str(args.first())?;
             let mut h = Sha512::new();
             h.update(s.as_bytes());
-            Ok(Value::Str(hex::encode(h.finalize())))
+            Ok(Value::Str(hex::encode(h.finalize()).into()))
         }
         ("crypto", "hmac_sha256") => {
             use hmac::{Hmac, KeyInit, Mac};
@@ -1088,14 +1088,14 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
         ("crypto", "base64_encode") => {
             use base64::{Engine, engine::general_purpose::STANDARD};
             let data = expect_bytes(args.first())?;
-            Ok(Value::Str(STANDARD.encode(data)))
+            Ok(Value::Str(STANDARD.encode(data).into()))
         }
         ("crypto", "base64_decode") => {
             use base64::{Engine, engine::general_purpose::STANDARD};
             let s = expect_str(args.first())?;
             match STANDARD.decode(s) {
                 Ok(b)  => Ok(ok_v(Value::Bytes(b))),
-                Err(e) => Ok(err_v(Value::Str(format!("base64: {e}")))),
+                Err(e) => Ok(err_v(Value::Str(format!("base64: {e}").into()))),
             }
         }
         // URL-safe base64 (#382). Alphabet `-_` instead of `+/`,
@@ -1104,25 +1104,25 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
         ("crypto", "base64url_encode") => {
             use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
             let data = expect_bytes(args.first())?;
-            Ok(Value::Str(URL_SAFE_NO_PAD.encode(data)))
+            Ok(Value::Str(URL_SAFE_NO_PAD.encode(data).into()))
         }
         ("crypto", "base64url_decode") => {
             use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
             let s = expect_str(args.first())?;
             match URL_SAFE_NO_PAD.decode(s) {
                 Ok(b)  => Ok(ok_v(Value::Bytes(b))),
-                Err(e) => Ok(err_v(Value::Str(format!("base64url: {e}")))),
+                Err(e) => Ok(err_v(Value::Str(format!("base64url: {e}").into()))),
             }
         }
         ("crypto", "hex_encode") => {
             let data = expect_bytes(args.first())?;
-            Ok(Value::Str(hex::encode(data)))
+            Ok(Value::Str(hex::encode(data).into()))
         }
         ("crypto", "hex_decode") => {
             let s = expect_str(args.first())?;
             match hex::decode(s) {
                 Ok(b)  => Ok(ok_v(Value::Bytes(b))),
-                Err(e) => Ok(err_v(Value::Str(format!("hex: {e}")))),
+                Err(e) => Ok(err_v(Value::Str(format!("hex: {e}").into()))),
             }
         }
         ("crypto", "constant_time_eq") | ("crypto", "eq") => {
@@ -1248,11 +1248,11 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
                 return Err(format!(
                     "parser.char: expected 1-character string, got {s:?}"));
             }
-            Ok(parser_node("Char", &[("ch", Value::Str(s))]))
+            Ok(parser_node("Char", &[("ch", Value::Str(s.into()))]))
         }
         ("parser", "string") => {
             let s = expect_str(args.first())?;
-            Ok(parser_node("String", &[("s", Value::Str(s))]))
+            Ok(parser_node("String", &[("s", Value::Str(s.into()))]))
         }
         ("parser", "digit") => Ok(parser_node("Digit", &[])),
         ("parser", "alpha") => Ok(parser_node("Alpha", &[])),
@@ -1311,8 +1311,8 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
         ("regex", "compile") => {
             let pat = expect_str(args.first())?;
             match get_or_compile_regex(&pat) {
-                Ok(_) => Ok(ok_v(Value::Str(pat))),
-                Err(e) => Ok(err_v(Value::Str(e))),
+                Ok(_) => Ok(ok_v(Value::Str(pat.into()))),
+                Err(e) => Ok(err_v(Value::Str(e.into()))),
             }
         }
         ("regex", "is_match") => {
@@ -1357,14 +1357,14 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             let s = expect_str(args.get(1))?;
             let rep = expect_str(args.get(2))?;
             let re = get_or_compile_regex(&pat).map_err(|e| format!("regex.replace: {e}"))?;
-            Ok(Value::Str(re.replace(&s, rep.as_str()).into_owned()))
+            Ok(Value::Str(re.replace(&s, rep.as_str()).into_owned().into()))
         }
         ("regex", "replace_all") => {
             let pat = expect_str(args.first())?;
             let s = expect_str(args.get(1))?;
             let rep = expect_str(args.get(2))?;
             let re = get_or_compile_regex(&pat).map_err(|e| format!("regex.replace_all: {e}"))?;
-            Ok(Value::Str(re.replace_all(&s, rep.as_str()).into_owned()))
+            Ok(Value::Str(re.replace_all(&s, rep.as_str()).into_owned().into()))
         }
         // -- datetime (pure ops; datetime.now is effectful and routes
         // through the handler under [time]) --
@@ -1372,12 +1372,12 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             let s = expect_str(args.first())?;
             match chrono::DateTime::parse_from_rfc3339(&s) {
                 Ok(dt) => Ok(ok_v(Value::Int(instant_from_chrono(dt)))),
-                Err(e) => Ok(err_v(Value::Str(format!("parse_iso: {e}")))),
+                Err(e) => Ok(err_v(Value::Str(format!("parse_iso: {e}").into()))),
             }
         }
         ("datetime", "format_iso") => {
             let n = expect_int(args.first())?;
-            Ok(Value::Str(format_iso(n)))
+            Ok(Value::Str(format_iso(n).into()))
         }
         ("datetime", "parse") => {
             let s = expect_str(args.first())?;
@@ -1390,24 +1390,24 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
                         None => Ok(err_v(Value::Str("parse: ambiguous local time".into()))),
                     }
                 }
-                Err(e) => Ok(err_v(Value::Str(format!("parse: {e}")))),
+                Err(e) => Ok(err_v(Value::Str(format!("parse: {e}").into()))),
             }
         }
         ("datetime", "format") => {
             let n = expect_int(args.first())?;
             let fmt = expect_str(args.get(1))?;
             let dt = chrono_from_instant(n);
-            Ok(Value::Str(dt.format(&fmt).to_string()))
+            Ok(Value::Str(dt.format(&fmt).to_string().into()))
         }
         ("datetime", "to_components") => {
             let n = expect_int(args.first())?;
             let tz = match parse_tz_arg(args.get(1)) {
                 Ok(t) => t,
-                Err(e) => return Ok(err_v(Value::Str(e))),
+                Err(e) => return Ok(err_v(Value::Str(e.into()))),
             };
             match resolve_tz_to_components(n, &tz) {
                 Ok(rec) => Ok(ok_v(rec)),
-                Err(e) => Ok(err_v(Value::Str(e))),
+                Err(e) => Ok(err_v(Value::Str(e.into()))),
             }
         }
         ("datetime", "from_components") => {
@@ -1417,7 +1417,7 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             };
             match instant_from_components(&rec) {
                 Ok(n) => Ok(ok_v(Value::Int(n))),
-                Err(e) => Ok(err_v(Value::Str(e))),
+                Err(e) => Ok(err_v(Value::Str(e.into()))),
             }
         }
         ("datetime", "add") => {
@@ -1469,7 +1469,7 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             let pat = expect_str(args.first())?;
             let s = expect_str(args.get(1))?;
             let re = get_or_compile_regex(&pat).map_err(|e| format!("regex.split: {e}"))?;
-            let parts: std::collections::VecDeque<Value> = re.split(&s).map(|p| Value::Str(p.to_string())).collect();
+            let parts: std::collections::VecDeque<Value> = re.split(&s).map(|p| Value::Str(p.into())).collect();
             Ok(Value::List(parts))
         }
 
@@ -1530,7 +1530,7 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
                 _ => return Err("http.text_body: HttpResponse.body must be Bytes".into()),
             };
             match String::from_utf8(body) {
-                Ok(s) => Ok(ok_v(Value::Str(s))),
+                Ok(s) => Ok(ok_v(Value::Str(s.into()))),
                 Err(e) => Ok(http_decode_err_pure(format!("body not UTF-8: {e}"))),
             }
         }
@@ -1570,12 +1570,12 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             let spec = value_to_json(args.first().unwrap_or(&Value::Unit));
             let argv: Vec<String> = expect_list(args.get(1))?
                 .iter().map(|v| match v {
-                    Value::Str(s) => Ok(s.clone()),
+                    Value::Str(s) => Ok(s.to_string()),
                     other => Err(format!("cli.parse: argv must be List[Str], got {other:?}")),
                 }).collect::<Result<_, _>>()?;
             match crate::cli::parse(&spec, &argv) {
                 Ok(parsed) => Ok(ok_v(value_from_json(parsed))),
-                Err(msg) => Ok(err_v(Value::Str(msg))),
+                Err(msg) => Ok(err_v(Value::Str(msg.into()))),
             }
         }
         ("cli", "envelope") => {
@@ -1590,7 +1590,7 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
         }
         ("cli", "help") => {
             let spec = value_to_json(args.first().unwrap_or(&Value::Unit));
-            Ok(Value::Str(crate::cli::help_text(&spec)))
+            Ok(Value::Str(crate::cli::help_text(&spec).into()))
         }
 
         _ => Err(format!("unknown pure builtin: {kind}.{op}")),
@@ -1604,7 +1604,7 @@ fn opt_str(arg: Option<&Value>) -> Option<String> {
     match arg {
         Some(Value::Variant { name, args }) if name == "Some" => {
             args.first().and_then(|v| match v {
-                Value::Str(s) => Some(s.clone()),
+                Value::Str(s) => Some(s.to_string()),
                 _ => None,
             })
         }
@@ -1643,15 +1643,16 @@ fn get_or_compile_regex(pattern: &str) -> Result<regex::Regex, String> {
 fn match_value(caps: &regex::Captures) -> Value {
     let m0 = caps.get(0).expect("regex match always has group 0");
     let mut rec = indexmap::IndexMap::new();
-    rec.insert("text".into(), Value::Str(m0.as_str().to_string()));
+    rec.insert("text".into(), Value::Str(m0.as_str().into()));
     rec.insert("start".into(), Value::Int(m0.start() as i64));
     rec.insert("end".into(), Value::Int(m0.end() as i64));
     let groups: std::collections::VecDeque<Value> = (1..caps.len())
         .map(|i| {
             Value::Str(
                 caps.get(i)
-                    .map(|m| m.as_str().to_string())
-                    .unwrap_or_default(),
+                    .map(|m| m.as_str())
+                    .unwrap_or_default()
+                    .into(),
             )
         })
         .collect();
@@ -1734,7 +1735,7 @@ fn tuple_index(v: &Value, i: usize) -> Result<Value, String> {
 
 fn expect_str(v: Option<&Value>) -> Result<String, String> {
     match v {
-        Some(Value::Str(s)) => Ok(s.clone()),
+        Some(Value::Str(s)) => Ok(s.to_string()),
         Some(other) => Err(format!("expected Str, got {other:?}")),
         None => Err("missing argument".into()),
     }
@@ -1855,7 +1856,7 @@ fn expect_record_pure(v: Option<&Value>) -> Result<&indexmap::IndexMap<String, V
 fn http_decode_err_pure(msg: String) -> Value {
     let inner = Value::Variant {
         name: "DecodeError".into(),
-        args: vec![Value::Str(msg)],
+        args: vec![Value::Str(msg.into())],
     };
     err_v(inner)
 }
@@ -1882,7 +1883,7 @@ fn http_set_header(
         MapKey::Str(s) => s.to_lowercase() != lowered,
         _ => true,
     });
-    headers.insert(key, Value::Str(value.to_string()));
+    headers.insert(key, Value::Str(value.into()));
     req.insert("headers".into(), Value::Map(headers));
     req
 }
@@ -1903,14 +1904,14 @@ fn http_append_query(
     };
     let mut pieces = Vec::new();
     for (k, v) in params {
-        let kk = match k { MapKey::Str(s) => s.clone(), _ => continue };
-        let vv = match v { Value::Str(s) => s.clone(), _ => continue };
+        let kk = match k { MapKey::Str(s) => s.to_string(), _ => continue };
+        let vv = match v { Value::Str(s) => s.to_string(), _ => continue };
         pieces.push(format!("{}={}", url_encode(&kk), url_encode(&vv)));
     }
     if pieces.is_empty() { return req; }
     let sep = if url.contains('?') { '&' } else { '?' };
     let new_url = format!("{url}{sep}{}", pieces.join("&"));
-    req.insert("url".into(), Value::Str(new_url));
+    req.insert("url".into(), Value::Str(new_url.into()));
     req
 }
 
@@ -1978,7 +1979,7 @@ fn required_field_names(arg: Option<&Value>) -> Result<Vec<String>, String> {
     let mut out = Vec::with_capacity(list.len());
     for v in list {
         match v {
-            Value::Str(s) => out.push(s.clone()),
+            Value::Str(s) => out.push(s.to_string()),
             other => return Err(format!(
                 "parse_strict: required-fields list must contain Str, got {other:?}"
             )),
@@ -2087,7 +2088,7 @@ fn extract_type_schema(v: Option<&Value>) -> Vec<(String, String)> {
             if let Value::Tuple(items) = p {
                 if items.len() == 2 {
                     if let (Value::Str(name), Value::Str(tag)) = (&items[0], &items[1]) {
-                        return Some((name.clone(), tag.clone()));
+                        return Some((name.to_string(), tag.to_string()));
                     }
                 }
             }
@@ -2254,7 +2255,7 @@ fn parse_tz_arg(v: Option<&Value>) -> Result<TzArg, String> {
                 })?;
                 Ok(TzArg::Offset(m))
             }
-            ("Iana", [Value::Str(s)]) => Ok(TzArg::Iana(s.clone())),
+            ("Iana", [Value::Str(s)]) => Ok(TzArg::Iana(s.to_string())),
             (other, _) => Err(format!(
                 "expected Tz variant (Utc | Local | Offset(Int) | Iana(Str)), got `{other}` with {} arg(s)",
                 args.len()
@@ -2405,7 +2406,8 @@ fn aead_result(ciphertext: Vec<u8>, tag: Vec<u8>) -> Value {
 }
 
 fn aead_err(msg: impl Into<String>) -> Value {
-    err_v(Value::Str(msg.into()))
+    let s: String = msg.into();
+    err_v(Value::Str(s.into()))
 }
 
 fn aes_gcm_seal_impl(args: &[Value]) -> Value {
@@ -2463,17 +2465,17 @@ fn aes_gcm_open_impl(args: &[Value]) -> Value {
     use aes_gcm::{Aes128Gcm, Aes256Gcm, Nonce};
     let (key, nonce, aad, ciphertext, tag) = match unpack5_bytes(args, "aes_gcm_open") {
         Ok(t) => t,
-        Err(e) => return err_v(Value::Str(e)),
+        Err(e) => return err_v(Value::Str(e.into())),
     };
     if nonce.len() != 12 {
         return err_v(Value::Str(format!(
             "aes_gcm_open: nonce must be exactly 12 bytes, got {}", nonce.len()
-        )));
+        ).into()));
     }
     if tag.len() != 16 {
         return err_v(Value::Str(format!(
             "aes_gcm_open: tag must be exactly 16 bytes, got {}", tag.len()
-        )));
+        ).into()));
     }
     // Rebuild the "ciphertext || tag" buffer the aes-gcm crate expects.
     let mut combined = Vec::with_capacity(ciphertext.len() + tag.len());
@@ -2490,11 +2492,11 @@ fn aes_gcm_open_impl(args: &[Value]) -> Value {
             .and_then(|c| c.decrypt(n, payload).map_err(|e| format!("aes_gcm_open: {e}"))),
         other => return err_v(Value::Str(format!(
             "aes_gcm_open: key must be 16 or 32 bytes, got {other}"
-        ))),
+        ).into())),
     };
     match plaintext {
         Ok(p) => ok_v(Value::Bytes(p)),
-        Err(e) => err_v(Value::Str(e)),
+        Err(e) => err_v(Value::Str(e.into())),
     }
 }
 
@@ -2538,22 +2540,22 @@ fn chacha20_open_impl(args: &[Value]) -> Value {
     use chacha20poly1305::{ChaCha20Poly1305, Nonce};
     let (key, nonce, aad, ciphertext, tag) = match unpack5_bytes(args, "chacha20_poly1305_open") {
         Ok(t) => t,
-        Err(e) => return err_v(Value::Str(e)),
+        Err(e) => return err_v(Value::Str(e.into())),
     };
     if key.len() != 32 {
         return err_v(Value::Str(format!(
             "chacha20_poly1305_open: key must be exactly 32 bytes, got {}", key.len()
-        )));
+        ).into()));
     }
     if nonce.len() != 12 {
         return err_v(Value::Str(format!(
             "chacha20_poly1305_open: nonce must be exactly 12 bytes, got {}", nonce.len()
-        )));
+        ).into()));
     }
     if tag.len() != 16 {
         return err_v(Value::Str(format!(
             "chacha20_poly1305_open: tag must be exactly 16 bytes, got {}", tag.len()
-        )));
+        ).into()));
     }
     let mut combined = Vec::with_capacity(ciphertext.len() + tag.len());
     combined.extend_from_slice(ciphertext);
@@ -2564,7 +2566,7 @@ fn chacha20_open_impl(args: &[Value]) -> Value {
     let payload = Payload { msg: &combined, aad };
     match cipher.and_then(|c| c.decrypt(n, payload).map_err(|e| format!("chacha20_poly1305_open: {e}"))) {
         Ok(p) => ok_v(Value::Bytes(p)),
-        Err(e) => err_v(Value::Str(e)),
+        Err(e) => err_v(Value::Str(e.into())),
     }
 }
 
@@ -2657,28 +2659,28 @@ fn pbkdf2_sha256_impl(args: &[Value]) -> Value {
     let op = "pbkdf2_sha256";
     let (password, salt, iterations, len) = match unpack_kdf4(args, op) {
         Ok(t) => t,
-        Err(e) => return err_v(Value::Str(e)),
+        Err(e) => return err_v(Value::Str(e.into())),
     };
     if iterations <= 0 {
         return err_v(Value::Str(format!(
             "{op}: iterations must be > 0, got {iterations}"
-        )));
+        ).into()));
     }
     let out_len = match check_len(op, len) {
         Ok(n) => n,
-        Err(e) => return err_v(Value::Str(e)),
+        Err(e) => return err_v(Value::Str(e.into())),
     };
     let rounds = match u32::try_from(iterations) {
         Ok(r) => r,
         Err(_) => {
             return err_v(Value::Str(format!(
                 "{op}: iterations must fit in u32, got {iterations}"
-            )))
+            ).into()))
         }
     };
     let mut out = vec![0u8; out_len];
     if let Err(e) = pbkdf2::pbkdf2::<Hmac<Sha256>>(password, salt, rounds, &mut out) {
-        return err_v(Value::Str(format!("{op}: {e}")));
+        return err_v(Value::Str(format!("{op}: {e}").into()));
     }
     ok_v(Value::Bytes(out))
 }
@@ -2689,11 +2691,11 @@ fn hkdf_sha256_impl(args: &[Value]) -> Value {
     let op = "hkdf_sha256";
     let (ikm, salt, info, len) = match unpack_hkdf4(args, op) {
         Ok(t) => t,
-        Err(e) => return err_v(Value::Str(e)),
+        Err(e) => return err_v(Value::Str(e.into())),
     };
     let out_len = match check_len(op, len) {
         Ok(n) => n,
-        Err(e) => return err_v(Value::Str(e)),
+        Err(e) => return err_v(Value::Str(e.into())),
     };
     // RFC 5869 caps output at 255 * HashLen; the `expand` call below
     // returns InvalidLength when exceeded — surface that as Err.
@@ -2702,7 +2704,7 @@ fn hkdf_sha256_impl(args: &[Value]) -> Value {
     let mut out = vec![0u8; out_len];
     match hk.expand(info, &mut out) {
         Ok(()) => ok_v(Value::Bytes(out)),
-        Err(e) => err_v(Value::Str(format!("{op}: {e}"))),
+        Err(e) => err_v(Value::Str(format!("{op}: {e}").into())),
     }
 }
 
@@ -2711,24 +2713,24 @@ fn argon2id_impl(args: &[Value]) -> Value {
     let op = "argon2id";
     let (password, salt, t_cost, m_cost, len) = match unpack_argon5(args, op) {
         Ok(t) => t,
-        Err(e) => return err_v(Value::Str(e)),
+        Err(e) => return err_v(Value::Str(e.into())),
     };
     let out_len = match check_len(op, len) {
         Ok(n) => n,
-        Err(e) => return err_v(Value::Str(e)),
+        Err(e) => return err_v(Value::Str(e.into())),
     };
     let t = match u32::try_from(t_cost) {
         Ok(n) if n >= 1 => n,
         _ => return err_v(Value::Str(format!(
             "{op}: t_cost must be a u32 >= 1, got {t_cost}"
-        ))),
+        ).into())),
     };
     let m = match u32::try_from(m_cost) {
         Ok(n) if n >= Params::MIN_M_COST => n,
         _ => return err_v(Value::Str(format!(
             "{op}: m_cost must be a u32 >= {}, got {m_cost}",
             Params::MIN_M_COST
-        ))),
+        ).into())),
     };
     // p=1 is the default and what every interop spec assumes (PHC
     // string, libsodium's argon2id_str). We don't expose parallelism
@@ -2736,12 +2738,12 @@ fn argon2id_impl(args: &[Value]) -> Value {
     // makes hashes uncomparable across machines.
     let params = match Params::new(m, t, 1, Some(out_len)) {
         Ok(p) => p,
-        Err(e) => return err_v(Value::Str(format!("{op}: {e}"))),
+        Err(e) => return err_v(Value::Str(format!("{op}: {e}").into())),
     };
     let hasher = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
     let mut out = vec![0u8; out_len];
     if let Err(e) = hasher.hash_password_into(password, salt, &mut out) {
-        return err_v(Value::Str(format!("{op}: {e}")));
+        return err_v(Value::Str(format!("{op}: {e}").into()));
     }
     ok_v(Value::Bytes(out))
 }

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -6,6 +6,7 @@
 
 use lex_bytecode::vm::{EffectHandler, Vm};
 use lex_bytecode::{Program, Value};
+use smol_str::SmolStr;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
@@ -154,7 +155,7 @@ impl DefaultHandler {
                         Ok(ok(Value::Unit))
                     }
                     None => Ok(err(Value::Str(format!(
-                        "log.set_level: unknown level `{s}`; expected debug|info|warn|error")))),
+                        "log.set_level: unknown level `{s}`; expected debug|info|warn|error").into()))),
                 }
             }
             "set_format" => {
@@ -163,7 +164,7 @@ impl DefaultHandler {
                     "text" => LogFormat::Text,
                     "json" => LogFormat::Json,
                     other => return Ok(err(Value::Str(format!(
-                        "log.set_format: unknown format `{other}`; expected text|json")))),
+                        "log.set_format: unknown format `{other}`; expected text|json").into()))),
                 };
                 log_state().lock().unwrap().format = fmt;
                 Ok(ok(Value::Unit))
@@ -175,7 +176,7 @@ impl DefaultHandler {
                     return Ok(ok(Value::Unit));
                 }
                 if let Err(e) = self.ensure_fs_write_path(path) {
-                    return Ok(err(Value::Str(e)));
+                    return Ok(err(Value::Str(e.into())));
                 }
                 match std::fs::OpenOptions::new()
                     .create(true).append(true).open(path)
@@ -184,7 +185,7 @@ impl DefaultHandler {
                         log_state().lock().unwrap().sink = LogSink::File(std::sync::Arc::new(Mutex::new(f)));
                         Ok(ok(Value::Unit))
                     }
-                    Err(e) => Ok(err(Value::Str(format!("log.set_sink `{path}`: {e}")))),
+                    Err(e) => Ok(err(Value::Str(format!("log.set_sink `{path}`: {e}").into()))),
                 }
             }
             other => Err(format!("unsupported log.{other}")),
@@ -200,7 +201,7 @@ impl DefaultHandler {
                     _ => return Err("process.spawn: args must be List[Str]".into()),
                 };
                 let str_args: Result<Vec<String>, String> = raw_args.iter().map(|v| match v {
-                    Value::Str(s) => Ok(s.clone()),
+                    Value::Str(s) => Ok(s.to_string()),
                     other => Err(format!("process.spawn: arg must be Str, got {other:?}")),
                 }).collect();
                 let str_args = str_args?;
@@ -219,7 +220,7 @@ impl DefaultHandler {
                         return Ok(err(Value::Str(format!(
                             "process.spawn: `{cmd}` not in --allow-proc {:?}",
                             self.policy.allow_proc
-                        ))));
+                        ).into())));
                     }
                 }
 
@@ -256,7 +257,7 @@ impl DefaultHandler {
 
                 let mut child = match command.spawn() {
                     Ok(c) => c,
-                    Err(e) => return Ok(err(Value::Str(format!("process.spawn `{cmd}`: {e}")))),
+                    Err(e) => return Ok(err(Value::Str(format!("process.spawn `{cmd}`: {e}").into()))),
                 };
 
                 if let Some(payload) = stdin_payload {
@@ -319,7 +320,7 @@ impl DefaultHandler {
                 // Windows). Signal-name dispatch is a v1.5 follow-up.
                 match state.child.kill() {
                     Ok(_) => Ok(ok(Value::Unit)),
-                    Err(e) => Ok(err(Value::Str(format!("process.kill: {e}")))),
+                    Err(e) => Ok(err(Value::Str(format!("process.kill: {e}").into()))),
                 }
             }
             "run" => {
@@ -329,7 +330,7 @@ impl DefaultHandler {
                     _ => return Err("process.run: args must be List[Str]".into()),
                 };
                 let str_args: Result<Vec<String>, String> = raw_args.iter().map(|v| match v {
-                    Value::Str(s) => Ok(s.clone()),
+                    Value::Str(s) => Ok(s.to_string()),
                     other => Err(format!("process.run: arg must be Str, got {other:?}")),
                 }).collect();
                 let str_args = str_args?;
@@ -342,21 +343,21 @@ impl DefaultHandler {
                         return Ok(err(Value::Str(format!(
                             "process.run: `{cmd}` not in --allow-proc {:?}",
                             self.policy.allow_proc
-                        ))));
+                        ).into())));
                     }
                 }
                 match std::process::Command::new(&cmd).args(&str_args).output() {
                     Ok(o) => {
                         let mut rec = indexmap::IndexMap::new();
                         rec.insert("stdout".into(), Value::Str(
-                            String::from_utf8_lossy(&o.stdout).to_string()));
+                            String::from_utf8_lossy(&o.stdout).into_owned().into()));
                         rec.insert("stderr".into(), Value::Str(
-                            String::from_utf8_lossy(&o.stderr).to_string()));
+                            String::from_utf8_lossy(&o.stderr).into_owned().into()));
                         rec.insert("exit_code".into(), Value::Int(
                             o.status.code().unwrap_or(-1) as i64));
                         Ok(ok(Value::Record(rec)))
                     }
-                    Err(e) => Ok(err(Value::Str(format!("process.run `{cmd}`: {e}")))),
+                    Err(e) => Ok(err(Value::Str(format!("process.run `{cmd}`: {e}").into()))),
                 }
             }
             other => Err(format!("unsupported process.{other}")),
@@ -391,7 +392,7 @@ impl DefaultHandler {
             Ok(_) => {
                 if line.ends_with('\n') { line.pop(); }
                 if line.ends_with('\r') { line.pop(); }
-                Ok(some(Value::Str(line)))
+                Ok(some(Value::Str(line.into())))
             }
             Err(e) => Err(format!("process.read_*_line: {e}")),
         }
@@ -402,28 +403,28 @@ impl DefaultHandler {
             "exists" => {
                 let path = expect_str(args.first())?.to_string();
                 if let Err(e) = self.ensure_fs_walk_path(&path) {
-                    return Ok(err(Value::Str(e)));
+                    return Ok(err(Value::Str(e.into())));
                 }
                 Ok(Value::Bool(std::path::Path::new(&path).exists()))
             }
             "is_file" => {
                 let path = expect_str(args.first())?.to_string();
                 if let Err(e) = self.ensure_fs_walk_path(&path) {
-                    return Ok(err(Value::Str(e)));
+                    return Ok(err(Value::Str(e.into())));
                 }
                 Ok(Value::Bool(std::path::Path::new(&path).is_file()))
             }
             "is_dir" => {
                 let path = expect_str(args.first())?.to_string();
                 if let Err(e) = self.ensure_fs_walk_path(&path) {
-                    return Ok(err(Value::Str(e)));
+                    return Ok(err(Value::Str(e.into())));
                 }
                 Ok(Value::Bool(std::path::Path::new(&path).is_dir()))
             }
             "stat" => {
                 let path = expect_str(args.first())?.to_string();
                 if let Err(e) = self.ensure_fs_walk_path(&path) {
-                    return Ok(err(Value::Str(e)));
+                    return Ok(err(Value::Str(e.into())));
                 }
                 match std::fs::metadata(&path) {
                     Ok(md) => {
@@ -439,13 +440,13 @@ impl DefaultHandler {
                         rec.insert("is_file".into(), Value::Bool(md.is_file()));
                         Ok(ok(Value::Record(rec)))
                     }
-                    Err(e) => Ok(err(Value::Str(format!("fs.stat `{path}`: {e}")))),
+                    Err(e) => Ok(err(Value::Str(format!("fs.stat `{path}`: {e}").into()))),
                 }
             }
             "list_dir" => {
                 let path = expect_str(args.first())?.to_string();
                 if let Err(e) = self.ensure_fs_walk_path(&path) {
-                    return Ok(err(Value::Str(e)));
+                    return Ok(err(Value::Str(e.into())));
                 }
                 match std::fs::read_dir(&path) {
                     Ok(rd) => {
@@ -454,27 +455,27 @@ impl DefaultHandler {
                             match ent {
                                 Ok(e) => {
                                     let p = e.path();
-                                    entries.push(Value::Str(p.to_string_lossy().into_owned()));
+                                    entries.push(Value::Str(p.to_string_lossy().into_owned().into()));
                                 }
-                                Err(e) => return Ok(err(Value::Str(format!("fs.list_dir: {e}")))),
+                                Err(e) => return Ok(err(Value::Str(format!("fs.list_dir: {e}").into()))),
                             }
                         }
                         Ok(ok(Value::List(entries.into())))
                     }
-                    Err(e) => Ok(err(Value::Str(format!("fs.list_dir `{path}`: {e}")))),
+                    Err(e) => Ok(err(Value::Str(format!("fs.list_dir `{path}`: {e}").into()))),
                 }
             }
             "walk" => {
                 let path = expect_str(args.first())?.to_string();
                 if let Err(e) = self.ensure_fs_walk_path(&path) {
-                    return Ok(err(Value::Str(e)));
+                    return Ok(err(Value::Str(e.into())));
                 }
                 let mut paths: Vec<Value> = Vec::new();
                 for ent in walkdir::WalkDir::new(&path) {
                     match ent {
                         Ok(e) => paths.push(Value::Str(
-                            e.path().to_string_lossy().into_owned())),
-                        Err(e) => return Ok(err(Value::Str(format!("fs.walk: {e}")))),
+                            e.path().to_string_lossy().into_owned().into())),
+                        Err(e) => return Ok(err(Value::Str(format!("fs.walk: {e}").into()))),
                     }
                 }
                 Ok(ok(Value::List(paths.into())))
@@ -487,7 +488,7 @@ impl DefaultHandler {
                 // `--allow-fs-read`.
                 let entries = match glob::glob(&pattern) {
                     Ok(e) => e,
-                    Err(e) => return Ok(err(Value::Str(format!("fs.glob: {e}")))),
+                    Err(e) => return Ok(err(Value::Str(format!("fs.glob: {e}").into()))),
                 };
                 let mut paths: Vec<Value> = Vec::new();
                 for ent in entries {
@@ -497,10 +498,10 @@ impl DefaultHandler {
                             if self.policy.allow_fs_read.is_empty()
                                 || self.policy.allow_fs_read.iter().any(|root| p.starts_with(root))
                             {
-                                paths.push(Value::Str(s));
+                                paths.push(Value::Str(s.into()));
                             }
                         }
-                        Err(e) => return Ok(err(Value::Str(format!("fs.glob: {e}")))),
+                        Err(e) => return Ok(err(Value::Str(format!("fs.glob: {e}").into()))),
                     }
                 }
                 Ok(ok(Value::List(paths.into())))
@@ -508,17 +509,17 @@ impl DefaultHandler {
             "mkdir_p" => {
                 let path = expect_str(args.first())?.to_string();
                 if let Err(e) = self.ensure_fs_write_path(&path) {
-                    return Ok(err(Value::Str(e)));
+                    return Ok(err(Value::Str(e.into())));
                 }
                 match std::fs::create_dir_all(&path) {
                     Ok(_) => Ok(ok(Value::Unit)),
-                    Err(e) => Ok(err(Value::Str(format!("fs.mkdir_p `{path}`: {e}")))),
+                    Err(e) => Ok(err(Value::Str(format!("fs.mkdir_p `{path}`: {e}").into()))),
                 }
             }
             "remove" => {
                 let path = expect_str(args.first())?.to_string();
                 if let Err(e) = self.ensure_fs_write_path(&path) {
-                    return Ok(err(Value::Str(e)));
+                    return Ok(err(Value::Str(e.into())));
                 }
                 let p = std::path::Path::new(&path);
                 let result = if p.is_dir() {
@@ -528,21 +529,21 @@ impl DefaultHandler {
                 };
                 match result {
                     Ok(_) => Ok(ok(Value::Unit)),
-                    Err(e) => Ok(err(Value::Str(format!("fs.remove `{path}`: {e}")))),
+                    Err(e) => Ok(err(Value::Str(format!("fs.remove `{path}`: {e}").into()))),
                 }
             }
             "copy" => {
                 let src = expect_str(args.first())?.to_string();
                 let dst = expect_str(args.get(1))?.to_string();
                 if let Err(e) = self.ensure_fs_walk_path(&src) {
-                    return Ok(err(Value::Str(e)));
+                    return Ok(err(Value::Str(e.into())));
                 }
                 if let Err(e) = self.ensure_fs_write_path(&dst) {
-                    return Ok(err(Value::Str(e)));
+                    return Ok(err(Value::Str(e.into())));
                 }
                 match std::fs::copy(&src, &dst) {
                     Ok(_) => Ok(ok(Value::Unit)),
-                    Err(e) => Ok(err(Value::Str(format!("fs.copy {src} -> {dst}: {e}")))),
+                    Err(e) => Ok(err(Value::Str(format!("fs.copy {src} -> {dst}: {e}").into()))),
                 }
             }
             other => Err(format!("unsupported fs.{other}")),
@@ -728,7 +729,7 @@ impl EffectHandler for DefaultHandler {
             let mut buf = vec![0u8; n as usize];
             SysRng.try_fill_bytes(&mut buf)
                 .map_err(|e| format!("crypto.random_str_hex: OS RNG: {e}"))?;
-            return Ok(Value::Str(hex::encode(&buf)));
+            return Ok(Value::Str(hex::encode(&buf).into()));
         }
         // `std.http` wire ops (send/get/post) gate on the `net`
         // effect kind, not the module name. This matches the
@@ -764,7 +765,7 @@ impl EffectHandler for DefaultHandler {
                 "local_complete" => Ok(dispatch_llm_local(args)),
                 "cloud_complete" => Ok(dispatch_llm_cloud(args)),
                 "cloud_stream"   => Ok(self.dispatch_cloud_stream(args)),
-                _ => Ok(ok(Value::Str(format!("<{effect_kind} stub>")))),
+                _ => Ok(ok(Value::Str(format!("<{effect_kind} stub>").into()))),
             };
         }
         if kind == "stream" {
@@ -825,8 +826,8 @@ impl EffectHandler for DefaultHandler {
                     return Err(format!("read of `{path}` outside --allow-fs-read"));
                 }
                 match std::fs::read_to_string(&resolved) {
-                    Ok(s) => Ok(ok(Value::Str(s))),
-                    Err(e) => Ok(err(Value::Str(format!("{e}")))),
+                    Ok(s) => Ok(ok(Value::Str(s.into()))),
+                    Err(e) => Ok(err(Value::Str(format!("{e}").into()))),
                 }
             }
             ("io", "write") => {
@@ -841,7 +842,7 @@ impl EffectHandler for DefaultHandler {
                 }
                 match std::fs::write(&path, contents) {
                     Ok(_) => Ok(ok(Value::Unit)),
-                    Err(e) => Ok(err(Value::Str(format!("{e}")))),
+                    Err(e) => Ok(err(Value::Str(format!("{e}").into()))),
                 }
             }
             ("time", "now") => {
@@ -877,10 +878,10 @@ impl EffectHandler for DefaultHandler {
                     if let Ok(secs) = s.trim().parse::<i64>() {
                         let dt = chrono::DateTime::<chrono::Utc>::from_timestamp(secs, 0)
                             .unwrap_or_else(chrono::Utc::now);
-                        return Ok(Value::Str(dt.to_rfc3339()));
+                        return Ok(Value::Str(dt.to_rfc3339().into()));
                     }
                 }
-                Ok(Value::Str(chrono::Utc::now().to_rfc3339()))
+                Ok(Value::Str(chrono::Utc::now().to_rfc3339().into()))
             }
             ("time", "mono_ns") => {
                 // Monotonic clock relative to process start. Cached
@@ -925,7 +926,7 @@ impl EffectHandler for DefaultHandler {
                 Ok(match std::env::var(name) {
                     Ok(v) => Value::Variant {
                         name: "Some".into(),
-                        args: vec![Value::Str(v)],
+                        args: vec![Value::Str(v.into())],
                     },
                     Err(_) => Value::Variant { name: "None".into(), args: Vec::new() },
                 })
@@ -1065,7 +1066,7 @@ impl EffectHandler for DefaultHandler {
                     let p = std::path::Path::new(&path);
                     if !self.policy.allow_fs_write.iter().any(|a| p.starts_with(a)) {
                         return Ok(err(Value::Str(format!(
-                            "kv.open: `{path}` outside --allow-fs-write"))));
+                            "kv.open: `{path}` outside --allow-fs-write").into())));
                     }
                 }
                 match sled::open(&path) {
@@ -1074,7 +1075,7 @@ impl EffectHandler for DefaultHandler {
                         kv_registry().lock().unwrap().insert(handle, db);
                         Ok(ok(Value::Int(handle as i64)))
                     }
-                    Err(e) => Ok(err(Value::Str(format!("kv.open: {e}")))),
+                    Err(e) => Ok(err(Value::Str(format!("kv.open: {e}").into()))),
                 }
             }
             ("kv", "close") => {
@@ -1101,7 +1102,7 @@ impl EffectHandler for DefaultHandler {
                 let db = reg.touch_get(h).ok_or_else(|| "kv.put: closed or unknown Kv handle".to_string())?;
                 match db.insert(key.as_bytes(), val) {
                     Ok(_) => Ok(ok(Value::Unit)),
-                    Err(e) => Ok(err(Value::Str(format!("kv.put: {e}")))),
+                    Err(e) => Ok(err(Value::Str(format!("kv.put: {e}").into()))),
                 }
             }
             ("kv", "delete") => {
@@ -1111,7 +1112,7 @@ impl EffectHandler for DefaultHandler {
                 let db = reg.touch_get(h).ok_or_else(|| "kv.delete: closed or unknown Kv handle".to_string())?;
                 match db.remove(key.as_bytes()) {
                     Ok(_) => Ok(ok(Value::Unit)),
-                    Err(e) => Ok(err(Value::Str(format!("kv.delete: {e}")))),
+                    Err(e) => Ok(err(Value::Str(format!("kv.delete: {e}").into()))),
                 }
             }
             ("kv", "contains") => {
@@ -1133,7 +1134,7 @@ impl EffectHandler for DefaultHandler {
                 for kv in db.scan_prefix(prefix.as_bytes()) {
                     let (k, _) = kv.map_err(|e| format!("kv.list_prefix: {e}"))?;
                     let s = String::from_utf8_lossy(&k).to_string();
-                    keys.push(Value::Str(s));
+                    keys.push(Value::Str(s.into()));
                 }
                 Ok(Value::List(keys.into()))
             }
@@ -1398,7 +1399,7 @@ impl EffectHandler for DefaultHandler {
             }
             ("sql", "get_str") => Ok(sql_get_col(&args, |v| match v {
                 Value::Str(s) => Some(Value::Str(s.clone())),
-                Value::Int(n) => Some(Value::Str(n.to_string())),
+                Value::Int(n) => Some(Value::Str(n.to_string().into())),
                 _ => None,
             })?),
             ("sql", "get_int") => Ok(sql_get_col(&args, |v| match v {
@@ -1438,7 +1439,7 @@ impl EffectHandler for DefaultHandler {
                     None => return Err("proc.spawn: missing args list".into()),
                 };
                 let str_args: Vec<String> = raw_args.iter().map(|v| match v {
-                    Value::Str(s) => Ok(s.clone()),
+                    Value::Str(s) => Ok(s.to_string()),
                     other => Err(format!("proc.spawn: arg must be Str, got {other:?}")),
                 }).collect::<Result<Vec<_>, _>>()?;
 
@@ -1454,7 +1455,7 @@ impl EffectHandler for DefaultHandler {
                         return Ok(err(Value::Str(format!(
                             "proc.spawn: `{cmd}` not in --allow-proc {:?}",
                             self.policy.allow_proc
-                        ))));
+                        ).into())));
                     }
                 }
 
@@ -1462,7 +1463,7 @@ impl EffectHandler for DefaultHandler {
                 // unbounded argv is a DoS vector.
                 if str_args.len() > 1024 {
                     return Ok(err(Value::Str(
-                        "proc.spawn: arg-count exceeds 1024".into())));
+                        SmolStr::new_inline("proc.spawn: arg-count exceeds 1024"))));
                 }
                 if str_args.iter().any(|a| a.len() > 65_536) {
                     return Ok(err(Value::Str(
@@ -1476,14 +1477,14 @@ impl EffectHandler for DefaultHandler {
                     Ok(o) => {
                         let mut rec = indexmap::IndexMap::new();
                         rec.insert("stdout".into(), Value::Str(
-                            String::from_utf8_lossy(&o.stdout).to_string()));
+                            String::from_utf8_lossy(&o.stdout).into_owned().into()));
                         rec.insert("stderr".into(), Value::Str(
-                            String::from_utf8_lossy(&o.stderr).to_string()));
+                            String::from_utf8_lossy(&o.stderr).into_owned().into()));
                         rec.insert("exit_code".into(), Value::Int(
                             o.status.code().unwrap_or(-1) as i64));
                         Ok(ok(Value::Record(rec)))
                     }
-                    Err(e) => Ok(err(Value::Str(format!("spawn `{cmd}`: {e}")))),
+                    Err(e) => Ok(err(Value::Str(format!("spawn `{cmd}`: {e}").into()))),
                 }
             }
             other => Err(format!("unsupported effect {}.{}", other.0, other.1)),
@@ -1760,16 +1761,16 @@ fn build_request_value_parts(
         if let Ok(v) = val.to_str() {
             headers_map.insert(
                 lex_bytecode::MapKey::Str(name.as_str().to_ascii_lowercase()),
-                Value::Str(v.to_string()),
+                Value::Str(v.to_string().into()),
             );
         }
     }
     let body_str = String::from_utf8_lossy(body).into_owned();
     let mut rec = indexmap::IndexMap::new();
-    rec.insert("method".into(), Value::Str(method));
-    rec.insert("path".into(), Value::Str(path));
-    rec.insert("query".into(), Value::Str(query));
-    rec.insert("body".into(), Value::Str(body_str));
+    rec.insert("method".into(), Value::Str(method.into()));
+    rec.insert("path".into(), Value::Str(path.into()));
+    rec.insert("query".into(), Value::Str(query.into()));
+    rec.insert("body".into(), Value::Str(body_str.into()));
     rec.insert("headers".into(), Value::Map(headers_map));
     Value::Record(rec)
 }
@@ -1786,16 +1787,16 @@ fn build_request_value_tiny(req: &mut tiny_http::Request) -> Value {
     for h in req.headers() {
         headers_map.insert(
             lex_bytecode::MapKey::Str(h.field.as_str().as_str().to_ascii_lowercase()),
-            Value::Str(h.value.as_str().to_string()),
+            Value::Str(h.value.as_str().to_string().into()),
         );
     }
     let mut body = String::new();
     let _ = req.as_reader().read_to_string(&mut body);
     let mut rec = indexmap::IndexMap::new();
-    rec.insert("method".into(), Value::Str(method));
-    rec.insert("path".into(), Value::Str(path));
-    rec.insert("query".into(), Value::Str(query));
-    rec.insert("body".into(), Value::Str(body));
+    rec.insert("method".into(), Value::Str(method.into()));
+    rec.insert("path".into(), Value::Str(path.into()));
+    rec.insert("query".into(), Value::Str(query.into()));
+    rec.insert("body".into(), Value::Str(body.into()));
     rec.insert("headers".into(), Value::Map(headers_map));
     Value::Record(rec)
 }
@@ -1809,7 +1810,7 @@ fn unpack_response(v: &Value) -> (u16, ResponseBodyOut, Vec<(String, String)>) {
         let body = match rec.get("body") {
             // Tagged ResponseBody (#375): BodyStr | BodyStream | BodyBytes.
             Some(Value::Variant { name, args }) => match (name.as_str(), args.as_slice()) {
-                ("BodyStr",    [Value::Str(s)])             => ResponseBodyOut::Str(s.clone()),
+                ("BodyStr",    [Value::Str(s)])             => ResponseBodyOut::Str(s.to_string()),
                 ("BodyStream", [iter_v])                    => ResponseBodyOut::TextChunks(drain_iter_str(iter_v)),
                 ("BodyBytes",  [iter_v])                    => ResponseBodyOut::BytesChunks(drain_iter_bytes(iter_v)),
                 _ => ResponseBodyOut::Str(String::new()),
@@ -1819,13 +1820,13 @@ fn unpack_response(v: &Value) -> (u16, ResponseBodyOut, Vec<(String, String)>) {
             // `body :: Str` (the pre-#375 contract). Lets internal
             // test handlers and one-liners keep working without
             // wrapping in `BodyStr(...)`.
-            Some(Value::Str(s)) => ResponseBodyOut::Str(s.clone()),
+            Some(Value::Str(s)) => ResponseBodyOut::Str(s.to_string()),
             _ => ResponseBodyOut::Str(String::new()),
         };
         let headers: Vec<(String, String)> = if let Some(Value::Map(hmap)) = rec.get("headers") {
             hmap.iter().filter_map(|(k, v)| {
                 if let (lex_bytecode::MapKey::Str(name), Value::Str(val)) = (k, v) {
-                    Some((name.clone(), val.clone()))
+                    Some((name.clone(), val.to_string()))
                 } else {
                     None
                 }
@@ -2092,7 +2093,7 @@ fn http_request(method: &str, url: &str, body: Option<&str>) -> Value {
             let status = r.status().as_u16();
             let body = r.body_mut().read_to_string().unwrap_or_default();
             if (200..300).contains(&status) {
-                Value::Variant { name: "Ok".into(), args: vec![Value::Str(body)] }
+                Value::Variant { name: "Ok".into(), args: vec![Value::Str(body.into())] }
             } else {
                 err_value(format!("status {status}: {body}"))
             }
@@ -2130,7 +2131,7 @@ fn http_error_value(e: ureq::Error) -> Value {
         ureq::Error::Rustls(r) => ("TlsError", Some(format!("{r}"))),
         _ => ("NetworkError", Some(format!("{e}"))),
     };
-    let args = match payload { Some(s) => vec![Value::Str(s)], None => vec![] };
+    let args = match payload { Some(s) => vec![Value::Str(s.into())], None => vec![] };
     let inner = Value::Variant { name: ctor.into(), args };
     Value::Variant { name: "Err".into(), args: vec![inner] }
 }
@@ -2138,7 +2139,7 @@ fn http_error_value(e: ureq::Error) -> Value {
 fn http_decode_err(msg: String) -> Value {
     let inner = Value::Variant {
         name: "DecodeError".into(),
-        args: vec![Value::Str(msg)],
+        args: vec![Value::Str(msg.into())],
     };
     Value::Variant { name: "Err".into(), args: vec![inner] }
 }
@@ -2211,7 +2212,7 @@ fn collect_response_headers(
     let mut out = std::collections::BTreeMap::new();
     for (name, value) in headers.iter() {
         let v = value.to_str().unwrap_or("").to_string();
-        out.insert(lex_bytecode::MapKey::Str(name.as_str().to_string()), Value::Str(v));
+        out.insert(lex_bytecode::MapKey::Str(name.as_str().to_string()), Value::Str(v.into()));
     }
     out
 }
@@ -2221,11 +2222,11 @@ fn collect_response_headers(
 /// `--allow-net-host` for the URL before sending.
 fn http_send_record(handler: &DefaultHandler, req: &indexmap::IndexMap<String, Value>) -> Value {
     let method = match req.get("method") {
-        Some(Value::Str(s)) => s.clone(),
+        Some(Value::Str(s)) => s.to_string(),
         _ => return http_decode_err("HttpRequest.method must be Str".into()),
     };
     let url = match req.get("url") {
-        Some(Value::Str(s)) => s.clone(),
+        Some(Value::Str(s)) => s.to_string(),
         _ => return http_decode_err("HttpRequest.url must be Str".into()),
     };
     if let Err(e) = handler.ensure_host_allowed(&url) {
@@ -2251,7 +2252,7 @@ fn http_send_record(handler: &DefaultHandler, req: &indexmap::IndexMap<String, V
     let headers: Vec<(String, String)> = match req.get("headers") {
         Some(Value::Map(m)) => m.iter().filter_map(|(k, v)| {
             let kk = match k { lex_bytecode::MapKey::Str(s) => s.clone(), _ => return None };
-            let vv = match v { Value::Str(s) => s.clone(), _ => return None };
+            let vv = match v { Value::Str(s) => s.to_string(), _ => return None };
             Some((kk, vv))
         }).collect(),
         _ => return http_decode_err("HttpRequest.headers must be Map[Str, Str]".into()),
@@ -2268,7 +2269,7 @@ fn expect_record(v: Option<&Value>) -> Result<&indexmap::IndexMap<String, Value>
 }
 
 fn err_value(msg: String) -> Value {
-    Value::Variant { name: "Err".into(), args: vec![Value::Str(msg)] }
+    Value::Variant { name: "Err".into(), args: vec![Value::Str(msg.into())] }
 }
 
 fn expect_str(v: Option<&Value>) -> Result<&str, String> {
@@ -2298,10 +2299,11 @@ fn err(v: Value) -> Value {
 /// `code` and `detail` are `None` by default; the driver-specific
 /// converters below populate them with real values.
 fn sql_error(message: impl Into<String>, code: Option<String>, detail: Option<String>) -> Value {
-    let some = |s: String| Value::Variant { name: "Some".into(), args: vec![Value::Str(s)] };
+    let some = |s: String| Value::Variant { name: "Some".into(), args: vec![Value::Str(s.into())] };
     let none = || Value::Variant { name: "None".into(), args: vec![] };
     let mut rec = indexmap::IndexMap::new();
-    rec.insert("message".into(), Value::Str(message.into()));
+    let msg: String = message.into();
+    rec.insert("message".into(), Value::Str(msg.into()));
     rec.insert("code".into(), match code {
         Some(c) => some(c),
         None => none(),
@@ -2415,12 +2417,12 @@ impl DefaultHandler {
         let parsed: serde_json::Value = match serde_json::from_str(&args_json) {
             Ok(v) => v,
             Err(e) => return err(Value::Str(format!(
-                "agent.call_mcp: args_json is not valid JSON: {e}"))),
+                "agent.call_mcp: args_json is not valid JSON: {e}").into())),
         };
         match self.mcp_clients.call(&server, &tool, parsed) {
             Ok(result) => ok(Value::Str(
-                serde_json::to_string(&result).unwrap_or_else(|_| "null".into()))),
-            Err(e) => err(Value::Str(e)),
+                serde_json::to_string(&result).unwrap_or_else(|_| "null".into()).into())),
+            Err(e) => err(Value::Str(e.into())),
         }
     }
 
@@ -2460,7 +2462,7 @@ impl DefaultHandler {
             Err(_) => return Value::Variant { name: "None".into(), args: vec![] },
         };
         match streams.get_mut(&handle).and_then(|it| it.next()) {
-            Some(chunk) => some(Value::Str(chunk)),
+            Some(chunk) => some(Value::Str(chunk.into())),
             None => {
                 streams.remove(&handle);
                 Value::Variant { name: "None".into(), args: vec![] }
@@ -2489,7 +2491,7 @@ impl DefaultHandler {
         };
         let mut out: std::collections::VecDeque<Value> = std::collections::VecDeque::new();
         for chunk in iter.by_ref() {
-            out.push_back(Value::Str(chunk));
+            out.push_back(Value::Str(chunk.into()));
         }
         Value::List(out)
     }
@@ -2519,7 +2521,7 @@ impl DefaultHandler {
 fn stream_handle_value(handle: String) -> Value {
     Value::Variant {
         name: "__StreamHandle".into(),
-        args: vec![Value::Str(handle)],
+        args: vec![Value::Str(handle.into())],
     }
 }
 
@@ -2529,7 +2531,7 @@ fn stream_handle_value(handle: String) -> Value {
 fn stream_handle_id(v: &Value) -> Option<String> {
     match v {
         Value::Variant { name, args } if name == "__StreamHandle" => match args.first() {
-            Some(Value::Str(h)) => Some(h.clone()),
+            Some(Value::Str(h)) => Some(h.to_string()),
             _ => None,
         },
         _ => None,
@@ -2547,8 +2549,8 @@ fn dispatch_llm_local(args: Vec<Value>) -> Value {
             "agent.local_complete(prompt): prompt must be Str".into())),
     };
     match crate::llm::local_complete(&prompt) {
-        Ok(text) => ok(Value::Str(text)),
-        Err(e) => err(Value::Str(e)),
+        Ok(text) => ok(Value::Str(text.into())),
+        Err(e) => err(Value::Str(e.into())),
     }
 }
 
@@ -2565,8 +2567,8 @@ fn dispatch_llm_cloud(args: Vec<Value>) -> Value {
             "agent.cloud_complete(prompt): prompt must be Str".into())),
     };
     match crate::llm::cloud_complete(&prompt) {
-        Ok(text) => ok(Value::Str(text)),
-        Err(e) => err(Value::Str(e)),
+        Ok(text) => ok(Value::Str(text.into())),
+        Err(e) => err(Value::Str(e.into())),
     }
 }
 
@@ -2605,7 +2607,7 @@ fn expect_sql_handle(v: Option<&Value>) -> Result<u64, String> {
 fn expect_str_list(v: Option<&Value>) -> Result<Vec<String>, String> {
     match v {
         Some(Value::List(items)) => items.iter().map(|x| match x {
-            Value::Str(s) => Ok(s.clone()),
+            Value::Str(s) => Ok(s.to_string()),
             other => Err(format!("expected List[Str] element, got {other:?}")),
         }).collect(),
         Some(other) => Err(format!("expected List[Str], got {other:?}")),
@@ -2625,7 +2627,7 @@ fn expect_sql_params(v: Option<&Value>) -> Result<Vec<SqlParamValue>, String> {
         match item {
             Value::Variant { name, args } => match name.as_str() {
                 "PStr"   => match args.first() {
-                    Some(Value::Str(s)) => Ok(SqlParamValue::Text(s.clone())),
+                    Some(Value::Str(s)) => Ok(SqlParamValue::Text(s.to_string())),
                     _ => Err("PStr requires a Str argument".into()),
                 },
                 "PInt"   => match args.first() {
@@ -2644,7 +2646,7 @@ fn expect_sql_params(v: Option<&Value>) -> Result<Vec<SqlParamValue>, String> {
                 other    => Err(format!("unknown SqlParam constructor `{other}`")),
             },
             // Backward-compat: bare strings are accepted as PStr.
-            Value::Str(s) => Ok(SqlParamValue::Text(s.clone())),
+            Value::Str(s) => Ok(SqlParamValue::Text(s.to_string())),
             other => Err(format!("expected SqlParam variant, got {other:?}")),
         }
     }).collect()
@@ -2750,7 +2752,7 @@ fn pg_row_to_lex_record(row: &postgres::Row) -> indexmap::IndexMap<String, Value
         } else if *ty == Type::BYTEA {
             row.get::<_, Option<Vec<u8>>>(i).map(Value::Bytes).unwrap_or(Value::Unit)
         } else {
-            row.get::<_, Option<String>>(i).map(Value::Str).unwrap_or(Value::Unit)
+            row.get::<_, Option<String>>(i).map(|s| Value::Str(s.into())).unwrap_or(Value::Unit)
         };
         rec.insert(col.name().to_string(), val);
     }
@@ -2784,7 +2786,7 @@ fn sql_value_ref_to_lex(v: rusqlite::types::ValueRef<'_>) -> Value {
         ValueRef::Null       => Value::Unit,
         ValueRef::Integer(n) => Value::Int(n),
         ValueRef::Real(f)    => Value::Float(f),
-        ValueRef::Text(s)    => Value::Str(String::from_utf8_lossy(s).into_owned()),
+        ValueRef::Text(s)    => Value::Str(String::from_utf8_lossy(s).into_owned().into()),
         ValueRef::Blob(b)    => Value::Bytes(b.to_vec()),
     }
 }

--- a/crates/lex-runtime/src/policy.rs
+++ b/crates/lex-runtime/src/policy.rs
@@ -57,13 +57,14 @@ impl Policy {
             // entries here cause valid stdlib calls to fail under
             // `lex test` / `lex repl` / any other consumer that opts
             // into the permissive policy.
-            "sql",       // std.sql (#362, #379)
-            "random",    // crypto.random / crypto.random_str_hex (#382)
-            "chat",      // chat.broadcast / chat.send (#359)
-            "log",       // std.log structured logging
-            "kv",        // std.kv key-value store
-            "stream",    // std.stream
-            "fs_walk",   // std.fs directory traversal
+            "sql",         // std.sql (#362, #379)
+            "random",      // crypto.random / crypto.random_str_hex (#382)
+            "chat",        // chat.broadcast / chat.send (#359)
+            "log",         // std.log structured logging
+            "kv",          // std.kv key-value store
+            "stream",      // std.stream
+            "fs_walk",     // std.fs directory traversal
+            "concurrent",  // conc.spawn / conc.ask / conc.tell (#381)
         ] {
             s.insert(k.to_string());
         }

--- a/crates/lex-runtime/src/ws.rs
+++ b/crates/lex-runtime/src/ws.rs
@@ -199,9 +199,9 @@ fn run_loop(
 
 fn build_ws_event(conn_id: u64, room: &str, body: &str) -> Value {
     let mut rec = IndexMap::new();
-    rec.insert("body".into(), Value::Str(body.to_string()));
+    rec.insert("body".into(), Value::Str(body.into()));
     rec.insert("conn_id".into(), Value::Int(conn_id as i64));
-    rec.insert("room".into(), Value::Str(room.to_string()));
+    rec.insert("room".into(), Value::Str(room.into()));
     Value::Record(rec)
 }
 
@@ -210,15 +210,15 @@ fn build_ws_event(conn_id: u64, room: &str, body: &str) -> Value {
 /// Build a `WsConn` record value for the typed closure-based handler.
 fn build_ws_conn(conn_id: u64, path: &str, subprotocol: &str) -> Value {
     let mut rec = IndexMap::new();
-    rec.insert("id".into(), Value::Str(conn_id.to_string()));
-    rec.insert("path".into(), Value::Str(path.to_string()));
-    rec.insert("subprotocol".into(), Value::Str(subprotocol.to_string()));
+    rec.insert("id".into(), Value::Str(conn_id.to_string().into()));
+    rec.insert("path".into(), Value::Str(path.into()));
+    rec.insert("subprotocol".into(), Value::Str(subprotocol.into()));
     Value::Record(rec)
 }
 
 /// Build a `WsMessage` variant value.
 fn build_ws_message_text(body: &str) -> Value {
-    Value::Variant { name: "WsText".into(), args: vec![Value::Str(body.to_string())] }
+    Value::Variant { name: "WsText".into(), args: vec![Value::Str(body.into())] }
 }
 
 fn build_ws_message_close() -> Value {
@@ -249,7 +249,7 @@ fn apply_ws_action<S: std::io::Read + std::io::Write>(
                 Some(Value::Str(s)) => s.clone(),
                 _ => return Err("WsSend payload must be Str".into()),
             };
-            ws.send(Message::Text(text.into()))
+            ws.send(Message::Text(text.to_string().into()))
                 .map_err(|e| format!("ws send: {e}"))
         }
         Value::Variant { name, args } if name == "WsSendBinary" => {
@@ -437,7 +437,7 @@ fn build_dial_result(ok: Result<(), String>) -> Value {
         },
         Err(msg) => Value::Variant {
             name: "Err".into(),
-            args: vec![Value::Str(msg)],
+            args: vec![Value::Str(msg.into())],
         },
     }
 }

--- a/crates/lex-runtime/tests/bytes_and_net.rs
+++ b/crates/lex-runtime/tests/bytes_and_net.rs
@@ -122,7 +122,7 @@ fn net_get_returns_response_body() {
 import "std.net" as net
 fn fetch(u :: Str) -> [net] Result[Str, Str] { net.get(u) }
 "#;
-    let r = run(src, "fetch", vec![Value::Str(url)], allow(&["net"]));
+    let r = run(src, "fetch", vec![Value::Str(url.into())], allow(&["net"]));
     let _ = handle.join();
     let (name, args) = match r {
         Value::Variant { name, args } => (name, args),

--- a/crates/lex-runtime/tests/concurrent_actor.rs
+++ b/crates/lex-runtime/tests/concurrent_actor.rs
@@ -1,0 +1,122 @@
+//! End-to-end tests for #381: conc.spawn / conc.ask / conc.tell.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::vm::Vm;
+use lex_bytecode::Value;
+use lex_runtime::{check_program, DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::collections::VecDeque;
+
+fn run(src: &str, entry: &str, args: Vec<Value>) -> Value {
+    let prog = parse_source(src).unwrap();
+    let stages = canonicalize_program(&prog);
+    let bc = lex_bytecode::compile_program(&stages);
+    let policy = Policy::permissive();
+    check_program(&bc, &policy).expect("policy check");
+    let handler = DefaultHandler::new(policy);
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(entry, args).unwrap()
+}
+
+// ── basic counter actor ──────────────────────────────────────────────────────
+
+#[test]
+fn actor_counter_ask_increments_state() {
+    let src = r#"
+import "std.conc" as conc
+
+fn counter_handler(state :: Int, msg :: Int) -> (Int, Int) {
+  let next := state + msg
+  (next, next)
+}
+
+fn make_and_use() -> Int {
+  let actor := conc.spawn(0, counter_handler)
+  let _     := conc.ask(actor, 5)
+  let r     := conc.ask(actor, 3)
+  r
+}
+"#;
+    assert_eq!(run(src, "make_and_use", vec![]), Value::Int(8));
+}
+
+// ── tell discards reply ──────────────────────────────────────────────────────
+
+#[test]
+fn actor_tell_returns_unit() {
+    let src = r#"
+import "std.conc" as conc
+
+fn acc_int_handler(state :: Int, msg :: Int) -> (Int, Int) {
+  let next := state + msg
+  (next, next)
+}
+
+fn test_tell() -> Int {
+  let actor := conc.spawn(0, acc_int_handler)
+  let _     := conc.tell(actor, 10)
+  let _     := conc.tell(actor, 10)
+  conc.ask(actor, 0)
+}
+"#;
+    // After two tell(10) calls state is 20; ask(0) → new state 20, reply 20.
+    assert_eq!(run(src, "test_tell", vec![]), Value::Int(20));
+}
+
+// ── actor state persists across calls ───────────────────────────────────────
+
+#[test]
+fn actor_state_accumulates() {
+    let src = r#"
+import "std.conc" as conc
+import "std.list" as list
+
+fn acc_handler(state :: List[Int], msg :: Int) -> (List[Int], List[Int]) {
+  let next := list.concat(state, list.cons(msg, []))
+  (next, next)
+}
+
+fn collect_items() -> List[Int] {
+  let actor := conc.spawn([], acc_handler)
+  let _ := conc.tell(actor, 1)
+  let _ := conc.tell(actor, 2)
+  let _ := conc.tell(actor, 3)
+  conc.ask(actor, 4)
+}
+"#;
+    let result = run(src, "collect_items", vec![]);
+    assert_eq!(
+        result,
+        Value::List(VecDeque::from(vec![
+            Value::Int(1),
+            Value::Int(2),
+            Value::Int(3),
+            Value::Int(4),
+        ]))
+    );
+}
+
+// ── multiple independent actors ──────────────────────────────────────────────
+
+#[test]
+fn two_independent_actors_have_separate_state() {
+    let src = r#"
+import "std.conc" as conc
+
+fn counter(state :: Int, msg :: Int) -> (Int, Int) {
+  (state + msg, state + msg)
+}
+
+fn test_two_actors() -> (Int, Int) {
+  let a := conc.spawn(0, counter)
+  let b := conc.spawn(100, counter)
+  let ra := conc.ask(a, 7)
+  let rb := conc.ask(b, 7)
+  (ra, rb)
+}
+"#;
+    assert_eq!(
+        run(src, "test_two_actors", vec![]),
+        Value::Tuple(vec![Value::Int(7), Value::Int(107)])
+    );
+}

--- a/crates/lex-runtime/tests/list_sort_by.rs
+++ b/crates/lex-runtime/tests/list_sort_by.rs
@@ -137,7 +137,7 @@ fn r(xs :: List[R]) -> List[R] {
         .iter()
         .map(|v| match v {
             Value::Record(f) => match f.get("tag") {
-                Some(Value::Str(t)) => t.clone(),
+                Some(Value::Str(t)) => t.to_string(),
                 _ => panic!(),
             },
             _ => panic!(),

--- a/crates/lex-runtime/tests/sql_error_codes.rs
+++ b/crates/lex-runtime/tests/sql_error_codes.rs
@@ -39,13 +39,13 @@ fn unpack_sql_error(v: &Value) -> (String, Option<String>, Option<String>) {
         other => panic!("expected SqlError record, got {other:?}"),
     };
     let message = match rec.get("message") {
-        Some(Value::Str(s)) => s.clone(),
+        Some(Value::Str(s)) => s.to_string(),
         other => panic!("expected message :: Str, got {other:?}"),
     };
     let read_opt = |key: &str| match rec.get(key) {
         Some(Value::Variant { name, args }) if name == "Some" && args.len() == 1 => {
             match &args[0] {
-                Value::Str(s) => Some(s.clone()),
+                Value::Str(s) => Some(s.to_string()),
                 _ => None,
             }
         }

--- a/crates/lex-runtime/tests/sql_query_iter.rs
+++ b/crates/lex-runtime/tests/sql_query_iter.rs
@@ -208,7 +208,7 @@ fn drains_all_rows_in_order() {
         other => panic!("expected List, got {other:?}"),
     };
     let expected: Vec<Value> = (0..5)
-        .map(|i| Value::Str(format!("r{i}")))
+        .map(|i| Value::Str(format!("r{i}").into()))
         .collect();
     assert_eq!(list, expected);
 }

--- a/crates/lex-runtime/tests/std_agent_mcp_client.rs
+++ b/crates/lex-runtime/tests/std_agent_mcp_client.rs
@@ -90,7 +90,7 @@ fn check_remotely(server :: Str, source :: Str) -> [mcp] Result[Str, Str] {
     // trivial but non-empty fn so success is unambiguous.
     let lex_src = r#"fn id(n :: Int) -> Int { n }"#;
     let v = run_program(src, "check_remotely",
-        vec![Value::Str(server_cmd), Value::Str(lex_src.to_string())],
+        vec![Value::Str(server_cmd.into()), Value::Str(lex_src.to_string().into())],
         Policy::permissive());
     match &v {
         Value::Variant { name, args } if name == "Ok" => match &args[0] {

--- a/crates/lex-runtime/tests/std_crypto.rs
+++ b/crates/lex-runtime/tests/std_crypto.rs
@@ -32,7 +32,7 @@ fn bytes(v: Value) -> Vec<u8> {
 
 fn s(v: Value) -> String {
     match v {
-        Value::Str(s) => s,
+        Value::Str(s) => s.to_string(),
         other => panic!("expected Str, got {other:?}"),
     }
 }

--- a/crates/lex-runtime/tests/std_crypto_aead.rs
+++ b/crates/lex-runtime/tests/std_crypto_aead.rs
@@ -46,7 +46,7 @@ fn unwrap_ok(v: Value) -> Value {
 fn unwrap_err(v: Value) -> String {
     match v {
         Value::Variant { name, args } if name == "Err" && args.len() == 1 => match args.into_iter().next().unwrap() {
-            Value::Str(s) => s,
+            Value::Str(s) => s.to_string(),
             other => panic!("Err payload not Str: {other:?}"),
         },
         other => panic!("expected Err(_), got {other:?}"),

--- a/crates/lex-runtime/tests/std_crypto_extras.rs
+++ b/crates/lex-runtime/tests/std_crypto_extras.rs
@@ -36,7 +36,7 @@ fn bytes(v: Value) -> Vec<u8> {
     match v { Value::Bytes(b) => b, other => panic!("expected Bytes, got {other:?}") }
 }
 fn s(v: Value) -> String {
-    match v { Value::Str(x) => x, other => panic!("expected Str, got {other:?}") }
+    match v { Value::Str(x) => x.to_string(), other => panic!("expected Str, got {other:?}") }
 }
 fn b(v: Value) -> bool {
     match v { Value::Bool(x) => x, other => panic!("expected Bool, got {other:?}") }

--- a/crates/lex-runtime/tests/std_crypto_kdf.rs
+++ b/crates/lex-runtime/tests/std_crypto_kdf.rs
@@ -49,7 +49,7 @@ fn unwrap_err(v: Value) -> String {
     match v {
         Value::Variant { name, args } if name == "Err" && args.len() == 1 => {
             match args.into_iter().next().unwrap() {
-                Value::Str(s) => s,
+                Value::Str(s) => s.to_string(),
                 other => panic!("Err payload not Str: {other:?}"),
             }
         }

--- a/crates/lex-runtime/tests/std_datetime.rs
+++ b/crates/lex-runtime/tests/std_datetime.rs
@@ -27,7 +27,7 @@ fn run(src: &str, fn_name: &str, args: Vec<Value>, policy: Policy) -> Value {
 
 fn s(v: Value) -> String {
     match v {
-        Value::Str(s) => s,
+        Value::Str(s) => s.to_string(),
         other => panic!("expected Str, got {other:?}"),
     }
 }

--- a/crates/lex-runtime/tests/std_fs.rs
+++ b/crates/lex-runtime/tests/std_fs.rs
@@ -93,7 +93,7 @@ fn exists_returns_true_for_a_real_path() {
     let v = run(
         SRC,
         "does_exist",
-        vec![Value::Str(dir.to_string_lossy().to_string())],
+        vec![Value::Str(dir.to_string_lossy().to_string().into())],
         policy_walk_only(&dir),
     );
     assert_eq!(v, Value::Bool(true));
@@ -106,7 +106,7 @@ fn exists_returns_false_for_nonexistent_path() {
     let v = run(
         SRC,
         "does_exist",
-        vec![Value::Str(phantom.to_string_lossy().to_string())],
+        vec![Value::Str(phantom.to_string_lossy().to_string().into())],
         policy_walk_only(&dir),
     );
     assert_eq!(v, Value::Bool(false));
@@ -118,10 +118,10 @@ fn is_dir_distinguishes_dir_from_file() {
     let file = dir.join("a.txt");
     std::fs::write(&file, "hi").unwrap();
 
-    let v = run(SRC, "is_a_dir", vec![Value::Str(dir.to_string_lossy().to_string())], policy_walk_only(&dir));
+    let v = run(SRC, "is_a_dir", vec![Value::Str(dir.to_string_lossy().to_string().into())], policy_walk_only(&dir));
     assert_eq!(v, Value::Bool(true));
 
-    let v = run(SRC, "is_a_dir", vec![Value::Str(file.to_string_lossy().to_string())], policy_walk_only(&dir));
+    let v = run(SRC, "is_a_dir", vec![Value::Str(file.to_string_lossy().to_string().into())], policy_walk_only(&dir));
     assert_eq!(v, Value::Bool(false));
 }
 
@@ -135,7 +135,7 @@ fn walk_returns_recursive_path_count() {
     let v = run(
         SRC,
         "count_walk",
-        vec![Value::Str(dir.to_string_lossy().to_string())],
+        vec![Value::Str(dir.to_string_lossy().to_string().into())],
         policy_walk_only(&dir),
     );
     assert_eq!(v, Value::Int(4));
@@ -151,7 +151,7 @@ fn list_dir_returns_immediate_children_only() {
     let v = run(
         SRC,
         "list_dir_count",
-        vec![Value::Str(dir.to_string_lossy().to_string())],
+        vec![Value::Str(dir.to_string_lossy().to_string().into())],
         policy_walk_only(&dir),
     );
     assert_eq!(v, Value::Int(2));
@@ -164,7 +164,7 @@ fn mkdir_p_creates_nested() {
     let v = run(
         SRC,
         "make_dir",
-        vec![Value::Str(nested.to_string_lossy().to_string())],
+        vec![Value::Str(nested.to_string_lossy().to_string().into())],
         policy_walk_and_write(&root, &root),
     );
     assert_eq!(v, Value::Bool(true));
@@ -178,7 +178,7 @@ fn mkdir_p_outside_write_root_returns_err() {
     let v = run(
         SRC,
         "make_dir",
-        vec![Value::Str(outside.to_string_lossy().to_string())],
+        vec![Value::Str(outside.to_string_lossy().to_string().into())],
         policy_walk_and_write(&allowed, &allowed),
     );
     assert_eq!(v, Value::Bool(false));
@@ -192,7 +192,7 @@ fn stat_returns_size_of_file() {
     let v = run(
         SRC,
         "stat_size",
-        vec![Value::Str(file.to_string_lossy().to_string())],
+        vec![Value::Str(file.to_string_lossy().to_string().into())],
         policy_walk_only(&dir),
     );
     assert_eq!(v, Value::Int(6));

--- a/crates/lex-runtime/tests/std_http.rs
+++ b/crates/lex-runtime/tests/std_http.rs
@@ -382,7 +382,7 @@ fn http_get_returns_response_with_status_and_body() {
 import "std.http" as http
 fn fetch(u :: Str) -> [net] Result[HttpResponse, HttpError] { http.get(u) }
 "#;
-    let v = run(src, "fetch", vec![Value::Str(url)], allow_net());
+    let v = run(src, "fetch", vec![Value::Str(url.into())], allow_net());
     let r = unwrap_ok_record(v);
     assert_eq!(r.get("status"), Some(&Value::Int(200)));
     match r.get("body") {
@@ -417,7 +417,7 @@ fn push(u :: Str, b :: Bytes) -> [net] Result[HttpResponse, HttpError] {
     let v = run(
         src,
         "push",
-        vec![Value::Str(url), Value::Bytes(b"\x00\x01\x02hi".to_vec())],
+        vec![Value::Str(url.into()), Value::Bytes(b"\x00\x01\x02hi".to_vec())],
         allow_net(),
     );
     let r = unwrap_ok_record(v);
@@ -454,7 +454,7 @@ fn fetch_authed(u :: Str, token :: Str) -> [net] Result[HttpResponse, HttpError]
         src,
         "fetch_authed",
         vec![
-            Value::Str(url),
+            Value::Str(url.into()),
             Value::Str("secret-jwt".into()),
         ],
         allow_net(),

--- a/crates/lex-runtime/tests/std_kv.rs
+++ b/crates/lex-runtime/tests/std_kv.rs
@@ -113,7 +113,7 @@ fn put_then_get_round_trips() {
         SRC,
         "put_then_get",
         vec![
-            Value::Str(path.to_string_lossy().to_string()),
+            Value::Str(path.to_string_lossy().to_string().into()),
             Value::Str("k1".into()),
             Value::Bytes(b"hello".to_vec()),
         ],
@@ -136,7 +136,7 @@ fn get_missing_returns_none() {
         SRC,
         "get_missing",
         vec![
-            Value::Str(path.to_string_lossy().to_string()),
+            Value::Str(path.to_string_lossy().to_string().into()),
             Value::Str("never_set".into()),
         ],
         policy,
@@ -152,7 +152,7 @@ fn contains_after_put() {
         SRC,
         "put_then_contains",
         vec![
-            Value::Str(path.to_string_lossy().to_string()),
+            Value::Str(path.to_string_lossy().to_string().into()),
             Value::Str("a".into()),
             Value::Bytes(b"x".to_vec()),
         ],
@@ -169,7 +169,7 @@ fn delete_removes_key() {
         SRC,
         "delete_then_contains",
         vec![
-            Value::Str(path.to_string_lossy().to_string()),
+            Value::Str(path.to_string_lossy().to_string().into()),
             Value::Str("a".into()),
             Value::Bytes(b"x".to_vec()),
         ],
@@ -183,14 +183,14 @@ fn list_prefix_returns_only_matching_keys() {
     let path = unique_db_path("list_prefix");
     let policy = policy_with_kv(&path);
     let v = run_with_policy(SRC, "list_prefix_keys", vec![
-        Value::Str(path.to_string_lossy().to_string()),
+        Value::Str(path.to_string_lossy().to_string().into()),
     ], policy);
 
     let keys: Vec<String> = match v {
         Value::List(items) => items
             .into_iter()
             .map(|i| match i {
-                Value::Str(s) => s,
+                Value::Str(s) => s.to_string(),
                 other => panic!("expected Str in list, got {other:?}"),
             })
             .collect(),
@@ -218,7 +218,7 @@ fn open_outside_fs_write_root_returns_err() {
         SRC,
         "put_then_get",
         vec![
-            Value::Str(outside.to_string_lossy().to_string()),
+            Value::Str(outside.to_string_lossy().to_string().into()),
             Value::Str("k".into()),
             Value::Bytes(b"v".to_vec()),
         ],

--- a/crates/lex-runtime/tests/std_log.rs
+++ b/crates/lex-runtime/tests/std_log.rs
@@ -111,7 +111,7 @@ fn text_format_includes_level_and_message() {
     let policy = policy_for_log(path.parent().unwrap());
 
     run(SRC, "setup_text",
-        vec![Value::Str(path.to_string_lossy().to_string())], policy.clone());
+        vec![Value::Str(path.to_string_lossy().to_string().into())], policy.clone());
     run(SRC, "emit_each_level", vec![], policy);
 
     let contents = std::fs::read_to_string(&path).expect("read log");
@@ -128,7 +128,7 @@ fn json_format_emits_one_object_per_line() {
     let policy = policy_for_log(path.parent().unwrap());
 
     run(SRC, "setup_json",
-        vec![Value::Str(path.to_string_lossy().to_string())], policy.clone());
+        vec![Value::Str(path.to_string_lossy().to_string().into())], policy.clone());
     run(SRC, "emit_one_info", vec![], policy);
 
     let contents = std::fs::read_to_string(&path).expect("read log");
@@ -146,7 +146,7 @@ fn level_threshold_drops_lower_levels() {
     let policy = policy_for_log(path.parent().unwrap());
 
     run(SRC, "setup_warn_threshold",
-        vec![Value::Str(path.to_string_lossy().to_string())], policy.clone());
+        vec![Value::Str(path.to_string_lossy().to_string().into())], policy.clone());
     run(SRC, "emit_each_level", vec![], policy);
 
     let contents = std::fs::read_to_string(&path).expect("read log");
@@ -195,6 +195,6 @@ fn setup(path :: Str) -> [io, fs_write] Bool {
 "#;
     let policy = policy_for_log(&allowed);
     let v = run(src, "setup",
-        vec![Value::Str(outside.to_string_lossy().to_string())], policy);
+        vec![Value::Str(outside.to_string_lossy().to_string().into())], policy);
     assert_eq!(v, Value::Bool(false));
 }

--- a/crates/lex-runtime/tests/std_process.rs
+++ b/crates/lex-runtime/tests/std_process.rs
@@ -90,7 +90,7 @@ fn run_capture_exit(cmd :: Str, args :: List[Str]) -> [proc] Int {
 
 fn s(v: Value) -> String {
     match v {
-        Value::Str(s) => s,
+        Value::Str(s) => s.to_string(),
         other => panic!("expected Str, got {other:?}"),
     }
 }

--- a/crates/lex-runtime/tests/std_regex.rs
+++ b/crates/lex-runtime/tests/std_regex.rs
@@ -20,7 +20,7 @@ fn run(src: &str, fn_name: &str, args: Vec<Value>) -> Value {
 
 fn s(v: Value) -> String {
     match v {
-        Value::Str(s) => s,
+        Value::Str(s) => s.to_string(),
         other => panic!("expected Str, got {other:?}"),
     }
 }
@@ -37,7 +37,7 @@ fn list_of_strs(v: Value) -> Vec<String> {
         Value::List(items) => items
             .into_iter()
             .map(|i| match i {
-                Value::Str(s) => s,
+                Value::Str(s) => s.to_string(),
                 other => panic!("expected Str in list, got {other:?}"),
             })
             .collect(),

--- a/crates/lex-runtime/tests/std_sql.rs
+++ b/crates/lex-runtime/tests/std_sql.rs
@@ -162,7 +162,7 @@ fn create_insert_query_round_trip() {
     let v = run(
         SRC,
         "create_insert_query",
-        vec![Value::Str(path.to_string_lossy().into_owned())],
+        vec![Value::Str(path.to_string_lossy().into_owned().into())],
         policy_with_sql(&dir),
     );
     let rows = match v {
@@ -193,14 +193,14 @@ fn pick_by_id_uses_parameter_binding() {
     let _ = run(
         SRC,
         "create_insert_query",
-        vec![Value::Str(path.to_string_lossy().into_owned())],
+        vec![Value::Str(path.to_string_lossy().into_owned().into())],
         policy_with_sql(&dir),
     );
     let v = run(
         SRC,
         "pick_by_id",
         vec![
-            Value::Str(path.to_string_lossy().into_owned()),
+            Value::Str(path.to_string_lossy().into_owned().into()),
             Value::Str("2".into()),
         ],
         policy_with_sql(&dir),
@@ -215,13 +215,13 @@ fn delete_returns_affected_row_count() {
     let _ = run(
         SRC,
         "create_insert_query",
-        vec![Value::Str(path.to_string_lossy().into_owned())],
+        vec![Value::Str(path.to_string_lossy().into_owned().into())],
         policy_with_sql(&dir),
     );
     let v = run(
         SRC,
         "delete_count",
-        vec![Value::Str(path.to_string_lossy().into_owned())],
+        vec![Value::Str(path.to_string_lossy().into_owned().into())],
         policy_with_sql(&dir),
     );
     assert_eq!(v, Value::Int(1));
@@ -255,7 +255,7 @@ fn try_open(p :: Str) -> [sql, fs_write] Str {
     let v = run(
         src,
         "try_open",
-        vec![Value::Str(outside.to_string_lossy().into_owned())],
+        vec![Value::Str(outside.to_string_lossy().into_owned().into())],
         policy_with_sql(&dir),
     );
     let s = match v {

--- a/crates/lex-runtime/tests/std_toml.rs
+++ b/crates/lex-runtime/tests/std_toml.rs
@@ -32,7 +32,7 @@ fn unwrap_ok(v: Value) -> Value {
 fn err_msg(v: Value) -> String {
     match v {
         Value::Variant { name, args } if name == "Err" => match args.into_iter().next() {
-            Some(Value::Str(s)) => s,
+            Some(Value::Str(s)) => s.to_string(),
             other => panic!("expected Err(Str), got {other:?}"),
         },
         other => panic!("expected Err, got {other:?}"),

--- a/crates/lex-trace/src/recorder.rs
+++ b/crates/lex-trace/src/recorder.rs
@@ -172,7 +172,7 @@ fn value_to_json(v: &Value) -> serde_json::Value {
         Value::Int(n) => J::from(*n),
         Value::Float(f) => J::from(*f),
         Value::Bool(b) => J::Bool(*b),
-        Value::Str(s) => J::String(s.clone()),
+        Value::Str(s) => J::String(s.to_string()),
         Value::Bytes(b) => J::String(b.iter().map(|b| format!("{:02x}", b)).collect()),
         Value::Unit => J::Null,
         Value::List(items) => J::Array(items.iter().map(value_to_json).collect()),
@@ -241,7 +241,7 @@ pub(crate) fn json_to_value(v: &serde_json::Value) -> Value {
             else if let Some(f) = n.as_f64() { Value::Float(f) }
             else { Value::Unit }
         }
-        J::String(s) => Value::Str(s.clone()),
+        J::String(s) => Value::Str(s.as_str().into()),
         J::Array(items) => Value::List(items.iter().map(json_to_value).collect()),
         J::Object(map) => {
             // Detect the $variant shape we emit on the way out.

--- a/crates/lex-trace/src/recorder.rs
+++ b/crates/lex-trace/src/recorder.rs
@@ -227,6 +227,7 @@ fn value_to_json(v: &Value) -> serde_json::Value {
                 items.iter().map(value_to_json).collect()));
             J::Object(o)
         }
+        Value::Actor(_) => J::String("<actor>".into()),
     }
 }
 

--- a/crates/lex-trace/tests/m7.rs
+++ b/crates/lex-trace/tests/m7.rs
@@ -53,7 +53,7 @@ fn value_to_json(v: &Value) -> serde_json::Value {
         Value::Int(n) => J::from(*n),
         Value::Float(f) => J::from(*f),
         Value::Bool(b) => J::Bool(*b),
-        Value::Str(s) => J::String(s.clone()),
+        Value::Str(s) => J::String(s.to_string()),
         Value::Bytes(b) => J::String(b.iter().map(|b| format!("{:02x}", b)).collect()),
         Value::Unit => J::Null,
         Value::List(items) => J::Array(items.iter().map(value_to_json).collect()),

--- a/crates/lex-trace/tests/m7.rs
+++ b/crates/lex-trace/tests/m7.rs
@@ -82,7 +82,7 @@ fn value_to_json(v: &Value) -> serde_json::Value {
             m.insert("data".into(), J::Array(data.iter().map(|f| J::from(*f)).collect()));
             J::Object(m)
         }
-        Value::Map(_) | Value::Set(_) | Value::Deque(_) => {
+        Value::Map(_) | Value::Set(_) | Value::Deque(_) | Value::Actor(_) => {
             // Tests in this file don't exercise these container values;
             // render as a placeholder so the match is exhaustive.
             J::String("<container>".into())

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -557,6 +557,44 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
             ));
             Some(Ty::Record(fields))
         }
+        "conc" => {
+            // Actor model (#381). Effect: [concurrent].
+            // spawn :: S, (S, M) -> [E] (S, R) -> [concurrent] Actor[S]
+            // ask   :: Actor[S], M -> [concurrent] R
+            // tell  :: Actor[S], M -> [concurrent] Unit
+            //
+            // The type variables used here are fresh placeholders;
+            // the checker instantiates them at each call site.
+            //   0 = S (state), 1 = M (message), 2 = R (reply), 3 = E (effect row)
+            let actor_t = |s: Ty| Ty::Con("Actor".into(), vec![s]);
+            let mut fields = IndexMap::new();
+            // spawn :: S, (S, M -> [E] (S, R)) -> [concurrent] Actor[S]
+            fields.insert("spawn".into(), Ty::function(
+                vec![
+                    Ty::Var(0),
+                    Ty::Function {
+                        params: vec![Ty::Var(0), Ty::Var(1)],
+                        effects: EffectSet::open_var(3),
+                        ret: Box::new(Ty::Tuple(vec![Ty::Var(0), Ty::Var(2)])),
+                    },
+                ],
+                EffectSet::singleton("concurrent"),
+                actor_t(Ty::Var(0)),
+            ));
+            // ask :: Actor[S], M -> [concurrent] R
+            fields.insert("ask".into(), Ty::function(
+                vec![actor_t(Ty::Var(0)), Ty::Var(1)],
+                EffectSet::singleton("concurrent"),
+                Ty::Var(2),
+            ));
+            // tell :: Actor[S], M -> [concurrent] Unit
+            fields.insert("tell".into(), Ty::function(
+                vec![actor_t(Ty::Var(0)), Ty::Var(1)],
+                EffectSet::singleton("concurrent"),
+                Ty::Unit,
+            ));
+            Some(Ty::Record(fields))
+        }
         "proc" => {
             // Subprocess dispatch. Effect: [proc]. Returns a Result
             // with a record on success carrying stdout / stderr /
@@ -2143,6 +2181,7 @@ pub fn module_for_import(reference: &str) -> Option<&'static str> {
         "agent" => "agent",
         "cli" => "cli",
         "stream" => "stream",
+        "conc" => "conc",
         _ => return None,
     })
 }

--- a/crates/spec-checker/src/checker.rs
+++ b/crates/spec-checker/src/checker.rs
@@ -230,7 +230,7 @@ fn eval(
         SpecExpr::IntLit { value } => Ok(Value::Int(*value)),
         SpecExpr::FloatLit { value } => Ok(Value::Float(*value)),
         SpecExpr::BoolLit { value } => Ok(Value::Bool(*value)),
-        SpecExpr::StrLit { value } => Ok(Value::Str(value.clone())),
+        SpecExpr::StrLit { value } => Ok(Value::Str(value.clone().into())),
         SpecExpr::Var { name } => bindings.get(name).cloned()
             .ok_or_else(|| format!("unbound spec var `{name}`")),
         SpecExpr::Let { name, value, body } => {

--- a/crates/spec-checker/src/gate.rs
+++ b/crates/spec-checker/src/gate.rs
@@ -183,7 +183,7 @@ fn eval_body(
         SpecExpr::IntLit { value } => Ok(Value::Int(*value)),
         SpecExpr::FloatLit { value } => Ok(Value::Float(*value)),
         SpecExpr::BoolLit { value } => Ok(Value::Bool(*value)),
-        SpecExpr::StrLit { value } => Ok(Value::Str(value.clone())),
+        SpecExpr::StrLit { value } => Ok(Value::Str(value.clone().into())),
         SpecExpr::Var { name } => bindings.get(name).cloned()
             .ok_or_else(|| format!("unbound spec var `{name}` (provide via gate bindings)")),
         SpecExpr::Let { name, value, body } => {


### PR DESCRIPTION
## Summary

- Replace `Value::Str(String)` with `Value::Str(SmolStr)` across the codebase
- `smol_str::SmolStr` stores strings ≤22 bytes inline (no heap allocation), eliminating allocations for HTTP methods, status codes, short field names, route segments, and other identifiers that dominate runtime string traffic
- `String` → `SmolStr` via `.into()`; `SmolStr` → `String` via `.to_string()`

## Files changed

- `Cargo.toml` — add `smol_str = "0.3"` (with serde feature) to workspace deps
- `crates/lex-bytecode/Cargo.toml` — add smol_str dep
- `crates/lex-bytecode/src/value.rs` — `Str(String)` → `Str(SmolStr)`, update `to_json`/`from_json`
- `crates/lex-bytecode/src/vm.rs` — update all `Value::Str` construction sites, string concat
- `crates/lex-bytecode/src/parser_runtime.rs` — fix char→SmolStr via `SmolStr::new_inline`
- `crates/lex-runtime/src/builtins.rs` — update all `Value::Str` construction sites
- `crates/lex-runtime/src/ws.rs` — update WebSocket message construction
- `crates/lex-trace/src/recorder.rs` — fix `value_to_json`/`json_to_value` for SmolStr

## Test plan

- [ ] `cargo build --workspace` passes cleanly
- [ ] `cargo test --workspace` — no regressions
- [ ] Existing HTTP/WS handler tests pass
- [ ] Trace recorder round-trip tests pass

## Notes

This is WIP — `crates/lex-runtime/src/handler.rs` still has SmolStr migration in progress (background fix running). Will push follow-up commit once handler.rs is clean.

https://claude.ai/code/session_01APBE4mmqZgBEsaB4pqDZ74

---
_Generated by [Claude Code](https://claude.ai/code/session_01APBE4mmqZgBEsaB4pqDZ74)_