### PR TITLE
perf(net): LEX_NET_INLINE_VM — skip spawn_blocking on net.serve_fn (#431, +33% on plaintext)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,22 @@ bumps may carry breaking changes when justified).
 
 ### Performance
 
+- **#431 (experimental): `LEX_NET_INLINE_VM=1` — skip `spawn_blocking`
+  on `net.serve` / `net.serve_fn`.** Per-request VM call runs directly on
+  the tokio worker instead of being dispatched to the blocking pool.
+  Measured on lex-web's TechEmpower-style bench (2-core `taskset`,
+  hyper 1.x + tokio default scheduler, 3 routes registered): **+33 % on
+  `/plaintext` (6 849 → 9 118 req/s), +28 % on `/json`, +17 % on routed
+  `/users/:id`.** Variance also tightens — baseline trials spread 25 %,
+  inline-vm trials spread 3 %.
+
+  **Tradeoff:** if a Lex handler does heavy CPU work (>1 ms of
+  bytecode) it now stalls the tokio worker it's on. For
+  microsecond-scale handlers (the common case for `net.serve_fn` apps)
+  this is the right tradeoff; for any handler doing real compute or
+  sync I/O, leave the flag unset and pay the `spawn_blocking` cost.
+  The default behaviour is unchanged unless the env var is set.
+
 - **#389 (slice 3): VM locals — stack-allocator arena.** Replaced the
   per-call-frame `Vec<Value>` for function locals with a shared slab
   (`Vm::locals_storage: Vec<Value>`) that acts as a stack allocator. Each

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -1587,6 +1587,12 @@ fn serve_http(
 /// Hyper 1.x + Tokio multi-thread HTTP/1.1 server for `net.serve`.
 /// Each connection is accepted in an async task; the synchronous Lex VM
 /// call runs inside `spawn_blocking` so it doesn't block the executor.
+///
+/// `LEX_NET_INLINE_VM=1` (or `=true`) skips the `spawn_blocking` hop and
+/// runs the VM directly on the tokio worker. Faster for handlers that
+/// return in tens of microseconds; pathological if handlers do real
+/// CPU/blocking work, since they stall the worker. Experimental — see
+/// lex-lang issue #431.
 fn serve_http_plain(
     port: u16,
     handler_name: String,
@@ -1599,6 +1605,7 @@ fn serve_http_plain(
     use hyper_util::rt::TokioIo;
     use tokio::net::TcpListener as TokioTcpListener;
 
+    let inline_vm = env_inline_vm();
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
@@ -1607,7 +1614,10 @@ fn serve_http_plain(
         let listener = TokioTcpListener::bind(("0.0.0.0", port))
             .await
             .map_err(|e| format!("net.serve bind {port}: {e}"))?;
-        eprintln!("net.serve: listening on http://0.0.0.0:{port}");
+        eprintln!(
+            "net.serve: listening on http://0.0.0.0:{port}{}",
+            if inline_vm { " (inline-vm)" } else { "" }
+        );
         loop {
             let (stream, _) = listener
                 .accept()
@@ -1632,14 +1642,25 @@ fn serve_http_plain(
                             .await
                             .map(|c| c.to_bytes())
                             .unwrap_or_default();
-                        let result = tokio::task::spawn_blocking(move || {
+                        let result = if inline_vm {
+                            // Inline path — run the VM on this tokio worker.
+                            // Cheap when handlers return in microseconds; will
+                            // stall the worker on heavy handlers (caveat per #431).
                             let lex_req = build_request_value_parts(&parts, &body_bytes);
                             let handler = DefaultHandler::new(policy)
                                 .with_program(Arc::clone(&program));
                             let mut vm = Vm::with_handler(&program, Box::new(handler));
-                            vm.call(&handler_name, vec![lex_req])
-                        })
-                        .await;
+                            Ok(vm.call(&handler_name, vec![lex_req]))
+                        } else {
+                            tokio::task::spawn_blocking(move || {
+                                let lex_req = build_request_value_parts(&parts, &body_bytes);
+                                let handler = DefaultHandler::new(policy)
+                                    .with_program(Arc::clone(&program));
+                                let mut vm = Vm::with_handler(&program, Box::new(handler));
+                                vm.call(&handler_name, vec![lex_req])
+                            })
+                            .await
+                        };
                         Ok::<_, std::convert::Infallible>(match result {
                             Ok(Ok(resp)) => build_hyper_response(&resp),
                             Ok(Err(e)) => error_response(500, &format!("internal error: {e}")),
@@ -1702,6 +1723,9 @@ fn handle_request_tls(
 }
 
 /// Hyper 1.x + Tokio multi-thread HTTP/1.1 server for `net.serve_fn`.
+///
+/// `LEX_NET_INLINE_VM=1` skips `spawn_blocking` — see `serve_http_plain`'s
+/// doc-comment for the tradeoffs. Same env var gates both paths.
 fn serve_http_fn(
     port: u16,
     closure: Value,
@@ -1714,6 +1738,7 @@ fn serve_http_fn(
     use hyper_util::rt::TokioIo;
     use tokio::net::TcpListener as TokioTcpListener;
 
+    let inline_vm = env_inline_vm();
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
@@ -1722,7 +1747,10 @@ fn serve_http_fn(
         let listener = TokioTcpListener::bind(("0.0.0.0", port))
             .await
             .map_err(|e| format!("net.serve_fn bind {port}: {e}"))?;
-        eprintln!("net.serve_fn: listening on http://0.0.0.0:{port}");
+        eprintln!(
+            "net.serve_fn: listening on http://0.0.0.0:{port}{}",
+            if inline_vm { " (inline-vm)" } else { "" }
+        );
         loop {
             let (stream, _) = listener
                 .accept()
@@ -1747,14 +1775,22 @@ fn serve_http_fn(
                             .await
                             .map(|c| c.to_bytes())
                             .unwrap_or_default();
-                        let result = tokio::task::spawn_blocking(move || {
+                        let result = if inline_vm {
                             let lex_req = build_request_value_parts(&parts, &body_bytes);
                             let handler = DefaultHandler::new(policy)
                                 .with_program(Arc::clone(&program));
                             let mut vm = Vm::with_handler(&program, Box::new(handler));
-                            vm.invoke_closure_value(closure, vec![lex_req])
-                        })
-                        .await;
+                            Ok(vm.invoke_closure_value(closure, vec![lex_req]))
+                        } else {
+                            tokio::task::spawn_blocking(move || {
+                                let lex_req = build_request_value_parts(&parts, &body_bytes);
+                                let handler = DefaultHandler::new(policy)
+                                    .with_program(Arc::clone(&program));
+                                let mut vm = Vm::with_handler(&program, Box::new(handler));
+                                vm.invoke_closure_value(closure, vec![lex_req])
+                            })
+                            .await
+                        };
                         Ok::<_, std::convert::Infallible>(match result {
                             Ok(Ok(resp)) => build_hyper_response(&resp),
                             Ok(Err(e)) => error_response(500, &format!("internal error: {e}")),
@@ -1768,6 +1804,20 @@ fn serve_http_fn(
             });
         }
     })
+}
+
+/// Read `LEX_NET_INLINE_VM` and report whether the runtime should skip
+/// `spawn_blocking` on the per-request VM call. Accepts `1` / `true`
+/// (case-insensitive); anything else (including unset) keeps the
+/// default `spawn_blocking` behaviour. See issue #431.
+fn env_inline_vm() -> bool {
+    match std::env::var("LEX_NET_INLINE_VM") {
+        Ok(v) => {
+            let s = v.trim().to_ascii_lowercase();
+            s == "1" || s == "true"
+        }
+        Err(_) => false,
+    }
 }
 
 /// Build a Lex request record from hyper request parts and pre-collected body bytes.


### PR DESCRIPTION
## Summary

Experimental opt-in path for issue #431. Adds `LEX_NET_INLINE_VM=1` (or `=true`, case-insensitive) — when set, `net.serve` and `net.serve_fn` skip `tokio::task::spawn_blocking` and run the Lex VM directly on the tokio worker. Default behaviour is unchanged.

The diff is a per-request `if` branch around the existing `spawn_blocking` block in two functions in `crates/lex-runtime/src/handler.rs`. Same env-var gate applies to both `net.serve` and `net.serve_fn` via a new `env_inline_vm()` helper. No type-system, builtin, or syntax change.

## Measurements

Run against `alpibrusl/lex-web`'s TechEmpower-style bench (the same harness used in `lex-web/bench/REPORT.md`). Setup: 2-core `taskset -c 0-1`, hyper 1.x + tokio default multi-thread scheduler, 3 routes registered, wrk `-t2 -c64 -d15s`, 3 trials per endpoint, medians shown.

| Endpoint        | spawn_blocking (default) | **inline-vm** | Δ        |
| --------------- | -----------------------: | ------------: | -------: |
| `/plaintext`    |                    6 849 |     **9 118** | **+33 %** |
| `/json`         |                    7 115 |     **9 081** | **+28 %** |
| `/users/:id`    |                    5 752 |     **6 724** | **+17 %** |

Per-trial spread also tightens substantially with inline-VM:

| Endpoint        | spawn_blocking trials | inline-vm trials |
| --------------- | --------------------- | ---------------- |
| `/plaintext`    | 7 511 / 6 849 / 5 991 (25 % spread) | 8 872 / 9 117 / 9 170 (3 % spread) |
| `/json`         | 7 197 / 7 115 / 5 889 (22 % spread) | 9 011 / 9 081 / 9 125 (1 % spread) |
| `/users/:id`    | 5 403 / 6 138 / 5 752 (13 % spread) | 6 723 / 6 624 / 6 760 (2 % spread) |

That second table is part of the story — `spawn_blocking` introduces variance, presumably from per-request scheduler decisions on which blocking thread picks the work up. Removing the hop gives much more consistent latency.

Per the decision rule in #431:
- **+50 % or more on plaintext** → productise to a `net.serve_fn_inline` builtin (option B in the issue).
- **+20–50 %** → ship as documented env-var experiment.
- **<20 %** → close the issue, the gap is elsewhere.

We're at +33 % on plaintext / +28 % on JSON — solidly in the middle band. My recommendation is to land this PR as-is (env-var-gated experiment, documented in CHANGELOG and the doc-comment) and revisit the `net.serve_fn_inline` builtin shape in a follow-up if a user opts in and reports back from production.

## Tradeoff

`spawn_blocking` exists for a reason — it keeps long-running CPU work off the tokio executor threads. With inline-VM, **a handler that does >1 ms of bytecode work stalls the tokio worker it's on**. With N workers, N concurrent slow handlers stall the executor and tail latency for everyone else goes up.

For the lex-web bench, handler bodies return in tens of microseconds and the trade is clearly worth it. For a real app that does, say, JSON parsing + a `[sql]` query inside the handler, the spawn_blocking default is probably still the right answer.

Documented in:
- The `serve_http_plain` doc-comment ("Experimental — see lex-lang issue #431")
- CHANGELOG under `[Unreleased] → Performance`, calling out the >1 ms threshold explicitly

If a user sets the flag and their handlers turn out to be slow, the symptom will be: under burst load, per-request latency tail balloons (one worker thread monopolised by a slow handler, others can't help). That's an observable, localised failure mode — and easy to undo by unsetting the env var.

## Out of scope (separate issues if this experiment graduates)

- `serve_http_tls_legacy` (still on `tiny_http`, no spawn_blocking path).
- WebSocket handlers (`serve_ws_fn` — different code path, different async story).
- A per-server / per-handler opt-in at the Lex source level (option B in #431).
- Auto-tuning per-request decision (option C in #431).

## Test plan

- [x] `cargo build --release -p lex-cli` clean.
- [x] Smoke-tested both code paths against lex-web's bench server: with `LEX_NET_INLINE_VM=1` the server logs `(inline-vm)` suffix and serves correctly; without the env var it behaves identically to before.
- [x] Measurements above, 3 trials per endpoint, captured under the same conditions as the existing `lex-web/bench/REPORT.md` matrix.
- [ ] Reviewer: confirm the inline path is sound for `serve_http_plain` (`net.serve`) too — I only re-measured `serve_http_fn` (`net.serve_fn`) since that's what lex-web uses; the diff to `serve_http_plain` is structurally identical but no end-to-end test.

Closes #431 if the band-2 ship decision sticks.

https://claude.ai/code/session_01DbByRTn5kedfuEmD9tsTw6

---
_Generated by [Claude Code](https://claude.ai/code/session_01DbByRTn5kedfuEmD9tsTw6)_