### PR TITLE
feat(lex-api): tenant-scoped State + handle_with_auth hook

### DIFF
--- a/crates/lex-api/src/handlers.rs
+++ b/crates/lex-api/src/handlers.rs
@@ -55,6 +55,13 @@ impl State {
             sessions: Mutex::new(HashMap::new()),
         })
     }
+
+    /// Construct a per-tenant `State` by prefixing `store_root` with the
+    /// tenant id. Single-tenant `lex serve` is unaffected — it calls
+    /// `State::open` directly.
+    pub fn new_with_tenant(tenant_id: &str, store_root: PathBuf) -> anyhow::Result<Self> {
+        Self::open(store_root.join(tenant_id))
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -154,6 +161,26 @@ pub fn handle(state: Arc<State>, mut req: Request) -> std::io::Result<()> {
 
     let resp = route(&state, &method, &path, &query, &body, x_lex_user.as_deref());
     req.respond(resp)
+}
+
+/// Auth-gated entry point. Calls `auth(path, headers)` before routing;
+/// returns 401 JSON when it returns false. Keeps auth logic out of the
+/// product-agnostic core.
+pub fn handle_with_auth<F>(state: Arc<State>, req: Request, auth: F) -> std::io::Result<()>
+where
+    F: FnOnce(&str, &[Header]) -> bool,
+{
+    let path = req.url().split('?').next().unwrap_or("").to_string();
+    if !auth(&path, req.headers()) {
+        return req.respond(
+            Response::from_data(br#"{"error":"unauthorized"}"#.to_vec())
+                .with_status_code(401)
+                .with_header(
+                    Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..]).unwrap(),
+                ),
+        );
+    }
+    handle(state, req)
 }
 
 fn route(
@@ -1323,4 +1350,5 @@ pub(crate) fn attestations_since_handler(state: &State, query: &str)
 
     json_response(200, &serde_json::to_value(&filtered).unwrap_or_default())
 }
+
 

--- a/crates/lex-api/src/handlers.rs
+++ b/crates/lex-api/src/handlers.rs
@@ -59,9 +59,34 @@ impl State {
     /// Construct a per-tenant `State` by prefixing `store_root` with the
     /// tenant id. Single-tenant `lex serve` is unaffected — it calls
     /// `State::open` directly.
+    ///
+    /// `tenant_id` is restricted to `[A-Za-z0-9_-]{1,64}`: anything else
+    /// (path separators, `..`, NUL, absolute paths, dotfiles, empty
+    /// string) is rejected before touching the filesystem. Without this
+    /// `PathBuf::join("/etc")` would silently replace `store_root`, and
+    /// `PathBuf::join("../foo")` would escape the tenant root.
     pub fn new_with_tenant(tenant_id: &str, store_root: PathBuf) -> anyhow::Result<Self> {
+        validate_tenant_id(tenant_id)?;
         Self::open(store_root.join(tenant_id))
     }
+}
+
+fn validate_tenant_id(tenant_id: &str) -> anyhow::Result<()> {
+    if tenant_id.is_empty() {
+        anyhow::bail!("tenant_id must not be empty");
+    }
+    if tenant_id.len() > 64 {
+        anyhow::bail!("tenant_id must be at most 64 bytes");
+    }
+    if !tenant_id
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
+    {
+        anyhow::bail!(
+            "tenant_id {tenant_id:?} contains characters outside [A-Za-z0-9_-]"
+        );
+    }
+    Ok(())
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1350,5 +1375,3 @@ pub(crate) fn attestations_since_handler(state: &State, query: &str)
 
     json_response(200, &serde_json::to_value(&filtered).unwrap_or_default())
 }
-
-

