### PR TITLE
docs: document http.stream_lines in AGENT.md; note ureq eager-collect

### DIFF
--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -2823,9 +2823,15 @@ fn err(v: Value) -> Value {
     Value::Variant { name: "Err".into(), args: vec![v] }
 }
 
-/// Perform a streaming HTTP POST and return a lazy line iterator
-/// as `Ok(__StreamHandle)`. The caller drains the iterator via the
-/// normal `Iter[T]` protocol. Connection errors become `Err(Str)`.
+/// HTTP POST that buffers the full response body then yields it split into lines.
+/// Intended for LLM provider APIs (OpenAI, Anthropic, Google) that use SSE/NDJSON
+/// and close the connection after sending all events. Connection errors → `Err(Str)`.
+///
+/// CAUTION: ureq 3.3's `Body` does not implement `std::io::Read` and exposes no
+/// incremental read API. The entire response is buffered via `read_to_vec()` before
+/// splitting. This means the call blocks until the server closes the connection —
+/// endpoints that hold the connection open indefinitely will hang. True per-line
+/// streaming requires a future HTTP client upgrade.
 fn http_stream_lines_impl(handler: &DefaultHandler, url: &str, headers_val: &Value, body: &str) -> Value {
     let body_bytes = body.as_bytes().to_vec();
     let agent = http_agent(None);

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -166,7 +166,20 @@ drops the name binding but existing `Actor[S]` handles held by callers
 keep working. `registered()` returns a sorted snapshot of names.
 
 ### `std.http`
-`get`, `post`, `put`, `delete`, `patch` — all require `[http.*]` effect.
+`get`, `post`, `put`, `delete`, `patch` — all require `[net]` effect.
+
+`stream_lines(url :: Str, headers :: Map[Str, Str], body :: Str) -> [net] Result[Iter[Str], Str]`
+— HTTP POST that reads the full response body and yields it split into lines as `Iter[Str]`.
+Designed for LLM provider APIs (OpenAI, Anthropic, Google) that use SSE or NDJSON and
+**close the connection** after sending all events. Requires `[net]` effect.
+
+**WARNING — eager buffer, not true streaming.** The current implementation (ureq 3.3) reads
+the entire response body into memory before splitting into lines. This means:
+- It blocks until the server closes the connection. Endpoints that hold connections open
+  indefinitely (traditional push-SSE feeds, infinite event streams) will hang forever.
+- The full response must fit in memory.
+
+Use only with endpoints that terminate the connection after sending all data.
 
 ### `std.net`
 `net.serve(port, handler_name)` — HTTP server, handler looked up by name string.


### PR DESCRIPTION
## Summary

- Add `stream_lines(url, headers, body) -> [net] Result[Iter[Str], Str]` to the `std.http` section in `docs/AGENT.md` with full signature and usage notes
- Add a code comment on `http_stream_lines_impl` in `handler.rs` explaining why ureq 3.3 forces an eager full-body buffer (no `Read` impl on `Body`, no zero-copy streaming path)
- Fix `std.http` effect annotation in the docs from the stale `[http.*]` form to `[net]`

## Test plan

- [ ] Verify `docs/AGENT.md` renders correctly and the `stream_lines` entry matches the builtins.rs type signature at line 2337
- [ ] Confirm `cargo check --workspace` passes (handler.rs comment-only change)
- [ ] Confirm no other stdlib docs sections need similar updates

---
_Generated by [Claude Code](https://claude.ai/code/session_01T93pHM94y99vRN2GW1rAGL)_