### PR TITLE
fix(lex-search): serialise env-touching http tests to kill flake

### DIFF
--- a/crates/lex-search/src/http.rs
+++ b/crates/lex-search/src/http.rs
@@ -193,6 +193,17 @@ impl Embedder for HttpEmbedder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// Serialises every test in this module that reads or mutates
+    /// `LEX_EMBED_*`. Cargo runs `#[test]`s inside a binary in
+    /// parallel by default, and `set_var` / `remove_var` are
+    /// process-wide — without a guard, one test's mutation leaks
+    /// into another's `from_env()` and the assert fires
+    /// non-deterministically. Rust 2024 marks env mutation `unsafe`
+    /// for exactly this reason; this lock is what makes those
+    /// `unsafe` blocks actually sound.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn ollama_endpoint_is_built_from_base() {
@@ -217,19 +228,21 @@ mod tests {
 
     #[test]
     fn from_env_returns_none_without_url() {
-        // Test relies on the env var being unset; tests don't share
-        // global env so we explicitly remove it.
-        // SAFETY: tests in this module are single-threaded with
-        // respect to env; not the case for parallel tests in real
-        // Rust test runs but this single-process check is fine.
-        // (We'd use std::env::set_var via a mutex lock for shared
-        // env, but here we simply remove and re-check.)
-        unsafe { std::env::remove_var("LEX_EMBED_URL"); }
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // SAFETY: ENV_LOCK serialises every other env-touching test
+        // in this module, so no concurrent reader observes the
+        // mid-mutation state.
+        unsafe {
+            std::env::remove_var("LEX_EMBED_URL");
+            std::env::remove_var("LEX_EMBED_PROVIDER");
+        }
         assert!(HttpEmbedder::from_env().unwrap().is_none());
     }
 
     #[test]
     fn from_env_rejects_unknown_provider() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // SAFETY: see `from_env_returns_none_without_url`.
         unsafe {
             std::env::set_var("LEX_EMBED_URL", "http://example.com");
             std::env::set_var("LEX_EMBED_PROVIDER", "voyage");


### PR DESCRIPTION
## Summary

`crates/lex-search/src/http.rs` had two `#[test]`s that mutated process-wide env vars (`LEX_EMBED_URL`, `LEX_EMBED_PROVIDER`) without any cross-test synchronisation. Cargo runs `#[test]`s inside a binary in parallel by default, so when the scheduler ran them concurrently, one test's `set_var` / `remove_var` leaked into the other's `from_env()` read and the assert fired non-deterministically.

Add a module-scoped `ENV_LOCK: Mutex<()>` and acquire it at the top of every env-touching test. `unwrap_or_else(|e| e.into_inner())` so a poisoned guard from a panicking sibling test doesn't cascade into spurious failures in the rest.

## Context

CI surfaced this as a `-p lex-search --lib` failure on #495's workspace test run, but `lex-search` doesn't depend on `lex-bytecode` — the crate #495 touches. The race is preexisting; the parallel scheduler just got unlucky on that run. Rust 2024 already marks env mutation `unsafe` for exactly this reason, so the existing `unsafe` blocks were necessary but not sufficient without a serializing lock.

## Test plan

- [x] `cargo test -p lex-search --lib` — 29/29 passing
- [x] Stress: ran `cargo test -p lex-search --lib http::tests::` 30× back-to-back with `--test-threads=8`, all green (was previously flaky on schedule)
- [x] `cargo clippy -p lex-search --all-targets -- -D warnings` clean

https://claude.ai/code/session_01XDQDQ5ByJxyGPoez8R7BEe

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDQDQ5ByJxyGPoez8R7BEe)_