### PR TITLE
fix(#389-slice4): complete SmolStr migration for handler.rs and tests

### DIFF
--- a/crates/conformance/src/runner.rs
+++ b/crates/conformance/src/runner.rs
@@ -172,7 +172,7 @@ fn json_to_value(v: &serde_json::Value) -> Value {
             else if let Some(f) = n.as_f64() { Value::Float(f) }
             else { Value::Unit }
         }
-        J::String(s) => Value::Str(s.clone()),
+        J::String(s) => Value::Str(s.clone().into()),
         J::Array(items) => Value::List(items.iter().map(json_to_value).collect()),
         J::Object(map) => {
             if let (Some(J::String(name)), Some(J::Array(args))) =

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -4806,7 +4806,7 @@ fn run_tool_once(
     let handler = DefaultHandler::new(policy.clone()).with_program(std::sync::Arc::clone(bc));
     let mut vm = Vm::with_handler(bc, Box::new(handler));
     vm.set_step_limit(max_steps);
-    let result = match vm.call("tool", vec![Value::Str(input.to_string())]) {
+    let result = match vm.call("tool", vec![Value::Str(input.to_string().into())]) {
         Ok(v) => v,
         Err(e) => {
             let msg = format!("{e}");
@@ -4832,7 +4832,7 @@ fn run_tool_once(
         }
     };
     Ok(match result {
-        Value::Str(s) => s,
+        Value::Str(s) => s.to_string(),
         other => value_to_json_string(&other),
     })
 }

--- a/crates/lex-cli/src/repl.rs
+++ b/crates/lex-cli/src/repl.rs
@@ -224,7 +224,7 @@ impl Session {
         // original value). Unwrap one layer so the user sees the
         // JSON directly, not a quoted string.
         match v {
-            lex_bytecode::Value::Str(s) => Ok(s),
+            lex_bytecode::Value::Str(s) => Ok(s.to_string()),
             other => Ok(serde_json::to_string(&other.to_json())
                 .unwrap_or_else(|_| format!("{other:?}"))),
         }

--- a/crates/lex-cli/src/tool_registry.rs
+++ b/crates/lex-cli/src/tool_registry.rs
@@ -273,8 +273,8 @@ fn invoke_tool(id: &str, body_str: &str, registry: &Registry) -> Response<std::i
     let handler = DefaultHandler::new(policy).with_program(Arc::clone(&prog));
     let mut vm = Vm::with_handler(&prog, Box::new(handler));
     vm.set_step_limit(1_000_000);
-    match vm.call("tool", vec![Value::Str(parsed.input)]) {
-        Ok(Value::Str(s)) => json_response(200, json!({ "output": s })),
+    match vm.call("tool", vec![Value::Str(parsed.input.into())]) {
+        Ok(Value::Str(s)) => json_response(200, json!({ "output": s.to_string() })),
         Ok(other) => json_response(200, json!({ "output": format!("{other:?}") })),
         Err(e) => {
             let msg = format!("{e}");

--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -48,6 +48,7 @@ csv = "1"
 rusqlite = { version = "0.39", features = ["bundled"] }
 postgres = "0.19"
 lex-bytecode = { path = "../lex-bytecode", version = "0.9.3" }
+smol_str = { workspace = true }
 
 [dev-dependencies]
 lex-syntax = { path = "../lex-syntax", version = "0.9.3" }

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -6,6 +6,7 @@
 
 use lex_bytecode::vm::{EffectHandler, Vm};
 use lex_bytecode::{Program, Value};
+use smol_str::SmolStr;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
@@ -154,7 +155,7 @@ impl DefaultHandler {
                         Ok(ok(Value::Unit))
                     }
                     None => Ok(err(Value::Str(format!(
-                        "log.set_level: unknown level `{s}`; expected debug|info|warn|error")))),
+                        "log.set_level: unknown level `{s}`; expected debug|info|warn|error").into()))),
                 }
             }
             "set_format" => {
@@ -163,7 +164,7 @@ impl DefaultHandler {
                     "text" => LogFormat::Text,
                     "json" => LogFormat::Json,
                     other => return Ok(err(Value::Str(format!(
-                        "log.set_format: unknown format `{other}`; expected text|json")))),
+                        "log.set_format: unknown format `{other}`; expected text|json").into()))),
                 };
                 log_state().lock().unwrap().format = fmt;
                 Ok(ok(Value::Unit))
@@ -175,7 +176,7 @@ impl DefaultHandler {
                     return Ok(ok(Value::Unit));
                 }
                 if let Err(e) = self.ensure_fs_write_path(path) {
-                    return Ok(err(Value::Str(e)));
+                    return Ok(err(Value::Str(e.into())));
                 }
                 match std::fs::OpenOptions::new()
                     .create(true).append(true).open(path)
@@ -184,7 +185,7 @@ impl DefaultHandler {
                         log_state().lock().unwrap().sink = LogSink::File(std::sync::Arc::new(Mutex::new(f)));
                         Ok(ok(Value::Unit))
                     }
-                    Err(e) => Ok(err(Value::Str(format!("log.set_sink `{path}`: {e}")))),
+                    Err(e) => Ok(err(Value::Str(format!("log.set_sink `{path}`: {e}").into()))),
                 }
             }
             other => Err(format!("unsupported log.{other}")),
@@ -200,7 +201,7 @@ impl DefaultHandler {
                     _ => return Err("process.spawn: args must be List[Str]".into()),
                 };
                 let str_args: Result<Vec<String>, String> = raw_args.iter().map(|v| match v {
-                    Value::Str(s) => Ok(s.clone()),
+                    Value::Str(s) => Ok(s.to_string()),
                     other => Err(format!("process.spawn: arg must be Str, got {other:?}")),
                 }).collect();
                 let str_args = str_args?;
@@ -219,7 +220,7 @@ impl DefaultHandler {
                         return Ok(err(Value::Str(format!(
                             "process.spawn: `{cmd}` not in --allow-proc {:?}",
                             self.policy.allow_proc
-                        ))));
+                        ).into())));
                     }
                 }
 
@@ -256,7 +257,7 @@ impl DefaultHandler {
 
                 let mut child = match command.spawn() {
                     Ok(c) => c,
-                    Err(e) => return Ok(err(Value::Str(format!("process.spawn `{cmd}`: {e}")))),
+                    Err(e) => return Ok(err(Value::Str(format!("process.spawn `{cmd}`: {e}").into()))),
                 };
 
                 if let Some(payload) = stdin_payload {
@@ -319,7 +320,7 @@ impl DefaultHandler {
                 // Windows). Signal-name dispatch is a v1.5 follow-up.
                 match state.child.kill() {
                     Ok(_) => Ok(ok(Value::Unit)),
-                    Err(e) => Ok(err(Value::Str(format!("process.kill: {e}")))),
+                    Err(e) => Ok(err(Value::Str(format!("process.kill: {e}").into()))),
                 }
             }
             "run" => {
@@ -329,7 +330,7 @@ impl DefaultHandler {
                     _ => return Err("process.run: args must be List[Str]".into()),
                 };
                 let str_args: Result<Vec<String>, String> = raw_args.iter().map(|v| match v {
-                    Value::Str(s) => Ok(s.clone()),
+                    Value::Str(s) => Ok(s.to_string()),
                     other => Err(format!("process.run: arg must be Str, got {other:?}")),
                 }).collect();
                 let str_args = str_args?;
@@ -342,21 +343,21 @@ impl DefaultHandler {
                         return Ok(err(Value::Str(format!(
                             "process.run: `{cmd}` not in --allow-proc {:?}",
                             self.policy.allow_proc
-                        ))));
+                        ).into())));
                     }
                 }
                 match std::process::Command::new(&cmd).args(&str_args).output() {
                     Ok(o) => {
                         let mut rec = indexmap::IndexMap::new();
                         rec.insert("stdout".into(), Value::Str(
-                            String::from_utf8_lossy(&o.stdout).to_string()));
+                            String::from_utf8_lossy(&o.stdout).into_owned().into()));
                         rec.insert("stderr".into(), Value::Str(
-                            String::from_utf8_lossy(&o.stderr).to_string()));
+                            String::from_utf8_lossy(&o.stderr).into_owned().into()));
                         rec.insert("exit_code".into(), Value::Int(
                             o.status.code().unwrap_or(-1) as i64));
                         Ok(ok(Value::Record(rec)))
                     }
