### PR TITLE
fix(syntax): preserve `#` line-comments through `lex fmt` (#417)

### DIFF
--- a/crates/lex-syntax/src/lib.rs
+++ b/crates/lex-syntax/src/lib.rs
@@ -11,7 +11,7 @@ pub mod workspace;
 
 pub use loader::{load_program, load_program_from_str, LoadError};
 pub use workspace::{find_manifest, Manifest, PackageError};
-pub use parser::{parse, ParseError};
+pub use parser::{parse, parse_with_src, ParseError};
 pub use printer::print_program;
 pub use syntax::*;
 pub use token::{lex, LexError, Token, TokenKind};
@@ -19,7 +19,7 @@ pub use token::{lex, LexError, Token, TokenKind};
 /// Convenience: lex + parse a source string.
 pub fn parse_source(src: &str) -> Result<Program, SyntaxError> {
     let toks = lex(src).map_err(SyntaxError::Lex)?;
-    parse(toks).map_err(SyntaxError::Parse)
+    parse_with_src(src, toks).map_err(SyntaxError::Parse)
 }
 
 /// Byte-offset start position of each `fn` declaration, keyed by
@@ -58,7 +58,7 @@ pub fn parse_source_with_positions(src: &str) -> Result<(Program, FnPositions), 
         }
         i += 1;
     }
-    let program = parse(toks).map_err(SyntaxError::Parse)?;
+    let program = parse_with_src(src, toks).map_err(SyntaxError::Parse)?;
     Ok((program, fn_positions))
 }
 

--- a/crates/lex-syntax/src/loader.rs
+++ b/crates/lex-syntax/src/loader.rs
@@ -170,7 +170,11 @@ impl LoaderState {
         // call still resolves so the parent's `path_imports` map gets
         // populated below.
         if self.loaded.contains(canonical) {
-            return Ok(Program { items: Vec::new() });
+            return Ok(Program {
+                items: Vec::new(),
+                leading_comments: Vec::new(),
+                trailing_comments: Vec::new(),
+            });
         }
         self.in_progress.push(canonical.to_path_buf());
 
@@ -255,7 +259,17 @@ impl LoaderState {
         }
         out.extend(merged_children);
         out.extend(mangled);
-        Ok(Program { items: out })
+        // Top-of-file comments live on each source file independently;
+        // after import merging the merged Program represents many
+        // files at once, and there is no obvious single "top of file"
+        // to attribute them to. Drop here — they're preserved by
+        // `lex fmt` (which operates per-file) but not by the loader's
+        // import-merging path. Same rationale for trailing_comments.
+        Ok(Program {
+            items: out,
+            leading_comments: Vec::new(),
+            trailing_comments: Vec::new(),
+        })
     }
 }
 
@@ -335,6 +349,7 @@ impl<'a> Mangler<'a> {
             name: self.qualify(&td.name),
             params: td.params,
             definition: self.mangle_type_expr(td.definition),
+            leading_comments: td.leading_comments,
         }
     }
 
@@ -376,6 +391,7 @@ impl<'a> Mangler<'a> {
             return_type: self.mangle_type_expr(fd.return_type),
             body: self.mangle_block(fd.body, &shadow),
             examples,
+            leading_comments: fd.leading_comments,
         }
     }
 

