### PR TITLE
fix(net): serve_ws_fn echoes Sec-WebSocket-Protocol on handshake (#421)

### DIFF
--- a/crates/lex-runtime/src/ws.rs
+++ b/crates/lex-runtime/src/ws.rs
@@ -313,11 +313,25 @@ fn handle_connection_fn(
     registry: Arc<ChatRegistry>,
 ) -> Result<(), String> {
     use tungstenite::{accept_hdr, handshake::server::{Request, Response}};
+    use tungstenite::http::HeaderValue;
 
     let mut path = String::new();
     let path_ref = &mut path;
-    let mut ws = accept_hdr(stream, |req: &Request, resp: Response| {
+    let subproto_for_handshake = subprotocol.clone();
+    let mut ws = accept_hdr(stream, |req: &Request, mut resp: Response| {
         *path_ref = req.uri().path().to_string();
+        // Echo the negotiated subprotocol back so strict clients
+        // (RFC 6455 §4.1, tungstenite ≥ 0.20) accept the handshake.
+        // Only echo when the server has a non-empty subprotocol *and*
+        // the client requested one — matches the dial_ws contract
+        // (empty subprotocol → no header on either side).
+        if !subproto_for_handshake.is_empty()
+            && req.headers().get("Sec-WebSocket-Protocol").is_some()
+        {
+            if let Ok(h) = HeaderValue::from_str(&subproto_for_handshake) {
+                resp.headers_mut().insert("Sec-WebSocket-Protocol", h);
+            }
+        }
         Ok(resp)
     }).map_err(|e| format!("ws handshake: {e}"))?;
 

--- a/crates/lex-runtime/src/ws.rs
+++ b/crates/lex-runtime/src/ws.rs
@@ -280,6 +280,20 @@ pub fn serve_ws_fn(
     policy: Policy,
     registry: Arc<ChatRegistry>,
 ) -> Result<Value, String> {
+    // Fail fast: a configured subprotocol that can't be a valid HTTP
+    // header value would silently break every handshake later (the
+    // accept_hdr callback's `HeaderValue::from_str` would always
+    // return Err). Reject at startup with a clear message instead.
+    if !subprotocol.is_empty() {
+        if let Err(e) =
+            tungstenite::http::HeaderValue::from_str(&subprotocol)
+        {
+            return Err(format!(
+                "net.serve_ws_fn: subprotocol {subprotocol:?} is not a valid \
+                 HTTP header value: {e}"
+            ));
+        }
+    }
     let listener = TcpListener::bind(("127.0.0.1", port))
         .map_err(|e| format!("net.serve_ws_fn bind {port}: {e}"))?;
     eprintln!("net.serve_ws_fn: listening on ws://127.0.0.1:{port}");
@@ -322,14 +336,34 @@ fn handle_connection_fn(
         *path_ref = req.uri().path().to_string();
         // Echo the negotiated subprotocol back so strict clients
         // (RFC 6455 §4.1, tungstenite ≥ 0.20) accept the handshake.
-        // Only echo when the server has a non-empty subprotocol *and*
-        // the client requested one — matches the dial_ws contract
-        // (empty subprotocol → no header on either side).
-        if !subproto_for_handshake.is_empty()
-            && req.headers().get("Sec-WebSocket-Protocol").is_some()
-        {
-            if let Ok(h) = HeaderValue::from_str(&subproto_for_handshake) {
-                resp.headers_mut().insert("Sec-WebSocket-Protocol", h);
+        // Only echo when (a) the server has a non-empty subprotocol,
+        // (b) the client offered subprotocols, and (c) the server's
+        // configured value is among the client's offers. RFC 6455
+        // §4.1 mandates the server MUST select one of the client's
+        // offers — echoing a value the client did not offer would
+        // be spec-noncompliant and trip strict clients. The empty
+        // server-side configuration → no echo branch matches the
+        // dial_ws contract (empty subprotocol = no header).
+        if !subproto_for_handshake.is_empty() {
+            if let Some(offered) = req.headers().get("Sec-WebSocket-Protocol") {
+                if let Ok(offered_str) = offered.to_str() {
+                    let client_offers =
+                        offered_str.split(',').map(|p| p.trim());
+                    if client_offers
+                        .clone()
+                        .any(|p| p == subproto_for_handshake)
+                    {
+                        // from_str cannot fail here: serve_ws_fn
+                        // validated `subprotocol` upfront. Belt-and-
+                        // braces: silently skip if it somehow does.
+                        if let Ok(h) =
+                            HeaderValue::from_str(&subproto_for_handshake)
+                        {
+                            resp.headers_mut()
+                                .insert("Sec-WebSocket-Protocol", h);
+                        }
+                    }
+                }
             }
         }
         Ok(resp)

--- a/crates/lex-runtime/tests/net_serve_ws_subprotocol.rs
+++ b/crates/lex-runtime/tests/net_serve_ws_subprotocol.rs
@@ -1,0 +1,111 @@
+//! Regression test for alpibrusl/lex-lang#421.
+//!
+//! `net.serve_ws_fn(port, subprotocol, handler)` must echo the
+//! negotiated `Sec-WebSocket-Protocol` header back in the handshake
+//! response when the client requested a subprotocol — otherwise
+//! strict WS clients (including `net.dial_ws`, and tungstenite ≥
+//! 0.20 generally) reject the handshake with
+//! "SubProtocol error: Server sent no subprotocol", per RFC 6455
+//! §4.1.
+//!
+//! The check_program / VM machinery is identical to ws_chat.rs;
+//! we just need a serve_ws_fn server in a background thread and
+//! a strict client driving the handshake from the test main thread.
+//!
+//! The server thread leaks (serve_ws_fn blocks forever — same
+//! limitation as ws_chat.rs); cargo test reaps it on process exit.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::collections::BTreeSet;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+use tungstenite::client::IntoClientRequest;
+
+fn spawn_serve_ws_fn(src: &str) {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors: {errs:#?}");
+    }
+    let bc = Arc::new(compile_program(&stages));
+    let mut policy = Policy::pure();
+    policy.allow_effects = ["net".to_string()]
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    thread::spawn(move || {
+        let handler = DefaultHandler::new(policy.clone()).with_program(Arc::clone(&bc));
+        let mut vm = Vm::with_handler(&bc, Box::new(handler));
+        let _ = vm.call("main", vec![]);
+    });
+    thread::sleep(Duration::from_millis(300));
+}
+
+fn ws_src_with_subprotocol(port: u16, subprotocol: &str) -> String {
+    format!(
+        r#"
+import "std.net" as net
+
+fn on_message(_c :: WsConn, _m :: WsMessage) -> WsAction {{ WsNoOp }}
+
+fn main() -> [net] Nil {{
+  net.serve_ws_fn({port}, "{subprotocol}", on_message)
+}}
+"#
+    )
+}
+
+#[test]
+fn serve_ws_fn_echoes_subprotocol_to_strict_client() {
+    let port = 19877;
+    spawn_serve_ws_fn(&ws_src_with_subprotocol(port, "ocpp1.6"));
+
+    let url = format!("ws://127.0.0.1:{port}/test");
+    let mut req = url
+        .as_str()
+        .into_client_request()
+        .expect("build client request");
+    req.headers_mut().insert(
+        "Sec-WebSocket-Protocol",
+        tungstenite::http::HeaderValue::from_static("ocpp1.6"),
+    );
+
+    let (mut ws, resp) =
+        tungstenite::connect(req).expect("ws handshake (regression #421)");
+
+    let echoed = resp
+        .headers()
+        .get("Sec-WebSocket-Protocol")
+        .expect("server must echo Sec-WebSocket-Protocol");
+    assert_eq!(
+        echoed.to_str().unwrap(),
+        "ocpp1.6",
+        "echoed subprotocol must match the server's configuration"
+    );
+
+    let _ = ws.close(None);
+}
+
+#[test]
+fn serve_ws_fn_omits_subprotocol_header_when_server_subprotocol_is_empty() {
+    // Symmetric case: when the server is configured with "" and the
+    // client asks for nothing either, no Sec-WebSocket-Protocol
+    // header should appear in the response. (Tests the negative
+    // branch of the echo condition.)
+    let port = 19878;
+    spawn_serve_ws_fn(&ws_src_with_subprotocol(port, ""));
+
+    let url = format!("ws://127.0.0.1:{port}/test");
+    let (mut ws, resp) =
+        tungstenite::connect(url.as_str()).expect("ws handshake");
+
+    assert!(
+        resp.headers().get("Sec-WebSocket-Protocol").is_none(),
+        "no echo when subprotocol negotiation isn't in play"
+    );
+
+    let _ = ws.close(None);
+}

--- a/crates/lex-runtime/tests/net_serve_ws_subprotocol.rs
+++ b/crates/lex-runtime/tests/net_serve_ws_subprotocol.rs
@@ -20,10 +20,25 @@ use lex_bytecode::{compile_program, vm::Vm};
 use lex_runtime::{DefaultHandler, Policy};
 use lex_syntax::parse_source;
 use std::collections::BTreeSet;
+use std::net::TcpListener;
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 use tungstenite::client::IntoClientRequest;
+
+/// Reserve a free port via a kernel-assigned bind then immediately
+/// release it, returning the port for the Lex server to claim. There
+/// is a tiny TOCTOU window between drop and the Lex bind, but in
+/// practice the kernel doesn't re-issue the port that quickly to an
+/// unrelated process on the same machine. Beats hardcoding magic
+/// numbers that collide on busy CI runners.
+fn free_port() -> u16 {
+    let listener =
+        TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let port = listener.local_addr().expect("local_addr").port();
+    drop(listener);
+    port
+}
 
 fn spawn_serve_ws_fn(src: &str) {
     let prog = parse_source(src).expect("parse");
@@ -60,7 +75,7 @@ fn main() -> [net] Nil {{
 
 #[test]
 fn serve_ws_fn_echoes_subprotocol_to_strict_client() {
-    let port = 19877;
+    let port = free_port();
     spawn_serve_ws_fn(&ws_src_with_subprotocol(port, "ocpp1.6"));
 
     let url = format!("ws://127.0.0.1:{port}/test");
@@ -95,7 +110,7 @@ fn serve_ws_fn_omits_subprotocol_header_when_server_subprotocol_is_empty() {
     // client asks for nothing either, no Sec-WebSocket-Protocol
     // header should appear in the response. (Tests the negative
     // branch of the echo condition.)
-    let port = 19878;
+    let port = free_port();
     spawn_serve_ws_fn(&ws_src_with_subprotocol(port, ""));
 
     let url = format!("ws://127.0.0.1:{port}/test");
@@ -108,4 +123,113 @@ fn serve_ws_fn_omits_subprotocol_header_when_server_subprotocol_is_empty() {
     );
 
     let _ = ws.close(None);
+}
+
+#[test]
+fn serve_ws_fn_does_not_echo_when_client_offers_different_subprotocol() {
+    // RFC 6455 §4.1: the server MUST select one of the subprotocols
+    // the client offered. If the server is configured for `ocpp1.6`
+    // but the client offers only `mqtt`, the server must NOT echo
+    // `ocpp1.6` — it would be advertising a subprotocol the client
+    // didn't propose. The handshake itself can still succeed (a
+    // strict client may then reject it on its own end); the server's
+    // job here is just to be RFC-compliant about what it advertises.
+    let port = free_port();
+    spawn_serve_ws_fn(&ws_src_with_subprotocol(port, "ocpp1.6"));
+
+    let url = format!("ws://127.0.0.1:{port}/test");
+    let mut req = url
+        .as_str()
+        .into_client_request()
+        .expect("build client request");
+    req.headers_mut().insert(
+        "Sec-WebSocket-Protocol",
+        tungstenite::http::HeaderValue::from_static("mqtt"),
+    );
+
+    // The handshake may succeed or fail depending on how strict the
+    // client is about an empty subprotocol-response; what we care
+    // about is the response header value (or absence of it).
+    match tungstenite::connect(req) {
+        Ok((mut ws, resp)) => {
+            assert!(
+                resp.headers().get("Sec-WebSocket-Protocol").is_none(),
+                "server must not echo a subprotocol the client didn't offer"
+            );
+            let _ = ws.close(None);
+        }
+        Err(_) => {
+            // Strict client rejected the empty echo — acceptable;
+            // the server-side behaviour is still RFC-compliant.
+        }
+    }
+}
+
+#[test]
+fn serve_ws_fn_picks_server_value_from_client_multi_offer() {
+    // Client offers a comma-separated list `ocpp1.6, ocpp2.0.1`,
+    // server configured for `ocpp1.6` → echo `ocpp1.6` (server's
+    // chosen value among the offered ones). This pins the matcher
+    // against the realistic OCPP-with-future-version scenario.
+    let port = free_port();
+    spawn_serve_ws_fn(&ws_src_with_subprotocol(port, "ocpp1.6"));
+
+    let url = format!("ws://127.0.0.1:{port}/test");
+    let mut req = url
+        .as_str()
+        .into_client_request()
+        .expect("build client request");
+    req.headers_mut().insert(
+        "Sec-WebSocket-Protocol",
+        tungstenite::http::HeaderValue::from_static("ocpp1.6, ocpp2.0.1"),
+    );
+
+    let (mut ws, resp) =
+        tungstenite::connect(req).expect("ws handshake");
+    let echoed = resp
+        .headers()
+        .get("Sec-WebSocket-Protocol")
+        .expect("server must echo when its value is in the offered list");
+    assert_eq!(echoed.to_str().unwrap(), "ocpp1.6");
+    let _ = ws.close(None);
+}
+
+#[test]
+fn serve_ws_fn_rejects_invalid_subprotocol_at_startup() {
+    // An invalid subprotocol value (one that can't form a valid HTTP
+    // header — e.g. one containing newlines) used to silently drop
+    // the Sec-WebSocket-Protocol header at every handshake, leaving
+    // a hard-to-diagnose runtime failure. serve_ws_fn now validates
+    // at startup and returns Err immediately. We invoke the runtime
+    // function directly here because the lex-syntax string literal
+    // wouldn't allow an embedded `\r\n` without escaping anyway.
+    use indexmap::IndexMap;
+    use lex_bytecode::{Program, Value};
+    use lex_runtime::ws::{serve_ws_fn, ChatRegistry};
+
+    let program = Arc::new(Program {
+        constants: vec![],
+        functions: vec![],
+        function_names: IndexMap::new(),
+        module_aliases: IndexMap::new(),
+        entry: None,
+    });
+    let policy = Policy::pure();
+    let registry = Arc::new(ChatRegistry::default());
+    // A closure-shaped Value::Unit stands in for the handler; the
+    // function never gets that far because the subprotocol check
+    // happens first.
+    let result = serve_ws_fn(
+        0,
+        "ocpp\r\nX-Injected: yes".to_string(),
+        Value::Unit,
+        program,
+        policy,
+        registry,
+    );
+    let err = result.expect_err("invalid subprotocol must reject at startup");
+    assert!(
+        err.contains("not a valid HTTP header value"),
+        "unexpected error message: {err}"
+    );
 }


### PR DESCRIPTION
Closes #421.

## The bug

`net.serve_ws_fn(port, subprotocol, handler)` configured with a non-empty subprotocol (e.g. `"ocpp1.6"`) never echoes `Sec-WebSocket-Protocol` back in the handshake response. Strict clients — including this repo's own `net.dial_ws` (via tungstenite 0.29) — reject the connection per RFC 6455 §4.1:

```
net.dial_ws: connect to `ws://localhost:9000/...`:
  WebSocket protocol error: SubProtocol error: Server sent no subprotocol
```

In `crates/lex-runtime/src/ws.rs:319-322` the `accept_hdr` callback captured the request path but returned the response unchanged:

```rust
let mut ws = accept_hdr(stream, |req: &Request, resp: Response| {
    *path_ref = req.uri().path().to_string();
    Ok(resp)          // ← never echoes Sec-WebSocket-Protocol
}).map_err(|e| format!("ws handshake: {e}"))?;
```

The test helper at `crates/lex-runtime/tests/net_dial_ws.rs:217-228` *already implements the correct pattern* with the comment *"Echo back so tungstenite considers the negotiation valid"* — the fix just was never carried over to production.

## Why Python-client smoke tests didn't catch it

Python's `websockets` library tolerates a missing subprotocol echo. That's why mobilityhouse/ocpp-style chargers appear to interoperate with `serve_ws_fn` — but Lex's own `dial_ws` (correctly) doesn't.

## The fix

`crates/lex-runtime/src/ws.rs` — echo the configured `subprotocol` when the server has a non-empty value AND the client requested one. Empty server-side or empty client request → no echo (matches the `dial_ws` contract documented at line 463).

```rust
let subproto_for_handshake = subprotocol.clone();
let mut ws = accept_hdr(stream, |req: &Request, mut resp: Response| {
    *path_ref = req.uri().path().to_string();
    if !subproto_for_handshake.is_empty()
        && req.headers().get("Sec-WebSocket-Protocol").is_some()
    {
        if let Ok(h) = HeaderValue::from_str(&subproto_for_handshake) {
            resp.headers_mut().insert("Sec-WebSocket-Protocol", h);
        }
    }
    Ok(resp)
}).map_err(|e| format!("ws handshake: {e}"))?;
```

## Tests

New integration test file `crates/lex-runtime/tests/net_serve_ws_subprotocol.rs`:

- **`serve_ws_fn_echoes_subprotocol_to_strict_client`** — spawns `net.serve_ws_fn(port, "ocpp1.6", _)` in a thread, connects from the test main thread with tungstenite as a strict client requesting subprotocol `ocpp1.6`, asserts the handshake completes AND the response carries `Sec-WebSocket-Protocol: ocpp1.6`. **Confirmed fails on unpatched main with `SecWebSocketSubProtocolError(NoSubProtocol)`**, passes with the fix.
- **`serve_ws_fn_omits_subprotocol_header_when_server_subprotocol_is_empty`** — symmetric: server configured with `""`, client requests nothing, response carries no echo. Guards the negative branch.

Both tests pass; the existing `net_dial_ws` suite continues to pass.

## End-to-end verification (alpibrusl/lex-ocpp simulator)

With the new `lex` binary installed, the `cp_simulator_v16.lex` + `csms_v16.lex` pair in alpibrusl/lex-ocpp now completes a full charging session over the OCPP-standard `Sec-WebSocket-Protocol: ocpp1.6` handshake:

```
=== cp_simulator_v16 → ws://localhost:9000/ocpp/SIM-CP-001
    subprotocol: ocpp1.6
→ open: sending BootNotification
← [3,"boot",{"currentTime":"2026-05-13T12:00:00Z","interval":300,"status":"Accepted"}]
→ StatusNotification(Available): ...
← [3,"status:init",{}]
→ Authorize: ...
← [3,"auth",{"idTagInfo":{"status":"Accepted"}}]
→ StartTransaction: ...
← [3,"start",{"transactionId":42,"idTagInfo":{"status":"Accepted"}}]
→ MeterValues: [2,"meter:tx42", ...]
← [3,"meter:tx42",{}]
→ Heartbeat: ...
← [3,"heartbeat:tx42", ...]
→ StopTransaction: [2,"stop:tx42",{"transactionId":42, ...}]
← [3,"stop:tx42",{"idTagInfo":{"status":"Accepted"}}]
→ StatusNotification(Available): ...
← [3,"status:final",{}]
=== session complete; idling (Ctrl-C to exit) ===
```

On unpatched main the same pair fails at the first `dial_ws` call:

```
dial failed: net.dial_ws: connect to `ws://localhost:9000/ocpp/SIM-CP-001`:
  WebSocket protocol error: SubProtocol error: Server sent no subprotocol
```

## Test plan

- [x] `cargo test -p lex-runtime --test net_serve_ws_subprotocol` — 2 passed
- [x] `cargo test -p lex-runtime --test net_dial_ws` — 4 passed (no regression)
- [x] Confirmed regression test fails without the fix (`SecWebSocketSubProtocolError(NoSubProtocol)`)
- [x] End-to-end OCPP 1.6J session against alpibrusl/lex-ocpp's simulator
- [ ] Re-run `cargo test -p lex-runtime` (full suite) once CI picks it up

---
_Generated by [Claude Code](https://claude.ai/code/session_014E7dNfuxQNfGn6SXgDFDmw)_