### PR TITLE
perf(#461): superinstructions slice 1 — fuse LoadLocal + PushConst(Int) + IntAdd

### DIFF
--- a/crates/lex-bytecode/src/compiler.rs
+++ b/crates/lex-bytecode/src/compiler.rs
@@ -223,6 +223,15 @@ pub fn compile_program(stages: &[a::Stage]) -> Program {
         p.functions[pl.fn_id as usize].locals_count = peak;
     }
 
+    // Peephole pass (#461 superinstructions). Rewrites fusable opcode
+    // patterns into single dispatch steps. Runs before `body_hash`
+    // computation, but `compute_body_hash` decomposes each fused op
+    // back to its primitive form on hash — so closure identity (#222)
+    // is invariant under this pass and the order doesn't matter.
+    for f in p.functions.iter_mut() {
+        apply_peephole(&mut f.code, &pool.pool);
+    }
+
     // Final pass: stamp every function with its content hash now that
     // every body is finalized (#222). Trampolines installed via
     // `install_trampoline` already have it; recomputing is cheap and
@@ -237,6 +246,64 @@ pub fn compile_program(stages: &[a::Stage]) -> Program {
     p.constants = pool.pool;
     p.record_shapes = pool.record_shapes;
     p
+}
+
+/// Peephole pass: rewrite fusable opcode patterns into superinstructions
+/// (#461). Each fused op claims its own slot in the code stream; the
+/// trailing primitive ops it absorbs stay in place as inert
+/// "tombstones" — the dispatch loop overrides its default `pc += 1`
+/// to step past them. Leaving the tombstones in place keeps
+/// `code.len()` invariant and means we don't have to renumber jump
+/// offsets.
+///
+/// Pattern (slice 1): `LoadLocal(i), PushConst(c), IntAdd` where
+/// `constants[c]` is a `Const::Int`. Fused to
+/// `LoadLocalAddIntConst { local_idx: i, imm_const_idx: c }`.
+/// Safety: the second and third slots must not be reachable from
+/// any Jump / JumpIf / JumpIfNot — otherwise a jump would land on a
+/// tombstone instead of the live op the source intended. The
+/// pre-pass below collects every jump target in the function and
+/// skips fusion sites whose tombstones overlap one.
+fn apply_peephole(code: &mut [Op], constants: &[Const]) {
+    if code.len() < 3 { return; }
+
+    // Collect jump targets so we don't fuse across them.
+    let mut jump_targets = std::collections::HashSet::new();
+    for (pc, op) in code.iter().enumerate() {
+        let off = match op {
+            Op::Jump(off) | Op::JumpIf(off) | Op::JumpIfNot(off) => Some(*off),
+            _ => None,
+        };
+        if let Some(off) = off {
+            let target = (pc as i32 + 1 + off) as usize;
+            jump_targets.insert(target);
+        }
+    }
+
+    let n = code.len();
+    let mut k = 0;
+    while k + 2 < n {
+        if let (Op::LoadLocal(local_idx), Op::PushConst(imm_const_idx), Op::IntAdd)
+            = (code[k], code[k + 1], code[k + 2])
+        {
+            let imm_is_int = matches!(
+                constants.get(imm_const_idx as usize),
+                Some(Const::Int(_))
+            );
+            // Tombstones at k+1 and k+2 must not be jump targets;
+            // k itself can be a target (it stays a live op — the
+            // fused form executes the same semantics in one step).
+            let safe = imm_is_int
+                && !jump_targets.contains(&(k + 1))
+                && !jump_targets.contains(&(k + 2));
+            if safe {
+                code[k] = Op::LoadLocalAddIntConst { local_idx, imm_const_idx };
+                k += 3;
+                continue;
+            }
+        }
+        k += 1;
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/lex-bytecode/src/op.rs
+++ b/crates/lex-bytecode/src/op.rs
@@ -110,4 +110,23 @@ pub enum Op {
     // strings
     StrConcat, StrLen, StrEq,
     BytesLen, BytesEq,
+
+    // superinstructions (#461)
+    //
+    // Fused opcodes emitted by the compiler's peephole pass to skip
+    // dispatch on common multi-op patterns. The pass leaves the
+    // original primitive ops in place at the trailing slots — the
+    // dispatch loop overrides its default `pc += 1` to step past
+    // them. Keeping `code.len()` invariant means existing
+    // Jump/JumpIf offsets remain valid without a renumbering pass.
+    /// Fused `LoadLocal(local_idx) + PushConst(imm_const_idx) +
+    /// IntAdd`. `imm_const_idx` must point to a `Const::Int`. The
+    /// dispatch arm reads the local, adds the constant, pushes the
+    /// result, and advances pc by 3 (past this op and the two
+    /// inert PushConst + IntAdd slots that follow). For
+    /// `body_hash` stability (#222) the canonical encoding decomposes
+    /// this op back to a standalone `LoadLocal(local_idx)` at hash
+    /// time; the unchanged PushConst / IntAdd at the next two
+    /// slots hash normally, so the total bytes match pre-fusion.
+    LoadLocalAddIntConst { local_idx: u16, imm_const_idx: u32 },
 }

--- a/crates/lex-bytecode/src/program.rs
+++ b/crates/lex-bytecode/src/program.rs
@@ -145,6 +145,17 @@ pub fn compute_body_hash(
                 }))
                 .expect("Op serialization must succeed")
             }
