### PR TITLE
feat(runtime): opt-in HTTP/2 support via LEX_NET_HTTP2 (#488)

### DIFF
--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -36,8 +36,8 @@ subtle = "2.6"
 rand = { version = "0.10", features = ["sys_rng"] }
 tiny_http = { version = "0.12", features = ["ssl-rustls"] }
 tokio = { version = "1", features = ["rt-multi-thread", "net"] }
-hyper = { version = "1", features = ["http1", "server"] }
-hyper-util = { version = "0.1", features = ["tokio"] }
+hyper = { version = "1", features = ["http1", "http2", "server"] }
+hyper-util = { version = "0.1", features = ["tokio", "server-auto", "http1", "http2"] }
 http-body-util = "0.1"
 bytes = "1"
 tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -1736,10 +1736,12 @@ fn serve_http_plain(
     use http_body_util::BodyExt as _;
     use hyper::server::conn::http1;
     use hyper::service::service_fn;
-    use hyper_util::rt::TokioIo;
+    use hyper_util::rt::{TokioExecutor, TokioIo};
+    use hyper_util::server::conn::auto;
     use tokio::net::TcpListener as TokioTcpListener;
 
     let inline_vm = env_inline_vm();
+    let http2 = env_http2();
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
@@ -1749,8 +1751,9 @@ fn serve_http_plain(
             .await
             .map_err(|e| format!("net.serve bind {port}: {e}"))?;
         eprintln!(
-            "net.serve: listening on http://0.0.0.0:{port}{}",
-            if inline_vm { " (inline-vm)" } else { "" }
+            "net.serve: listening on http://0.0.0.0:{port}{}{}",
+            if inline_vm { " (inline-vm)" } else { "" },
+            if http2 { " (http1+http2)" } else { "" }
         );
         loop {
             let (stream, _) = listener
@@ -1802,7 +1805,18 @@ fn serve_http_plain(
                         })
                     }
                 });
-                if let Err(e) = http1::Builder::new().serve_connection(io, svc).await {
+                let result = if http2 {
+                    auto::Builder::new(TokioExecutor::new())
+                        .serve_connection(io, svc)
+                        .await
+                        .map_err(|e| e.to_string())
+                } else {
+                    http1::Builder::new()
+                        .serve_connection(io, svc)
+                        .await
+                        .map_err(|e| e.to_string())
+                };
+                if let Err(e) = result {
                     eprintln!("net.serve: connection error: {e}");
                 }
             });
@@ -1869,10 +1883,12 @@ fn serve_http_fn(
     use http_body_util::BodyExt as _;
     use hyper::server::conn::http1;
     use hyper::service::service_fn;
-    use hyper_util::rt::TokioIo;
+    use hyper_util::rt::{TokioExecutor, TokioIo};
+    use hyper_util::server::conn::auto;
     use tokio::net::TcpListener as TokioTcpListener;
 
     let inline_vm = env_inline_vm();
+    let http2 = env_http2();
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
@@ -1882,8 +1898,9 @@ fn serve_http_fn(
             .await
             .map_err(|e| format!("net.serve_fn bind {port}: {e}"))?;
         eprintln!(
-            "net.serve_fn: listening on http://0.0.0.0:{port}{}",
-            if inline_vm { " (inline-vm)" } else { "" }
+            "net.serve_fn: listening on http://0.0.0.0:{port}{}{}",
+            if inline_vm { " (inline-vm)" } else { "" },
+            if http2 { " (http1+http2)" } else { "" }
         );
         loop {
             let (stream, _) = listener
@@ -1932,7 +1949,18 @@ fn serve_http_fn(
                         })
                     }
                 });
-                if let Err(e) = http1::Builder::new().serve_connection(io, svc).await {
+                let result = if http2 {
+                    auto::Builder::new(TokioExecutor::new())
+                        .serve_connection(io, svc)
+                        .await
+                        .map_err(|e| e.to_string())
+                } else {
+                    http1::Builder::new()
+                        .serve_connection(io, svc)
+                        .await
+                        .map_err(|e| e.to_string())
+                };
+                if let Err(e) = result {
                     eprintln!("net.serve_fn: connection error: {e}");
                 }
             });
@@ -2098,10 +2126,12 @@ fn serve_http_routed(
     use http_body_util::BodyExt as _;
     use hyper::server::conn::http1;
     use hyper::service::service_fn;
-    use hyper_util::rt::TokioIo;
+    use hyper_util::rt::{TokioExecutor, TokioIo};
+    use hyper_util::server::conn::auto;
     use tokio::net::TcpListener as TokioTcpListener;
 
     let inline_vm = env_inline_vm();
+    let http2 = env_http2();
     let routes = Arc::new(routes);
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -2112,9 +2142,10 @@ fn serve_http_routed(
             .await
             .map_err(|e| format!("net.serve_routed bind {port}: {e}"))?;
         eprintln!(
-            "net.serve_routed: listening on http://0.0.0.0:{port} ({} routes{})",
+            "net.serve_routed: listening on http://0.0.0.0:{port} ({} routes{}{})",
             routes.len(),
-            if inline_vm { ", inline-vm" } else { "" }
+            if inline_vm { ", inline-vm" } else { "" },
+            if http2 { ", http1+http2" } else { "" }
         );
         loop {
             let (stream, _) = listener
@@ -2181,7 +2212,18 @@ fn serve_http_routed(
                         })
                     }
                 });
