### PR TITLE
docs(#412, #411): canonicalization contract + infrastructure-sandbox bench rows

### DIFF
--- a/bench/REPORT.md
+++ b/bench/REPORT.md
@@ -6,6 +6,13 @@ Each row runs the same conceptual attack (or benign tool) through three sandboxe
 2. **Python (naive exec)** — `bench/python_naive_sandbox.py`. `exec()` with restricted `__builtins__` and a source-text blocklist; representative of common DIY attempts.
 3. **Python (RestrictedPython)** — `bench/python_restricted_sandbox.py`. Uses `compile_restricted` + `safe_builtins` + `safer_getattr`; the most-reached-for credible Python sandbox library.
 
+This compares **in-process Python sandboxes** specifically — the
+DIY-`exec` and library-based options a Python host typically reaches
+for first. The production comparison for agent-emitted code is
+infrastructure-level (WASM, Deno, gVisor, microVMs), covered in
+[§ Infrastructure-level sandboxes](#infrastructure-level-sandboxes)
+below.
+
 Regenerate: `cargo test -p lex-cli --test agent_sandbox_bench`.
 
 ## Summary
@@ -25,6 +32,41 @@ Regenerate: `cargo test -p lex-cli --test agent_sandbox_bench`.
 - Lex rejects at *type-check / policy gate*; RestrictedPython rejects at compile-time AST rewrite or runtime NameError. For agent-generated code, pre-execution rejection means the sandbox ran zero user code — useful when the attacker controls *both* the source text and the decision of when to trigger the bad effect.
 
 Cases 6 and 7 demonstrate Lex's per-path/per-host scopes: granting `[io]` but locking reads to `/tmp/safe`, or granting `[net]` but pinning the host to `api.openai.com`. RestrictedPython's scope is module-level — once `open` or `urllib` is in globals, it's available for any path/host.
+
+## Infrastructure-level sandboxes
+
+The Python comparison above answers "is Lex stronger than an in-process Python sandbox?" — the framing a Python host shop hits first when it needs to run agent-emitted code. That's not the production comparison for most non-Python stacks. For language-agnostic deployments the real competition is **WASM modules, Deno permissions, gVisor / seccomp+cgroups, and Firecracker microVMs**. Those win on a different axis than Lex picks, and an honest comparison has to say so.
+
+### The axis difference
+
+Infrastructure-level sandboxes are **language-agnostic** and **OS-enforced**. They draw the trust boundary at the process / syscall / WebAssembly-import layer. The OS or the WASM runtime is the policy decision point, and any language compiled to the sandbox's target gets the same containment. That's a real, battle-tested guarantee, and it's the right answer when "what language did the agent emit?" is itself untrusted input.
+
+Lex picks a different axis: the trust boundary is **per-function and type-checked**, drawn before any user code runs. The policy lives in the fn signature (`fn foo() -> [fs_read("/data"), net] Result[Str, Str]`), the type-checker rejects undeclared effects pre-execution, and per-path / per-host scopes apply within a granted effect. That's a tighter granularity than process-level containment can offer, but it's only meaningful inside the Lex language — it doesn't help if the agent emits something else.
+
+Neither axis dominates. The choice depends on the deployment shape:
+
+- **Process-level / OS-enforced** wins when (a) the host runs untrusted code in multiple languages, (b) syscall-level containment is the bar (e.g., multi-tenant SaaS, defence-in-depth), or (c) the threat model includes side channels the language layer can't see.
+- **Per-function / type-checked** wins when (a) the host gets to fix the language (Lex source from agent emitters / tool registries / `lex agent-tool`), (b) the threat model is "agent emits a body, runtime decides whether to run it," and (c) per-path / per-host scope granularity matters more than syscall-level containment.
+
+Many production systems use both: a microVM / gVisor envelope for the outer process, with a per-function effect surface inside. Lex composes with infrastructure sandboxes — running `lex agent-tool` inside a Firecracker microVM gets you both layers.
+
+### Comparison table
+
+| Sandbox | Trust boundary | Their advantage over Lex | Lex's advantage over them |
+|---|---|---|---|
+| **WASM component model** | Per-module capability imports (WASI) | Language-agnostic — any source compiled to WASM gets the same guarantees; OS-enforced via the WASM runtime; mature toolchain (Wasmtime, Wasmer); standardised by W3C | Effects checked at fn-signature granularity, **pre-execution**; per-path / per-host scopes inside an effect (`[fs_read("/data")]`, not just `[fs_read]`); rejection happens before bytecode emission, not at import-resolution time |
+| **Deno (`--allow-net=host`)** | Per-permission CLI flags applied process-wide | Mature TS/JS ecosystem; OS-enforced; widely deployed for agent-emitted JS/TS today | Per-function grants instead of process-wide; sandboxed *default* (effects must be declared) rather than permissive default (`--allow-…` opens); per-path scope finer than `--allow-read=DIR` |
+| **gVisor / seccomp + cgroups** | Process-level syscall filter / namespace | Language-agnostic, OS-enforced, battle-tested at scale (Google, AWS Lambda predecessors); covers side channels the language layer can't see | Granularity is fn-level rather than process-level; type-system integration means policy is reviewable in the source; rejection is pre-execution rather than runtime SIGKILL |
+| **Firecracker microVM** | Hardware-virtualised VM per workload | Strongest containment available short of hardware; language-agnostic; the AWS Lambda / Fargate substrate; cold-start in ~125ms is production-acceptable | Much lower overhead (no VM boot per call); per-fn rather than per-workload; works inside an existing process for tool-registry / agent-tool workflows where booting a VM per tool call is impractical |
+| **Python RestrictedPython** (covered above) | In-process AST rewrite + `safe_builtins` | Python-native; works with the existing CPython interpreter | Pre-execution rejection (RestrictedPython gates at compile-time AST rewrite but lets runtime NameErrors surface); per-path / per-host scopes; effects part of the type system, not a library config |
+
+### What this changes for the existing comparison
+
+Nothing in the per-case table below changes. The Python sandboxes are still the right comparison for **in-process Python deployments**, and Lex still beats them on the axes the cases exercise. The infrastructure-level row exists so readers don't walk away thinking "Lex vs. sandboxes" was the whole question.
+
+If your deployment shape is "agents emit one language, my host gets to pick which language": Lex is the right kind of answer.
+
+If your deployment shape is "I run arbitrary tenant code in any language": a microVM / gVisor envelope is the right kind of answer, and Lex sits inside it rather than replacing it.
 
 ## Cases
 

--- a/docs/design/canonicalization.md
+++ b/docs/design/canonicalization.md
@@ -1,0 +1,196 @@
+# Canonicalization contract
+
+Closes [#412](https://github.com/alpibrusl/lex-lang/issues/412).
+
+The promise "one canonical AST per meaning" underwrites a lot of lex's
+identity story: `SigId`s, the typed-transform VCS in `lex-vcs`, the
+content-addressed `body_hash` on closures, and any tooling agents build
+on top of those hashes. This doc says **exactly** which edits preserve a
+hash and which break it, so callers don't have to guess.
+
+There are two distinct hash boundaries in the codebase:
+
+| Hash | Pre-image | Lives in |
+|---|---|---|
+| **SigId / Stage hash** | Canonicalized AST (post-desugar) serialised as compact JSON | `crates/lex-ast/` |
+| **OpId** | Typed VCS `Operation` struct serialised as compact JSON | `crates/lex-vcs/src/canonical.rs` |
+| **`body_hash`** | Compiled bytecode (arity + locals + ops), **not** the AST | `crates/lex-bytecode/src/program.rs` |
+
+The rules differ per layer — `body_hash` is *not* an AST hash, and the
+OpId form has its own rule set on top of the AST rules. Sections 1-3
+cover the AST layer (the one users edit), §4 covers `body_hash`, §5
+covers OpId, §6 covers stability.
+
+---
+
+## 1. Edits that preserve the SigId
+
+Source-level rewrites in this list produce the **same** canonical AST,
+so the SigId is unchanged. Rules live in
+`crates/lex-ast/src/canonicalize.rs:1-12` (module header) with
+implementations cross-referenced below.
+
+- **Whitespace, indentation, line breaks** — stripped by the parser
+  before the canonicalizer ever runs (`lex-syntax`).
+- **Comments** — stripped by the parser.
+- **Redundant parentheses** — stripped at parse-time (`(x + y)`,
+  `((f x))`).
+- **Record-literal field order.** `{ a: 1, b: 2 }` and `{ b: 2, a: 1 }`
+  hash identically — fields are sorted alphabetically
+  (`canonicalize.rs:86-92`, `:284-293`).
+- **Record-type field order.** Same rule for type expressions
+  (`canonicalize.rs:284-293`).
+- **Union variant declaration order.** Variants in a `type T = A | B | C`
+  declaration sort alphabetically (`canonicalize.rs:115-125`).
+- **Effect-list order.** `[fs_read, net]` and `[net, fs_read]` hash the
+  same — effects sort alphabetically by name
+  (`canonicalize.rs:99-104`, `:328-332`).
+- **`if` / `else` → `Match` desugaring.** `if c { a } else { b }` becomes
+  `Match(c, [Arm(true, a), Arm(false, b)])`. As a side effect, an `if`
+  and a hand-written `match` with the same arm shapes hash equally
+  (`canonicalize.rs:267-279`).
+- **`?` → `Match` desugaring.** `e?` expands to the two-arm match from
+  spec §3.10 (`canonicalize.rs:226-253`).
+- **Pipe operator.** `x |> f` becomes `Call(f, [x])`;
+  `x |> f(args)` becomes `Call(f, [x, args...])`
+  (`canonicalize.rs:207-224`).
+- **Float-literal text form.** `1.0`, `1.00`, `1e0` all canonicalise to
+  the shortest round-trip form via Ryu (`canonicalize.rs:390-408`).
+- **Dead branches with literal scrutinees.** `match true { true => a, false => b }`
+  folds to `a` (`canonicalize/dead_branch.rs`).
+
+## 2. Edits that change the SigId
+
+Anything **not** in §1 changes the hash. The most common surprises:
+
+- **Function name.** Renaming `fn foo()` to `fn bar()` rotates the
+  SigId (test: `lex-ast/tests/canonical.rs:109-114`).
+- **Parameter names.** `fn add(x, y)` and `fn add(a, b)` are different
+  functions. There is no alpha-renaming pass — local-variable identity
+  is part of the canonical form.
+- **Top-level declaration order.** Function/type order in a module is
+  preserved as written. The module header at `canonicalize.rs:11-12`
+  flags this as a TODO (spec §5.3 rule 3) but it's not implemented; act
+  as if it never will be.
+- **Operator commutativity.** `x + y` and `y + x` hash differently.
+  Lex has no algebraic normalisation pass, and won't — a user-defined
+  `+` on a custom type may not commute, so the canonicalizer can't
+  assume it does even for built-in `Int`.
+- **`let`-chain order.** `let x = a; let y = b; …` and
+  `let y = b; let x = a; …` hash differently even when the two RHS
+  expressions are independent. Effect ordering may be observable
+  (`[fs_write]`, `[net]`, …), so reordering would change semantics in
+  general.
+- **Variable shadowing.** Rebinding a name preserves the source-level
+  binding structure.
+- **Eta-expansion / eta-reduction.** No `fn(x) -> f(x)` ↔ `f` rewrite.
+- **Constant folding.** `1 + 1` is `BinOp("+", 1, 1)` in the canonical
+  AST, not `2`. Constant folding happens at bytecode-emit time (or
+  later), after the SigId is fixed.
+- **Type annotations.** Adding or removing a redundant `:: Int`
+  annotation can change the canonical form (the AST records what the
+  user wrote).
+
+If you need a property that lives in §2 but want it in §1, that's a
+canonicalizer extension — file an issue against `lex-ast` with the
+specific rewrite and its semantics-preservation argument.
+
+## 3. The intentional gap on commutativity and let-reordering
+
+The audit note that prompted this doc called out that `x + y` vs `y + x`
+and `let`-reordering are "philosophically thorny" — they are, and the
+canonicalizer deliberately punts on both:
+
+- **Commutativity** isn't normalised because `+` on a user-defined
+  type isn't guaranteed to commute. The canonicalizer doesn't have
+  access to type information (it runs before type-check), so it can't
+  conditionally normalise per-type.
+- **`let`-chain reordering** isn't normalised because the effect
+  signature of each RHS may differ. Two adjacent `let`s could be
+  `[fs_write]` and `[net]`; reordering them changes the observable
+  effect interleaving. Again, the canonicalizer runs before
+  type/effect-check and can't safely decide.
+
+The trade-off is conscious: the canonicalizer normalises only
+rewrites that are obviously semantics-preserving at the syntax layer.
+Anything that needs type or effect information stays as written.
+
+## 4. `body_hash` on `Value::Closure`
+
+`body_hash` is **not** an AST hash. It lives in
+`crates/lex-bytecode/src/program.rs:41-128`
+(`Body::compute_body_hash`) and is the first 16 bytes of SHA-256 over:
+
+1. `arity` (u16 LE)
+2. `locals_count` (u16 LE)
+3. `code.len()` (u64 LE)
+4. Each `Op` serialised via `serde_json::to_vec`
+
+Things that are **not** part of the pre-image:
+
+- **Capture types.** Deliberately excluded
+  (`program.rs:95-105`). Two closures that capture the same value at
+  the same source position but differ in inferred capture type still
+  collide. This is intentional — the runtime uses `body_hash` only to
+  compare bodies, not capture environments, and including types would
+  break `flow.sequential` identity across monomorphisations.
+- **Constant-pool indices.** The hash hashes `Op` JSON which contains
+  pool indices. Two programs that emit the same closure body but
+  number their constant pools differently will hash differently. This
+  is acceptable in-process (same compilation) but means `body_hash` is
+  **not** stable across recompilations — it's a runtime equality
+  helper, not a content address.
+
+Use SigId for content-addressed AST identity. Use `body_hash` only for
+in-process closure equality (`Value::PartialEq`, `value.rs:97-99`,
+and the `flow.sequential` HOF use case from #222).
+
+## 5. OpId — the VCS layer
+
+`OpId` is a separate hash boundary. The V1 canonical form for OpIds is
+documented authoritatively in
+`crates/lex-vcs/src/canonical.rs:1-51`. Briefly:
+
+- Compact JSON, no pretty-printing.
+- Field order from struct/enum declaration.
+- `BTreeSet`/`BTreeMap` for unordered collections.
+- `parents` vectors sorted + deduped before hashing.
+- Empty `parents` arrays emitted (differs from on-disk JSON).
+- Optional fields with `skip_serializing_if = "Option::is_none"`.
+- SHA-256, lowercase hex, 64 chars.
+
+Any change to those rules rewrites every existing OpId. The module
+header is the source of truth.
+
+## 6. Stability across versions
+
+There is no formal versioning scheme on the canonical form today.
+Issue [#244](https://github.com/alpibrusl/lex-lang/issues/244) tracks
+that work for the VCS canonical form; until it lands, treat every rule
+in §1, §4, and §5 as load-bearing:
+
+- Changing a rule in §1 (the AST layer) rewrites every SigId. Existing
+  signature attestations stop matching.
+- Changing a rule in §4 (`body_hash`) breaks `Value::PartialEq` on
+  closures across processes, which would surprise `flow.sequential`
+  callers.
+- Changing a rule in §5 (OpId) rewrites every store on disk.
+
+Practical guidance for callers building on these hashes:
+
+- **Pin a lex version** if your tooling keys on SigIds or OpIds across
+  runs. Pre-1.0, hash-breaking changes are allowed at any minor.
+- **Don't persist `body_hash` to disk.** It's a runtime equality
+  helper.
+- **OpIds are stable within a major** once #244 lands; until then,
+  treat them as stable within a patch version only.
+- **New canonicalizer normalisations are non-breaking only in one
+  direction.** Adding a rule that maps two previously-distinct ASTs to
+  the same hash is a semver-major change (it breaks the
+  "this SigId means *that* exact source" invariant). Removing a rule
+  is also semver-major (it splits one SigId into two). There is no
+  safe additive change to §1.
+
+When in doubt, ask in the PR. The canonicalizer is small and
+contributor-readable; the hash-stability constraint is the part that's
+load-bearing.


### PR DESCRIPTION
## Summary

Bundles two docs tickets:

### Closes #412 — canonicalization contract

Adds `docs/design/canonicalization.md` documenting:

- **Which edits preserve a SigId** (whitespace, comments, parens, record/variant/effect-list ordering, `if`→`Match` desugaring, `?` desugaring, pipe, float-literal forms, dead-branch elimination) — with `canonicalize.rs:line` citations.
- **Which edits break it** (function/parameter names, declaration order, operator commutativity, `let`-chain order, eta-expansion, constant folding, type annotations) — and *why* the canonicalizer deliberately punts on commutativity and `let`-reordering (no access to type/effect info at the canonicalization stage).
- **`body_hash` on `Value::Closure`** — separate hash boundary derived from bytecode, not AST. Includes capture-type exclusion rationale (#222 / `flow.sequential`).
- **OpId** — separate hash boundary in `lex-vcs`, with pointer to the authoritative rule list in `canonical.rs:1-51`.
- **Stability promise pre-1.0** — hash-breaking changes allowed at any minor; #244 tracks formal versioning.

### Closes #411 — infrastructure-level sandbox comparison

Adds an "Infrastructure-level sandboxes" section to `bench/REPORT.md` acknowledging that the in-process Python comparison is the wrong axis for non-Python deployments. Adds:

- Prose on the per-function/type-checked vs language-agnostic/OS-enforced axis difference (and when each wins).
- Comparison table with rows for WASM component model, Deno `--allow-net=host`, gVisor / seccomp+cgroups, Firecracker microVM (plus RestrictedPython for consistency).
- A closing note that Lex composes with infrastructure sandboxes rather than replacing them.

The per-case Lex-vs-Python detail below is unchanged.

## Test plan

- [ ] Spot-check that the file:line citations in `canonicalization.md` point at the right code.
- [ ] Verify the axis-difference framing in `REPORT.md` matches how you'd describe it to someone evaluating Lex for a non-Python deployment.

https://claude.ai/code/session_01GKdeZw4hJ9SucFMPwBVeNt