### PR TITLE
infra(#462 slice 1): IC key migration — (fn_id, pc) → (fn_id, site_idx)

### DIFF
--- a/crates/lex-bytecode/src/compiler.rs
+++ b/crates/lex-bytecode/src/compiler.rs
@@ -142,6 +142,8 @@ pub fn compile_program(stages: &[a::Stage]) -> Program {
                         }),
                     _ => None,
                 }).collect(),
+                // Filled in below once the FnCompiler counts emit sites.
+                field_ic_sites: 0,
             });
         }
     }
@@ -163,6 +165,7 @@ pub fn compile_program(stages: &[a::Stage]) -> Program {
                 next_local: 0,
                 peak_local: 0,
                 local_types: IndexMap::new(),
+                field_get_sites: 0,
                 pool: &mut pool,
                 function_names: &function_names,
                 module_aliases: &module_aliases,
@@ -181,9 +184,11 @@ pub fn compile_program(stages: &[a::Stage]) -> Program {
             fc.code.push(Op::Return);
             let code = std::mem::take(&mut fc.code);
             let peak = fc.peak_local;
+            let field_sites = fc.field_get_sites as u16;
             drop(fc);
             let idx = function_names[&fd.name];
             p.functions[idx as usize].code = code;
+            p.functions[idx as usize].field_ic_sites = field_sites;
             p.functions[idx as usize].locals_count = peak;
         }
     }
@@ -198,6 +203,7 @@ pub fn compile_program(stages: &[a::Stage]) -> Program {
             next_local: 0,
             peak_local: 0,
             local_types: IndexMap::new(),
+            field_get_sites: 0,
             pool: &mut pool,
             function_names: &function_names,
             module_aliases: &module_aliases,
@@ -227,8 +233,10 @@ pub fn compile_program(stages: &[a::Stage]) -> Program {
         fc.code.push(Op::Return);
         let code = std::mem::take(&mut fc.code);
         let peak = fc.peak_local;
+        let field_sites = fc.field_get_sites as u16;
         drop(fc);
         p.functions[pl.fn_id as usize].code = code;
+        p.functions[pl.fn_id as usize].field_ic_sites = field_sites;
         p.functions[pl.fn_id as usize].locals_count = peak;
     }
 
@@ -398,6 +406,13 @@ struct FnCompiler<'a> {
     /// slot index so shadowed bindings are handled correctly via
     /// `IndexMap`'s insertion-order semantics.
     local_types: IndexMap<String, NumTy>,
+    /// Per-function counter for `Op::GetField` site indices (#462
+    /// slice 1). Each `Op::GetField` emit allocates the next index
+    /// here, giving every field-access site within this function a
+    /// stable identifier independent of pc. The VM uses
+    /// `(fn_id, site_idx)` as the inline-cache key, so the cache
+    /// survives the future dispatch rewrite (#461) and a JIT (#465).
+    field_get_sites: u32,
     pool: &'a mut ConstPool,
     function_names: &'a IndexMap<String, u32>,
     module_aliases: &'a IndexMap<String, String>,
@@ -512,8 +527,10 @@ impl<'a> FnCompiler<'a> {
             }
             a::CExpr::FieldAccess { value, field } => {
                 self.compile_expr(value, false);
-                let idx = self.pool.field(field);
-                self.emit(Op::GetField(idx));
+                let name_idx = self.pool.field(field);
+                let site_idx = self.field_get_sites;
+                self.field_get_sites += 1;
+                self.emit(Op::GetField { name_idx, site_idx });
             }
             a::CExpr::BinOp { op, lhs, rhs } => self.compile_binop(op, lhs, rhs),
             a::CExpr::UnaryOp { op, expr } => {
@@ -830,8 +847,10 @@ impl<'a> FnCompiler<'a> {
                 self.emit(Op::StoreLocal(slot));
                 for f in fields {
                     self.emit(Op::LoadLocal(slot));
-                    let fi = self.pool.field(&f.name);
-                    self.emit(Op::GetField(fi));
+                    let name_idx = self.pool.field(&f.name);
+                    let site_idx = self.field_get_sites;
+                    self.field_get_sites += 1;
+                    self.emit(Op::GetField { name_idx, site_idx });
                     let sub_fails = self.compile_pattern_test(&f.pattern, bindings);
                     fails.extend(sub_fails);
                 }
@@ -886,6 +905,9 @@ impl<'a> FnCompiler<'a> {
             // the parser). #209 stays focused on top-level fn decls;
             // closure-param refinements are a follow-up.
             refinements: Vec::new(),
+            // Lambda body hasn't been compiled yet; filled in by the
+            // deferred lambda-compile pass after FnCompiler walks it.
+            field_ic_sites: 0,
         });
 
         // Emit code at the lambda site: load each captured local, then MakeClosure.
@@ -2151,6 +2173,10 @@ impl<'a> FnCompiler<'a> {
             // Trampolines (flow.sequential / parallel / etc.) don't
             // surface refined params at this layer.
             refinements: Vec::new(),
+            // Trampolines never emit `Op::GetField` — they're pure
+            // scaffolding. Leaving this at 0 means the VM allocates
+            // an empty IC slot.
+            field_ic_sites: 0,
         });
         fn_id
     }

