### PR TITLE
perf(#461): typed-lowering pass — emit IntAdd / FloatAdd where statically known (1.94× on straight_arith)

### DIFF
--- a/crates/lex-bytecode/src/compiler.rs
+++ b/crates/lex-bytecode/src/compiler.rs
@@ -162,6 +162,7 @@ pub fn compile_program(stages: &[a::Stage]) -> Program {
                 locals: IndexMap::new(),
                 next_local: 0,
                 peak_local: 0,
+                local_types: IndexMap::new(),
                 pool: &mut pool,
                 function_names: &function_names,
                 module_aliases: &module_aliases,
@@ -172,6 +173,7 @@ pub fn compile_program(stages: &[a::Stage]) -> Program {
             for param in &fd.params {
                 let i = fc.next_local;
                 fc.locals.insert(param.name.clone(), i);
+                fc.local_types.insert(param.name.clone(), classify_type_expr(&param.ty));
                 fc.next_local += 1;
                 fc.peak_local = fc.next_local;
             }
@@ -195,6 +197,7 @@ pub fn compile_program(stages: &[a::Stage]) -> Program {
             locals: IndexMap::new(),
             next_local: 0,
             peak_local: 0,
+            local_types: IndexMap::new(),
             pool: &mut pool,
             function_names: &function_names,
             module_aliases: &module_aliases,
@@ -205,12 +208,18 @@ pub fn compile_program(stages: &[a::Stage]) -> Program {
         for name in &pl.capture_names {
             let i = fc.next_local;
             fc.locals.insert(name.clone(), i);
+            // Captures' static types aren't known at this layer
+            // — the closure's environment carries them dynamically.
+            // Conservative fallback; binop lowering stays correct
+            // because Unknown classifies through to NumAdd.
+            fc.local_types.insert(name.clone(), NumTy::Unknown);
             fc.next_local += 1;
             fc.peak_local = fc.next_local;
         }
         for p in &pl.params {
             let i = fc.next_local;
             fc.locals.insert(p.name.clone(), i);
+            fc.local_types.insert(p.name.clone(), classify_type_expr(&p.ty));
             fc.next_local += 1;
             fc.peak_local = fc.next_local;
         }
@@ -321,6 +330,21 @@ struct FnCompiler<'a> {
     next_local: u16,
     /// Peak local usage seen during compilation (for VM frame sizing).
     peak_local: u16,
+    /// Inferred numeric type of each local for typed numeric-op
+    /// lowering (#461). Populated when binding function parameters
+    /// (from their declared `TypeExpr::Named { name: "Int", .. }`
+    /// or `"Float"`) and when binding `let name := value` where
+    /// the RHS classifies statically. Used by `compile_binop` to
+    /// emit `Op::IntAdd` / `Op::FloatAdd` instead of the
+    /// polymorphic `Op::NumAdd` when both operands' types are
+    /// statically known. Conservative: falls back to `NumTy::Unknown`
+    /// (and the polymorphic op) whenever a type isn't locally
+    /// derivable.
+    ///
+    /// Keyed by local *name* (parallel to `locals`) rather than by
+    /// slot index so shadowed bindings are handled correctly via
+    /// `IndexMap`'s insertion-order semantics.
+    local_types: IndexMap<String, NumTy>,
     pool: &'a mut ConstPool,
     function_names: &'a IndexMap<String, u32>,
     module_aliases: &'a IndexMap<String, String>,
@@ -332,6 +356,28 @@ struct FnCompiler<'a> {
     /// Mutable view of the function table — used to allocate fn_ids for
     /// freshly-discovered lambdas.
     next_fn_id: &'a mut Vec<Function>,
+}
+
+/// Lightweight numeric-type classification used by `compile_binop`
+/// to decide whether to emit `IntAdd` / `FloatAdd` (specialized,
+/// fast) or `NumAdd` (polymorphic, runtime-typed dispatch). #461
+/// typed-lowering pass — conservative: anything not provably one
+/// of these returns `Unknown` and falls back to the polymorphic op.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NumTy { Int, Float, Unknown }
+
+fn classify_type_expr(ty: &a::TypeExpr) -> NumTy {
+    match ty {
+        a::TypeExpr::Named { name, args } if args.is_empty() => match name.as_str() {
+            "Int" => NumTy::Int,
+            "Float" => NumTy::Float,
+            _ => NumTy::Unknown,
+        },
+        // `Refined { base, .. }` (#209) — classify by the base type;
+        // the refinement predicate doesn't change the value's primitive shape.
+        a::TypeExpr::Refined { base, .. } => classify_type_expr(base),
+        _ => NumTy::Unknown,
+    }
 }
 
 impl<'a> FnCompiler<'a> {
@@ -364,9 +410,18 @@ impl<'a> FnCompiler<'a> {
                     panic!("unknown var in compiler: {name}");
                 }
             }
-            a::CExpr::Let { name, ty: _, value, body } => {
+            a::CExpr::Let { name, ty, value, body } => {
+                // Classify the RHS for typed-op lowering (#461). Prefer
+                // the declared annotation when present (cheap O(1)
+                // lookup); fall back to classifying the value
+                // expression structurally.
+                let nty = match ty {
+                    Some(t) => classify_type_expr(t),
+                    None => self.classify_expr(value),
+                };
                 self.compile_expr(value, false);
                 let slot = self.alloc_local(name);
+                self.local_types.insert(name.clone(), nty);
                 self.emit(Op::StoreLocal(slot));
                 self.compile_expr(body, tail);
             }
@@ -505,23 +560,95 @@ impl<'a> FnCompiler<'a> {
     }
 
     fn compile_binop(&mut self, op: &str, lhs: &a::CExpr, rhs: &a::CExpr) {
+        // #461 typed lowering: if we can statically prove both
+        // operands are the same numeric type, emit the typed
+        // primitive (`IntAdd` / `FloatAdd`) instead of the
+        // polymorphic `NumAdd` that runtime-matches on operand
+        // shape. The fast path skips one match per arithmetic op
+        // *and* unblocks downstream peephole fusions (slice 1)
+        // that scan for typed primitives. Conservative fallback
+        // to the polymorphic op when either side classifies as
+        // `Unknown`, so correctness for `Float` / mixed code is
+        // unchanged.
+        let lhs_ty = self.classify_expr(lhs);
+        let rhs_ty = self.classify_expr(rhs);
+        let typed = match (lhs_ty, rhs_ty) {
+            (NumTy::Int, NumTy::Int) => NumTy::Int,
+            (NumTy::Float, NumTy::Float) => NumTy::Float,
+            _ => NumTy::Unknown,
+        };
         self.compile_expr(lhs, false);
         self.compile_expr(rhs, false);
-        match op {
-            "+" => self.emit(Op::NumAdd),
-            "-" => self.emit(Op::NumSub),
-            "*" => self.emit(Op::NumMul),
-            "/" => self.emit(Op::NumDiv),
-            "%" => self.emit(Op::NumMod),
-            "==" => self.emit(Op::NumEq),
-            "!=" => { self.emit(Op::NumEq); self.emit(Op::BoolNot); }
-            "<" => self.emit(Op::NumLt),
-            "<=" => self.emit(Op::NumLe),
-            ">" => { self.emit_swap_top2(); self.emit(Op::NumLt); }
-            ">=" => { self.emit_swap_top2(); self.emit(Op::NumLe); }
-            "and" => self.emit(Op::BoolAnd),
-            "or" => self.emit(Op::BoolOr),
-            other => panic!("unknown binop: {other:?}"),
+        match (op, typed) {
+            ("+",  NumTy::Int)     => self.emit(Op::IntAdd),
+            ("+",  NumTy::Float)   => self.emit(Op::FloatAdd),
+            ("+",  NumTy::Unknown) => self.emit(Op::NumAdd),
+            ("-",  NumTy::Int)     => self.emit(Op::IntSub),
+            ("-",  NumTy::Float)   => self.emit(Op::FloatSub),
+            ("-",  NumTy::Unknown) => self.emit(Op::NumSub),
+            ("*",  NumTy::Int)     => self.emit(Op::IntMul),
+            ("*",  NumTy::Float)   => self.emit(Op::FloatMul),
+            ("*",  NumTy::Unknown) => self.emit(Op::NumMul),
+            ("/",  NumTy::Int)     => self.emit(Op::IntDiv),
+            ("/",  NumTy::Float)   => self.emit(Op::FloatDiv),
+            ("/",  NumTy::Unknown) => self.emit(Op::NumDiv),
+            // Int has %; Float doesn't (NumMod will reject at runtime).
+            ("%",  NumTy::Int)     => self.emit(Op::IntMod),
+            ("%",  _)              => self.emit(Op::NumMod),
+            ("==", NumTy::Int)     => self.emit(Op::IntEq),
+            ("==", NumTy::Float)   => self.emit(Op::FloatEq),
+            ("==", NumTy::Unknown) => self.emit(Op::NumEq),
+            ("!=", NumTy::Int)     => { self.emit(Op::IntEq);   self.emit(Op::BoolNot); }
+            ("!=", NumTy::Float)   => { self.emit(Op::FloatEq); self.emit(Op::BoolNot); }
+            ("!=", NumTy::Unknown) => { self.emit(Op::NumEq);   self.emit(Op::BoolNot); }
+            ("<",  NumTy::Int)     => self.emit(Op::IntLt),
+            ("<",  NumTy::Float)   => self.emit(Op::FloatLt),
+            ("<",  NumTy::Unknown) => self.emit(Op::NumLt),
+            ("<=", NumTy::Int)     => self.emit(Op::IntLe),
+            ("<=", NumTy::Float)   => self.emit(Op::FloatLe),
+            ("<=", NumTy::Unknown) => self.emit(Op::NumLe),
+            (">",  NumTy::Int)     => { self.emit_swap_top2(); self.emit(Op::IntLt); }
+            (">",  NumTy::Float)   => { self.emit_swap_top2(); self.emit(Op::FloatLt); }
+            (">",  NumTy::Unknown) => { self.emit_swap_top2(); self.emit(Op::NumLt); }
+            (">=", NumTy::Int)     => { self.emit_swap_top2(); self.emit(Op::IntLe); }
+            (">=", NumTy::Float)   => { self.emit_swap_top2(); self.emit(Op::FloatLe); }
+            (">=", NumTy::Unknown) => { self.emit_swap_top2(); self.emit(Op::NumLe); }
+            ("and", _) => self.emit(Op::BoolAnd),
+            ("or",  _) => self.emit(Op::BoolOr),
+            (other, _) => panic!("unknown binop: {other:?}"),
+        }
+    }
+
+    /// Classify an expression's static numeric type for #461 typed
+    /// lowering. Strictly conservative: only returns `Int` / `Float`
+    /// when the type is locally derivable from a literal, an
+    /// already-classified local, or a binary op on two same-typed
+    /// operands. Everything else (function calls, field access,
+    /// match expressions, ...) falls back to `Unknown` and the
+    /// polymorphic NumAdd-family op.
+    fn classify_expr(&self, e: &a::CExpr) -> NumTy {
+        match e {
+            a::CExpr::Literal { value: a::CLit::Int { .. } } => NumTy::Int,
+            a::CExpr::Literal { value: a::CLit::Float { .. } } => NumTy::Float,
+            a::CExpr::Var { name } =>
+                self.local_types.get(name).copied().unwrap_or(NumTy::Unknown),
+            a::CExpr::BinOp { op, lhs, rhs } => {
+                // Numeric ops preserve the operand type (Int+Int=Int,
+                // Float+Float=Float). Comparison/logical ops yield
+                // Bool, not a numeric type — return Unknown.
+                let is_numeric = matches!(op.as_str(), "+" | "-" | "*" | "/" | "%");
+                if !is_numeric { return NumTy::Unknown; }
+                match (self.classify_expr(lhs), self.classify_expr(rhs)) {
+                    (NumTy::Int, NumTy::Int) => NumTy::Int,
+                    (NumTy::Float, NumTy::Float) => NumTy::Float,
+                    _ => NumTy::Unknown,
+                }
+            }
+            a::CExpr::UnaryOp { op, expr } if op == "-" => self.classify_expr(expr),
+            // Let-expressions: the let-binding mutates `local_types`
+            // *during* compile_expr; classifying ahead of time would
+            // require simulating that. Conservative fallback.
+            _ => NumTy::Unknown,
         }
     }
 

--- a/crates/lex-bytecode/src/program.rs
+++ b/crates/lex-bytecode/src/program.rs
@@ -156,6 +156,25 @@ pub fn compute_body_hash(
                 serde_json::to_vec(&Op::LoadLocal(*local_idx))
                     .expect("Op serialization must succeed")
             }
+            // #461 typed-lowering compensation. The compiler now emits
+            // typed numeric primitives (`IntAdd` / `FloatAdd` / ...)
+            // wherever it can prove operand types, but the closure
+            // identity contract (#222) requires `body_hash` to remain
+            // bit-identical to the pre-lowering polymorphic form
+            // (`NumAdd` / ...). Lower the typed op to its polymorphic
+            // counterpart at hash time. Behavioral equivalence is
+            // guaranteed by the type checker — operand-type proofs the
+            // compiler used to specialize are exactly what makes the
+            // polymorphic op behave identically.
+            Op::IntAdd   | Op::FloatAdd => serde_json::to_vec(&Op::NumAdd).unwrap(),
+            Op::IntSub   | Op::FloatSub => serde_json::to_vec(&Op::NumSub).unwrap(),
+            Op::IntMul   | Op::FloatMul => serde_json::to_vec(&Op::NumMul).unwrap(),
+            Op::IntDiv   | Op::FloatDiv => serde_json::to_vec(&Op::NumDiv).unwrap(),
+            Op::IntMod                  => serde_json::to_vec(&Op::NumMod).unwrap(),
+            Op::IntNeg   | Op::FloatNeg => serde_json::to_vec(&Op::NumNeg).unwrap(),
+            Op::IntEq    | Op::FloatEq  => serde_json::to_vec(&Op::NumEq).unwrap(),
+            Op::IntLt    | Op::FloatLt  => serde_json::to_vec(&Op::NumLt).unwrap(),
+            Op::IntLe    | Op::FloatLe  => serde_json::to_vec(&Op::NumLe).unwrap(),
             _ => serde_json::to_vec(op).expect("Op serialization must succeed"),
         };
         hasher.update((bytes.len() as u64).to_le_bytes());


### PR DESCRIPTION
## Summary

The bytecode compiler used to emit `Op::NumAdd` (and the rest of the `Num*` family) for every source-level `+`, `-`, `<`, etc. — the polymorphic variant that runtime-matches on operand shape. The typed primitives (`Op::IntAdd`, `Op::FloatAdd`, ...) existed but were never produced by `compile_program`.

As a side effect, the slice-1 superinstruction peephole landed in #474 had never fired in production — it scans for `[LoadLocal, PushConst, IntAdd]`, which the compiler never emitted. **The "+27% from slice 1" number in #474's PR description was microarchitectural noise from touching the dispatch match, not actual fusion.** Discovered while implementing slice 2 (regression in the other direction tipped this off).

This PR adds local numeric-type inference inside `FnCompiler`:
- Parameter types are read from declared `TypeExpr::Named { name: "Int" | "Float", .. }`.
- `let` RHS types are classified recursively over literals, already-known locals, and same-type-preserving arithmetic.
- Where both binop operands classify as `Int` (resp. `Float`), `compile_binop` emits the specialized op; otherwise it falls back to the polymorphic `Num*` variant.

Conservative throughout — anything not locally derivable falls back, so correctness for `Float` / mixed / generic code is unchanged.

This is the "lower NumAdd → IntAdd|FloatAdd in a typed pass" TODO at `op.rs:101`.

## Body-hash compatibility (#222 + #461 acceptance criterion)

`compute_body_hash` now lowers each typed numeric op back to its polymorphic counterpart before serialization:

```rust
Op::IntAdd | Op::FloatAdd => serde_json::to_vec(&Op::NumAdd).unwrap(),
// ...same for Sub / Mul / Div / Mod / Neg / Eq / Lt / Le
```

Hash bytes stay bit-identical to the pre-this-PR form. Any closure that used `+` before still hashes to the same `body_hash`. The lowering is sound because behavioral equivalence of typed vs. polymorphic ops is exactly what the type checker's operand-type proof guaranteed.

`canonical_format_e2e` (the explicit body-hash determinism test) and `bytecode_is_reproducible` both still pass.

## Bench results

`dispatch/straight_arith` (n=5000):

| | Wall | Throughput | ns/step |
|---|---|---|---|
| main | 305 µs | 65.5 Melem/s | 15.3 |
| this | 157 µs | 127 Melem/s | 7.86 |

**1.94× speedup**, and we're now *below* the `dispatch/straight_arith_no_dispatch` floor (181 µs) — slice 1's superinstruction fires for the first time, fusing `LoadLocal + PushConst(Int) + IntAdd` into one op that bypasses the value stack entirely.

The straight_arith ceiling that #473's diagnostic established (~9 ns/step minimum given Value-handling cost) is now being beaten — the fused op cuts more than just dispatch by also bypassing the stack.

## Implication for #461 acceptance criterion

The 2× speedup bar on `/plaintext` is now more plausibly within reach with the existing slice-1 + future slice-2 superinstructions on top.

## Test plan

- [x] `cargo test -p lex-bytecode` (all passing, including `bytecode_is_reproducible`)
- [x] `cargo test -p lex-vcs` (closure identity)
- [x] `cargo test -p lex-runtime --test canonical_format_e2e` (body-hash determinism)
- [x] `cargo test -p lex-runtime --test m5 --test flow_canonicality --test analytics_app --test gateway_app --test inbox_app --test list_higher_order --test list_sort_by` (broad runtime coverage on numeric-heavy code)
- [x] `cargo check --workspace --tests` (everywhere compiles)
- [x] `cargo bench -p lex-bytecode --bench dispatch -- straight_arith` (1.94× speedup confirmed)
- [ ] CI workspace tests

## Follow-ups

- Re-bench slice 2 (the deferred `LoadLocalAddIntConstStoreLocal` fusion) on top of this — should now produce a real, measurable additional win since the path is live.
- The internal list-iteration scaffolding in `compiler.rs` (lines 801-2071) still emits `Op::NumAdd` / `Op::NumLt` for known-Int counter arithmetic. A follow-up could swap those to `Op::IntAdd` / `Op::IntLt` directly — should also produce wins on list-heavy code (the `record_field` and `arith_loop` benches).

https://claude.ai/code/session_01VEhcze986fxQDqJXKEwF2n

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEhcze986fxQDqJXKEwF2n)_