### PR TITLE
release: cut 0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+## [0.9.4] — 2026-05-15
+
 ### Added
 
 - **#427: `std.df` — Polars-backed query ops over `arrow.Table`.** The
@@ -118,6 +120,19 @@ bumps may carry breaking changes when justified).
   VM so it has full access to all effects (`sql`, `net`, `kv`, …). Requires
   the `[concurrent]` effect on any function that spawns or messages an actor.
   New import: `import "std.conc" as conc`.
+
+- **lex-api: `State::new_with_tenant` + `handle_with_auth` pre-routing hook.**
+  Two product-agnostic seams in support of multi-tenant hosts (lex-hub).
+  `State::new_with_tenant(tenant_id, store_root)` opens the store at
+  `<store_root>/<tenant_id>/`; tenant ids are restricted to
+  `[A-Za-z0-9_-]{1,64}`, so path-traversal payloads (`../foo`, absolute
+  `/etc`, embedded NUL, leading `.`) are rejected before they touch the
+  filesystem. `handle_with_auth(state, req, auth)` invokes a
+  `FnOnce(&str, &[Header]) -> bool` closure with the request path (query
+  string stripped) and headers before any routing; on `false` it returns
+  `401 {"error":"unauthorized"}` with `Content-Type: application/json`.
+  Single-tenant `lex serve` and the existing `handle` entry-point are
+  unaffected.
 
 ### Performance
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.9.3"
+version = "0.9.4"
 edition = "2021"
 license = "EUPL-1.2"
 repository = "https://github.com/alpibrusl/lex-lang"

--- a/crates/lex-api/Cargo.toml
+++ b/crates/lex-api/Cargo.toml
@@ -16,14 +16,14 @@ serde_json.workspace = true
 anyhow.workspace = true
 indexmap.workspace = true
 tiny_http = "0.12"
