### PR TITLE
bench(#462): field_access — isolated baseline for the IC rework

### DIFF
--- a/crates/lex-bytecode/Cargo.toml
+++ b/crates/lex-bytecode/Cargo.toml
@@ -29,3 +29,7 @@ criterion = { version = "0.5", default-features = false, features = ["cargo_benc
 [[bench]]
 name = "dispatch"
 harness = false
+
+[[bench]]
+name = "field_access"
+harness = false

--- a/crates/lex-bytecode/benches/field_access.rs
+++ b/crates/lex-bytecode/benches/field_access.rs
@@ -1,0 +1,133 @@
+//! Microbenchmarks for `Op::GetField` — the record-access hot path
+//! that #462's polymorphic inline cache reworks.
+//!
+//! The existing `dispatch.rs::record_field` bench mixes field access
+//! with tail-recursion overhead, so per-access cost is muddied by
+//! call-frame setup. This bench isolates field access by running a
+//! flat (non-recursive) chain of `GetField` ops inside a single
+//! function body, in three flavors:
+//!
+//! - `mono_first` — read field 0 of a 4-field record N times. Tests
+//!   the IC hit-rate on the cheapest possible access (first field
+//!   in the `IndexMap`).
+//! - `mono_last` — read the last field of an 8-field record N times.
+//!   Tests miss-path cost (hash walk that today scans the field list
+//!   linearly). Today's monomorphic IC hides this on hot loops, but
+//!   the absolute miss cost still matters for cold paths.
+//! - `mono_chain` — read x + y + z of a 3-field record per iteration,
+//!   inside a tail-recursive loop. Same as `dispatch.rs::record_field`
+//!   but kept here as the apples-to-apples #462 baseline that's
+//!   directly comparable to the issue's "≥ 3×" acceptance.
+//!
+//! All three workloads are monomorphic — the IC sees one shape per
+//! call site. The polymorphic / megamorphic cases are queued for a
+//! follow-up once #462's shape_id propagation (slice 3) lands; right
+//! now Lex's type checker enforces a single record type per
+//! `GetField` site, so synthetically constructing a polymorphic site
+//! requires the shape-ID changes.
+//!
+//! Run with `cargo bench -p lex-bytecode --bench field_access`.
+
+use std::sync::Arc;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use lex_ast::canonicalize_program;
+use lex_bytecode::vm::Vm;
+use lex_bytecode::{compile_program, Program, Value};
+use lex_syntax::parse_source;
+
+fn compile(src: &str) -> Arc<Program> {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    lex_types::check_program(&stages).expect("typecheck");
+    Arc::new(compile_program(&stages))
+}
+
+/// Build a function body that reads `field` of a record `n` times in
+/// a flat chain, summing into an accumulator. No recursion — straight
+/// chain of `LoadLocal(p) + GetField(field) + IntAdd` per step.
+fn make_flat_get_field(field: &str, type_decl: &str, ctor: &str, n: usize) -> String {
+    let mut body = String::new();
+    body.push_str(type_decl);
+    body.push_str("\n\nfn bench() -> Int {\n");
+    body.push_str(&format!("  let p :: R := {ctor}\n"));
+    body.push_str("  let a0 := 0\n");
+    for i in 1..=n {
+        body.push_str(&format!("  let a{i} := a{prev} + p.{field}\n", prev = i - 1));
+    }
+    body.push_str(&format!("  a{n}\n}}\n"));
+    body
+}
+
+fn bench_mono_first(c: &mut Criterion) {
+    let mut group = c.benchmark_group("field_access/mono_first");
+    let type_decl = "type R = { x :: Int, y :: Int, z :: Int, w :: Int }";
+    let ctor = "{ x: 1, y: 2, z: 3, w: 4 }";
+    for n in [100usize, 1_000, 5_000] {
+        let src = make_flat_get_field("x", type_decl, ctor, n);
+        let prog = compile(&src);
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_function(format!("n={n}"), |b| {
+            b.iter(|| {
+                let mut vm = Vm::new(&prog);
+                vm.set_step_limit(u64::MAX);
+                black_box(vm.call("bench", vec![]).unwrap());
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_mono_last(c: &mut Criterion) {
+    let mut group = c.benchmark_group("field_access/mono_last");
+    let type_decl = "type R = { a :: Int, b :: Int, c :: Int, d :: Int, e :: Int, f :: Int, g :: Int, h :: Int }";
+    let ctor = "{ a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8 }";
+    for n in [100usize, 1_000, 5_000] {
+        let src = make_flat_get_field("h", type_decl, ctor, n);
+        let prog = compile(&src);
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_function(format!("n={n}"), |b| {
+            b.iter(|| {
+                let mut vm = Vm::new(&prog);
+                vm.set_step_limit(u64::MAX);
+                black_box(vm.call("bench", vec![]).unwrap());
+            })
+        });
+    }
+    group.finish();
+}
+
+const CHAIN_SRC: &str = r#"
+type Point = { x :: Int, y :: Int, z :: Int }
+
+fn sum_fields(p :: Point, n :: Int, acc :: Int) -> Int {
+  match n {
+    0 => acc,
+    _ => sum_fields(p, n - 1, acc + p.x + p.y + p.z),
+  }
+}
+
+fn bench(n :: Int) -> Int {
+  let p :: Point := { x: 1, y: 2, z: 3 }
+  sum_fields(p, n, 0)
+}
+"#;
+
+fn bench_mono_chain(c: &mut Criterion) {
+    let prog = compile(CHAIN_SRC);
+    let mut group = c.benchmark_group("field_access/mono_chain");
+    for n in [100i64, 1_000, 5_000] {
+        group.throughput(Throughput::Elements((n * 3) as u64)); // 3 GetField per iter
+        group.bench_function(format!("n={n}"), |b| {
+            b.iter(|| {
+                let mut vm = Vm::new(&prog);
+                vm.set_step_limit(u64::MAX);
+                black_box(vm.call("bench", vec![Value::Int(n)]).unwrap());
+            })
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_mono_first, bench_mono_last, bench_mono_chain);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

#462's acceptance criterion lists `crates/lex-bytecode/benches/field_access.rs` — this lands it ahead of the optimization slices so we have a measurable baseline first.

The existing `dispatch::record_field` bench mixes field access with tail-recursion call-frame setup, so per-access cost is muddied. This is a cleaner, isolated bench with three workloads:

- **`mono_first`** — read field `[0]` of a 4-field record N times in a flat chain. Each access is at a unique pc, so today's `(fn_id, pc)`-keyed IC misses every time → measures **miss-path cost with a short walk**.
- **`mono_last`** — same but field `[7]` of an 8-field record. Same miss pattern, longer IndexMap walk → confirms the linear scan dominates miss cost.
- **`mono_chain`** — the existing 3-field-access loop from `dispatch::record_field` with throughput exposed as `3*n` so per-access numbers are directly readable. 3 stable pcs inside `sum_fields` → measures **hit-path cost** after warmup.

## Baseline (post-#479 main, n=5000)

| Workload    | per-access | What it shows |
|-------------|------------|---------------|
| `mono_chain`  |    307 ns  | IC hit-path |
| `mono_first`  |    286 ns  | Miss-path + short walk |
| `mono_last`   |    518 ns  | Miss-path + long walk (1.8× over `mono_first`) |

## Implications for the #462 slicing

- **`≥ 3× speedup`** (acceptance bar) means landing hit-path at **~100 ns/access**.
- For scale, typed dispatch ops cost ~8 ns/step on `straight_arith` post-#479. **GetField is ~40× more expensive** — IndexMap is the bottleneck.
- The **1.8× cliff between `mono_first` and `mono_last`** confirms shape_id caching (slice 3 of #462) is the highest-leverage single change: same miss frequency, only the walk length differs.

## Test plan

- [x] `cargo build -p lex-bytecode --benches`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo bench -p lex-bytecode --bench field_access` (all three workloads run, numbers above)
- [ ] CI workspace tests

## Follow-ups

This is the bench-only part of #462. Slices 1-4 (key migration, polymorphic cache, shape_id propagation, megamorphic fallback) come in follow-up PRs.

https://claude.ai/code/session_01VEhcze986fxQDqJXKEwF2n

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEhcze986fxQDqJXKEwF2n)_