### PR TITLE
feat(cli): add `lex agent-guidelines` + idiomatic-Lex authoring contract

### DIFF
--- a/.cli/README.md
+++ b/.cli/README.md
@@ -1,6 +1,6 @@
 # lex
 
-Version: 0.1.0
+Version: 0.9.3
 ACLI version: 0.1.0
 
 ## Commands
@@ -29,6 +29,12 @@ print canonical SigId/StageId hashes for each function
 
 Idempotent: true
 
+### blame
+
+show each fn's stage history from the store
+
+Idempotent: true
+
 ### publish
 
 publish each stage in a file to the store as Draft
@@ -38,6 +44,16 @@ Idempotent: false
 ### store
 
 browse the content-addressed code store
+
+### stage
+
+print stage info, or list attestations for a stage
+
+Idempotent: true
+
+### attest
+
+cross-stage attestation queries (CI / dashboards)
 
 ### trace
 
@@ -110,4 +126,32 @@ snapshot branches in lex-store (tier-1 agent-native VC)
 three-way merge between two branches in the store
 
 Idempotent: false
+
+### merge
+
+stateful agent-driven merge (CLI mirror of /v1/merge/*)
+
+### log
+
+show the merge journal of a branch (top-level alias for `lex branch log`)
+
+Idempotent: true
+
+### repl
+
+interactive evaluator (Lex source line-by-line)
+
+Idempotent: false
+
+### watch
+
+re-run check or run on file save (agent inner loop)
+
+Idempotent: false
+
+### agent-guidelines
+
+emit the AI-agent authoring contract (idiom rules) for this Lex toolchain
+
+Idempotent: true
 

--- a/.cli/commands.json
+++ b/.cli/commands.json
@@ -1,6 +1,6 @@
 {
   "name": "lex",
-  "version": "0.1.0",
+  "version": "0.9.3",
   "acli_version": "0.1.0",
   "commands": [
     {
@@ -164,6 +164,53 @@
       ]
     },
     {
+      "name": "blame",
+      "description": "show each fn's stage history from the store",
+      "arguments": [
+        {
+          "name": "file",
+          "type": "string",
+          "description": "path to a .lex file",
+          "required": true
+        }
+      ],
+      "options": [
+        {
+          "name": "--store",
+          "type": "string",
+          "description": "store root directory"
+        },
+        {
+          "name": "--with-evidence",
+          "type": "bool",
+          "description": "attach attestations to each history entry"
+        }
+      ],
+      "subcommands": [],
+      "idempotent": true,
+      "examples": [
+        {
+          "description": "Blame a file",
+          "invocation": "lex blame app.lex"
+        },
+        {
+          "description": "With evidence trail",
+          "invocation": "lex blame --with-evidence app.lex"
+        },
+        {
+          "description": "Machine-readable",
+          "invocation": "lex --output json blame app.lex"
+        }
+      ],
+      "see_also": [
+        "hash",
+        "publish",
+        "store",
+        "stage",
+        "log"
+      ]
+    },
+    {
       "name": "publish",
       "description": "publish each stage in a file to the store as Draft",
       "arguments": [
@@ -259,6 +306,106 @@
         "publish",
         "branch",
         "store-merge"
+      ]
+    },
+    {
+      "name": "stage",
+      "description": "print stage info, or list attestations for a stage",
+      "arguments": [
+        {
+          "name": "stage_id",
+          "type": "string",
+          "description": "StageId hex",
+          "required": true
+        }
+      ],
+      "options": [
+        {
+          "name": "--store",
+          "type": "string",
+          "description": "store root directory"
+        },
+        {
+          "name": "--attestations",
+          "type": "bool",
+          "description": "list attestations instead of stage info"
+        }
+      ],
+      "subcommands": [],
+      "idempotent": true,
+      "examples": [
+        {
+          "description": "Print stage info",
+          "invocation": "lex stage abc123..."
+        },
+        {
+          "description": "List attestations",
+          "invocation": "lex stage abc123... --attestations"
+        },
+        {
+          "description": "Machine-readable",
+          "invocation": "lex --output json stage abc123... --attestations"
+        }
+      ],
+      "see_also": [
+        "store",
+        "blame",
+        "publish"
+      ]
+    },
+    {
+      "name": "attest",
+      "description": "cross-stage attestation queries (CI / dashboards)",
+      "arguments": [],
+      "options": [],
+      "subcommands": [
+        {
+          "name": "filter",
+          "description": "list attestations matching kind / result / since filters",
+          "arguments": [],
+          "options": [
+            {
+              "name": "--kind",
+              "type": "string",
+              "description": "attestation kind: type_check | spec | examples | diff_body | effect_audit | sandbox_run"
+            },
+            {
+              "name": "--result",
+              "type": "string",
+              "description": "passed | failed | inconclusive"
+            },
+            {
+              "name": "--since",
+              "type": "string",
+              "description": "epoch seconds or YYYY-MM-DD; only attestations on or after this time"
+            },
+            {
+              "name": "--store",
+              "type": "string",
+              "description": "store root directory"
+            }
+          ],
+          "subcommands": [],
+          "idempotent": true
+        }
+      ],
+      "examples": [
+        {
+          "description": "All Spec verdicts that passed",
+          "invocation": "lex attest filter --kind spec --result passed"
+        },
+        {
+          "description": "Recent type-check evidence",
+          "invocation": "lex attest filter --kind type_check --since 2026-05-01"
+        },
+        {
+          "description": "Machine-readable",
+          "invocation": "lex --output json attest filter --kind spec"
+        }
+      ],
+      "see_also": [
+        "stage",
+        "blame"
       ]
     },
     {
@@ -451,6 +598,16 @@
               "name": "--source",
               "type": "string",
               "description": "source file to verify against"
+            },
+            {
+              "name": "--trials",
+              "type": "string",
+              "description": "randomized trial count (default 1000)"
+            },
+            {
+              "name": "--store",
+              "type": "string",
+              "description": "if set, persist a Spec attestation against the target stage"
             }
           ],
           "subcommands": [],
@@ -533,6 +690,11 @@
           "description": "differential evaluation: alternate body file"
         },
         {
+          "name": "--store",
+          "type": "string",
+          "description": "if set, persist verification attestations against the tool stage"
+        },
+        {
           "name": "--json",
           "type": "bool",
           "description": "machine-readable output"
@@ -548,12 +710,18 @@
         {
           "description": "Verify against spec",
           "invocation": "lex agent-tool --spec sort.spec --body-file body.lex --json"
+        },
+        {
+          "description": "Persist attestations",
+          "invocation": "lex agent-tool --examples cases.json --body-file body.lex --store ~/.lex/store"
         }
       ],
       "see_also": [
         "check",
         "spec",
-        "run"
+        "run",
+        "attest",
+        "stage"
       ]
     },
     {
@@ -624,6 +792,11 @@
           "name": "--json",
           "type": "bool",
           "description": "machine-readable output"
+        },
+        {
+          "name": "--store",
+          "type": "string",
+          "description": "with --effect, persist EffectAudit attestations against each scanned stage"
         }
       ],
       "subcommands": [],
@@ -636,11 +809,17 @@
         {
           "description": "Find a host as JSON",
           "invocation": "lex audit --host api.example.com --json src"
+        },
+        {
+          "description": "Persist effect audits",
+          "invocation": "lex audit --effect fs_write --store ~/.lex/store src"
         }
       ],
       "see_also": [
         "ast-diff",
-        "ast-merge"
+        "ast-merge",
+        "attest",
+        "stage"
       ]
     },
     {
@@ -779,7 +958,7 @@
         },
         {
           "name": "create",
-          "description": "create a branch",
+          "description": "create a branch (snapshot or predicate-defined)",
           "arguments": [
             {
               "name": "name",
@@ -793,6 +972,11 @@
               "name": "--from",
               "type": "string",
               "description": "parent branch (default: main)"
+            },
+            {
+              "name": "--predicate",
+              "type": "string",
+              "description": "JSON expression matching lex_vcs::Predicate; creates a saved query rather than a snapshot"
             },
             {
               "name": "--store",
@@ -858,6 +1042,84 @@
           ],
           "subcommands": [],
           "idempotent": true
+        },
+        {
+          "name": "log",
+          "description": "print the merge journal of a branch",
+          "arguments": [
+            {
+              "name": "name",
+              "type": "string",
+              "description": "branch name (default: current)",
+              "required": false
+            }
+          ],
+          "options": [
+            {
+              "name": "--store",
+              "type": "string",
+              "description": "store root"
+            }
+          ],
+          "subcommands": [],
+          "idempotent": true
+        },
+        {
+          "name": "peek",
+          "description": "list ops on another branch without switching to it",
+          "arguments": [
+            {
+              "name": "name",
+              "type": "string",
+              "description": "branch to inspect",
+              "required": true
+            }
+          ],
+          "options": [
+            {
+              "name": "--since-fork",
+              "type": "bool",
+              "description": "limit to ops since the fork from --vs (or `parent`)"
+            },
+            {
+              "name": "--vs",
+              "type": "string",
+              "description": "compare against this branch (default: <name>'s parent)"
+            },
+            {
+              "name": "--store",
+              "type": "string",
+              "description": "store root"
+            }
+          ],
+          "subcommands": [],
+          "idempotent": true
+        },
+        {
+          "name": "overlay",
+          "description": "preview a merge: project current branch as if <other> were merged in",
+          "arguments": [
+            {
+              "name": "other",
+              "type": "string",
+              "description": "branch whose ops would be merged in",
+              "required": true
+            }
+          ],
+          "options": [
+            {
+              "name": "--on",
+              "type": "string",
+              "description": "destination branch (default: current)"
+            },
+            {
+              "name": "--store",
+              "type": "string",
+              "description": "store root"
+            }
+          ],
+          "subcommands": [],
+          "idempotent": true
         }
       ],
       "examples": [
@@ -868,11 +1130,21 @@
         {
           "description": "Create a feature",
           "invocation": "lex branch create feature --from main"
+        },
+        {
+          "description": "Peek what feature has done since fork",
+          "invocation": "lex branch peek feature --since-fork"
+        },
+        {
+          "description": "Preview merging feature into main",
+          "invocation": "lex branch overlay feature --on main"
         }
       ],
       "see_also": [
         "store-merge",
-        "store"
+        "store",
+        "log",
+        "merge"
       ]
     },
     {
@@ -923,7 +1195,262 @@
       ],
       "see_also": [
         "branch",
-        "ast-merge"
+        "ast-merge",
+        "merge"
+      ]
+    },
+    {
+      "name": "merge",
+      "description": "stateful agent-driven merge (CLI mirror of /v1/merge/*)",
+      "arguments": [],
+      "options": [],
+      "subcommands": [
+        {
+          "name": "start",
+          "description": "open a stateful merge session and surface conflicts",
+          "arguments": [],
+          "options": [
+            {
+              "name": "--src",
+              "type": "string",
+              "description": "source branch (theirs)"
+            },
+            {
+              "name": "--dst",
+              "type": "string",
+              "description": "destination branch (ours)"
+            },
+            {
+              "name": "--store",
+              "type": "string",
+              "description": "store root directory"
+            }
+          ],
+          "subcommands": [],
+          "idempotent": false
+        },
+        {
+          "name": "status",
+          "description": "print remaining conflicts for a session",
+          "arguments": [
+            {
+              "name": "merge_id",
+              "type": "string",
+              "description": "session id from `lex merge start`",
+              "required": true
+            }
+          ],
+          "options": [
+            {
+              "name": "--store",
+              "type": "string",
+              "description": "store root directory"
+            }
+          ],
+          "subcommands": [],
+          "idempotent": true
+        },
+        {
+          "name": "resolve",
+          "description": "submit batched per-conflict resolutions",
+          "arguments": [
+            {
+              "name": "merge_id",
+              "type": "string",
+              "description": "session id",
+              "required": true
+            }
+          ],
+          "options": [
+            {
+              "name": "--file",
+              "type": "string",
+              "description": "JSON array of {conflict_id, resolution}"
+            },
+            {
+              "name": "--store",
+              "type": "string",
+              "description": "store root directory"
+            }
+          ],
+          "subcommands": [],
+          "idempotent": false
+        },
+        {
+          "name": "commit",
+          "description": "finalize the merge and advance dst's head",
+          "arguments": [
+            {
+              "name": "merge_id",
+              "type": "string",
+              "description": "session id",
+              "required": true
+            }
+          ],
+          "options": [
+            {
+              "name": "--store",
+              "type": "string",
+              "description": "store root directory"
+            }
+          ],
+          "subcommands": [],
+          "idempotent": false
+        }
+      ],
+      "examples": [
+        {
+          "description": "Open a merge",
+          "invocation": "lex merge start --src feature --dst main"
+        },
+        {
+          "description": "See remaining work",
+          "invocation": "lex merge status merge_..."
+        },
+        {
+          "description": "Submit resolutions",
+          "invocation": "lex merge resolve merge_... --file resolutions.json"
+        },
+        {
+          "description": "Land the merge",
+          "invocation": "lex merge commit merge_..."
+        }
+      ],
+      "see_also": [
+        "store-merge",
+        "branch",
+        "log"
+      ]
+    },
+    {
+      "name": "log",
+      "description": "show the merge journal of a branch (top-level alias for `lex branch log`)",
+      "arguments": [
+        {
+          "name": "name",
+          "type": "string",
+          "description": "branch name (default: current)",
+          "required": false
+        }
+      ],
+      "options": [
+        {
+          "name": "--store",
+          "type": "string",
+          "description": "store root"
+        }
+      ],
+      "subcommands": [],
+      "idempotent": true,
+      "examples": [
+        {
+          "description": "Log of the current branch",
+          "invocation": "lex log"
+        },
+        {
+          "description": "Log of a named branch as JSON",
+          "invocation": "lex --output json log feature"
+        }
+      ],
+      "see_also": [
+        "branch",
+        "store-merge"
+      ]
+    },
+    {
+      "name": "repl",
+      "description": "interactive evaluator (Lex source line-by-line)",
+      "arguments": [],
+      "options": [],
+      "subcommands": [],
+      "idempotent": false,
+      "examples": [
+        {
+          "description": "Start a session",
+          "invocation": "lex repl"
+        },
+        {
+          "description": "Evaluate at the prompt",
+          "invocation": "lex> 1 + 2 * 3"
+        }
+      ],
+      "see_also": [
+        "check",
+        "run"
+      ]
+    },
+    {
+      "name": "watch",
+      "description": "re-run check or run on file save (agent inner loop)",
+      "arguments": [
+        {
+          "name": "file",
+          "type": "string",
+          "description": "file or directory to watch",
+          "required": true
+        },
+        {
+          "name": "action",
+          "type": "enum[check|run]",
+          "description": "what to re-run on change (default: check)",
+          "required": false
+        },
+        {
+          "name": "forwarded",
+          "type": "string[]",
+          "description": "forwarded to the underlying subcommand",
+          "required": false
+        }
+      ],
+      "options": [],
+      "subcommands": [],
+      "idempotent": false,
+      "examples": [
+        {
+          "description": "Watch + check",
+          "invocation": "lex watch app.lex"
+        },
+        {
+          "description": "Watch + run",
+          "invocation": "lex watch app.lex run main"
+        }
+      ],
+      "see_also": [
+        "check",
+        "run"
+      ]
+    },
+    {
+      "name": "agent-guidelines",
+      "description": "emit the AI-agent authoring contract (idiom rules) for this Lex toolchain",
+      "arguments": [],
+      "options": [
+        {
+          "name": "--version-only",
+          "type": "bool",
+          "description": "print only the toolchain version"
+        }
+      ],
+      "subcommands": [],
+      "idempotent": true,
+      "examples": [
+        {
+          "description": "Read the rules",
+          "invocation": "lex agent-guidelines"
+        },
+        {
+          "description": "Capture into a repo",
+          "invocation": "lex agent-guidelines > AGENTS.md"
+        },
+        {
+          "description": "Version of the doc",
+          "invocation": "lex agent-guidelines --version-only"
+        }
+      ],
+      "see_also": [
+        "skill",
+        "introspect",
+        "init"
       ]
     }
   ]

--- a/.cli/examples/agent-guidelines.sh
+++ b/.cli/examples/agent-guidelines.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Examples for: agent-guidelines
+
+# Read the rules
+lex agent-guidelines
+
+# Capture into a repo
+lex agent-guidelines > AGENTS.md
+
+# Version of the doc
+lex agent-guidelines --version-only

--- a/.cli/examples/agent-tool.sh
+++ b/.cli/examples/agent-tool.sh
@@ -6,3 +6,6 @@ lex agent-tool --allow-effects fs_read --request "sum lines of /tmp/log"
 
 # Verify against spec
 lex agent-tool --spec sort.spec --body-file body.lex --json
+
+# Persist attestations
+lex agent-tool --examples cases.json --body-file body.lex --store ~/.lex/store

--- a/.cli/examples/attest.sh
+++ b/.cli/examples/attest.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Examples for: attest
+
+# All Spec verdicts that passed
+lex attest filter --kind spec --result passed
+
+# Recent type-check evidence
+lex attest filter --kind type_check --since 2026-05-01
+
+# Machine-readable
+lex --output json attest filter --kind spec

--- a/.cli/examples/audit.sh
+++ b/.cli/examples/audit.sh
@@ -6,3 +6,6 @@ lex audit --effect net examples
 
 # Find a host as JSON
 lex audit --host api.example.com --json src
+
+# Persist effect audits
+lex audit --effect fs_write --store ~/.lex/store src

--- a/.cli/examples/blame.sh
+++ b/.cli/examples/blame.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Examples for: blame
+
+# Blame a file
+lex blame app.lex
+
+# With evidence trail
+lex blame --with-evidence app.lex
+
+# Machine-readable
+lex --output json blame app.lex

--- a/.cli/examples/branch.sh
+++ b/.cli/examples/branch.sh
@@ -6,3 +6,9 @@ lex branch list
 
 # Create a feature
 lex branch create feature --from main
+
+# Peek what feature has done since fork
+lex branch peek feature --since-fork
+
+# Preview merging feature into main
+lex branch overlay feature --on main

--- a/.cli/examples/log.sh
+++ b/.cli/examples/log.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Examples for: log
+
+# Log of the current branch
+lex log
+
+# Log of a named branch as JSON
+lex --output json log feature

--- a/.cli/examples/merge.sh
+++ b/.cli/examples/merge.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Examples for: merge
+
+# Open a merge
+lex merge start --src feature --dst main
+
+# See remaining work
+lex merge status merge_...
+
+# Submit resolutions
+lex merge resolve merge_... --file resolutions.json
+
+# Land the merge
+lex merge commit merge_...

--- a/.cli/examples/repl.sh
+++ b/.cli/examples/repl.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Examples for: repl
+
+# Start a session
+lex repl
+
+# Evaluate at the prompt
+lex> 1 + 2 * 3

--- a/.cli/examples/stage.sh
+++ b/.cli/examples/stage.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Examples for: stage
+
+# Print stage info
+lex stage abc123...
+
+# List attestations
+lex stage abc123... --attestations
+
+# Machine-readable
+lex --output json stage abc123... --attestations

--- a/.cli/examples/watch.sh
+++ b/.cli/examples/watch.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Examples for: watch
+
+# Watch + check
+lex watch app.lex
+
+# Watch + run
+lex watch app.lex run main

--- a/crates/lex-cli/src/acli.rs
+++ b/crates/lex-cli/src/acli.rs
@@ -134,7 +134,23 @@ fn commands() -> Vec<CommandInfo> {
         cmd_log(),
         cmd_repl(),
         cmd_watch(),
+        cmd_agent_guidelines(),
     ]
+}
+
+fn cmd_agent_guidelines() -> CommandInfo {
+    CommandInfo::new(
+        "agent-guidelines",
+        "emit the AI-agent authoring contract (idiom rules) for this Lex toolchain",
+    )
+    .idempotent(true)
+    .add_option("--version-only", "bool", "print only the toolchain version", None)
+    .with_examples(vec![
+        ("Read the rules",         "lex agent-guidelines"),
+        ("Capture into a repo",    "lex agent-guidelines > AGENTS.md"),
+        ("Version of the doc",     "lex agent-guidelines --version-only"),
+    ])
+    .with_see_also(vec!["skill", "introspect", "init"])
 }
 
 fn cmd_repl() -> CommandInfo {

--- a/crates/lex-cli/src/agent_guidelines.rs
+++ b/crates/lex-cli/src/agent_guidelines.rs
@@ -1,0 +1,61 @@
+//! `lex agent-guidelines` — emit the canonical AI-agent authoring
+//! contract (`docs/AGENT_GUIDELINES.md`) baked into the binary at
+//! compile time.
+//!
+//! Why a subcommand instead of "just open the file": the guidelines
+//! travel with the toolchain version, so an agent running against a
+//! pinned `lex` binary gets the rules that match the type checker,
+//! stdlib, and effect kinds for *that* version. Reading the file on
+//! disk via a URL or path is brittle in CI / sandboxed agent
+//! environments; `lex agent-guidelines > AGENTS.md` works anywhere
+//! the toolchain works.
+//!
+//! The output is the file verbatim. JSON mode wraps it in the ACLI
+//! success envelope so agents that only consume JSON still get it.
+
+use acli::output::OutputFormat;
+use anyhow::Result;
+use serde_json::json;
+
+/// The doc, embedded at compile time. Bumps with every release.
+const GUIDELINES_MD: &str = include_str!("../../../docs/AGENT_GUIDELINES.md");
+
+pub fn cmd_agent_guidelines(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    // Optional flag for downstream tooling that wants to know which
+    // toolchain version emitted the doc without parsing markdown.
+    if args.iter().any(|a| a == "--version-only") {
+        match fmt {
+            OutputFormat::Json => {
+                let env = json!({
+                    "ok": true,
+                    "command": "agent-guidelines",
+                    "data": { "lex_version": env!("CARGO_PKG_VERSION") },
+                });
+                println!("{}", serde_json::to_string(&env).unwrap());
+            }
+            _ => println!("{}", env!("CARGO_PKG_VERSION")),
+        }
+        return Ok(());
+    }
+
+    match fmt {
+        OutputFormat::Json => {
+            let env = json!({
+                "ok": true,
+                "command": "agent-guidelines",
+                "data": {
+                    "lex_version": env!("CARGO_PKG_VERSION"),
+                    "format": "markdown",
+                    "content": GUIDELINES_MD,
+                },
+            });
+            println!("{}", serde_json::to_string(&env).unwrap());
+        }
+        OutputFormat::Text | OutputFormat::Table => {
+            // Print verbatim; no decoration. Suitable for redirection:
+            //   lex agent-guidelines > AGENTS.md
+            print!("{GUIDELINES_MD}");
+        }
+    }
+    Ok(())
+}

--- a/crates/lex-cli/src/init.rs
+++ b/crates/lex-cli/src/init.rs
@@ -183,7 +183,9 @@ jobs:
 /// AI-assistant cold-start guide dropped at the project root. Read by
 /// Claude Code (`CLAUDE.md`/`AGENTS.md`), Cursor, Aider, and most other
 /// agent tools that look for a project-conventions file. Deliberately
-/// short — points at the upstream `docs/AGENT.md` for the deep dive.
+/// short — points at `lex agent-guidelines` for the authoritative
+/// prescriptive rules, and at the upstream `docs/AGENT.md` for the
+/// reference deep dive.
 fn agents_md(name: &str) -> String {
     let version = env!("CARGO_PKG_VERSION");
     format!(
@@ -191,7 +193,8 @@ fn agents_md(name: &str) -> String {
 
 This file is for AI assistants (Claude Code, Cursor, Aider, Copilot, …)
 working in this repo. Humans should read `README.md` first; agents should
-read this **first**, then the upstream guide it points at.
+read this **first**, then run `lex agent-guidelines` for the authoritative
+idiom contract before writing any code.
 
 ## 1. Install the Lex toolchain
 
@@ -300,14 +303,43 @@ Key rules:
   after editing.
 - Before pushing: `lex ci`. CI runs the same command.
 
-## 5. Need more?
+## 5. Idiom rules — read before writing code
+
+Run this in the project root:
+
+```sh
+lex agent-guidelines               # full prescriptive contract (~10 pages)
+lex agent-guidelines > AGENTS.md   # capture into the repo so it travels with the code
+```
+
+The rules are numbered and stable. The four that matter most when
+you're tempted to skip them:
+
+1. **Narrow effects, always.** `fn foo() -> [fs_write("/tmp/x")] T`,
+   not `[fs_write]`. If the type checker rejects, narrow the *body*,
+   not the signature. Rule 1.2 in the guidelines.
+2. **Repair, don't regenerate.** When `lex check` fails, run
+   `lex --output json check` to get the structured error, then
+   `lex repair --apply --transform '<suggested_transform>'`. Only
+   regenerate after two failed repair attempts. Rules 4.1–4.3.
+3. **`examples {{}}` blocks on every pure fn.** They're part of the
+   SigId and run at `lex check` time — free regression tests with no
+   `tests/` boilerplate. Rule 2.1.
+4. **Use the stdlib.** `std.crypto` not hand-rolled crypto, `std.conc`
+   not threads, `std.sql` not string-concat SQL. Section 3.
+
+## 6. Need more?
 
 Deep references in the upstream repo:
 
-- **`docs/AGENT.md`** — full cold-start guide: error envelope schema,
-  effect kinds, stdlib module summary, every sharp edge.
-- **`docs/index.html`** — the design pitch (effects-as-types, content-
-  addressed AST, op log, attestations).
+- **`lex agent-guidelines`** — the authoritative idiom contract
+  (travels with the toolchain version).
+- **`docs/AGENT.md`** — reference: error envelope schema, every
+  `rule_tag`, stdlib module summary, every sharp edge.
+- **`docs/design/canonicalization.md`** — which edits preserve a
+  SigId and which break it.
+- **`docs/index.html`** — the design pitch (effects-as-types,
+  content-addressed AST, op log, attestations).
 - **`README.md`** in [alpibrusl/lex-lang](https://github.com/alpibrusl/lex-lang)
   — design rules, stdlib index, examples.
 

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -126,7 +126,7 @@ fn run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         "fmt"  => fmt::cmd_fmt(&args[1..]),
         "init" => init::cmd_init(&args[1..]),
         "ci"   => ci::cmd_ci(&args[1..]),
-        "agent-guidelines" => agent_guidelines::cmd_agent_guidelines(&fmt, &args[1..]),
+        "agent-guidelines" => agent_guidelines::cmd_agent_guidelines(fmt, &args[1..]),
         "help" | "--help" | "-h" => { print_usage(); Ok(()) }
         other => bail!("unknown command `{other}`. try `lex help`"),
     }

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -28,6 +28,7 @@ mod fmt;
 mod init;
 mod ci;
 mod examples_eval;
+mod agent_guidelines;
 
 use ::acli::OutputFormat;
 use anyhow::{anyhow, bail, Context, Result};
@@ -125,6 +126,7 @@ fn run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         "fmt"  => fmt::cmd_fmt(&args[1..]),
         "init" => init::cmd_init(&args[1..]),
         "ci"   => ci::cmd_ci(&args[1..]),
+        "agent-guidelines" => agent_guidelines::cmd_agent_guidelines(&fmt, &args[1..]),
         "help" | "--help" | "-h" => { print_usage(); Ok(()) }
         other => bail!("unknown command `{other}`. try `lex help`"),
     }

--- a/docs/AGENT_GUIDELINES.md
+++ b/docs/AGENT_GUIDELINES.md
@@ -1,0 +1,517 @@
+# Idiomatic Lex for AI Agents
+
+> **Audience.** This doc is for AI agents (Claude Code, Cursor, Aider, Codex,
+> Copilot, …) writing or modifying Lex code. Humans should read `README.md`
+> first.
+>
+> **Status.** Authoritative — the rules in this file are the project
+> conventions for any Lex codebase. Rule numbers are stable; new rules
+> append.
+>
+> **Discovery.**
+> ```sh
+> lex agent-guidelines                # print this doc to stdout
+> lex agent-guidelines > AGENTS.md    # capture into a downstream repo
+> ```
+
+The Lex toolchain encodes a lot of opinions the type checker enforces and
+a few more it doesn't. This doc is the second list — the discipline that
+makes Lex code idiomatic, auditable, and cheap for the next agent to
+extend. Skim once, then refer back when you write.
+
+**Semantics:**
+
+- **MUST** — non-negotiable. Agents that violate land code that's
+  type-correct but expensive to maintain.
+- **SHOULD** — strong preference. Override only with a one-line comment
+  explaining why.
+- **AVOID** — common anti-pattern. The fix is usually trivial; just don't.
+
+---
+
+## 1. Effect discipline
+
+The single highest-leverage thing you can do. Effect annotations are how
+the runtime decides whether to refuse a body before any code runs. Wide
+annotations are correct but worthless; the value of the effect system is
+exactly the narrowness.
+
+### 1.1 Declare the narrowest effect set (MUST)
+
+```lex
+# AVOID — shotgun annotation
+fn write_log(line :: Str) -> [io, fs_read, fs_write, net] Result[Unit, Str] {
+  fs.write("/var/log/app.log", line)
+}
+
+# GOOD — only what's used, with a path scope
+fn write_log(line :: Str) -> [fs_write("/var/log/app.log")] Result[Unit, Str] {
+  fs.write("/var/log/app.log", line)
+}
+```
+
+The compiler will *accept* the shotgun form — but `lex run` requires
+broader `--allow-effects` grants and reviewers can't tell what the fn
+actually touches.
+
+### 1.2 Don't broaden effects to satisfy the compiler (MUST)
+
+When `lex check` says "effect `fs_write` not declared at line X," the
+fix is **almost never** "add `fs_write` to the signature." It's "remove
+the code that needed `fs_write`," or "narrow the path scope to where the
+write actually happens."
+
+If a function is supposed to be pure and the checker says otherwise,
+**something is wrong with the body**, not the signature.
+
+### 1.3 Pure functions declare no effects (MUST)
+
+```lex
+# GOOD — no [...] before the return type
+fn double(n :: Int) -> Int { n * 2 }
+
+# AVOID — adding [io] "just in case" or "because the caller is impure"
+fn double(n :: Int) -> [io] Int { n * 2 }   # ← compiler will complain anyway
+```
+
+Purity is contagious in the right direction: pure fns can be called
+from anywhere, including from `examples {}` blocks, `spec {}` blocks,
+and inside `lex repair`'s safety-bounded environment.
+
+### 1.4 Use per-path / per-host scopes wherever you can (SHOULD)
+
+```lex
+# GOOD — fs_read scoped to a specific directory
+fn load_config(name :: Str) -> [fs_read("/etc/myapp/")] Result[Str, Str] { ... }
+
+# GOOD — net scoped to a specific host
+fn fetch_weather(zip :: Str) -> [net("api.weather.example")] Result[Str, Str] { ... }
+```
+
+The runtime enforces these scopes; per-fn `--allow-fs-read PATH` and
+`--allow-net-host HOST` grants do too. Wide scopes are auditable as
+"this function could touch anything"; narrow scopes are auditable as
+"this function touched what it claimed."
+
+### 1.5 Effect rows propagate through closures and HOFs (informational)
+
+You don't need to copy effects from a closure body to the surrounding
+fn signature manually — `list.map` and friends carry the closure's
+effects in their inferred row, and `lex check` propagates them. If the
+checker complains, the fix is to narrow the *body*, not to widen the
+outer signature.
+
+---
+
+## 2. Authoring style
+
+### 2.1 Every pure fn gets an `examples {}` block (SHOULD)
+
+```lex
+fn add(x :: Int, y :: Int) -> Int
+  examples {
+    add(0, 0)   => 0,
+    add(2, 3)   => 5,
+    add(-1, 1)  => 0,
+  }
+{
+  x + y
+}
+```
+
+Examples are folded into the canonical AST, so they're **part of the
+SigId**. Two implementations with different example sets are different
+signatures; this makes them load-bearing regression tests at no
+authoring cost.
+
+Effectful fns can't carry examples in v1 (determinism rule). See
+`#369` for the design.
+
+### 2.2 Use `spec {}` for behavioural contracts (SHOULD when behaviour matters)
+
+```lex
+spec clamp_bounds {
+  forall x :: Int, lo :: Int, hi :: Int where lo <= hi:
+    let r := clamp(x, lo, hi)
+    (r >= lo) and (r <= hi)
+}
+```
+
+Then `lex spec check clamp_bounds.spec --source clamp.lex` randomised-property checks
+it; `lex spec smt` emits SMT-LIB 2 for external Z3.
+
+### 2.3 Use `Result[T, E]` and `Option[T]` — no exceptions, no null (MUST)
+
+```lex
+# GOOD
+fn parse_int(s :: Str) -> Result[Int, ParseError] { ... }
+
+# AVOID — no exceptions in user code; the language doesn't have them
+fn parse_int(s :: Str) -> Int { throw "..."}   # ← won't compile
+```
+
+Idiom: `match res { Ok(x) => ..., Err(e) => ... }` or pipe through
+`result.map` / `result.and_then` / `result.map_err`.
+
+### 2.4 Pipe over nested match (SHOULD)
+
+```lex
+# AVOID — nested matches
+match parse_int(s) {
+  Ok(n) => match double(n) {
+    Ok(m) => Ok(m + 1),
+    Err(e) => Err(e),
+  },
+  Err(e) => Err(e),
+}
+
+# GOOD — pipe + and_then
+parse_int(s)
+  |> result.and_then(double)
+  |> result.map(fn (m :: Int) -> Int { m + 1 })
+```
+
+### 2.5 Exhaustive matches; no `_ =>` to silence (AVOID `_ =>` when not catch-all)
+
+```lex
+type Status = Healthy | Sick | Recovering
+
+# AVOID — adding `_ =>` swallows a new variant added later
+match s {
+  Healthy => "ok",
+  _       => "not ok",          # ← Recovering gets bucketed silently
+}
+
+# GOOD — listed exhaustively; the checker enforces it
+match s {
+  Healthy    => "ok",
+  Sick       => "nope",
+  Recovering => "wait",
+}
+```
+
+`_ =>` is fine when you genuinely want a catch-all (e.g., the right-hand
+side of a `try`); reserve it for that case.
+
+### 2.6 Syntax pitfalls — `::`, `:=`, `->` (MUST)
+
+Coming from Rust / TS / Python? These differ:
+
+| Lex | Meaning | Mistake to avoid |
+|---|---|---|
+| `x :: Int` | type annotation on a param / binding | `x: Int` (Lex error: expected `::`) |
+| `let x := e` | let binding | `let x = e` (Lex error: expected `:=`) |
+| `-> T` | return type | `: T` (Lex error: missing return arrow) |
+
+The checker error message is clear when you slip; this rule is here so
+you don't have to slip in the first place.
+
+---
+
+## 3. Module choice — use the stdlib
+
+Lex's stdlib is the slice the language owns. Whenever you reach for raw
+bytes, a syscall, or string-bashing — check the stdlib first.
+
+### 3.1 Concurrency: `std.conc` actors, never spawn threads (MUST)
+
+```lex
+import "std.conc" as conc
+
+fn counter(state :: Int, msg :: Int) -> (Int, Int) {
+  let next := state + msg
+  (next, next)
+}
+
+fn use_counter() -> [concurrent] Int {
+  let a := conc.spawn(0, counter)
+  conc.ask(a, 5)            # state becomes 5, reply 5
+}
+```
+
+`conc.spawn` / `conc.ask` / `conc.tell` are the actor primitives.
+Synchronous mailbox — handler runs on the caller's thread under a
+per-actor mutex. **Do not** try to spawn OS threads via FFI; you can't,
+and you don't need to.
+
+### 3.2 SQL: `std.sql` for SQLite and Postgres (MUST)
+
+```lex
+import "std.sql" as sql
+
+fn pg_users(conn :: Str) -> [sql, fs_write] Result[List[{ id :: Int, name :: Str }], SqlError] {
+  match sql.open(conn) {                # "postgres://...", ":memory:", or file path
+    Ok(db) => sql.query(db, "SELECT id, name FROM users ORDER BY id", []),
+    Err(e) => Err(e),
+  }
+}
+```
+
+Use parameterised queries (`sql.query(db, "... WHERE id = $1", [id])`),
+never string-concat into SQL.
+
+### 3.3 Crypto: `std.crypto`, never roll your own (MUST)
+
+`std.crypto` ships SHA-256/512, BLAKE2b, MD5, HMAC, AES-GCM,
+ChaCha20-Poly1305, PBKDF2, HKDF, Argon2id, base64, base64url, hex, and
+constant-time `eq`. CSPRNG is `crypto.random(n)` under `[random]`.
+
+Hand-rolling MACs, AEADs, or "XOR with a key" is wrong every time.
+
+### 3.4 Strings, regex, parsing — stdlib first (SHOULD)
+
+- `std.regex` over hand-rolled scanners
+- `std.str.split` / `.replace` / `.trim` over manual loops
+- `std.toml` / `std.yaml` / `std.csv` for config + tabular data
+- `std.json` (via `lex-types::builtins`) for JSON
+
+### 3.5 Orchestration: `std.flow` combinators (SHOULD)
+
+`flow.sequential` / `flow.branch` / `flow.parallel_list` over ad-hoc
+control flow. They compose cleanly and the closures carry their effects
+through the row inference.
+
+### 3.6 HTTP: `std.http` with per-host scopes (MUST for net)
+
+```lex
+import "std.http" as http
+
+fn fetch_json(url :: Str) -> [net] Result[HttpResponse, HttpError] {
+  http.get(url)
+}
+```
+
+Always pair with `--allow-net-host` at the policy gate. Never construct
+raw sockets.
+
+---
+
+## 4. The repair-not-regenerate rule
+
+When `lex check` rejects your code, you have two paths:
+
+1. Throw away the body and regenerate.
+2. Apply `lex repair --apply` with the structured fix the checker
+   suggested.
+
+**Always try path 2 first.** Path 1 burns budget and produces churn
+that's hostile to merge / blame / spec.
+
+### 4.1 On type-check failure, run `lex check --output json` (MUST)
+
+```json
+{
+  "kind": "type_error",
+  "rule_tag": "EFFECT_NOT_DECLARED",
+  "position": {"file": "src/handler.lex", "line": 14, "col": 22},
+  "rule_explanation": "effect `fs_write` reached at this position is not declared in the enclosing fn signature.",
+  "suggested_transform": { "kind": "narrow_path", "param": "path", "value": "/tmp/handler-output/" }
+}
+```
+
+The `rule_tag` and `suggested_transform` are what `lex repair --apply`
+consumes.
+
+### 4.2 If the error has a `suggested_transform`, apply it verbatim (SHOULD)
+
+```bash
+lex --output json repair <failed_op_id> \
+  --apply --transform '<paste the suggested_transform here>' \
+  --store .lex-store
+# → {"outcome":"passed","applied_op_id":"op_..."}
+```
+
+The output lands as a `RepairAttempt` attestation linked to the
+originating hint. Future agents (and `lex blame --with-evidence`) can
+follow the chain.
+
+### 4.3 Only regenerate the whole body after 2 failed repairs (SHOULD)
+
+If two `lex repair --apply` attempts fail, the structural fix doesn't
+exist — the body's design is wrong, not its syntax. Regenerate the body
+*intentionally* (not as a reflex), keeping the signature stable so the
+SigId — and the existing attestations — survive.
+
+---
+
+## 5. Multi-agent coordination
+
+Many agents may edit the same code in parallel. Lex provides primitives
+for this; use them.
+
+### 5.1 Use `Candidate` / `Promote` for parallel emit (SHOULD)
+
+Instead of racing to overwrite a branch head, propose `Candidate` ops
+that don't advance the head; a downstream policy `Promote`s the winner.
+
+```bash
+# Each proposer pushes a candidate; head is unchanged.
+lex publish --candidate --branch main src/handler.lex
+
+# Selector picks one (manually or via `lex producer-trust recompute`).
+lex stage promote-candidate <candidate_op_id> --branch main
+```
+
+CAS contention drops to zero. Each candidate is attested
+independently; the loser candidates remain in the log for replay.
+
+### 5.2 Respect the session budget gate (MUST)
+
+```http
+HTTP/1.1 503 Service Unavailable
+Retry-After: 0
+{"error":"session 'sid_xyz' budget exceeded (spent_after=450, cap=400)", ...}
+```
+
+`Retry-After: 0` is **not** "retry in 0 seconds." It's "don't retry
+as-is; either raise the cap, refactor to spend less, or stop." Auto-retry
+on this response makes the cap meaningless.
+
+### 5.3 Tool registry manifests match real effects (MUST)
+
+When you register a tool via `POST /tools`:
+
+```json
+{
+  "name": "weather-fetcher",
+  "effects": ["net('api.weather.example')"],
+  "source": "fn fetch(zip :: Str) -> ..."
+}
+```
+
+The declared `effects` field MUST match what the source's type-checked
+signature claims. Overdeclaring is bad; underdeclaring means the tool
+will fail at runtime in places callers didn't expect.
+
+---
+
+## 6. Hash and store hygiene
+
+The store keys on the canonical AST hash (SigId). Cosmetic changes that
+shift hashes are expensive — they invalidate attestations and force
+re-attest cycles.
+
+### 6.1 Run `lex fmt` before publish (MUST)
+
+```bash
+lex fmt src/        # auto-format
+lex fmt --check src/  # exit 1 if not formatted
+```
+
+`lex fmt` is canonical; two semantically-identical files normalise to
+byte-identical output.
+
+### 6.2 Don't reformat for "readability" (AVOID)
+
+If `lex fmt` produces output you don't like, file an issue; don't
+hand-rewrite into a non-canonical form. Hand-formatting that gets
+through `lex fmt --check` is a no-op anyway.
+
+### 6.3 Don't rename params/locals cosmetically (AVOID)
+
+Parameter and local names are part of the canonical AST.
+`fn add(x :: Int, y :: Int)` and `fn add(a :: Int, b :: Int)` have
+**different SigIds**. Rename only when the name was actually wrong.
+
+### 6.4 Don't reorder top-level fns cosmetically (AVOID)
+
+Top-level fn order is preserved by the canonicalizer. Reordering shifts
+the canonical AST; downstream tooling that keyed on SigIds may break.
+
+See `docs/design/canonicalization.md` for the full list of edits that
+preserve vs change a SigId.
+
+---
+
+## 7. Attestation hygiene
+
+Attestations are signed evidence that a gate (typecheck, spec, sandbox,
+examples, repair) covered a stage. The substrate emits them; you query
+them.
+
+### 7.1 Don't fabricate attestations (MUST)
+
+Attestations come from the gates (`lex check` → `TypeCheck`,
+`lex spec check` → `Spec`, `lex agent-tool` → `SandboxRun`, …). You
+cannot — and must not try to — write them directly. The signing
+boundary is what makes them load-bearing.
+
+### 7.2 Query attestations via `lex blame --with-evidence` (SHOULD)
+
+Before modifying a fn, check its evidence trail:
+
+```bash
+lex blame route --with-evidence --store .lex-store
+```
+
+Surfaces every TypeCheck / Spec / Examples / DiffBody / SandboxRun /
+RepairAttempt that touched the fn's stages. If you're about to redo
+work the substrate already attested, stop.
+
+### 7.3 `lex stage <id> --attestations` for a single stage (informational)
+
+Same query, scoped to one stage. Use when reviewing a `Candidate` you're
+considering promoting.
+
+---
+
+## 8. What NOT to do
+
+A short blocklist. Every one of these is a real anti-pattern AI agents
+emit. Avoid.
+
+| Pattern | Why it's wrong | Do instead |
+|---|---|---|
+| `_ => "ok"` outside a try/catch-all | Swallows new variants silently | List exhaustively |
+| Hand-rolled crypto | One bug = full compromise | `std.crypto` |
+| String-concat SQL | Injection | `sql.query(db, q, [args])` |
+| Wide `[net, io, fs_read, fs_write]` | Sandbox is meaningless | Narrow to what's used + path scopes |
+| `[io]` "just in case" | Pure fn won't typecheck anyway | Remove it |
+| Renaming params after publish | Different SigId; loses attestations | Don't |
+| Auto-retry on HTTP 503 from `lex serve` | Budget cap is intentional | Raise cap or refactor |
+| Mutation via FFI | No FFI; no mutation in user code | Build new values |
+| Spawning OS threads | Not supported; not needed | `std.conc` actors |
+| Bypassing the gate via `proc.exec` | Defeats the sandbox model | Don't; if you need OS access, declare `[proc]` explicitly |
+
+---
+
+## 9. Pre-"done" checklist
+
+Before claiming a task is complete, run all of:
+
+```bash
+lex check --strict src/        # type-check with extra lints
+lex fmt --check src/ tests/    # formatting
+lex test                        # all tests/test_*.lex
+lex ci                          # umbrella — same as above
+```
+
+Then verify by inspection:
+
+- [ ] Every fn signature declares the **narrowest** effect set.
+- [ ] Every pure fn has an `examples {}` block (or a one-line comment
+      explaining why not — usually "trivial accessor").
+- [ ] No `_ =>` arms outside catch-all error paths.
+- [ ] Stdlib used in preference to roll-your-own.
+- [ ] If you saw a `lex check` error during the task, you ran
+      `lex repair --apply` rather than regenerating the body.
+- [ ] No SigId churn from cosmetic edits (param renames, fn reordering).
+- [ ] Tool-registry manifests, if any, match the actual effect rows.
+
+---
+
+## 10. Where to read more
+
+- **`README.md`** — high-level pitch + agent-code loop overview.
+- **`docs/AGENT.md`** — reference: error envelope schema, every
+  `rule_tag`, stdlib module summary, sharp edges.
+- **`docs/design/canonicalization.md`** — which edits preserve a SigId
+  and which break it.
+- **`bench/REPORT.md`** — adversarial sandbox bench + infrastructure
+  comparison.
+- **`crates/lex-types/src/builtins.rs`** — every stdlib signature, the
+  source of truth.
+
+For an issue you can't resolve: file at
+<https://github.com/alpibrusl/lex-lang/issues>, include the
+`lex check --output json` envelope verbatim.

--- a/docs/templates/CLAUDE.md
+++ b/docs/templates/CLAUDE.md
@@ -1,0 +1,90 @@
+# CLAUDE.md / AGENTS.md — Lex project conventions
+
+> **Copy this file** into the root of any Lex project repository as
+> `CLAUDE.md` (read by Claude Code), `AGENTS.md` (read by Cursor /
+> Aider / Codex CLI / Copilot CLI), or both. Any AI agent that picks
+> the file up will follow the discipline below before writing code.
+
+This repository is a **Lex** project. Lex is not Python with weird
+syntax; it is a typed-effect language with a content-addressed AST and
+an attestation graph. Treat the rules in this file as part of the task
+brief.
+
+## Mandatory reading before writing code
+
+Run these in order:
+
+```sh
+lex --version                  # confirm Lex is installed; if missing, see below
+lex agent-guidelines           # authoritative idiom rules — read in full
+lex skill                      # CLI surface + exit codes (ACLI)
+```
+
+`lex agent-guidelines` is the prescriptive contract for this project.
+Do not write code until you have read it. The rules are numbered and
+stable; this CLAUDE.md exists only to point you at them and add
+project-specific overrides.
+
+## The discipline summary
+
+The full rules live in `lex agent-guidelines`. The four that matter
+most when you're tempted to skip them:
+
+1. **Narrow effects, always.** `fn foo() -> [fs_write("/tmp/x")] T`,
+   not `[fs_write]`, not `[fs_write, fs_read, io]`. If the type checker
+   rejects, narrow the **body**, not the signature.
+2. **Repair, don't regenerate.** When `lex check` fails, run
+   `lex --output json check` to get the structured error, then
+   `lex repair --apply --transform '<suggested_transform>'`. Only
+   regenerate after two failed repair attempts.
+3. **`examples {}` blocks on every pure fn.** They're part of the
+   SigId and run at `lex check` time — free regression tests with no
+   `tests/` boilerplate.
+4. **Use the stdlib.** `std.crypto` not hand-rolled crypto, `std.conc`
+   not threads, `std.sql` not string-concat SQL, `std.regex` not
+   manual scanners. Reach for raw bytes only after checking the
+   stdlib index.
+
+## The loop
+
+Every change goes through the same four steps. **Do not claim a task
+done before all four are green.**
+
+```sh
+lex check --strict src/        # type-check with extra lints
+lex fmt --check src/ tests/    # formatting (must be canonical)
+lex test                        # all tests/test_*.lex files
+lex ci                          # umbrella: same as the above + pkg install
+```
+
+If `lex check` fails, do **not** broaden the effect signature to
+make it pass. Investigate the body. See `lex agent-guidelines` § 1.2.
+
+## When in doubt
+
+```sh
+lex agent-guidelines        # the rules
+lex skill                   # the CLI surface
+lex --output json check <file>   # structured errors with rule_tag + suggested_transform
+lex blame <fn> --with-evidence   # what attestations already cover this fn
+```
+
+Lex toolchain version pinned by this project: see `lex.toml` /
+`.github/workflows/lex.yml`. If `lex --version` reports a different
+version locally, install the pinned one from
+<https://github.com/alpibrusl/lex-lang/releases> before continuing.
+
+## Project-specific overrides
+
+Add per-project conventions below this line. If you don't have any,
+delete this section.
+
+<!--
+Examples of useful overrides:
+
+- "All HTTP handlers live in `src/handlers/`; one handler per file."
+- "Tests use the `mocked_io` fixture in `tests/fixtures/`."
+- "Effect budgets are capped at `[budget(5000)]` per request."
+- "The `examples {}` block on every handler must include at least one
+  adversarial case (malformed input, oversize body, auth missing)."
+-->


### PR DESCRIPTION
## Summary

Adds the prescriptive contract AI agents need before writing Lex — the "use it as Lex, not as Python with weird syntax" rules — plus the discovery and templating wiring so any agent in any downstream Lex repo finds it without bespoke configuration.

Motivation: agents working in Lex codebases (lex-ocpp etc.) treat it like a generic language. They emit shotgun effect declarations (`[fs_read, fs_write, net, io]`), skip `examples {}` blocks, regenerate whole bodies on `lex check` failures instead of using `lex repair --apply`, hand-roll crypto, spawn threads instead of using `std.conc`. None of that is enforceable by the type checker — it's authoring discipline, and discipline needs a written contract.

## What ships

1. **`docs/AGENT_GUIDELINES.md`** — authoritative numbered rules. Sections:
   - **§ 1 Effect discipline** — narrowest effect set always (1.1), don't broaden to satisfy the compiler (1.2), pure fns declare nothing (1.3), per-path / per-host scopes (1.4), effect rows propagate through closures (1.5).
   - **§ 2 Authoring style** — `examples {}` on every pure fn (2.1), `spec {}` when behaviour matters (2.2), `Result`/`Option` not exceptions (2.3), pipe over nested match (2.4), exhaustive matches no `_` escape (2.5), syntax pitfalls (`::` / `:=` / `->`) (2.6).
   - **§ 3 Module choice** — `std.conc` not threads (3.1), `std.sql` parameterised (3.2), `std.crypto` not hand-rolled (3.3), stdlib regex/parsers (3.4), `std.flow` combinators (3.5), `std.http` with per-host scopes (3.6).
   - **§ 4 The repair-not-regenerate rule** — `lex check --output json` for structured errors (4.1), apply suggested transforms verbatim (4.2), regenerate only after two failed repairs (4.3).
   - **§ 5 Multi-agent coordination** — Candidate/Promote for parallel emit (5.1), respect HTTP 503 budget gate (5.2), tool registry manifests match real effects (5.3).
   - **§ 6 Hash + store hygiene** — `lex fmt` is canonical (6.1), don't reformat (6.2), don't rename params cosmetically (6.3), don't reorder top-level fns (6.4).
   - **§ 7 Attestation hygiene** — don't fabricate (7.1), query via `lex blame --with-evidence` (7.2).
   - **§ 8 What NOT to do** — anti-pattern blocklist (`_ =>` escape, hand-crypto, string-concat SQL, wide effects, mutation, OS threads, gate bypass, etc.).
   - **§ 9 Pre-done checklist**.

2. **`docs/templates/CLAUDE.md`** — drop-in template for downstream Lex project repos. Routes any agent reading `CLAUDE.md` / `AGENTS.md` to `lex agent-guidelines` for the contract.

3. **`lex agent-guidelines` subcommand** (`crates/lex-cli/src/agent_guidelines.rs`):
   - Embeds `AGENT_GUIDELINES.md` via `include_str!` so the doc travels with the toolchain version. `lex agent-guidelines > AGENTS.md` works anywhere the binary works.
   - `--output json` wraps the doc in the standard ACLI success envelope; `--version-only` returns just the toolchain version.
   - Registered in `acli.rs::commands()` so `lex skill`, `lex introspect`, and `.cli/commands.json` all surface it as a first-class command. Agents that browse GitHub at `.cli/` read about it without running the binary.

4. **`lex init` AGENTS.md refresh**: a fresh project's `AGENTS.md` now points at `lex agent-guidelines` as the first thing to run, with the four highest-leverage rules inlined for immediate context. All five existing `init_scaffold` tests still pass (markers preserved).

5. **`.cli/` regenerated**: picks up `agent-guidelines` plus several pre-existing commands (`attest`, `blame`, `log`, `merge`, `repl`, `stage`, `watch`) whose example shells had drifted from the registered set in `acli.rs`.

## How downstream repos enforce this

```sh
# New project — scaffold inherits the latest AGENTS.md from this version's `lex init`.
lex init my-tool

# Existing project — drop in the template.
cp /path/to/lex-lang/docs/templates/CLAUDE.md ./CLAUDE.md
# … then any agent in the repo reads CLAUDE.md → runs lex agent-guidelines → follows the rules.

# Or just emit the contract into the repo directly:
lex agent-guidelines > AGENTS.md
```

Claude Code reads `CLAUDE.md` automatically; Cursor / Aider / Codex CLI / Copilot CLI read `AGENTS.md`. Both forms route to the same place.

## Test plan

- [x] `lex agent-guidelines` prints the markdown verbatim (517 lines).
- [x] `lex --output json agent-guidelines --version-only` returns `{"command":"agent-guidelines","data":{"lex_version":"0.9.3"},"ok":true}`.
- [x] `lex introspect` lists `agent-guidelines` as a first-class command.
- [x] `cargo test -p lex-cli --test init_scaffold` — 5/5 pass (existing markers preserved in the refreshed AGENTS.md).
- [x] `cargo test --workspace --no-fail-fast` — no failures.
- [ ] After merge: confirm a downstream `lex init` picks up the new `AGENTS.md` text.
- [ ] After merge: confirm `cp docs/templates/CLAUDE.md .` in a downstream Lex repo + agent session routes the agent to `lex agent-guidelines` on first action.

https://claude.ai/code/session_01GKdeZw4hJ9SucFMPwBVeNt

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKdeZw4hJ9SucFMPwBVeNt)_