### PR TITLE
feat(net): net.serve_with(opts) — first-class ServeOpts record (#497)

### DIFF
--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -890,6 +890,13 @@ impl EffectHandler for DefaultHandler {
                 Err(e) => Ok(err(Value::Str(e.into()))),
             };
         }
+        // `net.default_opts()` is a pure record constructor — typed
+        // with `EffectSet::empty()` in builtins.rs. Bypass the generic
+        // `ensure_kind_allowed("net")` gate so callers don't need to
+        // declare `[net]` just to build a ServeOpts literal default.
+        if kind == "net" && op == "default_opts" {
+            return Ok(ServeOpts::lex_defaults().to_value());
+        }
         self.ensure_kind_allowed(kind)?;
         match (kind, op) {
             ("io", "print") => {
@@ -1055,7 +1062,7 @@ impl EffectHandler for DefaultHandler {
                 let program = self.program.clone()
                     .ok_or_else(|| "net.serve requires a Program reference; use DefaultHandler::with_program".to_string())?;
                 let policy = self.policy.clone();
-                serve_http(port, handler_name, program, policy, None)
+                serve_http(port, handler_name, program, policy, None, ServeOpts::from_env())
             }
             ("net", "serve_fn") => {
                 let port = match args.first() {
@@ -1069,7 +1076,7 @@ impl EffectHandler for DefaultHandler {
                 let program = self.program.clone()
                     .ok_or_else(|| "net.serve_fn requires a Program reference; use DefaultHandler::with_program".to_string())?;
                 let policy = self.policy.clone();
-                serve_http_fn(port, closure, program, policy)
+                serve_http_fn(port, closure, program, policy, ServeOpts::from_env())
             }
             ("net", "serve_routed") => {
                 let port = match args.first() {
@@ -1086,7 +1093,58 @@ impl EffectHandler for DefaultHandler {
                 let program = self.program.clone()
                     .ok_or_else(|| "net.serve_routed requires a Program reference; use DefaultHandler::with_program".to_string())?;
                 let policy = self.policy.clone();
-                serve_http_routed(port, routes, fallback, program, policy)
+                serve_http_routed(port, routes, fallback, program, policy, ServeOpts::from_env())
+            }
+            ("net", "serve_with") => {
+                // serve_with(port, handler_name, opts)
+                let port = match args.first() {
+                    Some(Value::Int(n)) if (0..=65535).contains(n) => *n as u16,
+                    _ => return Err("net.serve_with(port, handler, opts): port must be Int 0..=65535".into()),
+                };
+                let handler_name = expect_str(args.get(1))?.to_string();
+                let opts = decode_serve_opts(args.get(2)
+                    .ok_or_else(|| "net.serve_with(port, handler, opts): missing opts".to_string())?)?;
+                let program = self.program.clone()
+                    .ok_or_else(|| "net.serve_with requires a Program reference; use DefaultHandler::with_program".to_string())?;
+                let policy = self.policy.clone();
+                serve_http(port, handler_name, program, policy, None, opts)
+            }
+            ("net", "serve_fn_with") => {
+                // serve_fn_with(port, handler_closure, opts)
+                let port = match args.first() {
+                    Some(Value::Int(n)) if (0..=65535).contains(n) => *n as u16,
+                    _ => return Err("net.serve_fn_with(port, handler, opts): port must be Int 0..=65535".into()),
+                };
+                let opts = decode_serve_opts(args.get(2)
+                    .ok_or_else(|| "net.serve_fn_with(port, handler, opts): missing opts".to_string())?)?;
+                let closure = match args.into_iter().nth(1) {
+                    Some(c @ Value::Closure { .. }) => c,
+                    _ => return Err("net.serve_fn_with(port, handler, opts): handler must be a closure".into()),
+                };
+                let program = self.program.clone()
+                    .ok_or_else(|| "net.serve_fn_with requires a Program reference; use DefaultHandler::with_program".to_string())?;
+                let policy = self.policy.clone();
+                serve_http_fn(port, closure, program, policy, opts)
+            }
+            ("net", "serve_routed_with") => {
+                // serve_routed_with(port, routes, fallback, opts)
+                let port = match args.first() {
+                    Some(Value::Int(n)) if (0..=65535).contains(n) => *n as u16,
+                    _ => return Err("net.serve_routed_with(port, routes, fallback, opts): port must be Int 0..=65535".into()),
+                };
+                let routes_val = args.get(1).cloned()
+                    .ok_or_else(|| "net.serve_routed_with(port, routes, fallback, opts): missing routes".to_string())?;
+                let opts = decode_serve_opts(args.get(3)
+                    .ok_or_else(|| "net.serve_routed_with(port, routes, fallback, opts): missing opts".to_string())?)?;
+                let fallback = match args.into_iter().nth(2) {
+                    Some(c @ Value::Closure { .. }) => c,
+                    _ => return Err("net.serve_routed_with(port, routes, fallback, opts): fallback must be a closure".into()),
+                };
+                let routes = decode_routes_arg(routes_val)?;
+                let program = self.program.clone()
+                    .ok_or_else(|| "net.serve_routed_with requires a Program reference; use DefaultHandler::with_program".to_string())?;
+                let policy = self.policy.clone();
+                serve_http_routed(port, routes, fallback, program, policy, opts)
             }
             ("net", "serve_tls") => {
                 let port = match args.first() {
@@ -1103,7 +1161,7 @@ impl EffectHandler for DefaultHandler {
                     .map_err(|e| format!("net.serve_tls: read cert {cert_path}: {e}"))?;
                 let key = std::fs::read(&key_path)
                     .map_err(|e| format!("net.serve_tls: read key {key_path}: {e}"))?;
-                serve_http(port, handler_name, program, policy, Some(TlsConfig { cert, key }))
+                serve_http(port, handler_name, program, policy, Some(TlsConfig { cert, key }), ServeOpts::from_env())
             }
             ("net", "serve_ws") => {
                 let port = match args.first() {
@@ -1718,9 +1776,10 @@ fn serve_http(
     program: Arc<Program>,
     policy: Policy,
     tls: Option<TlsConfig>,
+    opts: ServeOpts,
 ) -> Result<Value, String> {
     match tls {
-        None => serve_http_plain(port, handler_name, program, policy),
+        None => serve_http_plain(port, handler_name, program, policy, opts),
         Some(cfg) => serve_http_tls_legacy(port, handler_name, program, policy, cfg),
     }
 }
@@ -1739,6 +1798,7 @@ fn serve_http_plain(
     handler_name: String,
     program: Arc<Program>,
     policy: Policy,
+    opts: ServeOpts,
 ) -> Result<Value, String> {
     use http_body_util::BodyExt as _;
     use hyper::server::conn::http1;
@@ -1747,18 +1807,19 @@ fn serve_http_plain(
     use hyper_util::server::conn::auto;
     use tokio::net::TcpListener as TokioTcpListener;
 
-    let inline_vm = env_inline_vm();
-    let http2 = env_http2();
+    let inline_vm = opts.inline_vm;
+    let http2 = opts.http2;
+    let host = opts.host.clone();
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .map_err(|e| format!("net.serve: tokio runtime: {e}"))?;
     rt.block_on(async move {
-        let listener = TokioTcpListener::bind(("0.0.0.0", port))
+        let listener = TokioTcpListener::bind((host.as_str(), port))
             .await
-            .map_err(|e| format!("net.serve bind {port}: {e}"))?;
+            .map_err(|e| format!("net.serve bind {host}:{port}: {e}"))?;
         eprintln!(
-            "net.serve: listening on http://0.0.0.0:{port}{}{}",
+            "net.serve: listening on http://{host}:{port}{}{}",
             if inline_vm { " (inline-vm)" } else { "" },
             if http2 { " (http1+http2)" } else { "" }
         );
@@ -1886,6 +1947,7 @@ fn serve_http_fn(
     closure: Value,
     program: Arc<Program>,
     policy: Policy,
+    opts: ServeOpts,
 ) -> Result<Value, String> {
     use http_body_util::BodyExt as _;
     use hyper::server::conn::http1;
@@ -1894,18 +1956,19 @@ fn serve_http_fn(
     use hyper_util::server::conn::auto;
     use tokio::net::TcpListener as TokioTcpListener;
 
-    let inline_vm = env_inline_vm();
-    let http2 = env_http2();
+    let inline_vm = opts.inline_vm;
+    let http2 = opts.http2;
+    let host = opts.host.clone();
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .map_err(|e| format!("net.serve_fn: tokio runtime: {e}"))?;
     rt.block_on(async move {
-        let listener = TokioTcpListener::bind(("0.0.0.0", port))
+        let listener = TokioTcpListener::bind((host.as_str(), port))
             .await
-            .map_err(|e| format!("net.serve_fn bind {port}: {e}"))?;
+            .map_err(|e| format!("net.serve_fn bind {host}:{port}: {e}"))?;
         eprintln!(
-            "net.serve_fn: listening on http://0.0.0.0:{port}{}{}",
+            "net.serve_fn: listening on http://{host}:{port}{}{}",
             if inline_vm { " (inline-vm)" } else { "" },
             if http2 { " (http1+http2)" } else { "" }
         );
@@ -2129,6 +2192,7 @@ fn serve_http_routed(
     fallback: Value,
     program: Arc<Program>,
     policy: Policy,
+    opts: ServeOpts,
 ) -> Result<Value, String> {
     use http_body_util::BodyExt as _;
     use hyper::server::conn::http1;
@@ -2137,19 +2201,20 @@ fn serve_http_routed(
     use hyper_util::server::conn::auto;
     use tokio::net::TcpListener as TokioTcpListener;
 
-    let inline_vm = env_inline_vm();
-    let http2 = env_http2();
+    let inline_vm = opts.inline_vm;
+    let http2 = opts.http2;
+    let host = opts.host.clone();
     let routes = Arc::new(routes);
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .map_err(|e| format!("net.serve_routed: tokio runtime: {e}"))?;
     rt.block_on(async move {
-        let listener = TokioTcpListener::bind(("0.0.0.0", port))
+        let listener = TokioTcpListener::bind((host.as_str(), port))
             .await
-            .map_err(|e| format!("net.serve_routed bind {port}: {e}"))?;
+            .map_err(|e| format!("net.serve_routed bind {host}:{port}: {e}"))?;
         eprintln!(
-            "net.serve_routed: listening on http://0.0.0.0:{port} ({} routes{}{})",
+            "net.serve_routed: listening on http://{host}:{port} ({} routes{}{})",
             routes.len(),
             if inline_vm { ", inline-vm" } else { "" },
             if http2 { ", http1+http2" } else { "" }
@@ -2250,6 +2315,76 @@ fn env_inline_vm() -> bool {
         }
         Err(_) => false,
     }
+}
+
+/// Server-config record threaded through `serve_http_plain` / `_fn` /
+/// `_routed`. Built from env vars on the legacy `net.serve*` paths
+/// (`ServeOpts::from_env`) or decoded from a user-supplied Lex record
+/// literal on the new `net.serve*_with` paths (`decode_serve_opts`).
+/// See lex-lang#497 for the design rationale.
+#[derive(Debug, Clone)]
+struct ServeOpts {
+    http2: bool,
+    inline_vm: bool,
+    host: String,
+}
+
+impl ServeOpts {
+    /// Default values that match the legacy behaviour with env vars
+    /// honoured. Use this when entering via `net.serve`, `net.serve_fn`,
+    /// or `net.serve_routed` — preserves backwards compatibility.
+    fn from_env() -> Self {
+        Self {
+            http2: env_http2(),
+            inline_vm: env_inline_vm(),
+            host: "0.0.0.0".to_string(),
+        }
+    }
+
+    /// Hard-coded defaults returned by `net.default_opts()`. Does NOT
+    /// consult env vars — the `*_with` paths read the opts record
+    /// literally, so the env-var escape hatch only applies to legacy
+    /// callers (`net.serve` et al).
+    fn lex_defaults() -> Self {
+        Self {
+            http2: false,
+            inline_vm: false,
+            host: "0.0.0.0".to_string(),
+        }
+    }
+
+    /// Convert to a Lex `Value::Record` for return from `default_opts()`.
+    fn to_value(&self) -> Value {
+        let mut rec = indexmap::IndexMap::new();
+        rec.insert("http2".to_string(),     Value::Bool(self.http2));
+        rec.insert("inline_vm".to_string(), Value::Bool(self.inline_vm));
+        rec.insert("host".to_string(),      Value::Str(self.host.clone().into()));
+        Value::Record(rec)
+    }
+}
+
+/// Decode a `ServeOpts` from a Lex record literal. Fields are
+/// required — the type-checker has already verified the shape, so
+/// here we just project them out. Any deviation from the expected
+/// shape is treated as an internal-consistency error.
+fn decode_serve_opts(v: &Value) -> Result<ServeOpts, String> {
+    let rec = match v {
+        Value::Record(r) => r,
+        other => return Err(format!("opts must be a Record, got {other:?}")),
+    };
+    let http2 = match rec.get("http2") {
+        Some(Value::Bool(b)) => *b,
+        _ => return Err("opts.http2 must be Bool".into()),
+    };
+    let inline_vm = match rec.get("inline_vm") {
+        Some(Value::Bool(b)) => *b,
+        _ => return Err("opts.inline_vm must be Bool".into()),
+    };
+    let host = match rec.get("host") {
+        Some(Value::Str(s)) => s.to_string(),
+        _ => return Err("opts.host must be Str".into()),
+    };
+    Ok(ServeOpts { http2, inline_vm, host })
 }
 
 /// Read `LEX_NET_HTTP2` and report whether the runtime should accept

--- a/crates/lex-runtime/tests/net_serve_with.rs
+++ b/crates/lex-runtime/tests/net_serve_with.rs
@@ -1,0 +1,182 @@
+//! Tests for `net.serve_with` / `net.serve_fn_with` / `net.serve_routed_with`
+//! and `net.default_opts()` — the first-class ServeOpts record API
+//! introduced in lex-lang#497 (replacing the LEX_NET_HTTP2 /
+//! LEX_NET_INLINE_VM env-var gates with a typed config record).
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::collections::BTreeSet;
+use std::io::{Read, Write};
+use std::net::{TcpStream, ToSocketAddrs};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+fn spawn_lex_server(src: &str, entry: &str) {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors: {errs:#?}");
+    }
+    let bc = Arc::new(compile_program(&stages));
+    let mut policy = Policy::pure();
+    policy.allow_effects = ["net".to_string()].into_iter().collect::<BTreeSet<_>>();
+    let entry = entry.to_string();
+    thread::spawn(move || {
+        let handler = DefaultHandler::new(policy.clone()).with_program(Arc::clone(&bc));
+        let mut vm = Vm::with_handler(&bc, Box::new(handler));
+        let _ = vm.call(&entry, vec![]);
+    });
+}
+
+fn wait_for_bind(port: u16, timeout: Duration) {
+    let deadline = std::time::Instant::now() + timeout;
+    let mut backoff = Duration::from_millis(20);
+    loop {
+        if let Ok(s) = TcpStream::connect_timeout(
+            &("127.0.0.1", port).to_socket_addrs().unwrap().next().unwrap(),
+            Duration::from_millis(200),
+        ) {
+            drop(s);
+            return;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("server on :{port} did not bind within {timeout:?}");
+        }
+        thread::sleep(backoff);
+        backoff = (backoff * 2).min(Duration::from_millis(200));
+    }
+}
+
+fn http(port: u16, method: &str, path: &str) -> (u16, String) {
+    let mut s = TcpStream::connect(("127.0.0.1", port)).expect("connect");
+    s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    let req = format!(
+        "{method} {path} HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n"
+    );
+    s.write_all(req.as_bytes()).unwrap();
+    let mut buf = String::new();
+    s.read_to_string(&mut buf).unwrap();
+    let (head, body) = buf.split_once("\r\n\r\n").unwrap_or((&buf, ""));
+    let status = head.split_whitespace().nth(1).unwrap_or("0").parse().unwrap_or(0);
+    (status, body.to_string())
+}
+
+const H2_PREFACE: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
+
+/// `net.serve_with` accepts a ServeOpts record literal and routes HTTP/1
+/// traffic to the handler exactly like `net.serve` does. Sanity check
+/// that the new path doesn't lose request marshaling.
+#[test]
+fn serve_with_default_opts_handles_http1() {
+    let src = r#"
+import "std.net" as net
+import "std.str" as str
+
+fn handle(req :: { body :: Str, method :: Str, path :: Str, query :: Str }) -> { body :: Str, status :: Int } {
+  { status: 200, body: str.concat("via opts: ", req.path) }
+}
+
+fn main() -> [net] Nil {
+  let opts := net.default_opts()
+  net.serve_with(18101, "handle", opts)
+}
+"#;
+    spawn_lex_server(src, "main");
+    wait_for_bind(18101, Duration::from_secs(5));
+    let (status, body) = http(18101, "GET", "/hello");
+    assert_eq!(status, 200);
+    assert_eq!(body, "via opts: /hello");
+}
+
+/// `serve_with` with `http2: true` accepts both HTTP/1 (backwards-compat
+/// via auto::Builder preface detection) and HTTP/2 prior-knowledge
+/// connections. This is the opts-record equivalent of the LEX_NET_HTTP2
+/// env-var test in `net_serve_http2.rs`.
+#[test]
+fn serve_with_http2_true_accepts_h2_preface() {
+    let src = r#"
+import "std.net" as net
+import "std.str" as str
+
+fn handle(req :: { body :: Str, method :: Str, path :: Str, query :: Str }) -> { body :: Str, status :: Int } {
+  { status: 200, body: str.concat("h2-ready: ", req.path) }
+}
+
+fn main() -> [net] Nil {
+  let opts := { http2: true, inline_vm: false, host: "0.0.0.0" }
+  net.serve_with(18102, "handle", opts)
+}
+"#;
+    spawn_lex_server(src, "main");
+    wait_for_bind(18102, Duration::from_secs(5));
+
+    // HTTP/1 still works.
+    let (status, body) = http(18102, "GET", "/x");
+    assert_eq!(status, 200);
+    assert_eq!(body, "h2-ready: /x");
+
+    // HTTP/2 preface elicits H/2 framing (SETTINGS, type 0x04).
+    let mut s = TcpStream::connect(("127.0.0.1", 18102)).expect("connect");
+    s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    s.write_all(H2_PREFACE).unwrap();
+    let mut buf = [0u8; 9];
+    let n = s.read(&mut buf).unwrap_or(0);
+    assert!(n >= 9, "expected H/2 SETTINGS frame, got {n} bytes");
+    assert_eq!(
+        buf[3], 0x04,
+        "expected SETTINGS (type=0x04), got header {buf:02x?}"
+    );
+}
+
+/// `host: "127.0.0.1"` actually binds to loopback only (not 0.0.0.0).
+/// We can't easily prove "binds only there" from a unit test, but we
+/// can prove "binds *at* there" by hitting 127.0.0.1 directly.
+#[test]
+fn serve_with_custom_host_binds_correctly() {
+    let src = r#"
+import "std.net" as net
+
+fn handle(_req :: { body :: Str, method :: Str, path :: Str, query :: Str }) -> { body :: Str, status :: Int } {
+  { status: 200, body: "loopback" }
+}
+
+fn main() -> [net] Nil {
+  let opts := { http2: false, inline_vm: false, host: "127.0.0.1" }
+  net.serve_with(18103, "handle", opts)
+}
+"#;
+    spawn_lex_server(src, "main");
+    wait_for_bind(18103, Duration::from_secs(5));
+    let (status, body) = http(18103, "GET", "/");
+    assert_eq!(status, 200);
+    assert_eq!(body, "loopback");
+}
+
+/// `serve_fn_with` accepts a closure handler + opts and dispatches
+/// HTTP/1 traffic. Mirrors `serve_with` but exercises the closure
+/// codepath (`serve_http_fn`). Uses the opaque `Request` / `Response`
+/// types (same as existing `serve_fn` tests in net_streaming.rs).
+#[test]
+fn serve_fn_with_closure_handler_works() {
+    let src = r#"
+import "std.net" as net
+import "std.map" as map
+
+fn handle(_req :: Request) -> Response {
+  { status: 200, body: BodyStr("closure-via-opts"), headers: map.new() }
+}
+
+fn main() -> [net] Nil {
+  let opts := { http2: false, inline_vm: false, host: "0.0.0.0" }
+  net.serve_fn_with(18104, handle, opts)
+}
+"#;
+    spawn_lex_server(src, "main");
+    wait_for_bind(18104, Duration::from_secs(5));
+    let (status, body) = http(18104, "GET", "/foo");
+    assert_eq!(status, 200);
+    assert_eq!(body, "closure-via-opts");
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -693,6 +693,82 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 EffectSet::open_var(0).union(&EffectSet::singleton("net")),
                 Ty::Unit,
             ));
+
+            // ServeOpts is a structural record literal — callers build
+            // it with `{ http2: ..., inline_vm: ..., host: ... }`. Used
+            // by `serve_with` / `serve_fn_with` / `serve_routed_with`
+            // to replace the legacy LEX_NET_HTTP2 / LEX_NET_INLINE_VM
+            // env-var gates with a first-class, type-checked config.
+            // See lex-lang#497.
+            let serve_opts_t = || {
+                let mut fs = IndexMap::new();
+                fs.insert("http2".into(),     Ty::bool());
+                fs.insert("inline_vm".into(), Ty::bool());
+                fs.insert("host".into(),      Ty::str());
+                Ty::Record(fs)
+            };
+
+            // default_opts :: () -> ServeOpts
+            // Returns the same defaults the legacy serve* paths use —
+            // http2=false, inline_vm=false, host="0.0.0.0". Pure; the
+            // env-var fallback only applies on the legacy serve* path,
+            // not here.
+            fields.insert("default_opts".into(), Ty::function(
+                vec![],
+                EffectSet::empty(),
+                serve_opts_t(),
+            ));
+
+            // serve_with :: (Int, Str, ServeOpts) -> [net] Unit
+            fields.insert("serve_with".into(), Ty::function(
+                vec![Ty::int(), Ty::str(), serve_opts_t()],
+                EffectSet::singleton("net"),
+                Ty::Unit,
+            ));
+
+            // serve_fn_with[Eff] :: (Int, (Request) -> [Eff] Response, ServeOpts)
+            //                       -> [net, Eff] Unit
+            fields.insert("serve_fn_with".into(), Ty::function(
+                vec![
+                    Ty::int(),
+                    Ty::function(
+                        vec![Ty::Con("Request".into(), vec![])],
+                        EffectSet::open_var(0),
+                        Ty::Con("Response".into(), vec![]),
+                    ),
+                    serve_opts_t(),
+                ],
+                EffectSet::open_var(0).union(&EffectSet::singleton("net")),
+                Ty::Unit,
+            ));
+
+            // serve_routed_with[Eff] :: (
+            //   Int, List[(Str, Str, (Request) -> [Eff] Response)],
+            //   (Request) -> [Eff] Response, ServeOpts
+            // ) -> [net, Eff] Unit
+            fields.insert("serve_routed_with".into(), Ty::function(
+                vec![
+                    Ty::int(),
+                    Ty::List(Box::new(Ty::Tuple(vec![
+                        Ty::str(),
+                        Ty::str(),
+                        Ty::function(
+                            vec![Ty::Con("Request".into(), vec![])],
+                            EffectSet::open_var(0),
+                            Ty::Con("Response".into(), vec![]),
+                        ),
+                    ]))),
+                    Ty::function(
+                        vec![Ty::Con("Request".into(), vec![])],
+                        EffectSet::open_var(0),
+                        Ty::Con("Response".into(), vec![]),
+                    ),
+                    serve_opts_t(),
+                ],
+                EffectSet::open_var(0).union(&EffectSet::singleton("net")),
+                Ty::Unit,
+            ));
+
             Some(Ty::Record(fields))
         }
         "chat" => {

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -190,6 +190,8 @@ fn my_handler(req :: Request) -> [io] Response {
 }
 fn main() -> [net, io] Nil { net.serve_fn(8080, my_handler) }
 ```
+
+`net.serve_with(port, handler_name, opts)` / `net.serve_fn_with(port, handler, opts)` / `net.serve_routed_with(port, routes, fallback, opts)` — same as the unsuffixed variants but accept a `ServeOpts` record literal (`{ http2: Bool, inline_vm: Bool, host: Str }`) instead of relying on `LEX_NET_HTTP2` / `LEX_NET_INLINE_VM` env vars. `net.default_opts()` returns the defaults (`http2: false, inline_vm: false, host: "0.0.0.0"`); construct your own literal to enable HTTP/2 or bind to a specific host. The legacy `serve` / `serve_fn` / `serve_routed` paths keep honouring the env vars for backwards compatibility — new code should prefer the `*_with` variants (#497).
 `net.serve_ws_fn(port, subprotocol, handler)` — WebSocket server:
 ```lex
 fn on_msg(conn :: WsConn, msg :: WsMessage) -> WsAction {


### PR DESCRIPTION
Closes #497. Replaces the `LEX_NET_HTTP2` / `LEX_NET_INLINE_VM` env-var gates with a typed, type-checked options record on three new builtins. The legacy `serve` / `serve_fn` / `serve_routed` paths keep honouring env vars for backwards compatibility.

## New surface

```lex
let opts := { http2: true, inline_vm: false, host: "127.0.0.1" }
net.serve_with(8080, "handle", opts)
net.serve_fn_with(8080, my_closure, opts)
net.serve_routed_with(8080, routes, fallback, opts)
```

`net.default_opts()` returns the same defaults the legacy `serve*` paths use (`http2=false`, `inline_vm=false`, `host="0.0.0.0"`). It's typed as pure (no `[net]` effect required) so it composes anywhere — same pattern as `http.{send,get,post}`'s effect-mapping intercept.

## What changes

**`crates/lex-types/src/builtins.rs`** — adds the structural `ServeOpts` record type used by all signatures, plus `default_opts :: () -> ServeOpts` (pure) and the three `serve_*_with` signatures preserving the existing effect-polymorphic shape (`open_var(0)` propagates handler effects to the call site).

**`crates/lex-runtime/src/handler.rs`**:
- New `ServeOpts` Rust struct with `from_env()` (legacy paths) and `lex_defaults()` (what `net.default_opts()` returns).
- `decode_serve_opts(&Value) -> Result<ServeOpts, String>` projects the three fields out of the record literal.
- Refactor `serve_http_plain` / `serve_http_fn` / `serve_http_routed` to take `ServeOpts` instead of reading env vars directly. Use `opts.host` for the bind address; log line now reports the resolved host.
- Existing dispatch arms (`("net", "serve")` etc.) pass `ServeOpts::from_env()` — byte-identical legacy behaviour, env vars still honoured.
- Three new arms (`serve_with` / `serve_fn_with` / `serve_routed_with`) decode the opts record and call the same underlying serve fns.
- `("net", "default_opts")` short-circuits before the generic `ensure_kind_allowed("net")` gate so it stays type-system-pure.

**`docs/AGENT.md`** — documents the new variants and points new code at them.

## Test plan

New `crates/lex-runtime/tests/net_serve_with.rs` — 4 tests:

- [x] `serve_with_default_opts_handles_http1` — round-trips HTTP/1 traffic via `net.default_opts()`
- [x] `serve_with_http2_true_accepts_h2_preface` — `{http2: true, ...}` accepts the H/2 client preface (SETTINGS frame back, not `HTTP/1.1 400`)
- [x] `serve_with_custom_host_binds_correctly` — `host: "127.0.0.1"` binds and serves loopback
- [x] `serve_fn_with_closure_handler_works` — closure dispatch path with opaque `Request`/`Response`

Regression coverage:

- [x] `cargo test -p lex-runtime --test net_serve` — 11/11 (legacy paths unchanged)
- [x] `cargo test -p lex-runtime --test net_serve_http2` — 1/1 (env-var path still works)
- [x] `cargo test -p lex-runtime --test net_serve_with` — 4/4 (new)
- [x] `cargo build -p lex-runtime` — clean
- [ ] CI green

## Out of scope (deferred follow-ups)

- `serve_quic_with` — depends on #496 (HTTP/3) landing first.
- `tls` field on `ServeOpts` — needs the tokio-rustls migration prereq from #496.
- `graceful_shutdown_ms` field — needs shutdown-signal wiring.

Each is an additive field to `ServeOpts`; existing call sites won't break.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PsrNeuuchvDLFJmY1CskFe)_