+            // Peephole-fused op (#461 superinstructions). The fused
+            // op occupies the slot where `LoadLocal(local_idx)` was;
+            // the next two slots in `code` still hold the unchanged
+            // `PushConst(imm_const_idx)` and `IntAdd`. Hashing as the
+            // original `LoadLocal` makes the total body-hash bytes
+            // match the pre-fusion form — closure identity (#222)
+            // stays invariant across peephole rewrites.
+            Op::LoadLocalAddIntConst { local_idx, .. } => {
+                serde_json::to_vec(&Op::LoadLocal(*local_idx))
+                    .expect("Op serialization must succeed")
+            }
             _ => serde_json::to_vec(op).expect("Op serialization must succeed"),
         };
         hasher.update((bytes.len() as u64).to_le_bytes());

--- a/crates/lex-bytecode/src/verify.rs
+++ b/crates/lex-bytecode/src/verify.rs
@@ -192,6 +192,14 @@ fn stack_delta(op: &Op) -> i32 {
         Op::StrEq     => -1,
         Op::BytesLen  =>  0,
         Op::BytesEq   => -1,
+
+        // Superinstructions (#461). The fused op contributes its
+        // net delta (+1, same shape as a bare LoadLocal). The two
+        // inert primitive ops the peephole leaves at pc+1 / pc+2
+        // are walked as if live: their deltas (+1 PushConst, -1
+        // IntAdd) cancel, so the depth at pc+3 matches what the
+        // unfused sequence would have produced.
+        Op::LoadLocalAddIntConst { .. } => 1,
     }
 }
 

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -1420,6 +1420,23 @@ impl<'a> Vm<'a> {
                     };
                     self.stack.push(Value::Bool(eq));
                 }
+
+                // Superinstructions (#461).
+                Op::LoadLocalAddIntConst { local_idx, imm_const_idx } => {
+                    let base = self.frames[frame_idx].locals_start;
+                    let a = self.locals_storage[base + local_idx as usize].as_int();
+                    let b = match &self.program.constants[imm_const_idx as usize] {
+                        Const::Int(n) => *n,
+                        c => return Err(VmError::TypeMismatch(
+                            format!("LoadLocalAddIntConst expected Int const, got {c:?}"))),
+                    };
+                    self.stack.push(Value::Int(a + b));
+                    // Override the default `pc + 1`: skip past the
+                    // two inert primitive ops (the original
+                    // PushConst + IntAdd) that the peephole pass
+                    // left in place for body-hash stability.
+                    self.frames[frame_idx].pc = pc + 3;
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

First superinstructions slice for #461. Adds `Op::LoadLocalAddIntConst { local_idx, imm_const_idx }` — a single-step replacement for the `LoadLocal + PushConst(Int) + IntAdd` triple, emitted by a peephole pass in the compiler. Cuts dispatch frequency for integer-arithmetic-heavy code in half (4 ops/binding → 2 ops/binding on straight_arith-shaped patterns).

## How it works

**Peephole** (`compiler.rs`): after each function is compiled, scan for the triple, verify the constant is `Const::Int` and the next two slots aren't reachable from any `Jump/JumpIf/JumpIfNot`, then rewrite the first slot to the fused op. The original PushConst/IntAdd stay in place as inert tombstones.

**Dispatch** (`vm.rs`): the fused arm executes the full triple's semantics, then overrides the default `pc += 1` with `pc + 3` to step past the tombstones. Tombstones never execute.

**Code-length invariant**: tombstones stay in place so `code.len()` doesn't change → existing jump offsets remain valid. No renumbering pass needed.

## Body-hash stability (#222)

`compute_body_hash` decomposes `LoadLocalAddIntConst { local_idx, .. }` back to `LoadLocal(local_idx)` at hash time. The unchanged tombstones at the next two slots hash normally as `PushConst` / `IntAdd`. Total hash bytes match the pre-fusion form — existing closures hash bit-identically.

`bytecode_is_reproducible` and `canonical_format_e2e` still pass.

## Bench results

`dispatch/straight_arith` (n=5000) on local hardware:

| | Wall | Throughput | ns/step |
|---|---|---|---|
| main | 305 µs | 65.5 Melem/s | 15.3 |
| this | 225 µs | 88.9 Melem/s | 11.2 |

**27% faster, 1.37× speedup.** The dispatch gap to the `straight_arith_no_dispatch` floor (181 µs, from PR #473) closed from 124 µs → 44 µs — about **64% of the addressable dispatch overhead** absorbed in this one fusion.

## Verifier soundness

`LoadLocalAddIntConst` declares stack-delta `+1` (net of the fused triple). The verifier walks the tombstones as if live — their deltas (`+1` PushConst, `-1` IntAdd) cancel — so the depth at `pc+3` matches the unfused form. Sound because tombstones are unreachable from jumps by construction of the peephole's safety check.

## Test plan

- [x] `cargo test -p lex-bytecode` (all passing, including `bytecode_is_reproducible`)
- [x] `cargo test -p lex-vcs -p lex-trace` (closure identity, body-hash recorder)
- [x] `cargo test -p lex-runtime --test canonical_format_e2e --test m5 --test flow_canonicality` (body-hash determinism + VM record handling)
- [x] `cargo check --workspace --tests` (compiles everywhere)
- [x] `cargo bench -p lex-bytecode --bench dispatch -- straight_arith` (1.37× speedup confirmed)
- [ ] CI workspace tests

## Future slices

- **Slice 2**: fuse the trailing `StoreLocal` into a `LoadLocalAddIntConstStoreLocal { src, imm, dest }` — 1 op for the full straight_arith increment pattern (would cover ~3× more of the dispatch headroom on this workload).
- Other fusions: `LoadLocal+LoadLocal` (binary ops with two locals), comparison chains (`X < Y && Y < Z`), constant comparison (`X < const`).

https://claude.ai/code/session_01VEhcze986fxQDqJXKEwF2n

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEhcze986fxQDqJXKEwF2n)_