### PR TITLE
feat(net): serve_ws_fn_actor — per-connection bridge actor for outbound sends (#459)

### DIFF
--- a/crates/lex-bytecode/src/value.rs
+++ b/crates/lex-bytecode/src/value.rs
@@ -10,13 +10,59 @@ use std::sync::{Arc, Mutex};
 
 /// Internal state of a `conc.Actor`. Protected by a `Mutex` so that
 /// concurrent callers serialise on message delivery (the actor processes
-/// one message at a time). The `handler` closure is called on the
-/// *calling* VM's thread — no extra OS thread required — which lets it
-/// invoke arbitrary effects (sql, net, …) through the same handler chain.
+/// one message at a time). The `handler` is dispatched on the
+/// *calling* VM's thread — no extra OS thread required — which lets
+/// Lex handlers invoke arbitrary effects (sql, net, …) through the
+/// same handler chain.
 #[derive(Debug, Clone)]
 pub struct ActorCell {
     pub state: Value,
-    pub handler: Value,
+    pub handler: ActorHandler,
+}
+
+/// Two ways an actor's handler can be implemented.
+///
+/// * `Lex(Value::Closure)` is the user-spawned shape from
+///   `conc.spawn(state, fn (s, m) -> (s, r) { … })`. The VM calls
+///   the closure with `(state, msg)` and expects `(new_state, reply)`.
+///
+/// * `Native(...)` is a Rust-side bridge — the actor cell wraps a
+///   `Box<dyn Fn(Value) -> Result<Value, String>>` that lives outside
+///   the VM. The `state` is ignored; the bridge is fire-and-forget
+///   over an out-of-band channel (e.g. a `mpsc::Sender<String>` to
+///   a WebSocket connection — see `lex-runtime::ws::serve_ws_fn_actor`).
+///   `conc.ask` against a native actor returns whatever the bridge
+///   produces; `conc.tell` discards it. v1 is only used internally by
+///   the WS server's outbound-bridge registration; not exposed via the
+///   `conc` builtin surface.
+#[derive(Clone)]
+pub enum ActorHandler {
+    Lex(Value),
+    Native(Arc<NativeActorHandler>),
+}
+
+/// Erased Rust-side handler for `ActorHandler::Native`. Boxed so we
+/// can store any closure that captures (e.g. an `mpsc::Sender`).
+/// Wrapped in `Arc` so cloning an `ActorCell` (which the existing
+/// `conc.tell` flow does — `let handler = guard.handler.clone()`)
+/// is cheap and the closure isn't duplicated.
+pub struct NativeActorHandler {
+    pub send: Box<dyn Fn(Value) -> Result<Value, String> + Send + Sync>,
+}
+
+impl std::fmt::Debug for NativeActorHandler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "<native actor handler>")
+    }
+}
+
+impl std::fmt::Debug for ActorHandler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ActorHandler::Lex(v) => f.debug_tuple("Lex").field(v).finish(),
+            ActorHandler::Native(n) => f.debug_tuple("Native").field(n).finish(),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/lex-bytecode/src/value.rs
+++ b/crates/lex-bytecode/src/value.rs
@@ -9,11 +9,19 @@ use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 
 /// Internal state of a `conc.Actor`. Protected by a `Mutex` so that