-                    Err(e) => Ok(err(Value::Str(format!("process.run `{cmd}`: {e}")))),
+                    Err(e) => Ok(err(Value::Str(format!("process.run `{cmd}`: {e}").into()))),
                 }
             }
             other => Err(format!("unsupported process.{other}")),
@@ -391,7 +392,7 @@ impl DefaultHandler {
             Ok(_) => {
                 if line.ends_with('\n') { line.pop(); }
                 if line.ends_with('\r') { line.pop(); }
-                Ok(some(Value::Str(line)))
+                Ok(some(Value::Str(line.into())))
             }
             Err(e) => Err(format!("process.read_*_line: {e}")),
         }
@@ -402,28 +403,28 @@ impl DefaultHandler {
             "exists" => {
                 let path = expect_str(args.first())?.to_string();
                 if let Err(e) = self.ensure_fs_walk_path(&path) {
-                    return Ok(err(Value::Str(e)));
+                    return Ok(err(Value::Str(e.into())));
                 }
                 Ok(Value::Bool(std::path::Path::new(&path).exists()))
             }
             "is_file" => {
                 let path = expect_str(args.first())?.to_string();
                 if let Err(e) = self.ensure_fs_walk_path(&path) {
-                    return Ok(err(Value::Str(e)));
+                    return Ok(err(Value::Str(e.into())));
                 }
                 Ok(Value::Bool(std::path::Path::new(&path).is_file()))
             }
             "is_dir" => {
                 let path = expect_str(args.first())?.to_string();
                 if let Err(e) = self.ensure_fs_walk_path(&path) {
-                    return Ok(err(Value::Str(e)));
+                    return Ok(err(Value::Str(e.into())));
                 }
                 Ok(Value::Bool(std::path::Path::new(&path).is_dir()))
             }
             "stat" => {
                 let path = expect_str(args.first())?.to_string();
                 if let Err(e) = self.ensure_fs_walk_path(&path) {
-                    return Ok(err(Value::Str(e)));
+                    return Ok(err(Value::Str(e.into())));
                 }
                 match std::fs::metadata(&path) {
                     Ok(md) => {
@@ -439,13 +440,13 @@ impl DefaultHandler {
                         rec.insert("is_file".into(), Value::Bool(md.is_file()));
                         Ok(ok(Value::Record(rec)))
                     }
-                    Err(e) => Ok(err(Value::Str(format!("fs.stat `{path}`: {e}")))),
+                    Err(e) => Ok(err(Value::Str(format!("fs.stat `{path}`: {e}").into()))),
                 }
             }
             "list_dir" => {
                 let path = expect_str(args.first())?.to_string();
                 if let Err(e) = self.ensure_fs_walk_path(&path) {
-                    return Ok(err(Value::Str(e)));
+                    return Ok(err(Value::Str(e.into())));
                 }
                 match std::fs::read_dir(&path) {
                     Ok(rd) => {
@@ -454,27 +455,27 @@ impl DefaultHandler {
                             match ent {
                                 Ok(e) => {
                                     let p = e.path();
-                                    entries.push(Value::Str(p.to_string_lossy().into_owned()));
+                                    entries.push(Value::Str(p.to_string_lossy().into_owned().into()));
                                 }
-                                Err(e) => return Ok(err(Value::Str(format!("fs.list_dir: {e}")))),
+                                Err(e) => return Ok(err(Value::Str(format!("fs.list_dir: {e}").into()))),
                             }
                         }
                         Ok(ok(Value::List(entries.into())))
                     }
-                    Err(e) => Ok(err(Value::Str(format!("fs.list_dir `{path}`: {e}")))),
+                    Err(e) => Ok(err(Value::Str(format!("fs.list_dir `{path}`: {e}").into()))),
                 }
             }
             "walk" => {
                 let path = expect_str(args.first())?.to_string();
                 if let Err(e) = self.ensure_fs_walk_path(&path) {
-                    return Ok(err(Value::Str(e)));
+                    return Ok(err(Value::Str(e.into())));
                 }
                 let mut paths: Vec<Value> = Vec::new();
                 for ent in walkdir::WalkDir::new(&path) {
                     match ent {
                         Ok(e) => paths.push(Value::Str(
-                            e.path().to_string_lossy().into_owned())),
-                        Err(e) => return Ok(err(Value::Str(format!("fs.walk: {e}")))),
+                            e.path().to_string_lossy().into_owned().into())),
+                        Err(e) => return Ok(err(Value::Str(format!("fs.walk: {e}").into()))),
                     }
                 }
                 Ok(ok(Value::List(paths.into())))
@@ -487,7 +488,7 @@ impl DefaultHandler {
                 // `--allow-fs-read`.
                 let entries = match glob::glob(&pattern) {
                     Ok(e) => e,
-                    Err(e) => return Ok(err(Value::Str(format!("fs.glob: {e}")))),
+                    Err(e) => return Ok(err(Value::Str(format!("fs.glob: {e}").into()))),
                 };
                 let mut paths: Vec<Value> = Vec::new();
                 for ent in entries {
@@ -497,10 +498,10 @@ impl DefaultHandler {
                             if self.policy.allow_fs_read.is_empty()
                                 || self.policy.allow_fs_read.iter().any(|root| p.starts_with(root))
                             {
-                                paths.push(Value::Str(s));
+                                paths.push(Value::Str(s.into()));
                             }
                         }
-                        Err(e) => return Ok(err(Value::Str(format!("fs.glob: {e}")))),
+                        Err(e) => return Ok(err(Value::Str(format!("fs.glob: {e}").into()))),
                     }
                 }
                 Ok(ok(Value::List(paths.into())))
@@ -508,17 +509,17 @@ impl DefaultHandler {
             "mkdir_p" => {
                 let path = expect_str(args.first())?.to_string();
                 if let Err(e) = self.ensure_fs_write_path(&path) {
-                    return Ok(err(Value::Str(e)));
+                    return Ok(err(Value::Str(e.into())));
                 }
                 match std::fs::create_dir_all(&path) {
                     Ok(_) => Ok(ok(Value::Unit)),
-                    Err(e) => Ok(err(Value::Str(format!("fs.mkdir_p `{path}`: {e}")))),
+                    Err(e) => Ok(err(Value::Str(format!("fs.mkdir_p `{path}`: {e}").into()))),
                 }
             }
             "remove" => {
                 let path = expect_str(args.first())?.to_string();
                 if let Err(e) = self.ensure_fs_write_path(&path) {
-                    return Ok(err(Value::Str(e)));
+                    return Ok(err(Value::Str(e.into())));
                 }
                 let p = std::path::Path::new(&path);
                 let result = if p.is_dir() {
@@ -528,21 +529,21 @@ impl DefaultHandler {
                 };
                 match result {
                     Ok(_) => Ok(ok(Value::Unit)),
-                    Err(e) => Ok(err(Value::Str(format!("fs.remove `{path}`: {e}")))),
+                    Err(e) => Ok(err(Value::Str(format!("fs.remove `{path}`: {e}").into()))),
                 }
             }
             "copy" => {
                 let src = expect_str(args.first())?.to_string();
                 let dst = expect_str(args.get(1))?.to_string();
                 if let Err(e) = self.ensure_fs_walk_path(&src) {
-                    return Ok(err(Value::Str(e)));
+                    return Ok(err(Value::Str(e.into())));
                 }
                 if let Err(e) = self.ensure_fs_write_path(&dst) {
-                    return Ok(err(Value::Str(e)));
+                    return Ok(err(Value::Str(e.into())));
                 }
                 match std::fs::copy(&src, &dst) {
                     Ok(_) => Ok(ok(Value::Unit)),
-                    Err(e) => Ok(err(Value::Str(format!("fs.copy {src} -> {dst}: {e}")))),
+                    Err(e) => Ok(err(Value::Str(format!("fs.copy {src} -> {dst}: {e}").into()))),
                 }
             }
             other => Err(format!("unsupported fs.{other}")),
@@ -728,7 +729,7 @@ impl EffectHandler for DefaultHandler {
             let mut buf = vec![0u8; n as usize];
             SysRng.try_fill_bytes(&mut buf)
                 .map_err(|e| format!("crypto.random_str_hex: OS RNG: {e}"))?;
-            return Ok(Value::Str(hex::encode(&buf)));
+            return Ok(Value::Str(hex::encode(&buf).into()));
         }
         // `std.http` wire ops (send/get/post) gate on the `net`
         // effect kind, not the module name. This matches the
@@ -764,7 +765,7 @@ impl EffectHandler for DefaultHandler {
                 "local_complete" => Ok(dispatch_llm_local(args)),
                 "cloud_complete" => Ok(dispatch_llm_cloud(args)),
                 "cloud_stream"   => Ok(self.dispatch_cloud_stream(args)),
-                _ => Ok(ok(Value::Str(format!("<{effect_kind} stub>")))),
+                _ => Ok(ok(Value::Str(format!("<{effect_kind} stub>").into()))),
             };
         }
         if kind == "stream" {
@@ -825,8 +826,8 @@ impl EffectHandler for DefaultHandler {
                     return Err(format!("read of `{path}` outside --allow-fs-read"));
                 }
                 match std::fs::read_to_string(&resolved) {
-                    Ok(s) => Ok(ok(Value::Str(s))),
-                    Err(e) => Ok(err(Value::Str(format!("{e}")))),
+                    Ok(s) => Ok(ok(Value::Str(s.into()))),
+                    Err(e) => Ok(err(Value::Str(format!("{e}").into()))),
                 }
             }
             ("io", "write") => {
@@ -841,7 +842,7 @@ impl EffectHandler for DefaultHandler {
                 }
                 match std::fs::write(&path, contents) {
                     Ok(_) => Ok(ok(Value::Unit)),
-                    Err(e) => Ok(err(Value::Str(format!("{e}")))),
+                    Err(e) => Ok(err(Value::Str(format!("{e}").into()))),
                 }
             }
             ("time", "now") => {
@@ -877,10 +878,10 @@ impl EffectHandler for DefaultHandler {
                     if let Ok(secs) = s.trim().parse::<i64>() {
                         let dt = chrono::DateTime::<chrono::Utc>::from_timestamp(secs, 0)
                             .unwrap_or_else(chrono::Utc::now);
-                        return Ok(Value::Str(dt.to_rfc3339()));
+                        return Ok(Value::Str(dt.to_rfc3339().into()));
                     }
                 }
-                Ok(Value::Str(chrono::Utc::now().to_rfc3339()))
+                Ok(Value::Str(chrono::Utc::now().to_rfc3339().into()))
             }
             ("time", "mono_ns") => {
                 // Monotonic clock relative to process start. Cached
@@ -925,7 +926,7 @@ impl EffectHandler for DefaultHandler {
                 Ok(match std::env::var(name) {
                     Ok(v) => Value::Variant {
                         name: "Some".into(),
-                        args: vec![Value::Str(v)],
+                        args: vec![Value::Str(v.into())],
                     },
                     Err(_) => Value::Variant { name: "None".into(), args: Vec::new() },
                 })
@@ -1065,7 +1066,7 @@ impl EffectHandler for DefaultHandler {
                     let p = std::path::Path::new(&path);
                     if !self.policy.allow_fs_write.iter().any(|a| p.starts_with(a)) {
                         return Ok(err(Value::Str(format!(
-                            "kv.open: `{path}` outside --allow-fs-write"))));
+                            "kv.open: `{path}` outside --allow-fs-write").into())));
                     }
                 }
                 match sled::open(&path) {
@@ -1074,7 +1075,7 @@ impl EffectHandler for DefaultHandler {
                         kv_registry().lock().unwrap().insert(handle, db);
                         Ok(ok(Value::Int(handle as i64)))
                     }
-                    Err(e) => Ok(err(Value::Str(format!("kv.open: {e}")))),
+                    Err(e) => Ok(err(Value::Str(format!("kv.open: {e}").into()))),
                 }
             }
             ("kv", "close") => {
@@ -1101,7 +1102,7 @@ impl EffectHandler for DefaultHandler {
                 let db = reg.touch_get(h).ok_or_else(|| "kv.put: closed or unknown Kv handle".to_string())?;
                 match db.insert(key.as_bytes(), val) {
                     Ok(_) => Ok(ok(Value::Unit)),
-                    Err(e) => Ok(err(Value::Str(format!("kv.put: {e}")))),
+                    Err(e) => Ok(err(Value::Str(format!("kv.put: {e}").into()))),
                 }
             }
             ("kv", "delete") => {
@@ -1111,7 +1112,7 @@ impl EffectHandler for DefaultHandler {
                 let db = reg.touch_get(h).ok_or_else(|| "kv.delete: closed or unknown Kv handle".to_string())?;
                 match db.remove(key.as_bytes()) {
                     Ok(_) => Ok(ok(Value::Unit)),
-                    Err(e) => Ok(err(Value::Str(format!("kv.delete: {e}")))),
+                    Err(e) => Ok(err(Value::Str(format!("kv.delete: {e}").into()))),
                 }
             }
             ("kv", "contains") => {
@@ -1133,7 +1134,7 @@ impl EffectHandler for DefaultHandler {
                 for kv in db.scan_prefix(prefix.as_bytes()) {
                     let (k, _) = kv.map_err(|e| format!("kv.list_prefix: {e}"))?;
                     let s = String::from_utf8_lossy(&k).to_string();
-                    keys.push(Value::Str(s));
+                    keys.push(Value::Str(s.into()));
                 }
                 Ok(Value::List(keys.into()))
             }
@@ -1398,7 +1399,7 @@ impl EffectHandler for DefaultHandler {
             }
             ("sql", "get_str") => Ok(sql_get_col(&args, |v| match v {
                 Value::Str(s) => Some(Value::Str(s.clone())),
-                Value::Int(n) => Some(Value::Str(n.to_string())),
+                Value::Int(n) => Some(Value::Str(n.to_string().into())),
                 _ => None,
             })?),
             ("sql", "get_int") => Ok(sql_get_col(&args, |v| match v {
@@ -1438,7 +1439,7 @@ impl EffectHandler for DefaultHandler {
                     None => return Err("proc.spawn: missing args list".into()),
                 };
                 let str_args: Vec<String> = raw_args.iter().map(|v| match v {
-                    Value::Str(s) => Ok(s.clone()),
+                    Value::Str(s) => Ok(s.to_string()),
                     other => Err(format!("proc.spawn: arg must be Str, got {other:?}")),
                 }).collect::<Result<Vec<_>, _>>()?;
 
@@ -1454,7 +1455,7 @@ impl EffectHandler for DefaultHandler {
                         return Ok(err(Value::Str(format!(
                             "proc.spawn: `{cmd}` not in --allow-proc {:?}",
                             self.policy.allow_proc
-                        ))));
+                        ).into())));
                     }
                 }
 
@@ -1462,7 +1463,7 @@ impl EffectHandler for DefaultHandler {
                 // unbounded argv is a DoS vector.
                 if str_args.len() > 1024 {
                     return Ok(err(Value::Str(
-                        "proc.spawn: arg-count exceeds 1024".into())));
+                        SmolStr::new_inline("proc.spawn: arg-count exceeds 1024"))));
                 }
                 if str_args.iter().any(|a| a.len() > 65_536) {
                     return Ok(err(Value::Str(
@@ -1476,14 +1477,14 @@ impl EffectHandler for DefaultHandler {
                     Ok(o) => {
                         let mut rec = indexmap::IndexMap::new();
                         rec.insert("stdout".into(), Value::Str(
-                            String::from_utf8_lossy(&o.stdout).to_string()));
+                            String::from_utf8_lossy(&o.stdout).into_owned().into()));
                         rec.insert("stderr".into(), Value::Str(
-                            String::from_utf8_lossy(&o.stderr).to_string()));
+                            String::from_utf8_lossy(&o.stderr).into_owned().into()));
                         rec.insert("exit_code".into(), Value::Int(
                             o.status.code().unwrap_or(-1) as i64));
                         Ok(ok(Value::Record(rec)))
                     }
-                    Err(e) => Ok(err(Value::Str(format!("spawn `{cmd}`: {e}")))),
+                    Err(e) => Ok(err(Value::Str(format!("spawn `{cmd}`: {e}").into()))),
                 }
             }
             other => Err(format!("unsupported effect {}.{}", other.0, other.1)),