-lex-syntax = { path = "../lex-syntax", version = "0.9.3" }
-lex-ast = { path = "../lex-ast", version = "0.9.3" }
-lex-types = { path = "../lex-types", version = "0.9.3" }
-lex-bytecode = { path = "../lex-bytecode", version = "0.9.3" }
-lex-runtime = { path = "../lex-runtime", version = "0.9.3" }
-lex-store = { path = "../lex-store", version = "0.9.3" }
-lex-trace = { path = "../lex-trace", version = "0.9.3" }
-lex-vcs = { path = "../lex-vcs", version = "0.9.3" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.4" }
+lex-ast = { path = "../lex-ast", version = "0.9.4" }
+lex-types = { path = "../lex-types", version = "0.9.4" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.9.4" }
+lex-runtime = { path = "../lex-runtime", version = "0.9.4" }
+lex-store = { path = "../lex-store", version = "0.9.4" }
+lex-trace = { path = "../lex-trace", version = "0.9.4" }
+lex-vcs = { path = "../lex-vcs", version = "0.9.4" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/lex-ast/Cargo.toml
+++ b/crates/lex-ast/Cargo.toml
@@ -16,4 +16,4 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-syntax = { path = "../lex-syntax", version = "0.9.3" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.4" }

--- a/crates/lex-bytecode/Cargo.toml
+++ b/crates/lex-bytecode/Cargo.toml
@@ -19,8 +19,8 @@ indexmap.workspace = true
 sha2.workspace = true
 arrow-array = "55"
 arrow-schema = "55"
-lex-ast = { path = "../lex-ast", version = "0.9.3" }
-lex-types = { path = "../lex-types", version = "0.9.3" }
+lex-ast = { path = "../lex-ast", version = "0.9.4" }
+lex-types = { path = "../lex-types", version = "0.9.4" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.9.3" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.4" }

--- a/crates/lex-lsp/Cargo.toml
+++ b/crates/lex-lsp/Cargo.toml
@@ -25,12 +25,12 @@ serde_json.workspace = true
 # are rust-analyzer-team-maintained.
 lsp-server = "0.7"
 lsp-types = "0.97"
-lex-syntax = { path = "../lex-syntax", version = "0.9.3" }
-lex-ast = { path = "../lex-ast", version = "0.9.3" }
-lex-types = { path = "../lex-types", version = "0.9.3" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.4" }
+lex-ast = { path = "../lex-ast", version = "0.9.4" }
+lex-types = { path = "../lex-types", version = "0.9.4" }
 # Phase 4 of #304: surface RepairHint attestations from the store.
-lex-vcs = { path = "../lex-vcs", version = "0.9.3" }
-lex-store = { path = "../lex-store", version = "0.9.3" }
+lex-vcs = { path = "../lex-vcs", version = "0.9.4" }
+lex-store = { path = "../lex-store", version = "0.9.4" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -54,11 +54,11 @@ arrow-arith = "55"
 arrow-cast = "55"
 arrow-csv = "55"
 polars = { version = "0.50", default-features = false, features = ["lazy", "is_in", "csv", "performant", "strings"] }
-lex-bytecode = { path = "../lex-bytecode", version = "0.9.3" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.9.4" }
 smol_str = { workspace = true }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.9.3" }
-lex-ast = { path = "../lex-ast", version = "0.9.3" }
-lex-types = { path = "../lex-types", version = "0.9.3" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.4" }
+lex-ast = { path = "../lex-ast", version = "0.9.4" }
+lex-types = { path = "../lex-types", version = "0.9.4" }
 tempfile = "3"

--- a/crates/lex-search/Cargo.toml
+++ b/crates/lex-search/Cargo.toml
@@ -17,10 +17,10 @@ thiserror.workspace = true
 sha2.workspace = true
 hex.workspace = true
 ureq = { version = "3.3", default-features = false, features = ["rustls", "platform-verifier", "json"] }
-lex-ast = { path = "../lex-ast", version = "0.9.3" }
-lex-store = { path = "../lex-store", version = "0.9.3" }
+lex-ast = { path = "../lex-ast", version = "0.9.4" }
+lex-store = { path = "../lex-store", version = "0.9.4" }
 
 [dev-dependencies]
 tempfile = "3"
 tiny_http = "0.12"
-lex-syntax = { path = "../lex-syntax", version = "0.9.3" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.4" }

--- a/crates/lex-store/Cargo.toml
+++ b/crates/lex-store/Cargo.toml
@@ -21,11 +21,11 @@ hex.workspace = true
 # transitive dep via tempfile; promoting to direct so the lock
 # call sites compile.
 fs2 = "0.4"
-lex-ast = { path = "../lex-ast", version = "0.9.3" }
-lex-trace = { path = "../lex-trace", version = "0.9.3" }
-lex-types = { path = "../lex-types", version = "0.9.3" }
-lex-vcs = { path = "../lex-vcs", version = "0.9.3" }
+lex-ast = { path = "../lex-ast", version = "0.9.4" }
+lex-trace = { path = "../lex-trace", version = "0.9.4" }
+lex-types = { path = "../lex-types", version = "0.9.4" }
+lex-vcs = { path = "../lex-vcs", version = "0.9.4" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.9.3" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.4" }
 tempfile = "3"

--- a/crates/lex-trace/Cargo.toml
+++ b/crates/lex-trace/Cargo.toml
@@ -16,9 +16,9 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-bytecode = { path = "../lex-bytecode", version = "0.9.3" }
-lex-ast = { path = "../lex-ast", version = "0.9.3" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.9.4" }
+lex-ast = { path = "../lex-ast", version = "0.9.4" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.9.3" }
-lex-runtime = { path = "../lex-runtime", version = "0.9.3" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.4" }
+lex-runtime = { path = "../lex-runtime", version = "0.9.4" }

--- a/crates/lex-types/Cargo.toml
+++ b/crates/lex-types/Cargo.toml
@@ -15,7 +15,7 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-ast = { path = "../lex-ast", version = "0.9.3" }
+lex-ast = { path = "../lex-ast", version = "0.9.4" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.9.3" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.4" }

--- a/crates/lex-vcs/Cargo.toml
+++ b/crates/lex-vcs/Cargo.toml
@@ -11,8 +11,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-lex-ast = { path = "../lex-ast", version = "0.9.3" }
-lex-types = { path = "../lex-types", version = "0.9.3" }
+lex-ast = { path = "../lex-ast", version = "0.9.4" }
+lex-types = { path = "../lex-types", version = "0.9.4" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
@@ -24,4 +24,4 @@ hex.workspace = true
 
 [dev-dependencies]
 tempfile = "3"
-lex-syntax = { path = "../lex-syntax", version = "0.9.3" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.4" }

--- a/crates/spec-checker/Cargo.toml
+++ b/crates/spec-checker/Cargo.toml
@@ -16,11 +16,11 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-syntax = { path = "../lex-syntax", version = "0.9.3" }
-lex-ast = { path = "../lex-ast", version = "0.9.3" }
-lex-types = { path = "../lex-types", version = "0.9.3" }
-lex-bytecode = { path = "../lex-bytecode", version = "0.9.3" }
-lex-runtime = { path = "../lex-runtime", version = "0.9.3" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.4" }
+lex-ast = { path = "../lex-ast", version = "0.9.4" }
+lex-types = { path = "../lex-types", version = "0.9.4" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.9.4" }
+lex-runtime = { path = "../lex-runtime", version = "0.9.4" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.9.3" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.4" }


### PR DESCRIPTION
## Summary

Cuts the **0.9.4** release. Workspace version bumped from 0.9.3 → 0.9.4 in `Cargo.toml`; all 11 path-dep pins in `crates/*/Cargo.toml` bumped in lockstep. CHANGELOG's `[Unreleased]` section renamed to `[0.9.4] — 2026-05-15` with one new entry added under `Added` for the lex-api work that landed in #429.

## Headlines of 0.9.4

- **#426 / #427**: `std.arrow` (Arrow tables as first-class `Value`, pure column kernels, `arrow.read_csv`) and `std.df` (Polars-backed `filter` / `sort` / `group_by_agg` / `inner_join` / `left_join`). On CSV-fed workloads lex is now within 5–10% of pandas at 100k rows and **1.2× faster than pandas at 1M rows** for the same ops.
- **#381**: `std.conc` — synchronous actor model (`conc.spawn` / `conc.ask` / `conc.tell`).
- **lex-api**: `State::new_with_tenant` + `handle_with_auth` (PR #429). Tenant ids validated against `[A-Za-z0-9_-]{1,64}` so path-traversal payloads (`../foo`, `/etc`, NUL) can't reach the filesystem.
- **#389 slices 2-3**: VM `GetField` inline cache + per-call locals arena.
- **#405**: `list.cons` O(n²) → O(n) via `VecDeque`-backed `Value::List`.

## Test plan

- [ ] `cargo build --workspace` green at 0.9.4
- [ ] `cargo test --workspace` green
- [ ] Tag `v0.9.4` once merged (or whatever tag convention the project adopts — currently no tags exist on the repo)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCds41GPd1VFDPr1KxvZ3v)_