-/// concurrent callers serialise on message delivery (the actor processes
-/// one message at a time). The `handler` is dispatched on the
-/// *calling* VM's thread — no extra OS thread required — which lets
-/// Lex handlers invoke arbitrary effects (sql, net, …) through the
-/// same handler chain.
+/// the `Lex` handler variant serialises on message delivery (one
+/// message processed at a time, state mutated under the lock). The
+/// `handler` is dispatched on the *calling* VM's thread — no extra
+/// OS thread required — which lets Lex handlers invoke arbitrary
+/// effects (sql, net, …) through the same handler chain.
+///
+/// Serialisation note: the `Native` variant releases the mutex
+/// *before* invoking its closure (`state` is unused for natives —
+/// the "state" is an external resource like a channel), so two
+/// concurrent `conc.tell`s on the same native bridge may invoke
+/// the closure on overlapping threads. Native bridges therefore
+/// need to be internally thread-safe; the `serve_ws_fn_actor`
+/// `mpsc::Sender` bridge is, because `Sender::send` is.
 #[derive(Debug, Clone)]
 pub struct ActorCell {
     pub state: Value,

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -558,7 +558,7 @@ impl<'a> Vm<'a> {
                 }
                 Ok(Value::Actor(Arc::new(Mutex::new(ActorCell {
                     state: init,
-                    handler,
+                    handler: crate::value::ActorHandler::Lex(handler),
                 }))))
             }
             "ask" | "tell" => {
@@ -574,20 +574,35 @@ impl<'a> Vm<'a> {
                 let mut guard = cell.lock().map_err(|e| format!("conc.{op}: actor mutex poisoned: {e}"))?;
                 let handler = guard.handler.clone();
                 let state = guard.state.clone();
-                // Call handler(state, msg) on this VM — full effect access.
-                let result = self.invoke_closure_value(handler, vec![state, msg])
-                    .map_err(|e| format!("conc.{op}: handler error: {e:?}"))?;
-                // Expect (new_state, reply) tuple.
-                match result {
-                    Value::Tuple(mut parts) if parts.len() == 2 => {
-                        let reply = parts.pop().unwrap();
-                        let new_state = parts.pop().unwrap();
-                        guard.state = new_state;
-                        drop(guard);
-                        if op == "ask" { Ok(reply) } else { Ok(Value::Unit) }
+                match handler {
+                    crate::value::ActorHandler::Lex(closure_val) => {
+                        // Call handler(state, msg) on this VM — full effect access.
+                        let result = self.invoke_closure_value(closure_val, vec![state, msg])
+                            .map_err(|e| format!("conc.{op}: handler error: {e:?}"))?;
+                        // Expect (new_state, reply) tuple.
+                        match result {
+                            Value::Tuple(mut parts) if parts.len() == 2 => {
+                                let reply = parts.pop().unwrap();
+                                let new_state = parts.pop().unwrap();
+                                guard.state = new_state;
+                                drop(guard);
+                                if op == "ask" { Ok(reply) } else { Ok(Value::Unit) }
+                            }
+                            other => Err(format!(
+                                "conc.{op}: handler must return a 2-tuple (new_state, reply), got {other:?}")),
+                        }
                     }
-                    other => Err(format!(
-                        "conc.{op}: handler must return a 2-tuple (new_state, reply), got {other:?}")),
+                    crate::value::ActorHandler::Native(native) => {
+                        // Native bridge: fire-and-forget; `state` is unused
+                        // (the bridge's "state" is the external resource, e.g.
+                        // a WebSocket connection). The closure receives `msg`
+                        // directly. `ask` returns whatever the bridge produces;
+                        // `tell` discards it. State stays untouched.
+                        drop(guard);
+                        let result = (native.send)(msg)
+                            .map_err(|e| format!("conc.{op}: native handler error: {e}"))?;
+                        if op == "ask" { Ok(result) } else { Ok(Value::Unit) }
+                    }
                 }
             }
             "register" => {

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -1151,6 +1151,31 @@ impl EffectHandler for DefaultHandler {
                     program, policy, registry,
                 )
             }
+            ("net", "serve_ws_fn_actor") => {
+                // serve_ws_fn_actor(port, subprotocol, name_of, on_message)
+                let port = match args.first() {
+                    Some(Value::Int(n)) if (0..=65535).contains(n) => *n as u16,
+                    _ => return Err("net.serve_ws_fn_actor(port, subprotocol, name_of, on_message): port must be Int 0..=65535".into()),
+                };
+                let subprotocol = expect_str(args.get(1))?.to_string();
+                let mut it = args.into_iter().skip(2);
+                let name_of_closure = match it.next() {
+                    Some(c @ Value::Closure { .. }) => c,
+                    _ => return Err("net.serve_ws_fn_actor(port, subprotocol, name_of, on_message): name_of must be a closure".into()),
+                };
+                let on_message_closure = match it.next() {
+                    Some(c @ Value::Closure { .. }) => c,
+                    _ => return Err("net.serve_ws_fn_actor(port, subprotocol, name_of, on_message): on_message must be a closure".into()),
+                };
+                let program = self.program.clone()
+                    .ok_or_else(|| "net.serve_ws_fn_actor requires a Program reference; use DefaultHandler::with_program".to_string())?;
+                let policy = self.policy.clone();
+                let registry = Arc::new(crate::ws::ChatRegistry::default());
+                crate::ws::serve_ws_fn_actor(
+                    port, subprotocol, name_of_closure, on_message_closure,
+                    program, policy, registry,
+                )
+            }
             ("net", "dial_ws") => {
                 // dial_ws(url, subprotocol, on_open, on_message)
                 let url = expect_str(args.first())?.to_string();

--- a/crates/lex-runtime/src/ws.rs
+++ b/crates/lex-runtime/src/ws.rs
@@ -656,6 +656,186 @@ fn run_loop_fn(
     Ok(())
 }
 
+// ── serve_ws_fn_actor — outbound-bridge actor registration (#459) ────────────
+//
+// Variant of `serve_ws_fn` that registers each connection as a named
+// actor in `conc_registry`, so non-WS callers (HTTP webhooks, scheduled
+// tasks, broadcast loops) can push frames into the socket via
+// `conc.lookup(name) |> conc.tell(frame)`.
+//
+// Signature:
+//
+//   net.serve_ws_fn_actor(
+//     port        :: Int,
+//     subprotocol :: Str,
+//     name_of     :: (WsConn) -> Str,                       # per-connection name
+//     on_message  :: (WsConn, WsMessage) -> [E] WsAction    # same as serve_ws_fn
+//   ) -> [net, concurrent, io] Unit
+//
+// On each accepted connection, the runtime:
+//   1. Builds the WsConn record (same shape as serve_ws_fn) and calls
+//      `name_of(conn)`. An empty-string return means "don't register
+//      this connection" — the socket still accepts inbound frames and
+//      runs `on_message`, but no outbound handle is exposed.
+//   2. Builds an `ActorHandler::Native` bridge whose `send` closure
+//      writes the message body to the per-connection `mpsc::Sender<String>`
+//      that already exists for the broadcast path.
+//   3. Registers the bridge actor under the name. Name collisions
+//      (`AlreadyRegistered`) abort the connection — surface the bug at
+//      the source level rather than silently overwriting an existing
+//      session.
+//   4. On disconnect, unregisters the name and tears down the socket.
+//
+// The inbound half (read frame → call `on_message` → apply `WsAction`)
+// is identical to `serve_ws_fn`.
+//
+// Out-of-scope for v1: binary message dispatch from a non-WS task. The
+// native bridge only accepts `Value::Str`; binary frames need a tagged
+// message type (`WsOut::Text(Str) | WsOut::Binary(List[Int])`) that the
+// native handler can match on. Filed as a follow-up.
+pub fn serve_ws_fn_actor(
+    port: u16,
+    subprotocol: String,
+    name_of_closure: Value,
+    on_message_closure: Value,
+    program: Arc<Program>,
+    policy: Policy,
+    registry: Arc<ChatRegistry>,
+) -> Result<Value, String> {
+    if !subprotocol.is_empty() {
+        if let Err(e) =
+            tungstenite::http::HeaderValue::from_str(&subprotocol)
+        {
+            return Err(format!(
+                "net.serve_ws_fn_actor: subprotocol {subprotocol:?} is not a valid \
+                 HTTP header value: {e}"
+            ));
+        }
+    }
+    let listener = TcpListener::bind(("127.0.0.1", port))
+        .map_err(|e| format!("net.serve_ws_fn_actor bind {port}: {e}"))?;
+    eprintln!("net.serve_ws_fn_actor: listening on ws://127.0.0.1:{port}");
+    for stream in listener.incoming() {
+        let stream = match stream {
+            Ok(s) => s,
+            Err(e) => { eprintln!("net.serve_ws_fn_actor accept: {e}"); continue; }
+        };
+        let program = Arc::clone(&program);
+        let policy = policy.clone();
+        let name_of_closure = name_of_closure.clone();
+        let on_message_closure = on_message_closure.clone();
+        let subprotocol = subprotocol.clone();
+        let registry = Arc::clone(&registry);
+        thread::spawn(move || {
+            if let Err(e) = handle_connection_fn_actor(
+                stream, program, policy, name_of_closure, on_message_closure,
+                subprotocol, registry,
+            ) {
+                eprintln!("net.serve_ws_fn_actor connection error: {e}");
+            }
+        });
+    }
+    Ok(Value::Unit)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn handle_connection_fn_actor(
+    stream: std::net::TcpStream,
+    program: Arc<Program>,
+    policy: Policy,
+    name_of_closure: Value,
+    on_message_closure: Value,
+    subprotocol: String,
+    registry: Arc<ChatRegistry>,
+) -> Result<(), String> {
+    use tungstenite::{accept_hdr, handshake::server::{Request, Response}};
+
+    let mut path = String::new();
+    let path_ref = &mut path;
+    let subproto_for_handshake = subprotocol.clone();
+    let mut ws = accept_hdr(stream, |req: &Request, mut resp: Response| {
+        *path_ref = req.uri().path().to_string();
+        maybe_echo_subprotocol(req, &mut resp, &subproto_for_handshake);
+        Ok(resp)
+    }).map_err(|e| format!("ws handshake: {e}"))?;
+
+    let (tx, rx) = mpsc::channel::<String>();
+    let conn_id = registry.register(path.trim_start_matches('/').to_string(), tx.clone());
+    let _ = ws.get_mut().set_read_timeout(Some(Duration::from_millis(50)));
+
+    // Build the WsConn record and ask the user's name_of closure what
+    // name to register this connection under. Empty string → opt-out.
+    let ws_conn = build_ws_conn(conn_id, &path, &subprotocol);
+    let registered_name: Option<String> = {
+        let handler = crate::handler::DefaultHandler::new(policy.clone())
+            .with_program(Arc::clone(&program))
+            .with_chat_registry(Arc::clone(&registry));
+        let mut vm = Vm::with_handler(&program, Box::new(handler));
+        match vm.invoke_closure_value(name_of_closure.clone(), vec![ws_conn.clone()]) {
+            Ok(Value::Str(s)) if !s.is_empty() => Some(s.to_string()),
+            Ok(Value::Str(_)) => None,
+            Ok(other) => {
+                eprintln!("net.serve_ws_fn_actor: name_of must return Str, got {other:?}");
+                None
+            }
+            Err(e) => {
+                eprintln!("net.serve_ws_fn_actor: name_of error: {e:?}");
+                None
+            }
+        }
+    };
+
+    // Register the native bridge actor in the conc registry. The
+    // bridge captures `tx` and writes any inbound message body to the
+    // outbound channel, which the run loop drains into the socket.
+    if let Some(ref name) = registered_name {
+        let tx_for_bridge = tx.clone();
+        let bridge = lex_bytecode::value::NativeActorHandler {
+            send: Box::new(move |msg: Value| -> Result<Value, String> {
+                match msg {
+                    Value::Str(s) => {
+                        tx_for_bridge.send(s.to_string()).map_err(|e| {
+                            format!("net.serve_ws_fn_actor: outbound channel closed: {e}")
+                        })?;
+                        Ok(Value::Unit)
+                    }
+                    other => Err(format!(
+                        "net.serve_ws_fn_actor: native bridge accepts Str messages only, got {other:?}"
+                    )),
+                }
+            }),
+        };
+        let cell = Value::Actor(Arc::new(Mutex::new(lex_bytecode::value::ActorCell {
+            state: Value::Unit,
+            handler: lex_bytecode::value::ActorHandler::Native(Arc::new(bridge)),
+        })));
+        if let Err(e) = lex_bytecode::conc_registry::register(name, cell) {
+            // Name collision: abort the connection. Surfacing the
+            // duplicate immediately is more useful than silently
+            // overwriting whichever session was registered first.
+            registry.unregister(conn_id);
+            let _ = ws.close(None);
+            return Err(format!(
+                "net.serve_ws_fn_actor: conc.register({name:?}) failed: {e:?}"
+            ));
+        }
+    }
+
+    let result = run_loop_fn(
+        &mut ws, &rx, conn_id, &path, &subprotocol,
+        &program, &policy, &on_message_closure, &registry,
+    );
+
+    // Tear down: unregister from both the conc registry (so a subsequent
+    // `conc.lookup(name)` returns None) and the chat registry.
+    if let Some(ref name) = registered_name {
+        let _ = lex_bytecode::conc_registry::unregister(name);
+    }
+    registry.unregister(conn_id);
+    let _ = ws.close(None);
+    result
+}
+
 // ── Closure-based WebSocket client (#390) ────────────────────────────────────
 //
 // Inverse of `serve_ws_fn`: open a connection to a remote WS server and

--- a/crates/lex-runtime/src/ws.rs
+++ b/crates/lex-runtime/src/ws.rs
@@ -764,7 +764,13 @@ fn handle_connection_fn_actor(
     let _ = ws.get_mut().set_read_timeout(Some(Duration::from_millis(50)));
 
     // Build the WsConn record and ask the user's name_of closure what
-    // name to register this connection under. Empty string → opt-out.
+    // name to register this connection under. Empty string is the
+    // documented opt-out (inbound still works, no outbound handle is
+    // exposed). Type mismatch or runtime error aborts the connection —
+    // the same "surface the bug at the source level" reasoning as a
+    // `conc.register` name collision below; silently degrading to an
+    // unregistered connection would have a non-WS caller's
+    // `conc.lookup` return None and conclude the session is offline.
     let ws_conn = build_ws_conn(conn_id, &path, &subprotocol);
     let registered_name: Option<String> = {
         let handler = crate::handler::DefaultHandler::new(policy.clone())
@@ -775,12 +781,18 @@ fn handle_connection_fn_actor(
             Ok(Value::Str(s)) if !s.is_empty() => Some(s.to_string()),
             Ok(Value::Str(_)) => None,
             Ok(other) => {
-                eprintln!("net.serve_ws_fn_actor: name_of must return Str, got {other:?}");
-                None
+                registry.unregister(conn_id);
+                let _ = ws.close(None);
+                return Err(format!(
+                    "net.serve_ws_fn_actor: name_of must return Str, got {other:?}"
+                ));
             }
             Err(e) => {
-                eprintln!("net.serve_ws_fn_actor: name_of error: {e:?}");
-                None
+                registry.unregister(conn_id);
+                let _ = ws.close(None);
+                return Err(format!(
+                    "net.serve_ws_fn_actor: name_of error: {e:?}"
+                ));
             }
         }
     };

--- a/crates/lex-runtime/tests/net_serve_ws_fn_actor.rs
+++ b/crates/lex-runtime/tests/net_serve_ws_fn_actor.rs
@@ -85,22 +85,20 @@ fn main() -> [net, concurrent] Nil {{
 /// it. Returns the registered actor handle (still held by the global
 /// registry).
 fn tell_via_lex_program(name: &str, body: &str) -> bool {
-    let src = format!(
-        r#"
+    let src = r#"
 import "std.conc" as conc
 
-fn tell_if_present(name :: Str, body :: Str) -> [concurrent] Bool {{
-  match conc.lookup(name) {{
+fn tell_if_present(name :: Str, body :: Str) -> [concurrent] Bool {
+  match conc.lookup(name) {
     None        => false,
-    Some(actor) => {{
+    Some(actor) => {
       let _ := conc.tell(actor, body)
       true
-    }},
-  }}
-}}
-"#
-    );
-    let prog = parse_source(&src).expect("parse");
+    },
+  }
+}
+"#;
+    let prog = parse_source(src).expect("parse");
     let stages = canonicalize_program(&prog);
     if let Err(errs) = lex_types::check_program(&stages) {
         panic!("type errors in tell helper: {errs:#?}");
@@ -121,7 +119,7 @@ fn tell_if_present(name :: Str, body :: Str) -> [concurrent] Bool {{
 
 #[test]
 fn outbound_tell_reaches_the_socket() {
-    let _ = conc_registry::_reset_for_tests();
+    conc_registry::_reset_for_tests();
     let port = free_port();
     spawn_server(&server_src(port));
 
@@ -160,7 +158,7 @@ fn outbound_tell_reaches_the_socket() {
 
 #[test]
 fn name_of_empty_string_skips_registration() {
-    let _ = conc_registry::_reset_for_tests();
+    conc_registry::_reset_for_tests();
     let port = free_port();
     // name_of returns "" — the connection should not appear in
     // conc_registry, but on_message should still run.
@@ -213,7 +211,7 @@ fn main() -> [net, concurrent] Nil {{
 
 #[test]
 fn unregister_on_disconnect_clears_the_name() {
-    let _ = conc_registry::_reset_for_tests();
+    conc_registry::_reset_for_tests();
     let port = free_port();
     spawn_server(&server_src(port));
 

--- a/crates/lex-runtime/tests/net_serve_ws_fn_actor.rs
+++ b/crates/lex-runtime/tests/net_serve_ws_fn_actor.rs
@@ -1,0 +1,251 @@
+//! End-to-end test for `net.serve_ws_fn_actor` (#459).
+//!
+//! The contract is: when a WebSocket client dials in, the runtime
+//! calls the user's `name_of` closure with a `WsConn`, registers a
+//! native bridge actor under the returned name in `conc_registry`,
+//! and any frame `conc.tell`'d to that actor from a non-WS context
+//! is written to the socket as a text frame. Unregistration on
+//! disconnect is verified separately.
+//!
+//! Server thread leaks (`serve_ws_fn_actor` blocks forever — same
+//! limitation as `serve_ws_fn`); cargo reaps it on process exit.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, conc_registry, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::collections::BTreeSet;
+use std::net::TcpListener;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+use tungstenite::client::IntoClientRequest;
+use tungstenite::stream::MaybeTlsStream;
+
+fn free_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let port = listener.local_addr().expect("local_addr").port();
+    drop(listener);
+    port
+}
+
+fn spawn_server(src: &str) {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors: {errs:#?}");
+    }
+    let bc = Arc::new(compile_program(&stages));
+    let mut policy = Policy::pure();
+    policy.allow_effects = ["net".to_string(), "concurrent".to_string(), "io".to_string()]
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    thread::spawn(move || {
+        let handler = DefaultHandler::new(policy.clone()).with_program(Arc::clone(&bc));
+        let mut vm = Vm::with_handler(&bc, Box::new(handler));
+        let _ = vm.call("main", vec![]);
+    });
+    // Give the server a moment to bind.
+    thread::sleep(Duration::from_millis(400));
+}
+
+fn server_src(port: u16) -> String {
+    // `name_of` derives the registry name from the request path:
+    // `/ws/<id>` → `ws:<id>`. on_message just echoes back so an
+    // inbound frame round-trip is observable.
+    format!(
+        r#"
+import "std.net"  as net
+import "std.str"  as str
+
+fn name_of(conn :: WsConn) -> Str {{
+  # path looks like "/ws/cp001"; strip the prefix.
+  match str.strip_prefix(conn.path, "/ws/") {{
+    Some(id) => str.concat("ws:", id),
+    None     => "",
+  }}
+}}
+
+fn on_message(_c :: WsConn, msg :: WsMessage) -> WsAction {{
+  match msg {{
+    WsText(body) => WsSend(str.concat("echo:", body)),
+    _            => WsNoOp,
+  }}
+}}
+
+fn main() -> [net, concurrent] Nil {{
+  net.serve_ws_fn_actor({port}, "", name_of, on_message)
+}}
+"#
+    )
+}
+
+/// Inspect `conc_registry::lookup` from the test thread, then run a
+/// short Lex program that fishes the actor back out and `conc.tell`s
+/// it. Returns the registered actor handle (still held by the global
+/// registry).
+fn tell_via_lex_program(name: &str, body: &str) -> bool {
+    let src = format!(
+        r#"
+import "std.conc" as conc
+
+fn tell_if_present(name :: Str, body :: Str) -> [concurrent] Bool {{
+  match conc.lookup(name) {{
+    None        => false,
+    Some(actor) => {{
+      let _ := conc.tell(actor, body)
+      true
+    }},
+  }}
+}}
+"#
+    );
+    let prog = parse_source(&src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors in tell helper: {errs:#?}");
+    }
+    let bc = compile_program(&stages);
+    let mut policy = Policy::pure();
+    policy.allow_effects = ["concurrent".to_string()].into_iter().collect();
+    let handler = DefaultHandler::new(policy);
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    let v = vm
+        .call(
+            "tell_if_present",
+            vec![Value::Str(name.into()), Value::Str(body.into())],
+        )
+        .expect("vm tell");
+    matches!(v, Value::Bool(true))
+}
+
+#[test]
+fn outbound_tell_reaches_the_socket() {
+    let _ = conc_registry::_reset_for_tests();
+    let port = free_port();
+    spawn_server(&server_src(port));
+
+    // Dial in. The path determines the registry name via `name_of`.
+    let url = format!("ws://127.0.0.1:{port}/ws/cp001");
+    let req = url.as_str().into_client_request().expect("request");
+    let (mut client, _resp) = tungstenite::connect(req).expect("ws connect");
+
+    // Wait for the server to finish registration.
+    let mut found = false;
+    for _ in 0..40 {
+        if conc_registry::lookup("ws:cp001").is_some() {
+            found = true;
+            break;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    assert!(found, "actor never appeared in conc_registry");
+
+    // Push a frame from a non-WS path.
+    let sent = tell_via_lex_program("ws:cp001", "hello-from-non-ws");
+    assert!(sent, "tell_if_present returned false");
+
+    // Read the frame off the wire.
+    use tungstenite::Message;
+    use tungstenite::stream::MaybeTlsStream;
+    if let MaybeTlsStream::Plain(s) = client.get_mut() {
+        let _ = s.set_read_timeout(Some(Duration::from_secs(3)));
+    }
+    let msg = client.read().expect("read");
+    match msg {
+        Message::Text(t) => assert_eq!(t.as_str(), "hello-from-non-ws"),
+        other => panic!("expected text frame, got {other:?}"),
+    }
+}
+
+#[test]
+fn name_of_empty_string_skips_registration() {
+    let _ = conc_registry::_reset_for_tests();
+    let port = free_port();
+    // name_of returns "" — the connection should not appear in
+    // conc_registry, but on_message should still run.
+    let src = format!(
+        r#"
+import "std.net" as net
+import "std.str" as str
+
+fn name_of(_c :: WsConn) -> Str {{ "" }}
+
+fn on_message(_c :: WsConn, msg :: WsMessage) -> WsAction {{
+  match msg {{
+    WsText(body) => WsSend(str.concat("seen:", body)),
+    _            => WsNoOp,
+  }}
+}}
+
+fn main() -> [net, concurrent] Nil {{
+  net.serve_ws_fn_actor({port}, "", name_of, on_message)
+}}
+"#
+    );
+    spawn_server(&src);
+
+    let url = format!("ws://127.0.0.1:{port}/anywhere");
+    let req = url.as_str().into_client_request().expect("request");
+    let (mut client, _resp) = tungstenite::connect(req).expect("ws connect");
+
+    // Give the server a beat to settle, then probe the registry.
+    thread::sleep(Duration::from_millis(200));
+    assert!(
+        conc_registry::registered().is_empty(),
+        "registry should be empty when name_of returns \"\""
+    );
+
+    // Inbound still works — the on_message handler echoes back with a "seen:" prefix.
+    use tungstenite::Message;
+    client
+        .send(Message::Text("ping".to_string().into()))
+        .expect("send");
+    if let MaybeTlsStream::Plain(s) = client.get_mut() {
+        let _ = s.set_read_timeout(Some(Duration::from_secs(3)));
+    }
+    let msg = client.read().expect("read");
+    match msg {
+        Message::Text(t) => assert_eq!(t.as_str(), "seen:ping"),
+        other => panic!("expected text frame, got {other:?}"),
+    }
+}
+
+#[test]
+fn unregister_on_disconnect_clears_the_name() {
+    let _ = conc_registry::_reset_for_tests();
+    let port = free_port();
+    spawn_server(&server_src(port));
+
+    let url = format!("ws://127.0.0.1:{port}/ws/cp002");
+    let req = url.as_str().into_client_request().expect("request");
+    let (mut client, _resp) = tungstenite::connect(req).expect("ws connect");
+
+    // Wait for register.
+    let mut found = false;
+    for _ in 0..40 {
+        if conc_registry::lookup("ws:cp002").is_some() {
+            found = true;
+            break;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    assert!(found, "actor never appeared after dial");
+
+    // Close from the client side. The server's read loop sees a
+    // Close frame, exits, and unregisters the name from conc_registry.
+    client.close(None).expect("close");
+    drop(client);
+
+    // Give the server's run loop a chance to observe the close +
+    // unregister. 1s is generous given the 50ms read poll interval.
+    let mut cleared = false;
+    for _ in 0..40 {
+        if conc_registry::lookup("ws:cp002").is_none() {
+            cleared = true;
+            break;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    assert!(cleared, "name should be unregistered after socket close");
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -556,6 +556,52 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 EffectSet::open_var(0).union(&EffectSet::singleton("net")),
                 Ty::Unit,
             ));
+            // serve_ws_fn_actor[Eff] ::
+            //   (Int, Str,
+            //    (WsConn) -> Str,                        # name_of, registry name
+            //    (WsConn, WsMessage) -> [Eff] WsAction)  # on_message
+            //   -> [net, concurrent, Eff] Unit
+            //
+            // Variant of serve_ws_fn that registers each accepted
+            // connection as a named actor in conc_registry. Non-WS
+            // callers can then `conc.lookup(name) |> conc.tell(frame)`
+            // to push outbound frames into the socket from arbitrary
+            // [concurrent]-tagged code (HTTP webhooks, scheduled tasks,
+            // broadcast loops). Documented in #459.
+            //
+            // name_of is intentionally pure: it inspects the WsConn
+            // record (id / path / subprotocol) and decides what
+            // name to register the connection under. Empty string
+            // means "don't register this connection" — `on_message`
+            // still runs but no outbound handle is exposed.
+            //
+            // The result row carries `concurrent` because the runtime
+            // registers an `ActorHandler::Native` bridge in the conc
+            // registry; lookups from non-WS callers are themselves
+            // `[concurrent]` effects.
+            fields.insert("serve_ws_fn_actor".into(), Ty::function(
+                vec![
+                    Ty::int(),
+                    Ty::str(), // subprotocol
+                    Ty::function(
+                        vec![Ty::Con("WsConn".into(), vec![])],
+                        EffectSet::empty(),
+                        Ty::str(),
+                    ),
+                    Ty::function(
+                        vec![
+                            Ty::Con("WsConn".into(), vec![]),
+                            Ty::Con("WsMessage".into(), vec![]),
+                        ],
+                        EffectSet::open_var(0),
+                        Ty::Con("WsAction".into(), vec![]),
+                    ),
+                ],
+                EffectSet::open_var(0)
+                    .union(&EffectSet::singleton("net"))
+                    .union(&EffectSet::singleton("concurrent")),
+                Ty::Unit,
+            ));
             // dial_ws[Eff] :: (Str, Str, () -> [Eff] WsAction,
             //                  (WsMessage) -> [Eff] WsAction)
             //                  -> [net, Eff] Result[Unit, Str]


### PR DESCRIPTION
## Summary

Closes #459 (and unblocks [alpibrusl/lex-web#4](https://github.com/alpibrusl/lex-web/issues/4) — lex-ocpp's CSMS→CP flow). Adds a new entry point that registers each accepted WebSocket connection as a named actor in `conc_registry`, so non-WS callers can push frames into the socket via the existing `conc.lookup` + `conc.tell` surface — no new module, no API divergence from the issue.

## API

```lex
net.serve_ws_fn_actor(
  port        :: Int,
  subprotocol :: Str,
  name_of     :: (WsConn) -> Str,                       # pure
  on_message  :: (WsConn, WsMessage) -> [E] WsAction    # same as serve_ws_fn
) -> [net, concurrent, E] Unit
```

`name_of` runs once per accepted connection and returns the registry key (typically derived from the connection's URL path or subprotocol). An empty string opts the connection out of registration — inbound still works, no outbound handle is exposed.

Outbound from any `[concurrent]` context:

```lex
match conc.lookup("charger:cp001") {
  None        => Err("charger offline"),
  Some(actor) => { let _ := conc.tell(actor, frame_str)  Ok(()) },
}
```

## Why an `ActorHandler` variant (not a parallel `ws.send_to` surface)

The runtime already has the per-connection `mpsc::Sender<String>` plumbing for the broadcast/chat path. Instead of forking the `conc` surface or inventing a parallel `ws.send_to`, extend `ActorCell.handler` from a bare `Value` to an `ActorHandler` enum:

```rust
enum ActorHandler {
    Lex(Value),                       // existing — user closures from conc.spawn
    Native(Arc<NativeActorHandler>),  // new — Rust-side bridge to a channel
}
```

`conc.tell` dispatches on the variant. `Lex` is the existing "call `handler(state, msg)` on this VM, expect `(new_state, reply)`" path — **unchanged for every user-spawned actor**. `Native` is fire-and-forget over a captured `mpsc::Sender`; state is unused (the "state" is the external resource — here the socket). `conc.ask` against a native actor returns whatever the bridge produces; `conc.tell` discards it.

User-facing `conc.spawn` still requires a `Value::Closure` — `ActorHandler::Native` is internal-only, constructed by `serve_ws_fn_actor` itself. **No new public construction surface.**

## Lifecycle

- On accept, runtime calls `name_of(conn)`. Empty string → skip registration entirely.
- If non-empty, build a `NativeActorHandler` capturing the connection's `tx` (the same channel the chat broadcast registry uses), register under the name. Name collisions (`AlreadyRegistered`) abort the connection — surface the duplicate immediately rather than silently overwriting.
- On disconnect, the run loop's tear-down calls `conc_registry::unregister(name)`. A subsequent `conc.lookup(name)` returns None.

## Tests

`crates/lex-runtime/tests/net_serve_ws_fn_actor.rs`, three cases — all passing:

| Case | What it verifies |
|---|---|
| `outbound_tell_reaches_the_socket` | dial a client, lookup the registered actor from a non-WS task, `tell` it, verify the client receives the exact bytes on the wire |
| `name_of_empty_string_skips_registration` | connections that return `""` never appear in `conc_registry`; inbound `on_message` still echoes back |
| `unregister_on_disconnect_clears_the_name` | client-side close removes the name within the run loop's 50ms poll budget |

Existing suites unchanged: `conc_registry`, `concurrent_actor`, `net_serve_ws_fn_auth`, `net_serve_ws_subprotocol`, `net_dial_ws`.

## Out of scope for v1

- **Binary frame dispatch from non-WS callers.** The native bridge only accepts `Value::Str`; binary needs a tagged message union (`WsOut::Text | WsOut::Binary`) that the bridge can match on. Filed inline in `ws.rs`.
- **Compile-time type-tagging at register/lookup.** Inherits the same v1 type-opacity gap as `conc.register` itself; #444's `TypeMismatch` `ConcError` variant is reserved for the future check.

## What changed (+580 / -17, 6 files)

- `crates/lex-bytecode/src/value.rs` — `ActorHandler` enum + `NativeActorHandler` struct
- `crates/lex-bytecode/src/vm.rs` — `conc.tell` / `conc.ask` dispatch on variant
- `crates/lex-runtime/src/ws.rs` — `serve_ws_fn_actor` + `handle_connection_fn_actor` (mostly mirrors `serve_ws_fn`)
- `crates/lex-runtime/src/handler.rs` — `("net", "serve_ws_fn_actor")` op dispatch
- `crates/lex-types/src/builtins.rs` — type signature with `[net, concurrent, E]` effect row
- `crates/lex-runtime/tests/net_serve_ws_fn_actor.rs` — three integration tests (new file)

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test -p lex-runtime --test net_serve_ws_fn_actor` — 3/3 passing
- [x] Regression: `conc_registry`, `concurrent_actor`, `net_serve_ws_*` suites still green
- [ ] Reviewer: verify the `ActorHandler` refactor matches the codebase's preferred enum-on-a-value pattern (alternative: trait object on `ActorCell`)
- [ ] Once released, bump `lex.toml` in lex-web and close [alpibrusl/lex-web#4](https://github.com/alpibrusl/lex-web/issues/4); lex-ocpp can then ship `csms_with_outbound.lex` exercising `RemoteStartTransaction`

---
_Generated by [Claude Code](https://claude.ai/code/session_01PsrNeuuchvDLFJmY1CskFe)_