@@ -1760,16 +1761,16 @@ fn build_request_value_parts(
         if let Ok(v) = val.to_str() {
             headers_map.insert(
                 lex_bytecode::MapKey::Str(name.as_str().to_ascii_lowercase()),
-                Value::Str(v.to_string()),
+                Value::Str(v.to_string().into()),
             );
         }
     }
     let body_str = String::from_utf8_lossy(body).into_owned();
     let mut rec = indexmap::IndexMap::new();
-    rec.insert("method".into(), Value::Str(method));
-    rec.insert("path".into(), Value::Str(path));
-    rec.insert("query".into(), Value::Str(query));
-    rec.insert("body".into(), Value::Str(body_str));
+    rec.insert("method".into(), Value::Str(method.into()));
+    rec.insert("path".into(), Value::Str(path.into()));
+    rec.insert("query".into(), Value::Str(query.into()));
+    rec.insert("body".into(), Value::Str(body_str.into()));
     rec.insert("headers".into(), Value::Map(headers_map));
     Value::Record(rec)
 }
@@ -1786,16 +1787,16 @@ fn build_request_value_tiny(req: &mut tiny_http::Request) -> Value {
     for h in req.headers() {
         headers_map.insert(
             lex_bytecode::MapKey::Str(h.field.as_str().as_str().to_ascii_lowercase()),
-            Value::Str(h.value.as_str().to_string()),
+            Value::Str(h.value.as_str().to_string().into()),
         );
     }
     let mut body = String::new();
     let _ = req.as_reader().read_to_string(&mut body);
     let mut rec = indexmap::IndexMap::new();
-    rec.insert("method".into(), Value::Str(method));
-    rec.insert("path".into(), Value::Str(path));
-    rec.insert("query".into(), Value::Str(query));
-    rec.insert("body".into(), Value::Str(body));
+    rec.insert("method".into(), Value::Str(method.into()));
+    rec.insert("path".into(), Value::Str(path.into()));
+    rec.insert("query".into(), Value::Str(query.into()));
+    rec.insert("body".into(), Value::Str(body.into()));
     rec.insert("headers".into(), Value::Map(headers_map));
     Value::Record(rec)
 }
