### PR TITLE
fix(#439): substitute formals when unfolding parametric record aliases

### DIFF
--- a/crates/lex-types/src/checker.rs
+++ b/crates/lex-types/src/checker.rs
@@ -340,11 +340,19 @@ fn ty_to_tag(u: &Unifier, ty: &Ty) -> String {
 /// moved/destructured.
 fn unfold_record_alias_static(env: &TypeEnv, ty: Ty) -> Ty {
     if let Ty::Con(ref n, ref args) = ty {
-        if args.is_empty() {
-            if let Some(td) = env.types.get(n) {
-                if let TypeDefKind::Alias(inner) = &td.kind {
+        if let Some(td) = env.types.get(n) {
+            if let TypeDefKind::Alias(inner) = &td.kind {
+                if td.params.len() != args.len() {
+                    return ty;
+                }
+                if td.params.is_empty() {
                     return inner.clone();
                 }
+                let mut subst = IndexMap::new();
+                for (i, a) in args.iter().enumerate() {
+                    subst.insert(i as u32, a.clone());
+                }
+                return subst_vars(inner, &subst, &IndexMap::new());
             }
         }
     }
@@ -462,31 +470,49 @@ impl Checker {
         }
     }
 
-    /// If `ty` is a `Ty::Con(name, [])` whose definition is a type
-    /// alias (record or otherwise), return the aliased type.
-    /// Otherwise return `ty` unchanged.
+    /// If `ty` is a `Ty::Con(name, args)` whose definition is a type
+    /// alias (record or otherwise), return the aliased type with the
+    /// alias's formal parameters substituted by `args`. For zero-arg
+    /// aliases this is the identity substitution. For parametric
+    /// aliases (#439, e.g. `type Box[T] = { value :: T }`), the
+    /// formal `Ty::Var(i)` for the i-th param is replaced by `args[i]`
+    /// so `Box[Str]` unfolds to `{ value :: Str }` rather than to the
+    /// unsubstituted body. Returns `ty` unchanged when arity doesn't
+    /// match or the name doesn't resolve to an alias.
     fn unfold_record_alias(&self, ty: Ty) -> Ty {
         if let Ty::Con(ref n, ref args) = ty {
-            if args.is_empty() {
-                if let Some(td) = self.type_env.types.get(n) {
-                    if let TypeDefKind::Alias(inner) = &td.kind {
+            if let Some(td) = self.type_env.types.get(n) {
+                if let TypeDefKind::Alias(inner) = &td.kind {
+                    if td.params.len() != args.len() {
+                        return ty;
+                    }
+                    if td.params.is_empty() {
                         return inner.clone();
                     }
+                    let mut subst = IndexMap::new();
+                    for (i, a) in args.iter().enumerate() {
+                        subst.insert(i as u32, a.clone());
+                    }
+                    return subst_vars(inner, &subst, &IndexMap::new());
                 }
             }
         }
         ty
     }
 
-    /// True iff `ty` is a 0-arg `Ty::Con(name, [])` whose definition
-    /// is a `TypeDefKind::Alias`. Used by `unify_coerce_inner` to
-    /// detect the case where both sides are nominal aliases and
-    /// unfolding would collapse the nominal distinction (#323).
+    /// True iff `ty` is a `Ty::Con(name, args)` whose definition is a
+    /// `TypeDefKind::Alias` and whose arity matches. Used by
+    /// `unify_coerce_inner` to detect the case where both sides are
+    /// nominal aliases and unfolding would collapse the nominal
+    /// distinction (#323 / #439). For parametric aliases the arity
+    /// match guards against `Box[Str]` vs an inconsistent `Box[Str, Int]`.
     fn is_alias_con(&self, ty: &Ty) -> bool {
         if let Ty::Con(name, args) = ty {
-            if args.is_empty() {
-                if let Some(td) = self.type_env.types.get(name) {
-                    return matches!(td.kind, TypeDefKind::Alias(_));
+            if let Some(td) = self.type_env.types.get(name) {
+                if matches!(td.kind, TypeDefKind::Alias(_))
+                    && td.params.len() == args.len()
+                {
+                    return true;
                 }
             }
         }
@@ -827,16 +853,22 @@ impl Checker {
             a::CExpr::FieldAccess { value, field } => {
                 let vt = self.check_expr(value, node_id, locals, effs)?;
                 let resolved = self.u.resolve(&vt);
-                // Unfold a Record-aliased Con (e.g. `type Request = { ... }`).
-                let resolved = match resolved {
-                    Ty::Con(ref n, _) => match self.type_env.types.get(n) {
-                        Some(td) => match &td.kind {
-                            TypeDefKind::Alias(inner @ Ty::Record(_)) => inner.clone(),
-                            _ => resolved,
-                        },
-                        None => resolved,
-                    },
-                    other => other,
+                // Unfold a Record-aliased Con (e.g. `type Request = { ... }`
+                // or `type Box[T] = { value :: T }`). For parametric aliases
+                // the helper substitutes the actual args for the formal
+                // params; the post-unfold shape is only a Record when the
+                // alias body was a record, so non-record aliases (e.g.
+                // `type UserId = Int`) fall through to the
+                // "expected record" error below.
+                let resolved = if let Ty::Con(_, _) = &resolved {
+                    let unfolded = self.unfold_record_alias(resolved.clone());
+                    if matches!(unfolded, Ty::Record(_)) {
+                        unfolded
+                    } else {
+                        resolved
+                    }
+                } else {
+                    resolved
                 };
                 match resolved {
                     Ty::Record(fields) => fields.get(field).cloned()

--- a/crates/lex-types/tests/record_coercion.rs
+++ b/crates/lex-types/tests/record_coercion.rs
@@ -144,3 +144,140 @@ fn main() -> Pt { id({ x: 1, y: "no" }) }
 "#;
     check(src).expect_err("should reject wrong-typed field");
 }
+
+// ===== #439 — parametric record aliases =====
+//
+// `type Foo[T] = { ... }` parametric aliases were previously rejected
+// from accepting an anonymous record literal at the use site: the
+// unfold rule walked the `Ty::Con(_, args)` head only when `args` was
+// empty, so `Box[Str]` never reached the structural record-coercion
+// case. The fix substitutes the actuals (`args`) for the formal
+// `Ty::Var(i)` slots in the alias body before unfolding.
+
+#[test]
+fn parametric_record_alias_coerces_at_function_return() {
+    // The minimal reproducer from #439.
+    let src = r#"
+type Box[T] = { value :: T }
+
+fn wrap_str(s :: Str) -> Box[Str] {
+  { value: s }
+}
+"#;
+    check(src).expect("should accept Box[Str] from record literal");
+}
+
+#[test]
+fn parametric_record_alias_coerces_at_argument_position() {
+    let src = r#"
+type Box[T] = { value :: T }
+
+fn unbox_int(b :: Box[Int]) -> Int { b.value }
+
+fn main() -> Int {
+  unbox_int({ value: 42 })
+}
+"#;
+    check(src).expect("should accept Box[Int] at argument position");
+}
+
+#[test]
+fn parametric_record_alias_field_access_substitutes_args() {
+    // `b.value` on `b :: Box[Str]` should resolve to `Str`, not the
+    // formal `T`. Pre-fix, this either failed to type-check or bound
+    // the inferred return to the formal param's index.
+    let src = r#"
+type Box[T] = { value :: T }
+
+fn unbox(b :: Box[Str]) -> Str { b.value }
+"#;
+    check(src).expect("Box[Str].value should type as Str");
+}
+
+#[test]
+fn parametric_record_alias_with_multiple_fields() {
+    // The pagination shape from the issue body.
+    let src = r#"
+type Page[T] = {
+  items  :: List[T],
+  offset :: Int,
+  limit  :: Int,
+  total  :: Int,
+}
+
+fn empty_page() -> Page[Int] {
+  { items: [], offset: 0, limit: 0, total: 0 }
+}
+"#;
+    check(src).expect("multi-field parametric record alias should coerce");
+}
+
+#[test]
+fn parametric_record_alias_nested_generic_field() {
+    // `Page[T]` with `items :: List[T]` — exercises substitution
+    // walking into a nested `List[Ty::Var(0)]`.
+    let src = r#"
+type Page[T] = { items :: List[T], total :: Int }
+
+fn one_int_page() -> Page[Int] {
+  { items: [1, 2, 3], total: 3 }
+}
+"#;
+    check(src).expect("nested List[T] should substitute to List[Int]");
+}
+
+#[test]
+fn parametric_record_alias_wrong_inner_type_still_rejects() {
+    // Substituting `T → Int` means `value :: Int`; a Str literal
+    // must still be rejected.
+    let src = r#"
+type Box[T] = { value :: T }
+
+fn bad() -> Box[Int] { { value: "not an int" } }
+"#;
+    check(src).expect_err("should reject Str where Box[Int] expected Int");
+}
+
+#[test]
+fn distinct_parametric_aliases_with_same_shape_still_reject() {
+    // Nominal distinction extends to parametric aliases: `Box[Int]`
+    // and `Crate[Int]` have the same unfolded shape but are not
+    // interchangeable.
+    let src = r#"
+type Box[T]   = { value :: T }
+type Crate[T] = { value :: T }
+
+fn ship(c :: Crate[Int]) -> Int { c.value }
+fn make_box() -> Box[Int] { { value: 7 } }
+
+fn main() -> Int { ship(make_box()) }
+"#;
+    let errs = check(src).expect_err("should reject Box where Crate expected");
+    let msg = format!("{errs:?}");
+    assert!(msg.contains("Box") || msg.contains("Crate"), "msg: {msg}");
+}
+
+#[test]
+fn parametric_record_alias_in_let_binding() {
+    let src = r#"
+type Box[T] = { value :: T }
+
+fn main() -> Int {
+  let b :: Box[Int] := { value: 9 }
+  b.value
+}
+"#;
+    check(src).expect("let-binding annotation should coerce parametric alias");
+}
+
+#[test]
+fn parametric_record_alias_as_list_element() {
+    let src = r#"
+type Box[T] = { value :: T }
+
+fn boxes() -> List[Box[Int]] {
+  [{ value: 1 }, { value: 2 }]
+}
+"#;
+    check(src).expect("list element should coerce to Box[Int]");
+}


### PR DESCRIPTION
## Summary

- Generalises `unfold_record_alias` and `unfold_record_alias_static` to walk through type parameters, substituting actual args for the formal `Ty::Var(i)` slots in the alias body via the existing `subst_vars` helper.
- `is_alias_con` and the inline `FieldAccess` unfold path get the same treatment, so `Box[Str].value` types as `Str` and nominal distinction is preserved between e.g. `Box[T]` and `Crate[T]` declared with identical shapes.

## Why

The previous unfold rule only walked the `Ty::Con(_, args)` head when `args.is_empty()`, so a record literal like `{ value: s }` never reached the structural unify-record case when the expected type was a parametric alias like `Box[Str]`. The minimal repro from the issue:

```lex
type Box[T] = { value :: T }

fn wrap_str(s :: Str) -> Box[Str] {
  { value: s }   # was: expected Box[Str], got { value :: Str }
}
```

This blocked every parameterised container abstraction (`Page[T]`, `Repo[T]`, `Cache[T]`, `Stream[T]`) the reporter wanted to share across `lex-ocpi`, `lex-orm`, etc. — they had to either concrete to a single inner type or leak it through callers.

## Test plan

- [x] `cargo test -p lex-types --test record_coercion` — 19 passing (9 new for #439, 10 pre-existing).
- [x] `cargo test -p lex-types --no-fail-fast` — full suite 42 passing.
- [x] `cargo clippy -p lex-types --all-targets -- -D warnings` — clean.
- [ ] Reviewer: confirm the substitution direction (formal `Ty::Var(i)` → `args[i]`) doesn't collide with the unifier's fresh-var namespace. My read: the alias-body `Ty::Var(i)` only exists inside `TypeDef.kind` and is substituted out by `unfold_record_alias` before the result enters the unifier, so the namespaces never meet at runtime.

New tests cover:

- Function-return position (the minimal reproducer)
- Argument position
- Field access (`b.value` on `Box[Str]` → `Str`)
- Multi-field generic (the `Page[T]` pagination shape from the issue body)
- Nested generic field (`items :: List[T]` substituted to `List[Int]`)
- Wrong inner type still rejected (`Box[Int]` ≠ `{value: Str}`)
- Two distinct parametric aliases with identical shapes stay nominally distinct
- `let` binding annotation + list-element position

## What's NOT in this PR

- Higher-kinded polymorphism (`Functor[F]` etc.) — out of scope; this is monomorphic instantiation only.
- Recursive parametric aliases (`type Tree[T] = { value :: T, children :: List[Tree[T]] }`) — the current unfold is one-step and doesn't recurse; if this turns out to bite a real downstream user, it's a separate fix.

Closes #439.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WGG3GpdagcF18nYBQJLWbT)_