### PR TITLE
perf(#461): superinstructions slice 2 — LoadLocalAddIntConstStoreLocal (1.72× over #476, 3.35× cumulative)

### DIFF
--- a/crates/lex-bytecode/src/compiler.rs
+++ b/crates/lex-bytecode/src/compiler.rs
@@ -237,8 +237,12 @@ pub fn compile_program(stages: &[a::Stage]) -> Program {
     // computation, but `compute_body_hash` decomposes each fused op
     // back to its primitive form on hash — so closure identity (#222)
     // is invariant under this pass and the order doesn't matter.
+    //
+    // Slices run sequentially: slice 2 looks for slice-1 output
+    // followed by a StoreLocal, so it must follow slice 1.
     for f in p.functions.iter_mut() {
         apply_peephole(&mut f.code, &pool.pool);
+        apply_peephole_slice2(&mut f.code);
     }
 
     // Final pass: stamp every function with its content hash now that
@@ -275,19 +279,7 @@ pub fn compile_program(stages: &[a::Stage]) -> Program {
 /// skips fusion sites whose tombstones overlap one.
 fn apply_peephole(code: &mut [Op], constants: &[Const]) {
     if code.len() < 3 { return; }
-
-    // Collect jump targets so we don't fuse across them.
-    let mut jump_targets = std::collections::HashSet::new();
-    for (pc, op) in code.iter().enumerate() {
-        let off = match op {
-            Op::Jump(off) | Op::JumpIf(off) | Op::JumpIfNot(off) => Some(*off),
-            _ => None,
-        };
-        if let Some(off) = off {
-            let target = (pc as i32 + 1 + off) as usize;
-            jump_targets.insert(target);
-        }
-    }
+    let jump_targets = collect_jump_targets(code);
 
     let n = code.len();
     let mut k = 0;
@@ -313,6 +305,67 @@ fn apply_peephole(code: &mut [Op], constants: &[Const]) {
         }
         k += 1;
     }
+}
+
+/// Slice 2: fuse `[LoadLocalAddIntConst, _, _, StoreLocal(dest)]`
+/// into `LoadLocalAddIntConstStoreLocal { src, imm_const_idx, dest }`.
+/// The two `_` slots are slice-1 tombstones (the original PushConst
+/// + IntAdd) and stay in place as slice-2 tombstones too — the
+/// dispatch loop advances pc by 4 past all three trailing slots
+/// after executing the fused op.
+fn apply_peephole_slice2(code: &mut [Op]) {
+    if code.len() < 4 { return; }
+    let jump_targets = collect_jump_targets(code);
+
+    let n = code.len();
+    let mut k = 0;
+    while k + 3 < n {
+        if let (
+            Op::LoadLocalAddIntConst { local_idx: src, imm_const_idx },
+            _,
+            _,
+            Op::StoreLocal(dest),
+        ) = (code[k], code[k + 1], code[k + 2], code[k + 3])
+        {
+            // Slice-1 contract: code[k+1] is the original
+            // PushConst(imm_const_idx) and code[k+2] is the
+            // original IntAdd. We don't re-verify those — slice 1
+            // is the only producer of LoadLocalAddIntConst and
+            // always leaves the contract intact.
+            //
+            // Safety: tombstones at k+1..k+3 must not be reachable
+            // from any jump. k itself can be (it's still a live
+            // op carrying the same semantics).
+            let safe = !jump_targets.contains(&(k + 1))
+                && !jump_targets.contains(&(k + 2))
+                && !jump_targets.contains(&(k + 3));
+            if safe {
+                code[k] = Op::LoadLocalAddIntConstStoreLocal {
+                    src,
+                    imm_const_idx,
+                    dest,
+                };
+                k += 4;
+                continue;
+            }
+        }
+        k += 1;
+    }
+}
+
+fn collect_jump_targets(code: &[Op]) -> std::collections::HashSet<usize> {
+    let mut targets = std::collections::HashSet::new();
+    for (pc, op) in code.iter().enumerate() {
+        let off = match op {
+            Op::Jump(off) | Op::JumpIf(off) | Op::JumpIfNot(off) => Some(*off),
+            _ => None,
+        };
+        if let Some(off) = off {
+            let target = (pc as i32 + 1 + off) as usize;
+            targets.insert(target);
+        }
+    }
+    targets
 }
 
 #[derive(Debug, Clone)]

--- a/crates/lex-bytecode/src/compiler.rs
+++ b/crates/lex-bytecode/src/compiler.rs
@@ -310,7 +310,7 @@ fn apply_peephole(code: &mut [Op], constants: &[Const]) {
 /// Slice 2: fuse `[LoadLocalAddIntConst, _, _, StoreLocal(dest)]`
 /// into `LoadLocalAddIntConstStoreLocal { src, imm_const_idx, dest }`.
 /// The two `_` slots are slice-1 tombstones (the original PushConst
-/// + IntAdd) and stay in place as slice-2 tombstones too — the
+/// and IntAdd) and stay in place as slice-2 tombstones too. The
 /// dispatch loop advances pc by 4 past all three trailing slots
 /// after executing the fused op.
 fn apply_peephole_slice2(code: &mut [Op]) {

--- a/crates/lex-bytecode/src/op.rs
+++ b/crates/lex-bytecode/src/op.rs
@@ -129,4 +129,17 @@ pub enum Op {
     /// time; the unchanged PushConst / IntAdd at the next two
     /// slots hash normally, so the total bytes match pre-fusion.
     LoadLocalAddIntConst { local_idx: u16, imm_const_idx: u32 },
+    /// Fused `LoadLocal(src) + PushConst(imm_const_idx) + IntAdd +
+    /// StoreLocal(dest)` (#461 superinstruction slice 2). Bypasses
+    /// the value stack entirely: reads `locals[src]`, adds the Int
+    /// constant, writes `locals[dest]`. Advances pc by 4. Stack
+    /// delta: 0.
+    ///
+    /// The peephole pass that emits this op runs *after* slice 1,
+    /// looking for `[LoadLocalAddIntConst, ., ., StoreLocal]` where
+    /// the middle two slots are slice-1 tombstones (the original
+    /// PushConst + IntAdd). The verifier and the body-hash decoder
+    /// both treat the 3 following slots as tombstones owned by
+    /// this op.
+    LoadLocalAddIntConstStoreLocal { src: u16, imm_const_idx: u32, dest: u16 },
 }

--- a/crates/lex-bytecode/src/program.rs
+++ b/crates/lex-bytecode/src/program.rs
@@ -152,7 +152,15 @@ pub fn compute_body_hash(
             // original `LoadLocal` makes the total body-hash bytes
             // match the pre-fusion form — closure identity (#222)
             // stays invariant across peephole rewrites.
-            Op::LoadLocalAddIntConst { local_idx, .. } => {
+            Op::LoadLocalAddIntConst { local_idx, .. }
+            | Op::LoadLocalAddIntConstStoreLocal { src: local_idx, .. } => {
+                // Slice 1: this slot was `LoadLocal(local_idx)`.
+                // Slice 2: this slot was *also* `LoadLocal(src)`
+                // — the fused op now owns 4 slots, but the very
+                // first one was originally `LoadLocal`. The other
+                // 3 (PushConst / IntAdd / StoreLocal) remain in
+                // the code stream as tombstones and hash normally,
+                // so the total byte stream matches pre-fusion.
                 serde_json::to_vec(&Op::LoadLocal(*local_idx))
                     .expect("Op serialization must succeed")
             }

--- a/crates/lex-bytecode/src/verify.rs
+++ b/crates/lex-bytecode/src/verify.rs
@@ -99,6 +99,16 @@ pub fn verify_function(func: &Function, errors: &mut Vec<StackError>) {
             }
             // Terminators: no successors.
             Op::Return | Op::TailCall { .. } | Op::Panic(_) => {}
+            // Slice-2 superinstruction (#461) owns 4 slots: the fused
+            // op + 3 tombstones (original PushConst + IntAdd +
+            // StoreLocal). The trailing tombstones' deltas don't
+            // cancel (+1, -1, -1 = -1), so we can't let the verifier
+            // walk them as live — it'd drift the depth at pc+4 vs the
+            // pre-fusion form. Skip directly to pc+4 with the
+            // unfused-equivalent depth.
+            Op::LoadLocalAddIntConstStoreLocal { .. } => {
+                worklist.push((pc + 4, next_depth));
+            }
             // All other ops: single sequential successor.
             _ => {
                 worklist.push((pc + 1, next_depth));
@@ -200,6 +210,10 @@ fn stack_delta(op: &Op) -> i32 {
         // IntAdd) cancel, so the depth at pc+3 matches what the
         // unfused sequence would have produced.
         Op::LoadLocalAddIntConst { .. } => 1,
+        // Slice-2 fused op: src → dest with no net stack effect.
+        // Tombstones at the next 3 slots are *not* walked (see the
+        // control-flow successor logic in `verify_function`).
+        Op::LoadLocalAddIntConstStoreLocal { .. } => 0,
     }
 }
 

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -1452,6 +1452,20 @@ impl<'a> Vm<'a> {
                     // left in place for body-hash stability.
                     self.frames[frame_idx].pc = pc + 3;
                 }
+                Op::LoadLocalAddIntConstStoreLocal { src, imm_const_idx, dest } => {
+                    let base = self.frames[frame_idx].locals_start;
+                    let a = self.locals_storage[base + src as usize].as_int();
+                    let b = match &self.program.constants[imm_const_idx as usize] {
+                        Const::Int(n) => *n,
+                        c => return Err(VmError::TypeMismatch(
+                            format!("LoadLocalAddIntConstStoreLocal expected Int const, got {c:?}"))),
+                    };
+                    self.locals_storage[base + dest as usize] = Value::Int(a + b);
+                    // Skip past the 3 inert primitive ops we
+                    // absorbed (original PushConst + IntAdd +
+                    // StoreLocal).
+                    self.frames[frame_idx].pc = pc + 4;
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Fuses `LoadLocal(src) + PushConst(imm) + IntAdd + StoreLocal(dest)` into one op that bypasses the value stack entirely. The peephole runs *after* slice 1: it scans for `[LoadLocalAddIntConst, ., ., StoreLocal]` where the middle two slots are slice-1 tombstones.

This is the second peephole superinstruction for #461. Slice 2 was prototyped earlier in this milestone but shelved when benches showed a regression. The root cause turned out to be that slice 1 itself had never fired in production (compiler emitted `NumAdd`, peephole scanned for `IntAdd`). #476 fixed that with typed lowering, so I popped the slice 2 stash and re-benched.

## Bench results

`dispatch/straight_arith` (n=5000):

| Stage                                | Wall   | Thrpt          |
|--------------------------------------|--------|----------------|
| pre-#476 main (NumAdd, slice 1 dead) | 305 µs |  65.5 Melem/s  |
| post-#476 main (typed + slice 1)     | 157 µs | 127   Melem/s  |
| **this branch (slice 1 + slice 2)**  | **91 µs** | **219 Melem/s** |

**Slice 2 alone: 1.72× on top of #476. Cumulative vs pre-#476: 3.35×.**

The bytecode interpreter is now **2.3× faster than the inline-Rust no-stack baseline** (`straight_arith_no_dispatch`: 208 µs at n=5000). That's because the fused op skips the value stack entirely — one read, one write, no push/pop, no boxing.

## Stability contracts

- **Body-hash (#222 closure identity).** The fused op owns 4 code slots; the trailing 3 (original `PushConst + IntAdd + StoreLocal`) remain in place as tombstones and hash normally. `compute_body_hash` lowers the fused slot back to its original `LoadLocal(src)` form, so the byte stream matches pre-fusion exactly.
- **Stack verifier.** The tombstones' deltas don't cancel (+1, -1, -1 = -1), so the verifier can't walk them as live — it'd drift the depth at pc+4 vs the pre-fusion form. The fused op is treated as a single instruction with delta 0 and its sole successor is pc+4.

## Test plan

- [x] `cargo test -p lex-bytecode` (all passing, including `bytecode_is_reproducible`)
- [x] `cargo test -p lex-vcs` (closure identity, 142 tests)
- [x] `cargo test -p lex-runtime --test canonical_format_e2e` (body-hash determinism)
- [x] `cargo test -p lex-runtime --test m5 --test list_higher_order --test analytics_app` (numeric/list-heavy runtime)
- [x] `cargo bench -p lex-bytecode --bench dispatch -- straight_arith` (1.72× over #476 confirmed)
- [ ] CI workspace tests

## Follow-ups

- Re-bench on the `/plaintext` workload — that's #461's actual acceptance bar (2× plaintext throughput). With 3.35× on the synthetic straight_arith bench, the plaintext goal should be within reach but needs measuring.
- The internal list-iteration scaffolding (`compiler.rs` lines 801-2071) still emits `Op::NumAdd` / `Op::NumLt` for known-Int counters. Swapping to `Op::IntAdd` / `Op::IntLt` would let slice 1 + slice 2 fire on `for x in xs` loops too (record_field / arith_loop benches).

https://claude.ai/code/session_01VEhcze986fxQDqJXKEwF2n

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEhcze986fxQDqJXKEwF2n)_