-                if let Err(e) = http1::Builder::new().serve_connection(io, svc).await {
+                let result = if http2 {
+                    auto::Builder::new(TokioExecutor::new())
+                        .serve_connection(io, svc)
+                        .await
+                        .map_err(|e| e.to_string())
+                } else {
+                    http1::Builder::new()
+                        .serve_connection(io, svc)
+                        .await
+                        .map_err(|e| e.to_string())
+                };
+                if let Err(e) = result {
                     eprintln!("net.serve_routed: connection error: {e}");
                 }
             });
@@ -2195,6 +2237,25 @@ fn serve_http_routed(
 /// default `spawn_blocking` behaviour. See issue #431.
 fn env_inline_vm() -> bool {
     match std::env::var("LEX_NET_INLINE_VM") {
+        Ok(v) => {
+            let s = v.trim().to_ascii_lowercase();
+            s == "1" || s == "true"
+        }
+        Err(_) => false,
+    }
+}
+
+/// Read `LEX_NET_HTTP2` and report whether the runtime should accept
+/// HTTP/2 connections via hyper-util's auto builder (HTTP/1 ↔ HTTP/2
+/// preface detection). Accepts `1` / `true` (case-insensitive); anything
+/// else (including unset) keeps the HTTP/1-only default.
+///
+/// h2c (cleartext HTTP/2) needs prior-knowledge clients
+/// (`curl --http2-prior-knowledge`, wrk/h2load, gRPC). Browsers do not
+/// speak h2c — they require ALPN over TLS, which is a separate path.
+/// See lex-lang#488.
+fn env_http2() -> bool {
+    match std::env::var("LEX_NET_HTTP2") {
         Ok(v) => {
             let s = v.trim().to_ascii_lowercase();
             s == "1" || s == "true"

--- a/crates/lex-runtime/tests/net_serve_http2.rs
+++ b/crates/lex-runtime/tests/net_serve_http2.rs
@@ -1,0 +1,134 @@
+//! `LEX_NET_HTTP2=1` switches the server's per-connection builder
+//! from hyper's HTTP/1-only to hyper-util's auto::Builder, which
+//! accepts both HTTP/1 and HTTP/2 (via preface detection — h2c /
+//! prior-knowledge clients).
+//!
+//! This file is a separate test binary so the env-var change doesn't
+//! race with other server tests that assume HTTP/1-only behaviour.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::collections::BTreeSet;
+use std::io::{Read, Write};
+use std::net::{TcpStream, ToSocketAddrs};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+fn spawn_lex_server(src: &str, entry: &str) {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors: {errs:#?}");
+    }
+    let bc = Arc::new(compile_program(&stages));
+    let mut policy = Policy::pure();
+    policy.allow_effects = ["net".to_string()].into_iter().collect::<BTreeSet<_>>();
+    let entry = entry.to_string();
+    thread::spawn(move || {
+        let handler = DefaultHandler::new(policy.clone()).with_program(Arc::clone(&bc));
+        let mut vm = Vm::with_handler(&bc, Box::new(handler));
+        let _ = vm.call(&entry, vec![]);
+    });
+}
+
+fn wait_for_bind(port: u16, timeout: Duration) {
+    let deadline = std::time::Instant::now() + timeout;
+    let mut backoff = Duration::from_millis(20);
+    loop {
+        if let Ok(s) = TcpStream::connect_timeout(
+            &("127.0.0.1", port).to_socket_addrs().unwrap().next().unwrap(),
+            Duration::from_millis(200),
+        ) {
+            drop(s);
+            return;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("server on :{port} did not bind within {timeout:?}");
+        }
+        thread::sleep(backoff);
+        backoff = (backoff * 2).min(Duration::from_millis(200));
+    }
+}
+
+/// HTTP/2 connection preface — fixed 24 bytes that any h2 / h2c
+/// client sends first. The auto builder uses these bytes to decide
+/// between HTTP/1 and HTTP/2 framing for the rest of the connection.
+const H2_PREFACE: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
+
+/// Server with HTTP/2 enabled must:
+///   1. still serve normal HTTP/1.1 requests (auto builder is
+///      backwards-compatible).
+///   2. respond with HTTP/2 framing (binary SETTINGS frame, not
+///      `HTTP/1.1 400`) when the client sends the H/2 preface.
+#[test]
+fn lex_net_http2_env_enables_auto_builder() {
+    // Set BEFORE spawning so the server's env_http2() read sees `1`.
+    // Single-test binary → no cross-test env race.
+    // SAFETY: process is single-threaded at this point; no other thread
+    // can observe the env mutation.
+    unsafe {
+        std::env::set_var("LEX_NET_HTTP2", "1");
+    }
+
+    let src = r#"
+import "std.net" as net
+import "std.str" as str
+
+fn handle(req :: { body :: Str, method :: Str, path :: Str, query :: Str }) -> { body :: Str, status :: Int } {
+  { status: 200, body: str.concat("ok ", req.path) }
+}
+
+fn main() -> [net] Nil { net.serve(18099, "handle") }
+"#;
+    spawn_lex_server(src, "main");
+    wait_for_bind(18099, Duration::from_secs(5));
+
+    // --- assertion 1: HTTP/1.1 still works ----------------------
+    {
+        let mut s = TcpStream::connect(("127.0.0.1", 18099)).expect("connect");
+        s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+        s.write_all(
+            b"GET /hello HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n",
+        )
+        .unwrap();
+        let mut buf = String::new();
+        s.read_to_string(&mut buf).unwrap();
+        assert!(
+            buf.starts_with("HTTP/1.1 200"),
+            "expected HTTP/1.1 200, got: {buf:?}"
+        );
+        assert!(
+            buf.contains("ok /hello"),
+            "expected handler body in response, got: {buf:?}"
+        );
+    }
+
+    // --- assertion 2: HTTP/2 preface elicits H/2 framing --------
+    {
+        let mut s = TcpStream::connect(("127.0.0.1", 18099)).expect("connect");
+        s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+        s.write_all(H2_PREFACE).unwrap();
+        // Server's first response on a fresh H/2 connection is a
+        // SETTINGS frame: 9-byte header where byte 3 == 0x04
+        // (SETTINGS type) and stream_id == 0. We just check that
+        // the first 9 bytes don't look like an HTTP/1 status line.
+        let mut buf = [0u8; 9];
+        let n = s.read(&mut buf).unwrap_or(0);
+        assert!(
+            n >= 9,
+            "expected at least 9 bytes of H/2 framing, got {n}"
+        );
+        // HTTP/1 reply would start with `H` `T` `T` `P` `/` `1`.
+        // H/2 SETTINGS frame's type byte is at offset 3; payload
+        // length lives in bytes 0..3 (big-endian u24).
+        let frame_type = buf[3];
+        assert_eq!(
+            frame_type, 0x04,
+            "expected SETTINGS frame (type=0x04), got header bytes: {buf:02x?} \
+             (HTTP/1 would start with 0x48 0x54 0x54 0x50)"
+        );
+    }
+}


### PR DESCRIPTION
Closes the Phase-1 checkbox on #488.

## What this PR adds

All three serve loops (`serve_http_plain`, `serve_http_fn`, `serve_http_routed`) gain an opt-in HTTP/2 path, gated on the `LEX_NET_HTTP2` env var. Default behaviour is unchanged — set `LEX_NET_HTTP2=1` to flip on H/1 ↔ H/2 auto-negotiation per connection (via `hyper_util::server::conn::auto::Builder`).

Mechanism:

- `hyper` gains the `http2` feature; `hyper-util` gains `server-auto`, `http1`, `http2`.
- New helper `env_http2()` mirrors the existing `env_inline_vm()` shape (`1` / `true` → on, anything else → off).
- Each serve loop's per-connection block swaps between `http1::Builder::new()` (default) and `auto::Builder::new(TokioExecutor::new())` (opt-in).
- Startup log line gets a `(http1+http2)` suffix when the flag is on, for observability.

## Why opt-in for v1

The auto builder is backwards-compatible with HTTP/1 clients (preface-detected fallback), so flipping the default would *technically* be safe. But changing runtime behaviour for every existing deployment on the next release is too aggressive for a Phase-1 cut. Default-on can come once the env-var flag has seen field use.

## Test plan

New isolated test binary `tests/net_serve_http2.rs`:

1. With `LEX_NET_HTTP2=1`, HTTP/1.1 requests still return `HTTP/1.1 200` + handler body.
2. Sending the H/2 client preface bytes elicits a SETTINGS frame (type byte `0x04` at offset 3), not `HTTP/1.1 400`.

Isolation rationale: env-var mutations are process-global, and `tests/net_serve.rs` assumes the HTTP/1-only path. Each test binary has its own process and env, so a dedicated file avoids races.

- [x] `cargo build -p lex-runtime` — clean
- [x] `cargo test -p lex-runtime --test net_serve_http2` — 1/1 passing
- [x] `cargo test -p lex-runtime --test net_serve` — 11/11 passing (no regression)
- [ ] CI green

## Out of scope (follow-ups on #488)

- Phase 2 — HTTP/3 via `h3` + `quinn`, distinct serve primitive (`net.serve_quic`) since the QUIC lifecycle differs.
- `serve_http_tls_legacy` still uses `tiny_http` — independent modernisation, pending the tokio-rustls migration.
- Surfacing the option through a Lex-level API (`net.serve_with(opts)`) instead of an env var — pending a broader options-record story.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PsrNeuuchvDLFJmY1CskFe)_