@@ -1809,7 +1810,7 @@ fn unpack_response(v: &Value) -> (u16, ResponseBodyOut, Vec<(String, String)>) {
         let body = match rec.get("body") {
             // Tagged ResponseBody (#375): BodyStr | BodyStream | BodyBytes.
             Some(Value::Variant { name, args }) => match (name.as_str(), args.as_slice()) {
-                ("BodyStr",    [Value::Str(s)])             => ResponseBodyOut::Str(s.clone()),
+                ("BodyStr",    [Value::Str(s)])             => ResponseBodyOut::Str(s.to_string()),
                 ("BodyStream", [iter_v])                    => ResponseBodyOut::TextChunks(drain_iter_str(iter_v)),
                 ("BodyBytes",  [iter_v])                    => ResponseBodyOut::BytesChunks(drain_iter_bytes(iter_v)),
                 _ => ResponseBodyOut::Str(String::new()),
@@ -1819,13 +1820,13 @@ fn unpack_response(v: &Value) -> (u16, ResponseBodyOut, Vec<(String, String)>) {
             // `body :: Str` (the pre-#375 contract). Lets internal
             // test handlers and one-liners keep working without
             // wrapping in `BodyStr(...)`.
-            Some(Value::Str(s)) => ResponseBodyOut::Str(s.clone()),
+            Some(Value::Str(s)) => ResponseBodyOut::Str(s.to_string()),
             _ => ResponseBodyOut::Str(String::new()),
         };
         let headers: Vec<(String, String)> = if let Some(Value::Map(hmap)) = rec.get("headers") {
             hmap.iter().filter_map(|(k, v)| {
                 if let (lex_bytecode::MapKey::Str(name), Value::Str(val)) = (k, v) {
-                    Some((name.clone(), val.clone()))
+                    Some((name.clone(), val.to_string()))
                 } else {
                     None
                 }
@@ -2092,7 +2093,7 @@ fn http_request(method: &str, url: &str, body: Option<&str>) -> Value {
             let status = r.status().as_u16();
             let body = r.body_mut().read_to_string().unwrap_or_default();
             if (200..300).contains(&status) {
-                Value::Variant { name: "Ok".into(), args: vec![Value::Str(body)] }
+                Value::Variant { name: "Ok".into(), args: vec![Value::Str(body.into())] }
             } else {
                 err_value(format!("status {status}: {body}"))
             }
@@ -2130,7 +2131,7 @@ fn http_error_value(e: ureq::Error) -> Value {
         ureq::Error::Rustls(r) => ("TlsError", Some(format!("{r}"))),
         _ => ("NetworkError", Some(format!("{e}"))),
     };
-    let args = match payload { Some(s) => vec![Value::Str(s)], None => vec![] };
+    let args = match payload { Some(s) => vec![Value::Str(s.into())], None => vec![] };
     let inner = Value::Variant { name: ctor.into(), args };
     Value::Variant { name: "Err".into(), args: vec![inner] }
 }
@@ -2138,7 +2139,7 @@ fn http_error_value(e: ureq::Error) -> Value {
 fn http_decode_err(msg: String) -> Value {
     let inner = Value::Variant {
         name: "DecodeError".into(),
-        args: vec![Value::Str(msg)],
+        args: vec![Value::Str(msg.into())],
     };
     Value::Variant { name: "Err".into(), args: vec![inner] }
 }
@@ -2211,7 +2212,7 @@ fn collect_response_headers(
     let mut out = std::collections::BTreeMap::new();
     for (name, value) in headers.iter() {
         let v = value.to_str().unwrap_or("").to_string();
-        out.insert(lex_bytecode::MapKey::Str(name.as_str().to_string()), Value::Str(v));
+        out.insert(lex_bytecode::MapKey::Str(name.as_str().to_string()), Value::Str(v.into()));
     }
     out
 }
@@ -2221,11 +2222,11 @@ fn collect_response_headers(
 /// `--allow-net-host` for the URL before sending.
 fn http_send_record(handler: &DefaultHandler, req: &indexmap::IndexMap<String, Value>) -> Value {
     let method = match req.get("method") {
-        Some(Value::Str(s)) => s.clone(),
+        Some(Value::Str(s)) => s.to_string(),
         _ => return http_decode_err("HttpRequest.method must be Str".into()),
     };
     let url = match req.get("url") {
-        Some(Value::Str(s)) => s.clone(),
+        Some(Value::Str(s)) => s.to_string(),
         _ => return http_decode_err("HttpRequest.url must be Str".into()),
     };
     if let Err(e) = handler.ensure_host_allowed(&url) {
@@ -2251,7 +2252,7 @@ fn http_send_record(handler: &DefaultHandler, req: &indexmap::IndexMap<String, V
     let headers: Vec<(String, String)> = match req.get("headers") {
         Some(Value::Map(m)) => m.iter().filter_map(|(k, v)| {
             let kk = match k { lex_bytecode::MapKey::Str(s) => s.clone(), _ => return None };
-            let vv = match v { Value::Str(s) => s.clone(), _ => return None };
+            let vv = match v { Value::Str(s) => s.to_string(), _ => return None };
             Some((kk, vv))
         }).collect(),
         _ => return http_decode_err("HttpRequest.headers must be Map[Str, Str]".into()),
@@ -2268,7 +2269,7 @@ fn expect_record(v: Option<&Value>) -> Result<&indexmap::IndexMap<String, Value>
 }
 
 fn err_value(msg: String) -> Value {
-    Value::Variant { name: "Err".into(), args: vec![Value::Str(msg)] }
+    Value::Variant { name: "Err".into(), args: vec![Value::Str(msg.into())] }
 }
 
 fn expect_str(v: Option<&Value>) -> Result<&str, String> {
@@ -2298,10 +2299,11 @@ fn err(v: Value) -> Value {
 /// `code` and `detail` are `None` by default; the driver-specific
 /// converters below populate them with real values.
 fn sql_error(message: impl Into<String>, code: Option<String>, detail: Option<String>) -> Value {
-    let some = |s: String| Value::Variant { name: "Some".into(), args: vec![Value::Str(s)] };
+    let some = |s: String| Value::Variant { name: "Some".into(), args: vec![Value::Str(s.into())] };
     let none = || Value::Variant { name: "None".into(), args: vec![] };
     let mut rec = indexmap::IndexMap::new();
-    rec.insert("message".into(), Value::Str(message.into()));
+    let msg: String = message.into();
+    rec.insert("message".into(), Value::Str(msg.into()));
     rec.insert("code".into(), match code {
         Some(c) => some(c),
         None => none(),
@@ -2415,12 +2417,12 @@ impl DefaultHandler {
         let parsed: serde_json::Value = match serde_json::from_str(&args_json) {
             Ok(v) => v,
             Err(e) => return err(Value::Str(format!(
-                "agent.call_mcp: args_json is not valid JSON: {e}"))),
+                "agent.call_mcp: args_json is not valid JSON: {e}").into())),
         };
         match self.mcp_clients.call(&server, &tool, parsed) {
             Ok(result) => ok(Value::Str(
-                serde_json::to_string(&result).unwrap_or_else(|_| "null".into()))),
-            Err(e) => err(Value::Str(e)),
+                serde_json::to_string(&result).unwrap_or_else(|_| "null".into()).into())),
+            Err(e) => err(Value::Str(e.into())),
         }
     }
 
@@ -2460,7 +2462,7 @@ impl DefaultHandler {
             Err(_) => return Value::Variant { name: "None".into(), args: vec![] },
         };
         match streams.get_mut(&handle).and_then(|it| it.next()) {
-            Some(chunk) => some(Value::Str(chunk)),
+            Some(chunk) => some(Value::Str(chunk.into())),
             None => {
                 streams.remove(&handle);
                 Value::Variant { name: "None".into(), args: vec![] }
@@ -2489,7 +2491,7 @@ impl DefaultHandler {
         };
         let mut out: std::collections::VecDeque<Value> = std::collections::VecDeque::new();
         for chunk in iter.by_ref() {
-            out.push_back(Value::Str(chunk));
+            out.push_back(Value::Str(chunk.into()));
         }
         Value::List(out)
     }
@@ -2519,7 +2521,7 @@ impl DefaultHandler {
 fn stream_handle_value(handle: String) -> Value {
     Value::Variant {
         name: "__StreamHandle".into(),
-        args: vec![Value::Str(handle)],
+        args: vec![Value::Str(handle.into())],
     }
 }
 
@@ -2529,7 +2531,7 @@ fn stream_handle_value(handle: String) -> Value {
 fn stream_handle_id(v: &Value) -> Option<String> {
     match v {
         Value::Variant { name, args } if name == "__StreamHandle" => match args.first() {
-            Some(Value::Str(h)) => Some(h.clone()),
+            Some(Value::Str(h)) => Some(h.to_string()),
             _ => None,
         },
         _ => None,
@@ -2547,8 +2549,8 @@ fn dispatch_llm_local(args: Vec<Value>) -> Value {
             "agent.local_complete(prompt): prompt must be Str".into())),
     };
     match crate::llm::local_complete(&prompt) {
-        Ok(text) => ok(Value::Str(text)),
-        Err(e) => err(Value::Str(e)),
+        Ok(text) => ok(Value::Str(text.into())),
+        Err(e) => err(Value::Str(e.into())),
     }
 }
 
@@ -2565,8 +2567,8 @@ fn dispatch_llm_cloud(args: Vec<Value>) -> Value {
             "agent.cloud_complete(prompt): prompt must be Str".into())),
     };
     match crate::llm::cloud_complete(&prompt) {
-        Ok(text) => ok(Value::Str(text)),
-        Err(e) => err(Value::Str(e)),
+        Ok(text) => ok(Value::Str(text.into())),
+        Err(e) => err(Value::Str(e.into())),
     }
 }
 
@@ -2605,7 +2607,7 @@ fn expect_sql_handle(v: Option<&Value>) -> Result<u64, String> {
 fn expect_str_list(v: Option<&Value>) -> Result<Vec<String>, String> {
     match v {
         Some(Value::List(items)) => items.iter().map(|x| match x {
-            Value::Str(s) => Ok(s.clone()),
+            Value::Str(s) => Ok(s.to_string()),
             other => Err(format!("expected List[Str] element, got {other:?}")),
         }).collect(),
         Some(other) => Err(format!("expected List[Str], got {other:?}")),
@@ -2625,7 +2627,7 @@ fn expect_sql_params(v: Option<&Value>) -> Result<Vec<SqlParamValue>, String> {
         match item {
             Value::Variant { name, args } => match name.as_str() {
                 "PStr"   => match args.first() {
-                    Some(Value::Str(s)) => Ok(SqlParamValue::Text(s.clone())),
+                    Some(Value::Str(s)) => Ok(SqlParamValue::Text(s.to_string())),
                     _ => Err("PStr requires a Str argument".into()),
                 },
                 "PInt"   => match args.first() {
@@ -2644,7 +2646,7 @@ fn expect_sql_params(v: Option<&Value>) -> Result<Vec<SqlParamValue>, String> {
                 other    => Err(format!("unknown SqlParam constructor `{other}`")),
             },
             // Backward-compat: bare strings are accepted as PStr.
-            Value::Str(s) => Ok(SqlParamValue::Text(s.clone())),
+            Value::Str(s) => Ok(SqlParamValue::Text(s.to_string())),
             other => Err(format!("expected SqlParam variant, got {other:?}")),
         }
     }).collect()
@@ -2750,7 +2752,7 @@ fn pg_row_to_lex_record(row: &postgres::Row) -> indexmap::IndexMap<String, Value
         } else if *ty == Type::BYTEA {
             row.get::<_, Option<Vec<u8>>>(i).map(Value::Bytes).unwrap_or(Value::Unit)
         } else {
-            row.get::<_, Option<String>>(i).map(Value::Str).unwrap_or(Value::Unit)
+            row.get::<_, Option<String>>(i).map(|s| Value::Str(s.into())).unwrap_or(Value::Unit)
         };
         rec.insert(col.name().to_string(), val);
     }
@@ -2784,7 +2786,7 @@ fn sql_value_ref_to_lex(v: rusqlite::types::ValueRef<'_>) -> Value {
         ValueRef::Null       => Value::Unit,
         ValueRef::Integer(n) => Value::Int(n),
         ValueRef::Real(f)    => Value::Float(f),
-        ValueRef::Text(s)    => Value::Str(String::from_utf8_lossy(s).into_owned()),
+        ValueRef::Text(s)    => Value::Str(String::from_utf8_lossy(s).into_owned().into()),
         ValueRef::Blob(b)    => Value::Bytes(b.to_vec()),
     }
 }

--- a/crates/lex-runtime/tests/bytes_and_net.rs
+++ b/crates/lex-runtime/tests/bytes_and_net.rs
@@ -122,7 +122,7 @@ fn net_get_returns_response_body() {
 import "std.net" as net
 fn fetch(u :: Str) -> [net] Result[Str, Str] { net.get(u) }
 "#;
-    let r = run(src, "fetch", vec![Value::Str(url)], allow(&["net"]));
+    let r = run(src, "fetch", vec![Value::Str(url.into())], allow(&["net"]));
     let _ = handle.join();
     let (name, args) = match r {
         Value::Variant { name, args } => (name, args),

--- a/crates/lex-runtime/tests/list_sort_by.rs
+++ b/crates/lex-runtime/tests/list_sort_by.rs
@@ -137,7 +137,7 @@ fn r(xs :: List[R]) -> List[R] {
         .iter()
         .map(|v| match v {
             Value::Record(f) => match f.get("tag") {
-                Some(Value::Str(t)) => t.clone(),
+                Some(Value::Str(t)) => t.to_string(),
                 _ => panic!(),
             },
             _ => panic!(),

--- a/crates/lex-runtime/tests/sql_error_codes.rs
+++ b/crates/lex-runtime/tests/sql_error_codes.rs
@@ -39,13 +39,13 @@ fn unpack_sql_error(v: &Value) -> (String, Option<String>, Option<String>) {
         other => panic!("expected SqlError record, got {other:?}"),
     };
     let message = match rec.get("message") {
-        Some(Value::Str(s)) => s.clone(),
+        Some(Value::Str(s)) => s.to_string(),
         other => panic!("expected message :: Str, got {other:?}"),
     };
     let read_opt = |key: &str| match rec.get(key) {
         Some(Value::Variant { name, args }) if name == "Some" && args.len() == 1 => {
             match &args[0] {
-                Value::Str(s) => Some(s.clone()),
+                Value::Str(s) => Some(s.to_string()),
                 _ => None,
             }
         }

--- a/crates/lex-runtime/tests/sql_query_iter.rs
+++ b/crates/lex-runtime/tests/sql_query_iter.rs
@@ -208,7 +208,7 @@ fn drains_all_rows_in_order() {
         other => panic!("expected List, got {other:?}"),
     };
     let expected: Vec<Value> = (0..5)
-        .map(|i| Value::Str(format!("r{i}")))
+        .map(|i| Value::Str(format!("r{i}").into()))
         .collect();
     assert_eq!(list, expected);
 }

--- a/crates/lex-runtime/tests/std_agent_mcp_client.rs
+++ b/crates/lex-runtime/tests/std_agent_mcp_client.rs
@@ -90,7 +90,7 @@ fn check_remotely(server :: Str, source :: Str) -> [mcp] Result[Str, Str] {
     // trivial but non-empty fn so success is unambiguous.
     let lex_src = r#"fn id(n :: Int) -> Int { n }"#;
     let v = run_program(src, "check_remotely",
-        vec![Value::Str(server_cmd), Value::Str(lex_src.to_string())],
+        vec![Value::Str(server_cmd.into()), Value::Str(lex_src.to_string().into())],
         Policy::permissive());
     match &v {
         Value::Variant { name, args } if name == "Ok" => match &args[0] {

--- a/crates/lex-runtime/tests/std_crypto.rs
+++ b/crates/lex-runtime/tests/std_crypto.rs
@@ -32,7 +32,7 @@ fn bytes(v: Value) -> Vec<u8> {
 
 fn s(v: Value) -> String {
     match v {
-        Value::Str(s) => s,
+        Value::Str(s) => s.to_string(),
         other => panic!("expected Str, got {other:?}"),
     }
 }

--- a/crates/lex-runtime/tests/std_crypto_aead.rs
+++ b/crates/lex-runtime/tests/std_crypto_aead.rs
@@ -46,7 +46,7 @@ fn unwrap_ok(v: Value) -> Value {
 fn unwrap_err(v: Value) -> String {
     match v {
         Value::Variant { name, args } if name == "Err" && args.len() == 1 => match args.into_iter().next().unwrap() {
-            Value::Str(s) => s,
+            Value::Str(s) => s.to_string(),
             other => panic!("Err payload not Str: {other:?}"),
         },
         other => panic!("expected Err(_), got {other:?}"),

--- a/crates/lex-runtime/tests/std_crypto_extras.rs
+++ b/crates/lex-runtime/tests/std_crypto_extras.rs
@@ -36,7 +36,7 @@ fn bytes(v: Value) -> Vec<u8> {
     match v { Value::Bytes(b) => b, other => panic!("expected Bytes, got {other:?}") }
 }
 fn s(v: Value) -> String {
-    match v { Value::Str(x) => x, other => panic!("expected Str, got {other:?}") }
+    match v { Value::Str(x) => x.to_string(), other => panic!("expected Str, got {other:?}") }
 }
 fn b(v: Value) -> bool {
     match v { Value::Bool(x) => x, other => panic!("expected Bool, got {other:?}") }

--- a/crates/lex-runtime/tests/std_crypto_kdf.rs
+++ b/crates/lex-runtime/tests/std_crypto_kdf.rs
@@ -49,7 +49,7 @@ fn unwrap_err(v: Value) -> String {
     match v {
         Value::Variant { name, args } if name == "Err" && args.len() == 1 => {
             match args.into_iter().next().unwrap() {
-                Value::Str(s) => s,
+                Value::Str(s) => s.to_string(),
                 other => panic!("Err payload not Str: {other:?}"),
             }
         }

--- a/crates/lex-runtime/tests/std_datetime.rs
+++ b/crates/lex-runtime/tests/std_datetime.rs
@@ -27,7 +27,7 @@ fn run(src: &str, fn_name: &str, args: Vec<Value>, policy: Policy) -> Value {
 
 fn s(v: Value) -> String {
     match v {
-        Value::Str(s) => s,
+        Value::Str(s) => s.to_string(),
         other => panic!("expected Str, got {other:?}"),
     }
 }

--- a/crates/lex-runtime/tests/std_fs.rs
+++ b/crates/lex-runtime/tests/std_fs.rs
@@ -93,7 +93,7 @@ fn exists_returns_true_for_a_real_path() {
     let v = run(
         SRC,
         "does_exist",
-        vec![Value::Str(dir.to_string_lossy().to_string())],
+        vec![Value::Str(dir.to_string_lossy().to_string().into())],
         policy_walk_only(&dir),
     );
     assert_eq!(v, Value::Bool(true));
@@ -106,7 +106,7 @@ fn exists_returns_false_for_nonexistent_path() {
     let v = run(
         SRC,
         "does_exist",
-        vec![Value::Str(phantom.to_string_lossy().to_string())],
+        vec![Value::Str(phantom.to_string_lossy().to_string().into())],
         policy_walk_only(&dir),
     );
     assert_eq!(v, Value::Bool(false));
@@ -118,10 +118,10 @@ fn is_dir_distinguishes_dir_from_file() {
     let file = dir.join("a.txt");
     std::fs::write(&file, "hi").unwrap();
 
-    let v = run(SRC, "is_a_dir", vec![Value::Str(dir.to_string_lossy().to_string())], policy_walk_only(&dir));
+    let v = run(SRC, "is_a_dir", vec![Value::Str(dir.to_string_lossy().to_string().into())], policy_walk_only(&dir));
     assert_eq!(v, Value::Bool(true));
 
-    let v = run(SRC, "is_a_dir", vec![Value::Str(file.to_string_lossy().to_string())], policy_walk_only(&dir));
+    let v = run(SRC, "is_a_dir", vec![Value::Str(file.to_string_lossy().to_string().into())], policy_walk_only(&dir));
     assert_eq!(v, Value::Bool(false));
 }
 
@@ -135,7 +135,7 @@ fn walk_returns_recursive_path_count() {
     let v = run(
         SRC,
         "count_walk",
-        vec![Value::Str(dir.to_string_lossy().to_string())],
+        vec![Value::Str(dir.to_string_lossy().to_string().into())],
         policy_walk_only(&dir),
     );
     assert_eq!(v, Value::Int(4));
@@ -151,7 +151,7 @@ fn list_dir_returns_immediate_children_only() {
     let v = run(
         SRC,
         "list_dir_count",
-        vec![Value::Str(dir.to_string_lossy().to_string())],
+        vec![Value::Str(dir.to_string_lossy().to_string().into())],
         policy_walk_only(&dir),
     );
     assert_eq!(v, Value::Int(2));
@@ -164,7 +164,7 @@ fn mkdir_p_creates_nested() {
     let v = run(
         SRC,
         "make_dir",
-        vec![Value::Str(nested.to_string_lossy().to_string())],
+        vec![Value::Str(nested.to_string_lossy().to_string().into())],
         policy_walk_and_write(&root, &root),
     );
     assert_eq!(v, Value::Bool(true));
@@ -178,7 +178,7 @@ fn mkdir_p_outside_write_root_returns_err() {
     let v = run(
         SRC,
         "make_dir",
-        vec![Value::Str(outside.to_string_lossy().to_string())],
+        vec![Value::Str(outside.to_string_lossy().to_string().into())],
         policy_walk_and_write(&allowed, &allowed),
     );
     assert_eq!(v, Value::Bool(false));
@@ -192,7 +192,7 @@ fn stat_returns_size_of_file() {
     let v = run(
         SRC,
         "stat_size",
-        vec![Value::Str(file.to_string_lossy().to_string())],
+        vec![Value::Str(file.to_string_lossy().to_string().into())],
         policy_walk_only(&dir),
     );
     assert_eq!(v, Value::Int(6));

--- a/crates/lex-runtime/tests/std_http.rs
+++ b/crates/lex-runtime/tests/std_http.rs
@@ -382,7 +382,7 @@ fn http_get_returns_response_with_status_and_body() {
 import "std.http" as http
 fn fetch(u :: Str) -> [net] Result[HttpResponse, HttpError] { http.get(u) }
 "#;
-    let v = run(src, "fetch", vec![Value::Str(url)], allow_net());
+    let v = run(src, "fetch", vec![Value::Str(url.into())], allow_net());
     let r = unwrap_ok_record(v);
     assert_eq!(r.get("status"), Some(&Value::Int(200)));
     match r.get("body") {
@@ -417,7 +417,7 @@ fn push(u :: Str, b :: Bytes) -> [net] Result[HttpResponse, HttpError] {
     let v = run(
         src,
         "push",
-        vec![Value::Str(url), Value::Bytes(b"\x00\x01\x02hi".to_vec())],
+        vec![Value::Str(url.into()), Value::Bytes(b"\x00\x01\x02hi".to_vec())],
         allow_net(),
     );
     let r = unwrap_ok_record(v);
@@ -454,7 +454,7 @@ fn fetch_authed(u :: Str, token :: Str) -> [net] Result[HttpResponse, HttpError]
         src,
         "fetch_authed",
         vec![
-            Value::Str(url),
+            Value::Str(url.into()),
             Value::Str("secret-jwt".into()),
         ],
         allow_net(),

--- a/crates/lex-runtime/tests/std_kv.rs
+++ b/crates/lex-runtime/tests/std_kv.rs
@@ -113,7 +113,7 @@ fn put_then_get_round_trips() {
         SRC,
         "put_then_get",
         vec![
-            Value::Str(path.to_string_lossy().to_string()),
+            Value::Str(path.to_string_lossy().to_string().into()),
             Value::Str("k1".into()),
             Value::Bytes(b"hello".to_vec()),
         ],
@@ -136,7 +136,7 @@ fn get_missing_returns_none() {
         SRC,
         "get_missing",
         vec![
-            Value::Str(path.to_string_lossy().to_string()),
+            Value::Str(path.to_string_lossy().to_string().into()),
             Value::Str("never_set".into()),
         ],
         policy,
@@ -152,7 +152,7 @@ fn contains_after_put() {
         SRC,
         "put_then_contains",
         vec![
-            Value::Str(path.to_string_lossy().to_string()),
+            Value::Str(path.to_string_lossy().to_string().into()),
             Value::Str("a".into()),
             Value::Bytes(b"x".to_vec()),
         ],
@@ -169,7 +169,7 @@ fn delete_removes_key() {
         SRC,
         "delete_then_contains",
         vec![
-            Value::Str(path.to_string_lossy().to_string()),
+            Value::Str(path.to_string_lossy().to_string().into()),
             Value::Str("a".into()),
             Value::Bytes(b"x".to_vec()),
         ],
@@ -183,14 +183,14 @@ fn list_prefix_returns_only_matching_keys() {
     let path = unique_db_path("list_prefix");
     let policy = policy_with_kv(&path);
     let v = run_with_policy(SRC, "list_prefix_keys", vec![
-        Value::Str(path.to_string_lossy().to_string()),
+        Value::Str(path.to_string_lossy().to_string().into()),
     ], policy);
 
     let keys: Vec<String> = match v {
         Value::List(items) => items
             .into_iter()
             .map(|i| match i {
-                Value::Str(s) => s,
+                Value::Str(s) => s.to_string(),
                 other => panic!("expected Str in list, got {other:?}"),
             })
             .collect(),
@@ -218,7 +218,7 @@ fn open_outside_fs_write_root_returns_err() {
         SRC,
         "put_then_get",
         vec![
-            Value::Str(outside.to_string_lossy().to_string()),
+            Value::Str(outside.to_string_lossy().to_string().into()),
             Value::Str("k".into()),
             Value::Bytes(b"v".to_vec()),
         ],

--- a/crates/lex-runtime/tests/std_log.rs
+++ b/crates/lex-runtime/tests/std_log.rs
@@ -111,7 +111,7 @@ fn text_format_includes_level_and_message() {
     let policy = policy_for_log(path.parent().unwrap());
 
     run(SRC, "setup_text",
-        vec![Value::Str(path.to_string_lossy().to_string())], policy.clone());
+        vec![Value::Str(path.to_string_lossy().to_string().into())], policy.clone());
     run(SRC, "emit_each_level", vec![], policy);
 
     let contents = std::fs::read_to_string(&path).expect("read log");
@@ -128,7 +128,7 @@ fn json_format_emits_one_object_per_line() {
     let policy = policy_for_log(path.parent().unwrap());
 
     run(SRC, "setup_json",
-        vec![Value::Str(path.to_string_lossy().to_string())], policy.clone());
+        vec![Value::Str(path.to_string_lossy().to_string().into())], policy.clone());
     run(SRC, "emit_one_info", vec![], policy);
 
     let contents = std::fs::read_to_string(&path).expect("read log");
@@ -146,7 +146,7 @@ fn level_threshold_drops_lower_levels() {
     let policy = policy_for_log(path.parent().unwrap());
 
     run(SRC, "setup_warn_threshold",
-        vec![Value::Str(path.to_string_lossy().to_string())], policy.clone());
+        vec![Value::Str(path.to_string_lossy().to_string().into())], policy.clone());
     run(SRC, "emit_each_level", vec![], policy);
 
     let contents = std::fs::read_to_string(&path).expect("read log");
@@ -195,6 +195,6 @@ fn setup(path :: Str) -> [io, fs_write] Bool {
 "#;
     let policy = policy_for_log(&allowed);
     let v = run(src, "setup",
-        vec![Value::Str(outside.to_string_lossy().to_string())], policy);
+        vec![Value::Str(outside.to_string_lossy().to_string().into())], policy);
     assert_eq!(v, Value::Bool(false));
 }

--- a/crates/lex-runtime/tests/std_process.rs
+++ b/crates/lex-runtime/tests/std_process.rs
@@ -90,7 +90,7 @@ fn run_capture_exit(cmd :: Str, args :: List[Str]) -> [proc] Int {
 
 fn s(v: Value) -> String {
     match v {
-        Value::Str(s) => s,
+        Value::Str(s) => s.to_string(),
         other => panic!("expected Str, got {other:?}"),
     }
 }

--- a/crates/lex-runtime/tests/std_regex.rs
+++ b/crates/lex-runtime/tests/std_regex.rs
@@ -20,7 +20,7 @@ fn run(src: &str, fn_name: &str, args: Vec<Value>) -> Value {
 
 fn s(v: Value) -> String {
     match v {
-        Value::Str(s) => s,
+        Value::Str(s) => s.to_string(),
         other => panic!("expected Str, got {other:?}"),
     }
 }
@@ -37,7 +37,7 @@ fn list_of_strs(v: Value) -> Vec<String> {
         Value::List(items) => items
             .into_iter()
             .map(|i| match i {
-                Value::Str(s) => s,
+                Value::Str(s) => s.to_string(),
                 other => panic!("expected Str in list, got {other:?}"),
             })
             .collect(),

--- a/crates/lex-runtime/tests/std_sql.rs
+++ b/crates/lex-runtime/tests/std_sql.rs
@@ -162,7 +162,7 @@ fn create_insert_query_round_trip() {
     let v = run(
         SRC,
         "create_insert_query",
-        vec![Value::Str(path.to_string_lossy().into_owned())],
+        vec![Value::Str(path.to_string_lossy().into_owned().into())],
         policy_with_sql(&dir),
     );
     let rows = match v {
@@ -193,14 +193,14 @@ fn pick_by_id_uses_parameter_binding() {
     let _ = run(
         SRC,
         "create_insert_query",
-        vec![Value::Str(path.to_string_lossy().into_owned())],
+        vec![Value::Str(path.to_string_lossy().into_owned().into())],
         policy_with_sql(&dir),
     );
     let v = run(
         SRC,
         "pick_by_id",
         vec![
-            Value::Str(path.to_string_lossy().into_owned()),
+            Value::Str(path.to_string_lossy().into_owned().into()),
             Value::Str("2".into()),
         ],
         policy_with_sql(&dir),
@@ -215,13 +215,13 @@ fn delete_returns_affected_row_count() {
     let _ = run(
         SRC,
         "create_insert_query",
-        vec![Value::Str(path.to_string_lossy().into_owned())],
+        vec![Value::Str(path.to_string_lossy().into_owned().into())],
         policy_with_sql(&dir),
     );
     let v = run(
         SRC,
         "delete_count",
-        vec![Value::Str(path.to_string_lossy().into_owned())],
+        vec![Value::Str(path.to_string_lossy().into_owned().into())],
         policy_with_sql(&dir),
     );
     assert_eq!(v, Value::Int(1));
@@ -255,7 +255,7 @@ fn try_open(p :: Str) -> [sql, fs_write] Str {
     let v = run(
         src,
         "try_open",
-        vec![Value::Str(outside.to_string_lossy().into_owned())],
+        vec![Value::Str(outside.to_string_lossy().into_owned().into())],
         policy_with_sql(&dir),
     );
     let s = match v {

--- a/crates/lex-runtime/tests/std_toml.rs
+++ b/crates/lex-runtime/tests/std_toml.rs
@@ -32,7 +32,7 @@ fn unwrap_ok(v: Value) -> Value {
 fn err_msg(v: Value) -> String {
     match v {
         Value::Variant { name, args } if name == "Err" => match args.into_iter().next() {
-            Some(Value::Str(s)) => s,
+            Some(Value::Str(s)) => s.to_string(),
             other => panic!("expected Err(Str), got {other:?}"),
         },
         other => panic!("expected Err, got {other:?}"),

--- a/crates/lex-trace/tests/m7.rs
+++ b/crates/lex-trace/tests/m7.rs
@@ -53,7 +53,7 @@ fn value_to_json(v: &Value) -> serde_json::Value {
         Value::Int(n) => J::from(*n),
         Value::Float(f) => J::from(*f),
         Value::Bool(b) => J::Bool(*b),
-        Value::Str(s) => J::String(s.clone()),
+        Value::Str(s) => J::String(s.to_string()),
         Value::Bytes(b) => J::String(b.iter().map(|b| format!("{:02x}", b)).collect()),
         Value::Unit => J::Null,
         Value::List(items) => J::Array(items.iter().map(value_to_json).collect()),

--- a/crates/spec-checker/src/checker.rs
+++ b/crates/spec-checker/src/checker.rs
@@ -230,7 +230,7 @@ fn eval(
         SpecExpr::IntLit { value } => Ok(Value::Int(*value)),
         SpecExpr::FloatLit { value } => Ok(Value::Float(*value)),
         SpecExpr::BoolLit { value } => Ok(Value::Bool(*value)),
-        SpecExpr::StrLit { value } => Ok(Value::Str(value.clone())),
+        SpecExpr::StrLit { value } => Ok(Value::Str(value.clone().into())),
         SpecExpr::Var { name } => bindings.get(name).cloned()
             .ok_or_else(|| format!("unbound spec var `{name}`")),
         SpecExpr::Let { name, value, body } => {

--- a/crates/spec-checker/src/gate.rs
+++ b/crates/spec-checker/src/gate.rs
@@ -183,7 +183,7 @@ fn eval_body(
         SpecExpr::IntLit { value } => Ok(Value::Int(*value)),
         SpecExpr::FloatLit { value } => Ok(Value::Float(*value)),
         SpecExpr::BoolLit { value } => Ok(Value::Bool(*value)),
-        SpecExpr::StrLit { value } => Ok(Value::Str(value.clone())),
+        SpecExpr::StrLit { value } => Ok(Value::Str(value.clone().into())),
         SpecExpr::Var { name } => bindings.get(name).cloned()
             .ok_or_else(|| format!("unbound spec var `{name}` (provide via gate bindings)")),
         SpecExpr::Let { name, value, body } => {


### PR DESCRIPTION
## Summary

Finishes the `Value::Str(String) → Value::Str(SmolStr)` migration started in edf944a (PR #413). That commit left handler.rs (93 errors), spec-checker, conformance, lex-cli, and the lex-runtime test suite uncompiled — `test` CI on #413 was failing as a result.

Fixes the build/test gate without altering any runtime behavior.

## Files changed

- `crates/lex-runtime/Cargo.toml` — add `smol_str.workspace = true`
- `crates/lex-runtime/src/handler.rs` — every `Value::Str` construction site now passes `SmolStr` (mostly via `.into()` on `String`/`&str`; `.to_string()` where a `String` is needed downstream, e.g. `SqlParamValue::Text`, `ResponseBodyOut::Str`, `Vec<(String, String)>` header lists)
- `crates/spec-checker/src/{checker,gate}.rs` — `StrLit` eval converts to SmolStr
- `crates/conformance/src/runner.rs` — `json_to_value` for `J::String`
- `crates/lex-cli/src/{main,repl,tool_registry}.rs` — `Value::Str` unwraps use `.to_string()`; constructions add `.into()`
- `crates/lex-runtime/tests/*.rs` + `crates/lex-trace/tests/m7.rs` — same conversion at test helpers

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace` — all green locally

## Notes

Once this lands on `feat/389-slice4-smolstr`, the `test` job on PR #413 should pass.

https://claude.ai/code/session_01GKdeZw4hJ9SucFMPwBVeNt

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKdeZw4hJ9SucFMPwBVeNt)_