--- a/crates/lex-api/tests/tenant_and_auth.rs
+++ b/crates/lex-api/tests/tenant_and_auth.rs
@@ -1,0 +1,184 @@
+//! Tests for the multi-tenant `State::new_with_tenant` constructor and
+//! the `handle_with_auth` pre-routing hook added in PR #429.
+
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpStream};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
+};
+use std::thread;
+use std::time::Duration;
+
+use lex_api::handlers::{handle_with_auth, State};
+use tempfile::TempDir;
+
+// ---------- State::new_with_tenant ----------
+
+#[test]
+fn new_with_tenant_opens_under_prefix() {
+    let tmp = TempDir::new().unwrap();
+    let _state =
+        State::new_with_tenant("acme", tmp.path().to_path_buf()).expect("valid tenant id");
+    // Store::open creates `<root>/stages` and `<root>/traces`, so the
+    // tenant root must exist after a successful open.
+    assert!(
+        tmp.path().join("acme/stages").is_dir(),
+        "tenant store should be initialised at <store_root>/<tenant_id>/"
+    );
+    assert!(
+        !tmp.path().join("stages").exists(),
+        "store root should not be polluted at the parent level"
+    );
+}
+
+#[test]
+fn new_with_tenant_isolates_two_tenants() {
+    let tmp = TempDir::new().unwrap();
+    let _a = State::new_with_tenant("alpha", tmp.path().to_path_buf()).unwrap();
+    let _b = State::new_with_tenant("beta", tmp.path().to_path_buf()).unwrap();
+    assert!(tmp.path().join("alpha/stages").is_dir());
+    assert!(tmp.path().join("beta/stages").is_dir());
+}
+
+#[test]
+fn new_with_tenant_rejects_unsafe_ids() {
+    let tmp = TempDir::new().unwrap();
+    // Each of these would break tenant isolation if accepted:
+    //   ""        — empty rejects before fs op
+    //   ".."      — PathBuf::join("..") escapes one level up
+    //   "../foo"  — same, with payload
+    //   "/etc"    — PathBuf::join("/etc") replaces the root entirely
+    //   "foo/bar" — nested traversal under another tenant
+    //   "foo\\bar"— Windows-style separator
+    //   "."       — dotfile / current-dir hazard
+    //   ".hidden" — leading dot
+    //   "a\0b"    — embedded NUL
+    let bad = [
+        "",
+        "..",
+        "../foo",
+        "/etc",
+        "foo/bar",
+        "foo\\bar",
+        ".",
+        ".hidden",
+        "a\0b",
+    ];
+    for id in &bad {
+        let r = State::new_with_tenant(id, tmp.path().to_path_buf());
+        assert!(r.is_err(), "tenant_id {id:?} should be rejected");
+    }
+    // Length cap: 65 ASCII chars must fail, 64 must pass.
+    let too_long = "a".repeat(65);
+    assert!(State::new_with_tenant(&too_long, tmp.path().to_path_buf()).is_err());
+    let at_limit = "a".repeat(64);
+    assert!(State::new_with_tenant(&at_limit, tmp.path().to_path_buf()).is_ok());
+}
+
+// ---------- handle_with_auth ----------
+
+fn http(addr: &SocketAddr, path: &str, header: Option<(&str, &str)>) -> (u16, String) {
+    let mut s = TcpStream::connect(addr).unwrap();
+    s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    let extra = match header {
+        Some((k, v)) => format!("{k}: {v}\r\n"),
+        None => String::new(),
+    };
+    let req = format!(
+        "GET {path} HTTP/1.1\r\nHost: 127.0.0.1\r\n{extra}Connection: close\r\n\r\n"
+    );
+    s.write_all(req.as_bytes()).unwrap();
+    let mut buf = String::new();
+    s.read_to_string(&mut buf).unwrap();
+    let (head, body) = buf.split_once("\r\n\r\n").unwrap_or((&buf, ""));
+    let status = head
+        .split_whitespace()
+        .nth(1)
+        .unwrap_or("0")
+        .parse()
+        .unwrap_or(0);
+    (status, body.to_string())
+}
+
+struct AuthServer {
+    addr: SocketAddr,
+    stop: Arc<AtomicBool>,
+    seen: Arc<Mutex<Vec<(String, bool)>>>,
+}
+
+/// Spin up a tiny_http server whose request loop calls `handle_with_auth`
+/// with a closure that returns `true` iff the request carries a header
+/// matching `expected_token`. Records the (path, auth_outcome) pair for
+/// each request so the test can assert pass-through vs 401.
+fn start_auth_server(expected_token: &'static str) -> AuthServer {
+    let tmp = TempDir::new().unwrap();
+    let server = tiny_http::Server::http(("127.0.0.1", 0)).unwrap();
+    let addr = match server.server_addr() {
+        tiny_http::ListenAddr::IP(a) => a,
+        _ => panic!("expected IP listener"),
+    };
+    let state = Arc::new(State::open(tmp.path().to_path_buf()).unwrap());
+    let stop = Arc::new(AtomicBool::new(false));
+    let seen: Arc<Mutex<Vec<(String, bool)>>> = Arc::new(Mutex::new(Vec::new()));
+    let stop_for_thread = Arc::clone(&stop);
+    let seen_for_thread = Arc::clone(&seen);
+    // Hold tmp alive until the server stops, by capturing it in the thread.
+    thread::spawn(move || {
+        let _hold = tmp;
+        for request in server.incoming_requests() {
+            if stop_for_thread.load(Ordering::Relaxed) {
+                break;
+            }
+            let state = Arc::clone(&state);
+            let seen = Arc::clone(&seen_for_thread);
+            let _ = handle_with_auth(state, request, move |path, headers| {
+                let ok = headers
+                    .iter()
+                    .any(|h| h.field.as_str().as_str() == "X-Auth"
+                        && h.value.as_str() == expected_token);
+                seen.lock().unwrap().push((path.to_string(), ok));
+                ok
+            });
+        }
+    });
+    thread::sleep(Duration::from_millis(20));
+    AuthServer { addr, stop, seen }
+}
+
+#[test]
+fn handle_with_auth_returns_401_without_token() {
+    let srv = start_auth_server("secret");
+    let (status, body) = http(&srv.addr, "/v1/health", None);
+    assert_eq!(status, 401, "missing token should 401");
+    assert!(
+        body.contains("\"error\":\"unauthorized\""),
+        "401 body shape: {body:?}"
+    );
+    let seen = srv.seen.lock().unwrap();
+    assert_eq!(seen.len(), 1);
+    assert_eq!(seen[0].0, "/v1/health");
+    assert!(!seen[0].1, "auth closure should have returned false");
+    srv.stop.store(true, Ordering::Relaxed);
+}
+
+#[test]
+fn handle_with_auth_passes_through_with_token() {
+    let srv = start_auth_server("secret");
+    let (status, body) = http(&srv.addr, "/v1/health", Some(("X-Auth", "secret")));
+    assert_eq!(status, 200, "valid token should pass through, got: {body}");
+    assert!(body.contains("\"ok\":true"), "health body: {body:?}");
+    let seen = srv.seen.lock().unwrap();
+    assert_eq!(seen.len(), 1);
+    assert!(seen[0].1);
+    srv.stop.store(true, Ordering::Relaxed);
+}
+
+#[test]
+fn handle_with_auth_strips_query_string_before_auth() {
+    let srv = start_auth_server("secret");
+    let (_status, _body) = http(&srv.addr, "/v1/health?token=oops", None);
+    let seen = srv.seen.lock().unwrap();
+    assert_eq!(seen[0].0, "/v1/health", "auth path should not include query string");
+    srv.stop.store(true, Ordering::Relaxed);
+}


### PR DESCRIPTION
## Summary

- `State::new_with_tenant(tenant_id, store_root)` — prefixes the on-disk store path with the tenant id. `lex serve` single-tenant path (`State::open`) is unchanged.
- `handle_with_auth(state, req, auth)` — pre-routing auth hook with signature `FnOnce(&str, &[Header]) -> bool`. Returns 401 JSON when the closure returns false; otherwise delegates to `handle`. Mirrors the `serve_ws_fn_auth` pattern already in lex-lang.

## Why this order

lex-hub's scaffold ([lex-hub#2](https://github.com/alpibrusl/lex-hub/pull/2)) exposed these two gaps immediately — `handle` had no auth seam and `State` had no tenant-prefix path. Both fixes are small and product-agnostic.

## Test plan

- [ ] `cargo build --workspace --all-targets` green
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] `cargo test --workspace --no-fail-fast` green
- [ ] `State::new_with_tenant("acme", store_root)` opens store at `store_root/acme/`
- [ ] `handle_with_auth` returns 401 when closure returns false; routes normally when it returns true

---
_Generated by [Claude Code](https://claude.ai/code/session_018BnD57wxbG347bm2WCotsE)_