--- a/crates/lex-syntax/src/parser.rs
+++ b/crates/lex-syntax/src/parser.rs
@@ -5,7 +5,18 @@ use crate::syntax::*;
 use crate::token::{Token, TokenKind};
 
 pub fn parse(tokens: Vec<Token>) -> Result<Program, ParseError> {
-    let mut p = Parser::new(tokens);
+    // Back-compat entry: no source available, so leading comments are
+    // not recovered. `parse_source` in `lib.rs` calls
+    // `parse_with_src` directly and is the path that preserves them.
+    parse_with_src("", tokens)
+}
+
+/// Parse + attach `#` line-comments to the AST. The source string is
+/// used only to scan the gaps between tokens (where the lexer skipped
+/// whitespace and comments); the parser itself still operates purely
+/// on tokens. See `Program::leading_comments` for the data model.
+pub fn parse_with_src(src: &str, tokens: Vec<Token>) -> Result<Program, ParseError> {
+    let mut p = Parser::new(src, tokens);
     let program = p.parse_program()?;
     p.skip_newlines();
     if !p.at_eof() {
@@ -21,7 +32,12 @@ pub struct ParseError {
     pub msg: String,
 }
 
-struct Parser {
+struct Parser<'a> {
+    /// Source text — needed only for trivia recovery (line comments
+    /// in the gaps between tokens). Empty when called through the
+    /// legacy `parse(tokens)` entry; comments are silently dropped
+    /// in that path.
+    src: &'a str,
     tokens: Vec<Token>,
     idx: usize,
     /// Recursion depth across `parse_expr`. Capped at `MAX_DEPTH`
@@ -47,9 +63,39 @@ struct Parser {
 /// count around 400-500 — well below even a 2 MiB test stack.
 const MAX_DEPTH: u32 = 96;
 
-impl Parser {
-    fn new(tokens: Vec<Token>) -> Self {
-        Self { tokens, idx: 0, depth: 0, discard_counter: 0 }
+impl<'a> Parser<'a> {
+    fn new(src: &'a str, tokens: Vec<Token>) -> Self {
+        Self { src, tokens, idx: 0, depth: 0, discard_counter: 0 }
+    }
+
+    /// Extract `#` line-comments from the source byte range
+    /// `start..end`. The range must be a "gap" between two tokens
+    /// (or between source-start/end and a token); by construction
+    /// such gaps contain only whitespace and `#` comments — string
+    /// contents never appear because the lexer's logos rules would
+    /// have produced a `Str(...)` token covering them.
+    ///
+    /// Each returned entry is a single source line, trimmed of leading
+    /// whitespace (the `#` and everything after it preserved) and of
+    /// trailing whitespace. Blank lines between consecutive comments
+    /// are dropped — preserving inter-comment blank lines is left to
+    /// a follow-up; the bug this addresses (#417) is about comments
+    /// disappearing entirely.
+    fn extract_comments(&self, start: usize, end: usize) -> Vec<String> {
+        if start >= end || end > self.src.len() {
+            return Vec::new();
+        }
+        self.src[start..end]
+            .lines()
+            .filter_map(|line| {
+                let trimmed = line.trim_start();
+                if trimmed.starts_with('#') {
+                    Some(trimmed.trim_end().to_string())
+                } else {
+                    None
+                }
+            })
+            .collect()
     }
 
     fn at_eof(&self) -> bool {
@@ -124,14 +170,39 @@ impl Parser {
 
     fn parse_program(&mut self) -> Result<Program, ParseError> {
         let mut items = Vec::new();
+        let mut leading_comments: Vec<String> = Vec::new();
+        // Byte offset of the end of the last consumed token (or 0 at
+        // start of file). The next gap to scan for comments is from
+        // here up to the start of the upcoming item's first token.
+        let mut gap_start: usize = 0;
         loop {
             self.skip_newlines();
             if self.at_eof() {
                 break;
             }
-            items.push(self.parse_item()?);
+            let item_start = self.tokens[self.idx].span.start;
+            let gap_comments = self.extract_comments(gap_start, item_start);
+            let pending_comments = if items.is_empty() {
+                leading_comments = gap_comments;
+                Vec::new()
+            } else {
+                gap_comments
+            };
+            let mut item = self.parse_item()?;
+            if !pending_comments.is_empty() {
+                attach_leading_comments(&mut item, pending_comments);
+            }
+            gap_start = self
+                .tokens
+                .get(self.idx.saturating_sub(1))
+                .map(|t| t.span.end)
+                .unwrap_or(gap_start);
+            items.push(item);
         }
-        Ok(Program { items })
+        // Trailing comments live after the last consumed token (or
+        // span the whole file when there are no items).
+        let trailing_comments = self.extract_comments(gap_start, self.src.len());
+        Ok(Program { items, leading_comments, trailing_comments })
     }
 
     fn parse_item(&mut self) -> Result<Item, ParseError> {
@@ -153,7 +224,7 @@ impl Parser {
         };
         self.expect(&TokenKind::As, "in import")?;
         let alias = self.expect_ident("for import alias")?;
-        Ok(Import { reference, alias })
+        Ok(Import { reference, alias, leading_comments: Vec::new() })
     }
 
     fn parse_type_decl(&mut self) -> Result<TypeDecl, ParseError> {
@@ -168,7 +239,7 @@ impl Parser {
         };
         self.expect(&TokenKind::Eq, "in type decl")?;
         let definition = self.parse_type_decl_rhs()?;
-        Ok(TypeDecl { name, params, definition })
+        Ok(TypeDecl { name, params, definition, leading_comments: Vec::new() })
     }
 
     fn parse_ident_list(&mut self) -> Result<Vec<String>, ParseError> {
@@ -374,7 +445,7 @@ impl Parser {
         let return_type = self.parse_type_expr()?;
         let examples = self.parse_examples_block()?;
         let body = self.parse_block()?;
-        Ok(FnDecl { name, type_params, params, effects, return_type, body, examples })
+        Ok(FnDecl { name, type_params, params, effects, return_type, body, examples, leading_comments: Vec::new() })
     }
 
     /// Parse an optional `examples { call(a, b) => expected, ... }` block
@@ -932,5 +1003,19 @@ fn type_to_variant(t: TypeExpr) -> Result<UnionVariant, ParseError> {
             pos: 0,
             msg: "union variant must be a constructor name".into(),
         }),
+    }
+}
+
+/// Attach a collected list of `#` comments to whichever top-level
+/// item variant carries them. Empty input is a no-op; the per-variant
+/// `leading_comments: Vec<String>` field is always present.
+fn attach_leading_comments(item: &mut Item, comments: Vec<String>) {
+    if comments.is_empty() {
+        return;
+    }
+    match item {
+        Item::Import(i) => i.leading_comments = comments,
+        Item::TypeDecl(t) => t.leading_comments = comments,
+        Item::FnDecl(f) => f.leading_comments = comments,
     }
 }

--- a/crates/lex-syntax/src/printer.rs
+++ b/crates/lex-syntax/src/printer.rs
@@ -29,6 +29,16 @@ impl Printer {
     }
 
     fn program(&mut self, p: &Program) {
+        // Top-of-file comments live above any item. Always emitted at
+        // column 0 — agents and humans both expect module-level
+        // documentation to start at the left margin (`lex fmt`
+        // canonical form).
+        for c in &p.leading_comments {
+            writeln!(self.out, "{c}").unwrap();
+        }
+        if !p.leading_comments.is_empty() && !p.items.is_empty() {
+            self.nl();
+        }
         for (i, item) in p.items.iter().enumerate() {
             if i > 0 { self.nl(); }
             self.item(item);
@@ -36,9 +46,29 @@ impl Printer {
         if !p.items.is_empty() {
             self.nl();
         }
+        // Trailing comments at the end of file (after the last item).
+        // Most code doesn't have these; preserved for round-trip
+        // fidelity on the rare file that does.
+        if !p.trailing_comments.is_empty() {
+            if !p.items.is_empty() { self.nl(); }
+            for c in &p.trailing_comments {
+                writeln!(self.out, "{c}").unwrap();
+            }
+        }
     }
 
     fn item(&mut self, item: &Item) {
+        // Emit any leading-comment block attached to the item before
+        // the item itself. Each entry is a raw source line including
+        // the `#` prefix; written verbatim, one per line.
+        let leading: &[String] = match item {
+            Item::Import(i) => &i.leading_comments,
+            Item::TypeDecl(td) => &td.leading_comments,
+            Item::FnDecl(fd) => &fd.leading_comments,
+        };
+        for c in leading {
+            writeln!(self.out, "{c}").unwrap();
+        }
         match item {
             Item::Import(i) => {
                 writeln!(self.out, "import \"{}\" as {}", i.reference, i.alias).unwrap();

--- a/crates/lex-syntax/src/syntax.rs
+++ b/crates/lex-syntax/src/syntax.rs
@@ -8,6 +8,16 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Program {
     pub items: Vec<Item>,
+    /// Comments at the top of the file, before the first item. Each
+    /// entry is one line of source, including the leading `#`.
+    /// Preserved by the formatter (`lex fmt`); stripped by the
+    /// canonicalizer so they never participate in SigId.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub leading_comments: Vec<String>,
+    /// Comments after the last item (or all of the file, if `items`
+    /// is empty). Same semantics as `leading_comments`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub trailing_comments: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -21,6 +31,11 @@ pub enum Item {
 pub struct Import {
     pub reference: String,
     pub alias: String,
+    /// Comments immediately preceding this import (one line each, `#`
+    /// preserved). Preserved by the formatter; ignored everywhere
+    /// else.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub leading_comments: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -28,6 +43,10 @@ pub struct TypeDecl {
     pub name: String,
     pub params: Vec<String>,
     pub definition: TypeExpr,
+    /// Comments immediately preceding this declaration. See `Import`
+    /// for semantics.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub leading_comments: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -46,6 +65,10 @@ pub struct FnDecl {
     /// with pre-#369 signatures when the block is absent.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub examples: Vec<Example>,
+    /// Comments immediately preceding this fn declaration. See
+    /// `Import` for semantics.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub leading_comments: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/lex-syntax/tests/comments_417.rs
+++ b/crates/lex-syntax/tests/comments_417.rs
@@ -1,0 +1,115 @@
+//! Regression coverage for #417 — `lex fmt` was stripping top-of-file
+//! and inter-item line comments because the lexer's logos `skip`
+//! directive discarded them before the parser saw them. The parser
+//! now scans the gaps between tokens for `#` comments and attaches
+//! them to the AST (`Program::leading_comments` for top-of-file,
+//! `{Import,TypeDecl,FnDecl}::leading_comments` for per-item).
+//!
+//! The bug: a leading-docstring block on `lex-schema`'s `src/schema.lex`
+//! vanished on `lex fmt`, taking ~140 lines of module documentation
+//! with it. These tests pin the round-trip property so any future
+//! regression is loud.
+
+use lex_syntax::{parse_source, print_program};
+
+fn fmt(src: &str) -> String {
+    let prog = parse_source(src).unwrap_or_else(|e| {
+        panic!("parse failed: {e}\nsource:\n{src}")
+    });
+    print_program(&prog)
+}
+
+#[test]
+fn top_of_file_doc_block_survives_fmt() {
+    // The shape from #417's repro: a multi-line `#` docblock followed
+    // by import + fn. Pre-fix the docblock was lopped off entirely.
+    let src = "\
+# lex-schema — schema introspection + JSON Schema / OpenAPI export
+#
+# Pydantic's `Model.schema()` returns a JSON Schema describing the
+# request/response contract. Lex doesn't have that yet — this module
+# is the start.
+import \"std.str\" as str
+
+fn id(s :: Str) -> Str { s }
+";
+    let out = fmt(src);
+    for marker in &[
+        "# lex-schema — schema introspection + JSON Schema / OpenAPI export",
+        "# Pydantic's `Model.schema()` returns a JSON Schema describing the",
+        "# request/response contract. Lex doesn't have that yet — this module",
+        "# is the start.",
+    ] {
+        assert!(
+            out.contains(marker),
+            "leading docblock dropped — missing {marker:?}\noutput:\n{out}"
+        );
+    }
+}
+
+#[test]
+fn inter_item_comments_survive_fmt() {
+    // Comments between top-level items must also be preserved.
+    let src = "\
+import \"std.str\" as str
+
+# The main entry. Keep this concise.
+fn main() -> Str { \"hi\" }
+
+# Helper: clamps to [0, 100].
+fn clamp(n :: Int) -> Int { n }
+";
+    let out = fmt(src);
+    assert!(
+        out.contains("# The main entry. Keep this concise."),
+        "comment before `main` lost\noutput:\n{out}"
+    );
+    assert!(
+        out.contains("# Helper: clamps to [0, 100]."),
+        "comment before `clamp` lost\noutput:\n{out}"
+    );
+}
+
+#[test]
+fn fmt_is_idempotent_with_comments() {
+    // Once-through formatting must equal twice-through — the canonical
+    // form a project's `lex fmt --check` step depends on.
+    let src = "\
+# Top docstring.
+
+import \"std.str\" as str
+
+# Above main.
+fn main() -> Str { \"hi\" }
+";
+    let once = fmt(src);
+    let twice = fmt(&once);
+    assert_eq!(once, twice, "fmt not idempotent:\nonce:\n{once}\ntwice:\n{twice}");
+}
+
+#[test]
+fn parse_then_print_roundtrips_with_comments() {
+    // The full round-trip property: parse, print, re-parse, structural
+    // equality. Mirrors the existing round_trip tests but with
+    // comments present (which previously vanished, so the test would
+    // have trivially passed even on broken behaviour).
+    let src = "\
+# Module header.
+import \"std.str\" as str
+
+# Doc on type.
+type Status = Ok | Bad
+
+# Doc on fn.
+fn label(s :: Status) -> Str {
+  match s {
+    Ok  => \"ok\",
+    Bad => \"nope\",
+  }
+}
+";
+    let prog1 = parse_source(src).expect("parse 1");
+    let printed = print_program(&prog1);
+    let prog2 = parse_source(&printed).expect("parse 2");
+    assert_eq!(prog1, prog2, "round-trip differs.\nprinted:\n{printed}");
+}


### PR DESCRIPTION
## Summary

Closes #417.

`lex fmt` was silently stripping top-of-file doc-comments and between-item comments because the logos lexer skipped `#` regex matches before they reached the parser. Downstream repos (lex-schema PR #7) could not adopt `lex ci` / `lex fmt --check` without losing every module's header docstring.

## What changed

- **`syntax.rs`** — added `leading_comments: Vec<String>` to `Program`, `Import`, `TypeDecl`, and `FnDecl`, plus `trailing_comments` on `Program`. All fields are `#[serde(default, skip_serializing_if = "Vec::is_empty")]` so the JSON shape stays bit-compatible with pre-#417 ASTs.
- **`parser.rs`** — `Parser` now carries `src: &'a str`. After each `parse_item()`, the parser scans the byte range between the previous item's end and the next item's first-token start for `#`-prefixed lines. Comments before the first item land on `Program.leading_comments`; between items attach to the next item; after the last item land on `Program.trailing_comments`. The byte gap between two tokens contains only whitespace and `#` comments by lexer construction, so the scan is safe without string-literal awareness. A new `parse_with_src` entry preserves the legacy `parse(tokens)` API.
- **`printer.rs`** — emits leading comments at column 0 before each item; top-of-file leading_comments above the first item; trailing comments after the last item.
- **`lib.rs`** — `parse_source` and `parse_source_with_positions` switch to `parse_with_src` so comments flow through the default entry.
- **`loader.rs`** — import-merging path drops module-level leading/trailing comments (a merged Program represents many files); per-item comments survive mangling.

## SigId invariance

The canonical AST has **no comment fields**, so SigIds, attestation hashes, and `lex hash` output stay byte-identical to pre-fix. Verified directly:

```
$ lex hash schema_like.lex          # with comments
id  canonical_ast=038b854b161c1298...  stage_id=a6fe88f9...

$ lex hash no_comments.lex          # same file, comments removed
id  canonical_ast=038b854b161c1298...  stage_id=a6fe88f9...
```

Matches the canonicalization contract from #412 (`docs/design/canonicalization.md` § 1 already calls out that comments don't participate in SigId).

## Test plan

`crates/lex-syntax/tests/comments_417.rs` (new, 4 cases):
- [x] `top_of_file_doc_block_survives_fmt` — the exact shape from #417's repro (multi-line `#` block at top of file).
- [x] `inter_item_comments_survive_fmt` — comments between fn decls.
- [x] `fmt_is_idempotent_with_comments` — once-through == twice-through (the property `lex fmt --check` depends on).
- [x] `parse_then_print_roundtrips_with_comments` — full structural round-trip.

End-to-end against a synthesised lex-schema-like file:
```
$ wc -l /tmp/schema_like.lex      # before fmt
16

$ lex fmt /tmp/schema_like.lex
reformatted /tmp/schema_like.lex
1 reformatted, 0 unchanged

$ wc -l /tmp/schema_like.lex      # after fmt — docblock preserved
17

$ head -6 /tmp/schema_like.lex
# lex-schema — schema introspection + JSON Schema / OpenAPI export
#
# Pydantic's `Model.schema()` returns a JSON Schema describing the
# request/response contract. Lex doesn't have that yet — this module
# is the start.
```

- [x] `cargo test --workspace --no-fail-fast` — clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.

After merge:
- [ ] Bump lex-schema's pinned toolchain (`.github/workflows/lex.yml` LEX_VERSION) and re-run `lex fmt --check` on its PR #7 — should turn green.

## Out of scope (deliberately)

- **Comments inside fn bodies / type-decl RHS / expressions.** Not in #417's repro and requires attaching trivia to inner nodes — a much larger refactor. Bug-fix scope is what `lex-schema` and similar repos need to adopt `lex ci`.
- **Preserving blank lines between consecutive comments.** Adjacent comments emit contiguously today.

Both are reasonable follow-ups; happy to file them if useful.

https://claude.ai/code/session_01GKdeZw4hJ9SucFMPwBVeNt

---
_Generated by [Claude Code](https://claude.ai/code/session_01GKdeZw4hJ9SucFMPwBVeNt)_