--- a/crates/lex-bytecode/src/op.rs
+++ b/crates/lex-bytecode/src/op.rs
@@ -46,7 +46,16 @@ pub enum Op {
     MakeTuple(u16),
     MakeList(u32),
     MakeVariant { name_idx: u32, arity: u16 },
-    GetField(u32),         // field name const idx
+    /// Record field access. `name_idx` indexes a `Const::FieldName`
+    /// in the constant pool — the field to read. `site_idx` is a
+    /// stable per-function index assigned by the compiler at emit
+    /// time (#462 slice 1), keyed into the per-fn inline-cache table
+    /// in the VM. Replaces the pre-#462 `(fn_id << 32 | pc)` IC key
+    /// so the cache survives the future dispatch rewrite (#461) and
+    /// a JIT (#465). `body_hash` stability: the canonical encoding
+    /// drops `site_idx` and serializes as the historical `GetField(u32)`
+    /// tuple form, so closure identity (#222) is unchanged.
+    GetField { name_idx: u32, site_idx: u32 },
     GetElem(u16),          // tuple element index
     TestVariant(u32),      // pushes Bool: top-of-stack matches variant name?
     GetVariant(u32),       // extracts payload (replaces variant on stack with its args list)

--- a/crates/lex-bytecode/src/program.rs
+++ b/crates/lex-bytecode/src/program.rs
@@ -77,6 +77,13 @@ pub struct Function {
     /// as a runtime gate's `gate.verdict`.
     #[serde(default)]
     pub refinements: Vec<Option<Refinement>>,
+    /// Number of `Op::GetField` sites in this function (#462 slice 1).
+    /// Populated by the compiler so the VM can lazily one-shot
+    /// allocate the inline-cache `Vec<Option<usize>>` to its final
+    /// size on first GetField — no per-op resize bookkeeping.
+    /// `#[serde(default)]` because pre-#462 programs don't carry it.
+    #[serde(default)]
+    pub field_ic_sites: u16,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -174,6 +181,19 @@ pub fn compute_body_hash(
             // guaranteed by the type checker — operand-type proofs the
             // compiler used to specialize are exactly what makes the
             // polymorphic op behave identically.
+            // #462 slice 1 — `GetField` carries a `site_idx` now,
+            // but the canonical body-hash form is the historical
+            // single-field tuple `GetField(name_idx)`. Lowering keeps
+            // closure identity (#222) bit-identical to pre-#462 builds.
+            // `site_idx` is a compile-time perf-side-channel; behavior
+            // doesn't depend on it (identical input → identical
+            // observable result).
+            Op::GetField { name_idx, .. } => {
+                #[derive(Serialize)]
+                enum LegacyOp { GetField(u32) }
+                serde_json::to_vec(&LegacyOp::GetField(*name_idx))
+                    .expect("Op serialization must succeed")
+            }
             Op::IntAdd   | Op::FloatAdd => serde_json::to_vec(&Op::NumAdd).unwrap(),
             Op::IntSub   | Op::FloatSub => serde_json::to_vec(&Op::NumSub).unwrap(),
             Op::IntMul   | Op::FloatMul => serde_json::to_vec(&Op::NumMul).unwrap(),

--- a/crates/lex-bytecode/src/verify.rs
+++ b/crates/lex-bytecode/src/verify.rs
@@ -139,7 +139,7 @@ fn stack_delta(op: &Op) -> i32 {
         Op::MakeVariant { arity, .. } => -(*arity as i32) + 1,
 
         // Field/element access: pop 1, push 1
-        Op::GetField(_)    => 0,
+        Op::GetField { .. } => 0,
         Op::GetElem(_)     => 0,
         Op::GetListElem(_) => 0,
         Op::GetListLen     => 0,
@@ -232,6 +232,7 @@ mod tests {
             effects: vec![],
             body_hash: crate::program::ZERO_BODY_HASH,
             refinements: vec![],
+            field_ic_sites: 0,
         }
     }
 

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -152,13 +152,22 @@ pub struct Vm<'a> {
     /// Diagnostic counters for `--trace` observability (#229).
     pub pure_memo_hits: u64,
     pub pure_memo_misses: u64,
-    /// Monomorphic inline caches for `Op::GetField` (#389 slice 2).
-    /// Key: `(fn_id as u64) << 32 | pc as u64` — one entry per
-    /// call site. Value: the IndexMap offset of the field at that
-    /// site. On a hit we verify the field name at the cached offset
-    /// in O(1) and skip the hash-table lookup entirely; on a miss we
-    /// fall back to `IndexMap::get_full` and populate the cache.
-    field_ics: std::collections::HashMap<u64, usize>,
+    /// Monomorphic inline caches for `Op::GetField` (#462 slice 1).
+    /// Indexed by `[fn_id as usize][site_idx as usize]` — one entry
+    /// per field-access site within each function. `site_idx` is
+    /// assigned at compile time by `FnCompiler::field_get_sites` so
+    /// every emit produces a stable identifier independent of pc.
+    /// The cache survives the planned dispatch rewrite (#461) and a
+    /// future JIT (#465). Replaces the pre-#462 monomorphic
+    /// `HashMap<(fn_id << 32 | pc), usize>`.
+    ///
+    /// Outer Vec is pre-sized to `program.functions.len()`; each inner
+    /// Vec is empty until the first GetField in that function runs,
+    /// at which point we one-shot allocate it to the compiler-recorded
+    /// `field_ic_sites` size and never resize again. Lazy on the inner
+    /// side so VMs created for short-lived scripts don't eagerly
+    /// allocate IC slots for functions they never enter.
+    field_ics: Vec<Vec<Option<usize>>>,
     /// Stack allocator for function locals (#389 slice 3).
     ///
     /// Every function frame claims `locals_count` contiguous slots from
@@ -472,7 +481,7 @@ impl<'a> Vm<'a> {
             pure_memo: std::collections::HashMap::new(),
             pure_memo_hits: 0,
             pure_memo_misses: 0,
-            field_ics: std::collections::HashMap::new(),
+            field_ics: vec![Vec::new(); program.functions.len()],
             // 256 slots handles ~32 frames × 8 locals; grows on demand and
             // retains capacity across consecutive vm.call() invocations.
             locals_storage: Vec::with_capacity(256),
@@ -850,17 +859,31 @@ impl<'a> Vm<'a> {
                     };
                     self.stack.push(Value::Variant { name, args });
                 }
-                Op::GetField(i) => {
-                    let name_idx = i;
+                Op::GetField { name_idx, site_idx } => {
                     let v = self.pop()?;
                     match v {
                         Value::Record(r) => {
-                            // Inline cache keyed by call site: (fn_id << 32 | pc).
-                            // On hit: verify field name at cached offset (O(1), no
-                            // string hash); on miss: walk by name + populate cache.
-                            let site = (fn_id as u64) << 32 | pc as u64;
+                            // Inline cache keyed by (fn_id, site_idx) — #462
+                            // slice 1. Direct array index instead of the
+                            // pre-#462 `HashMap<(fn_id << 32 | pc), usize>`.
+                            // The inner Vec is empty until first GetField in
+                            // this function runs; we one-shot allocate it to
+                            // the compiler-recorded site count and never
+                            // resize again. After init, the hot path is two
+                            // array dereferences. On hit: verify the cached
+                            // offset still points at the requested field
+                            // (name compare — shape_id propagation is the
+                            // next slice). On miss: walk the IndexMap by
+                            // name, populate.
+                            let fid = fn_id as usize;
+                            let sid = site_idx as usize;
+                            if self.field_ics[fid].is_empty() {
+                                let n = self.program.functions[fid].field_ic_sites as usize;
+                                self.field_ics[fid] = vec![None; n];
+                            }
+                            let cached = self.field_ics[fid][sid];
                             let value = 'ic: {
-                                if let Some(&off) = self.field_ics.get(&site) {
+                                if let Some(off) = cached {
                                     if let Some((k, val)) = r.get_index(off) {
                                         if let Const::FieldName(s) =
                                             &self.program.constants[name_idx as usize]
@@ -878,7 +901,7 @@ impl<'a> Vm<'a> {
                                 let (off, _, val) = r.get_full(name)
                                     .ok_or_else(|| VmError::TypeMismatch(
                                         format!("missing field `{name}`")))?;
-                                self.field_ics.insert(site, off);
+                                self.field_ics[fid][sid] = Some(off);
                                 val.clone()
                             };
                             self.stack.push(value);


### PR DESCRIPTION
## Summary

Setup-only PR for #462. **No measurable perf delta solo** — the win comes in the follow-up slice that propagates `shape_id` through `Value::Record` and replaces the per-hit name compare with a u32 shape compare.

#462's "Approach" calls for this key change explicitly: the pre-#462 IC keyed `(fn_id << 32 | pc)` won't survive the planned dispatch rewrite (#461) — pc is no longer the right notion of "site" once the dispatch loop shuffles ops. A stable per-fn site index, assigned at compile time, will. The other slice 1 win is moving the per-site table from a `HashMap` to a `Vec<Vec<Option<usize>>>` indexed by `(fn_id, site_idx)` — array index instead of hash on the hot path.

## Changes

- `Op::GetField(u32)` → `Op::GetField { name_idx, site_idx }`. Compile-time `FnCompiler.field_get_sites` is a monotonic counter so two GetField sites within a function get distinct `site_idx`'s.
- `Function.field_ic_sites: u16` carries the compiler's site count forward so the VM can size the IC vec without scanning bytecode. `#[serde(default)]` for pre-#462 program compatibility.
- VM `field_ics: Vec<Vec<Option<usize>>>` — outer pre-sized to `functions.len()`, inner empty until first GetField in the function (lazy one-shot allocation, then never resized).
- `compute_body_hash` lowers `GetField { name_idx, .. }` → the historical `GetField(name_idx)` tuple form. Closure identity (#222) stays bit-identical to pre-#462 builds; `site_idx` is a compile-time perf side-channel that doesn't change observable behavior.

## Why no measurable bench win solo

The hot-path lookup goes from `HashMap::get(&u64)` (~10-15 ns) to `vec[fid][sid]` (~2-5 ns + bounds checks) — theoretically faster. But on the `field_access` bench (#490), per-iter `Vm::new` re-allocates the outer Vec on each iteration, masking the per-access saving with the upfront cost.

**The real expected win lands when slice 2/3 replace the IndexMap-walk-on-name-compare on every hit with a 2× u32 shape_id compare**, cutting `mono_chain`'s 307 ns/access toward the acceptance bar of ~100 ns/access. Slice 1 is the infrastructure that slice 2/3 sits on.

(This is also the lesson learned from #461: the original slice 1 was framed as a perf win but turned out to be noise — the real win came when typed lowering landed on top. Framing this one honestly avoids the repeat.)

## Test plan

- [x] `cargo build -p lex-bytecode`
- [x] `cargo test -p lex-bytecode` (17 tests passing)
- [x] `cargo test -p lex-vcs` (142 tests passing)
- [x] `cargo test -p lex-runtime --test canonical_format_e2e` (body-hash determinism — confirms the `compute_body_hash` lowering is correct and closure identity unchanged)
- [x] `cargo clippy -p lex-bytecode --all-targets -- -D warnings`
- [ ] CI workspace tests

## Follow-up

Slice 2/3: propagate `shape_id` from `Op::MakeRecord { shape_idx, .. }` through `Value::Record` (struct-variant the enum: `{ shape_id: u32, fields: IndexMap<String, Value> }`); polymorphic IC `[(shape_id, offset); 4]` per site replacing the monomorphic `Option<usize>`. ~95 `Value::Record` references workspace-wide, mostly mechanical pattern-match updates. Real measurable win expected on `mono_chain`.

https://claude.ai/code/session_01VEhcze986fxQDqJXKEwF2n

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEhcze986fxQDqJXKEwF2n)_