### PR TITLE
perf(#461): dispatch microbench harness (baseline, no VM changes)

### DIFF
--- a/crates/lex-bytecode/Cargo.toml
+++ b/crates/lex-bytecode/Cargo.toml
@@ -24,3 +24,8 @@ lex-types = { path = "../lex-types", version = "0.9.4" }
 
 [dev-dependencies]
 lex-syntax = { path = "../lex-syntax", version = "0.9.4" }
+criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
+
+[[bench]]
+name = "dispatch"
+harness = false

--- a/crates/lex-bytecode/benches/dispatch.rs
+++ b/crates/lex-bytecode/benches/dispatch.rs
@@ -1,0 +1,126 @@
+//! Microbenchmarks for the bytecode VM's dispatch loop (#461).
+//!
+//! Establishes a baseline against which the planned dispatch rewrite
+//! (function-table / computed-goto) is measured. Three workloads stress
+//! different shapes of the hot path:
+//!
+//! - `arith_loop` — tight integer arithmetic via tail-recursive `sum_to`.
+//!   Dense mix of trivial-handler opcodes: PushConst, IntAdd, IntSub,
+//!   LoadLocal/StoreLocal, Call, Return, match-arm jumps.
+//! - `record_field` — repeated `GetField` over the same record shape.
+//!   Stresses the inline-cache hot path that #462 will rework.
+//! - `call_heavy` — recursive factorial. Stresses Call/Return overhead
+//!   relative to the per-call work done.
+//!
+//! Run with `cargo bench -p lex-bytecode --bench dispatch`.
+
+use std::sync::Arc;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use lex_ast::canonicalize_program;
+use lex_bytecode::vm::Vm;
+use lex_bytecode::{compile_program, Program, Value};
+use lex_syntax::parse_source;
+
+const ARITH_LOOP_SRC: &str = r#"
+fn sum_to(n :: Int, acc :: Int) -> Int {
+  match n {
+    0 => acc,
+    _ => sum_to(n - 1, acc + n),
+  }
+}
+"#;
+
+const RECORD_FIELD_SRC: &str = r#"
+type Point = { x :: Int, y :: Int, z :: Int }
+
+fn sum_fields(p :: Point, n :: Int, acc :: Int) -> Int {
+  match n {
+    0 => acc,
+    _ => sum_fields(p, n - 1, acc + p.x + p.y + p.z),
+  }
+}
+
+fn bench(n :: Int) -> Int {
+  let p :: Point := { x: 1, y: 2, z: 3 }
+  sum_fields(p, n, 0)
+}
+"#;
+
+const CALL_HEAVY_SRC: &str = r#"
+fn factorial(n :: Int) -> Int {
+  match n {
+    0 => 1,
+    _ => n * factorial(n - 1),
+  }
+}
+"#;
+
+fn compile(src: &str) -> Arc<Program> {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    lex_types::check_program(&stages).expect("typecheck");
+    Arc::new(compile_program(&stages))
+}
+
+fn bench_arith_loop(c: &mut Criterion) {
+    let prog = compile(ARITH_LOOP_SRC);
+    let mut group = c.benchmark_group("dispatch/arith_loop");
+    for n in [100i64, 1_000, 10_000] {
+        group.bench_function(format!("n={n}"), |b| {
+            b.iter(|| {
+                let mut vm = Vm::new(&prog);
+                vm.set_step_limit(u64::MAX);
+                black_box(
+                    vm.call("sum_to", vec![Value::Int(n), Value::Int(0)])
+                        .expect("call sum_to"),
+                )
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_record_field(c: &mut Criterion) {
+    let prog = compile(RECORD_FIELD_SRC);
+    let mut group = c.benchmark_group("dispatch/record_field");
+    for n in [100i64, 1_000, 10_000] {
+        group.bench_function(format!("n={n}"), |b| {
+            b.iter(|| {
+                let mut vm = Vm::new(&prog);
+                vm.set_step_limit(u64::MAX);
+                black_box(
+                    vm.call("bench", vec![Value::Int(n)])
+                        .expect("call bench"),
+                )
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_call_heavy(c: &mut Criterion) {
+    let prog = compile(CALL_HEAVY_SRC);
+    let mut group = c.benchmark_group("dispatch/call_heavy");
+    for n in [10i64, 15, 20] {
+        group.bench_function(format!("n={n}"), |b| {
+            b.iter(|| {
+                let mut vm = Vm::new(&prog);
+                vm.set_step_limit(u64::MAX);
+                black_box(
+                    vm.call("factorial", vec![Value::Int(n)])
+                        .expect("call factorial"),
+                )
+            })
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_arith_loop,
+    bench_record_field,
+    bench_call_heavy
+);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

First slice of #461 (interpreter dispatch loop rewrite). **Pure measurement infrastructure — no VM code changes yet.**

The acceptance criteria for #461 require a criterion micro-bench and ≥ 2× speedup on the dispatch path. Both depend on a baseline being on the record before any rewrite. This PR establishes that baseline so subsequent slices have something to beat.

## What's here

- `criterion = "0.5"` added to `lex-bytecode`'s dev-dependencies (no runtime impact)
- New `crates/lex-bytecode/benches/dispatch.rs` with three workloads:
  - `dispatch/arith_loop` — tail-recursive `sum_to`; dense mix of trivial-handler opcodes (PushConst, IntAdd/Sub, LoadLocal/StoreLocal, Call/Return, jumps).
  - `dispatch/record_field` — repeated `GetField` over a Point; exercises the inline-cache hot path that #462 will rework.
  - `dispatch/call_heavy` — recursive factorial; isolates Call/Return overhead.

## Baseline (this machine, criterion `--measurement-time 0.5 --sample-size 10`)

| Bench | n=small | n=mid | n=large |
|---|---|---|---|
| `arith_loop` | ~24 µs (n=100) | ~249 µs (n=1k) | ~2.4 ms (n=10k) |
| `record_field` | ~87 µs (n=100) | ~851 µs (n=1k) | ~9.0 ms (n=10k) |
| `call_heavy` | ~5.9 µs (n=10) | ~9.1 µs (n=15) | ~11.8 µs (n=20) |

Linear scaling on all three confirms the bench is measuring the dispatch loop rather than fixed setup cost.

## What's NOT here (deferred to follow-up PRs)

- The actual dispatch rewrite (function-table or computed-goto) — that's the next slice and where the real risk lives.
- IC key migration to `(fn_id, site_index)` — best landed *with* the dispatch rewrite per #462, not before.
- Stack-alloc / arena scaffolding — those are separate issues (#463, #464).

## Why slice this way

Splitting the measurement scaffolding out of the rewrite means the rewrite PR can show before/after numbers from this exact harness, and any regressions surface at a known baseline. Reviewable in isolation; zero risk to runtime behavior.

## Test plan

- [x] `cargo test -p lex-bytecode` — 7/7 pass (pre-existing tests unaffected)
- [x] `cargo bench -p lex-bytecode --no-run` — bench harness compiles
- [x] `cargo bench -p lex-bytecode --bench dispatch -- --warm-up-time 0.1 --measurement-time 0.5 --sample-size 10` — all 9 cases produce numbers
- [ ] Reviewer: confirm the three workloads cover the dispatch shapes you care about before the rewrite lands

## Links

- Tracks #461
- Bench will also be consumed by #462 (record_field), #463 (arena, indirectly), and #465 (JIT, as the comparison baseline once the interpreter ceiling is mapped out)

https://claude.ai/code/session_01VEhcze986fxQDqJXKEwF2n

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEhcze986fxQDqJXKEwF2n)_