### PR TITLE
feat(net): net.serve_quic — HTTP/3 over QUIC + std.tls (#496)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,12 @@ jobs:
       # `cargo test` already compiles every test target. Dropping the
       # standalone build step halves the peak debug-target footprint.
       - run: cargo test --workspace --no-fail-fast
+      # `quic` is an opt-in feature on lex-runtime (#496). Build +
+      # exercise the H/3 test separately so the default `cargo test`
+      # step stays cheap — pulling in quinn + h3 + rcgen + rustls is
+      # ~300 MB of additional dep-graph link cost we don't want to
+      # pay on every workspace test. Tests under the feature are
+      # all gated `#![cfg(feature = "quic")]`, so this single test
+      # binary is enough.
+      - run: cargo test -p lex-runtime --features quic --test net_serve_quic
       - run: cargo clippy --workspace --all-targets -- -D warnings

--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -42,6 +42,15 @@ http-body-util = "0.1"
 bytes = "1"
 tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
 ureq = { version = "3.3", default-features = false, features = ["rustls", "platform-verifier"] }
+# HTTP/3 (#496). `quic` feature gates the heavy quinn+h3+rcgen deps so
+# the default build stays slim. Without the feature the serve_quic
+# dispatch arms return a "compiled without quic feature" error.
+quinn  = { version = "0.11", optional = true, default-features = false, features = ["runtime-tokio", "rustls", "ring"] }
+h3     = { version = "0.0.8", optional = true }
+h3-quinn = { version = "0.0.10", optional = true }
+rustls = { version = "0.23", optional = true, default-features = false, features = ["ring", "std"] }
+rustls-pemfile = { version = "2", optional = true }
+rcgen  = { version = "0.13", optional = true, default-features = false, features = ["ring", "pem"] }
 toml = "1.1"
 serde_yaml = "0.9"
 csv = "1"
@@ -57,6 +66,13 @@ parquet = { version = "55", default-features = false, features = ["arrow", "snap
 polars = { version = "0.50", default-features = false, features = ["lazy", "is_in", "csv", "performant", "strings"] }
 lex-bytecode = { path = "../lex-bytecode", version = "0.9.5" }
 smol_str = { workspace = true }
+
+[features]
+default = []
+# `quic` brings in quinn / h3 / rcgen / rustls + rustls-pemfile. Off
+# by default to keep `cargo build` slim; enable with `--features quic`
+# to use `net.serve_quic`, `tls.from_pem_files`, or `tls.self_signed`.
+quic = ["dep:quinn", "dep:h3", "dep:h3-quinn", "dep:rustls", "dep:rustls-pemfile", "dep:rcgen"]
 
 [dev-dependencies]
 lex-syntax = { path = "../lex-syntax", version = "0.9.5" }

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -897,6 +897,23 @@ impl EffectHandler for DefaultHandler {
         if kind == "net" && op == "default_opts" {
             return Ok(ServeOpts::lex_defaults().to_value());
         }
+        // `tls.*` (#496) — TlsConfig constructors map to different
+        // effect kinds than the namespace name suggests:
+        //   `tls.from_pem_files` :: [fs_read]   (reads cert + key PEM)
+        //   `tls.self_signed`    :: pure        (rcgen, in-memory)
+        // Intercept before the generic `ensure_kind_allowed("tls")`
+        // gate so policy can check the *real* effect. Same pattern
+        // as the `http.{send,get,post}` arms above.
+        if kind == "tls" {
+            return match op {
+                "from_pem_files" => {
+                    self.ensure_kind_allowed("fs_read")?;
+                    dispatch_tls_from_pem_files(self, args)
+                }
+                "self_signed" => dispatch_tls_self_signed(args),
+                other => Err(format!("unsupported tls.{other}")),
+            };
+        }
         self.ensure_kind_allowed(kind)?;
         match (kind, op) {
             ("io", "print") => {
@@ -1146,6 +1163,9 @@ impl EffectHandler for DefaultHandler {
                 let policy = self.policy.clone();
                 serve_http_routed(port, routes, fallback, program, policy, opts)
             }
+            ("net", "serve_quic") => self.dispatch_serve_quic_named(args),
+            ("net", "serve_quic_fn") => self.dispatch_serve_quic_fn(args),
+            ("net", "serve_quic_routed") => self.dispatch_serve_quic_routed(args),
             ("net", "serve_tls") => {
                 let port = match args.first() {
                     Some(Value::Int(n)) if (0..=65535).contains(n) => *n as u16,
@@ -2042,7 +2062,7 @@ fn serve_http_fn(
 /// once at registration time so the per-request match loop is just a
 /// length check + segment-by-segment compare.
 #[derive(Clone, Debug)]
-enum RouteSeg {
+pub(crate) enum RouteSeg {
     Literal(String),
     /// `:name` capture — binds the request segment under `name` in
     /// `req.path_params`.
@@ -2152,7 +2172,7 @@ fn decode_routes_arg(
 /// handler closure plus captured path-params. Method match is
 /// case-insensitive vs the request (already uppercased at decode
 /// time); `"*"` in a route matches any method.
-fn dispatch_route<'a>(
+pub(crate) fn dispatch_route<'a>(
     routes: &'a [(String, Vec<RouteSeg>, Value)],
     req_method: &str,
     req_path: &str,
@@ -2172,7 +2192,7 @@ fn dispatch_route<'a>(
 /// Overwrite the `path_params` field on a Request record with the
 /// captured map. Request records are always built with an empty
 /// `path_params` field, so this just updates the existing slot.
-fn stamp_path_params(
+pub(crate) fn stamp_path_params(
     req: &mut Value,
     params: std::collections::BTreeMap<lex_bytecode::MapKey, Value>,
 ) {
@@ -2323,10 +2343,10 @@ fn env_inline_vm() -> bool {
 /// literal on the new `net.serve*_with` paths (`decode_serve_opts`).
 /// See lex-lang#497 for the design rationale.
 #[derive(Debug, Clone)]
-struct ServeOpts {
-    http2: bool,
-    inline_vm: bool,
-    host: String,
+pub(crate) struct ServeOpts {
+    pub(crate) http2: bool,
+    pub(crate) inline_vm: bool,
+    pub(crate) host: String,
 }
 
 impl ServeOpts {
@@ -2387,6 +2407,158 @@ fn decode_serve_opts(v: &Value) -> Result<ServeOpts, String> {
     Ok(ServeOpts { http2, inline_vm, host })
 }
 
+// ── tls.* and net.serve_quic* dispatch helpers (#496) ──────────────
+//
+// `TlsConfig` is opaque in the type system (a `Ty::Con("TlsConfig",…)`)
+// but at runtime it's a `Value::Record({cert :: Bytes, key :: Bytes})`
+// carrying the PEM-encoded chain + private key. The opacity matters
+// because we may switch the in-runtime representation to a Resource
+// handle later (e.g. to keep the private key out of GC-visible
+// memory) without breaking source code.
+
+fn make_tls_config_value(cert_pem: Vec<u8>, key_pem: Vec<u8>) -> Value {
+    let mut rec = indexmap::IndexMap::new();
+    rec.insert("cert".into(), Value::Bytes(cert_pem));
+    rec.insert("key".into(),  Value::Bytes(key_pem));
+    Value::Record(rec)
+}
+
+#[cfg(feature = "quic")]
+fn decode_tls_config(v: &Value) -> Result<crate::quic::QuicTls, String> {
+    let rec = match v {
+        Value::Record(r) => r,
+        other => return Err(format!("TlsConfig: expected Record, got {other:?}")),
+    };
+    let cert = match rec.get("cert") {
+        Some(Value::Bytes(b)) => b.to_vec(),
+        _ => return Err("TlsConfig.cert: must be Bytes".into()),
+    };
+    let key = match rec.get("key") {
+        Some(Value::Bytes(b)) => b.to_vec(),
+        _ => return Err("TlsConfig.key: must be Bytes".into()),
+    };
+    Ok(crate::quic::QuicTls { cert_pem: cert, key_pem: key })
+}
+
+fn dispatch_tls_from_pem_files(
+    handler: &DefaultHandler,
+    args: Vec<Value>,
+) -> Result<Value, String> {
+    let cert_path = expect_str(args.first())?.to_string();
+    let key_path  = expect_str(args.get(1))?.to_string();
+    let cert_resolved = handler.resolve_read_path(&cert_path);
+    let key_resolved  = handler.resolve_read_path(&key_path);
+    if !handler.policy.allow_fs_read.is_empty() {
+        let allowed = |p: &std::path::Path| -> bool {
+            handler.policy.allow_fs_read.iter().any(|a| p.starts_with(a))
+        };
+        if !allowed(&cert_resolved) {
+            return Ok(err(Value::Str(
+                format!("tls.from_pem_files: cert `{cert_path}` outside --allow-fs-read").into(),
+            )));
+        }
+        if !allowed(&key_resolved) {
+            return Ok(err(Value::Str(
+                format!("tls.from_pem_files: key `{key_path}` outside --allow-fs-read").into(),
+            )));
+        }
+    }
+    let cert = match std::fs::read(&cert_resolved) {
+        Ok(b) => b,
+        Err(e) => return Ok(err(Value::Str(format!("read cert {cert_path}: {e}").into()))),
+    };
+    let key = match std::fs::read(&key_resolved) {
+        Ok(b) => b,
+        Err(e) => return Ok(err(Value::Str(format!("read key {key_path}: {e}").into()))),
+    };
+    Ok(ok(make_tls_config_value(cert, key)))
+}
+
+#[cfg(feature = "quic")]
+fn dispatch_tls_self_signed(args: Vec<Value>) -> Result<Value, String> {
+    let hostname = expect_str(args.first())?.to_string();
+    match crate::quic::self_signed_pem(&hostname) {
+        Ok((cert, key)) => Ok(ok(make_tls_config_value(cert, key))),
+        Err(e) => Ok(err(Value::Str(format!("tls.self_signed: {e}").into()))),
+    }
+}
+
+#[cfg(not(feature = "quic"))]
+fn dispatch_tls_self_signed(_args: Vec<Value>) -> Result<Value, String> {
+    Ok(err(Value::Str(
+        "tls.self_signed: lex-runtime was compiled without the `quic` feature (needed for rcgen)".into(),
+    )))
+}
+
+impl DefaultHandler {
+    #[cfg(feature = "quic")]
+    fn dispatch_serve_quic_named(&self, args: Vec<Value>) -> Result<Value, String> {
+        let port = match args.first() {
+            Some(Value::Int(n)) if (0..=65535).contains(n) => *n as u16,
+            _ => return Err("net.serve_quic(port, tls, handler): port must be Int 0..=65535".into()),
+        };
+        let tls = decode_tls_config(args.get(1)
+            .ok_or_else(|| "net.serve_quic(port, tls, handler): missing tls".to_string())?)?;
+        let handler_name = expect_str(args.get(2))?.to_string();
+        let program = self.program.clone()
+            .ok_or_else(|| "net.serve_quic requires a Program reference; use DefaultHandler::with_program".to_string())?;
+        let policy = self.policy.clone();
+        crate::quic::serve_http3_named(port, handler_name, tls, program, policy, ServeOpts::from_env())
+    }
+
+    #[cfg(feature = "quic")]
+    fn dispatch_serve_quic_fn(&self, args: Vec<Value>) -> Result<Value, String> {
+        let port = match args.first() {
+            Some(Value::Int(n)) if (0..=65535).contains(n) => *n as u16,
+            _ => return Err("net.serve_quic_fn(port, tls, handler): port must be Int 0..=65535".into()),
+        };
+        let tls = decode_tls_config(args.get(1)
+            .ok_or_else(|| "net.serve_quic_fn(port, tls, handler): missing tls".to_string())?)?;
+        let closure = match args.into_iter().nth(2) {
+            Some(c @ Value::Closure { .. }) => c,
+            _ => return Err("net.serve_quic_fn(port, tls, handler): handler must be a closure".into()),
+        };
+        let program = self.program.clone()
+            .ok_or_else(|| "net.serve_quic_fn requires a Program reference; use DefaultHandler::with_program".to_string())?;
+        let policy = self.policy.clone();
+        crate::quic::serve_http3_fn(port, closure, tls, program, policy, ServeOpts::from_env())
+    }
+
+    #[cfg(feature = "quic")]
+    fn dispatch_serve_quic_routed(&self, args: Vec<Value>) -> Result<Value, String> {
+        let port = match args.first() {
+            Some(Value::Int(n)) if (0..=65535).contains(n) => *n as u16,
+            _ => return Err("net.serve_quic_routed(port, tls, routes, fallback): port must be Int 0..=65535".into()),
+        };
+        let tls = decode_tls_config(args.get(1)
+            .ok_or_else(|| "net.serve_quic_routed(port, tls, routes, fallback): missing tls".to_string())?)?;
+        let routes_val = args.get(2).cloned()
+            .ok_or_else(|| "net.serve_quic_routed(port, tls, routes, fallback): missing routes".to_string())?;
+        let fallback = match args.into_iter().nth(3) {
+            Some(c @ Value::Closure { .. }) => c,
+            _ => return Err("net.serve_quic_routed(port, tls, routes, fallback): fallback must be a closure".into()),
+        };
+        let routes = decode_routes_arg(routes_val)?;
+        let program = self.program.clone()
+            .ok_or_else(|| "net.serve_quic_routed requires a Program reference; use DefaultHandler::with_program".to_string())?;
+        let policy = self.policy.clone();
+        crate::quic::serve_http3_routed(port, routes, fallback, tls, program, policy, ServeOpts::from_env())
+    }
+
+    #[cfg(not(feature = "quic"))]
+    fn dispatch_serve_quic_named(&self, _args: Vec<Value>) -> Result<Value, String> {
+        Err("net.serve_quic: lex-runtime was compiled without the `quic` feature (needed for quinn + h3)".into())
+    }
+    #[cfg(not(feature = "quic"))]
+    fn dispatch_serve_quic_fn(&self, _args: Vec<Value>) -> Result<Value, String> {
+        Err("net.serve_quic_fn: lex-runtime was compiled without the `quic` feature (needed for quinn + h3)".into())
+    }
+    #[cfg(not(feature = "quic"))]
+    fn dispatch_serve_quic_routed(&self, _args: Vec<Value>) -> Result<Value, String> {
+        Err("net.serve_quic_routed: lex-runtime was compiled without the `quic` feature (needed for quinn + h3)".into())
+    }
+}
+
 /// Read `LEX_NET_HTTP2` and report whether the runtime should accept
 /// HTTP/2 connections via hyper-util's auto builder (HTTP/1 ↔ HTTP/2
 /// preface detection). Accepts `1` / `true` (case-insensitive); anything
@@ -2407,16 +2579,20 @@ fn env_http2() -> bool {
 }
 
 /// Build a Lex request record from hyper request parts and pre-collected body bytes.
-fn build_request_value_parts(
+pub(crate) fn build_request_value_parts(
     parts: &hyper::http::request::Parts,
     body: &bytes::Bytes,
 ) -> Value {
     let method = parts.method.as_str().to_string();
-    let uri = parts.uri.to_string();
-    let (path, query) = match uri.split_once('?') {
-        Some((p, q)) => (p.to_string(), q.to_string()),
-        None => (uri, String::new()),
-    };
+    // `Uri::path()` returns just the origin-form path, regardless of
+    // whether the wire URI was relative (`/foo` — HTTP/1.1) or
+    // absolute (`https://host/foo` — HTTP/2 and HTTP/3 fold the
+    // `:scheme` + `:authority` pseudo-headers into the full URI).
+    // Reading `to_string()` would leak the scheme/authority into the
+    // Lex handler's `req.path`, which surprised handlers built for
+    // HTTP/1.1 (#496 surfaced this against `serve_quic`).
+    let path = parts.uri.path().to_string();
+    let query = parts.uri.query().map(str::to_string).unwrap_or_default();
     let mut headers_map = std::collections::BTreeMap::new();
     for (name, val) in &parts.headers {
         if let Ok(v) = val.to_str() {
@@ -2464,7 +2640,7 @@ fn build_request_value_tiny(req: &mut tiny_http::Request) -> Value {
     Value::Record(rec)
 }
 
-fn unpack_response(v: &Value) -> (u16, ResponseBodyOut, Vec<(String, String)>) {
+pub(crate) fn unpack_response(v: &Value) -> (u16, ResponseBodyOut, Vec<(String, String)>) {
     if let Value::Record(rec) = v {
         let status = rec.get("status").and_then(|s| match s {
             Value::Int(n) => Some(*n as u16),
@@ -2617,7 +2793,7 @@ fn respond_with_body_tls(
 /// different `tiny_http` path: a single `Response::from_string` for
 /// `Str`, and a chunked-encoding `Response::new` with a `Read`-backed
 /// chunk list for the streaming variants.
-enum ResponseBodyOut {
+pub(crate) enum ResponseBodyOut {
     Str(String),
     /// Pre-drained text chunks. v1 ships eager-iter only; lazy producers
     /// (#376 follow-up) will replace this with a Read adapter that pulls

--- a/crates/lex-runtime/src/lib.rs
+++ b/crates/lex-runtime/src/lib.rs
@@ -19,6 +19,8 @@ pub mod df;
 pub mod cli;
 pub mod policy;
 pub mod handler;
+#[cfg(feature = "quic")]
+pub mod quic;
 pub mod ws;
 pub mod mcp_client;
 pub mod llm;

--- a/crates/lex-runtime/src/quic.rs
+++ b/crates/lex-runtime/src/quic.rs
@@ -1,0 +1,391 @@
+//! HTTP/3 server impl behind the `quic` feature flag (#496).
+//!
+//! Parallels `serve_http_plain` / `serve_http_fn` / `serve_http_routed`
+//! in `handler.rs` but on a different transport: QUIC over UDP via
+//! `quinn`, with `h3` as the HTTP/3 wire-protocol layer. TLS is
+//! mandatory in HTTP/3 — there's no plaintext equivalent. Callers
+//! pass a `TlsConfig` (built via `tls.from_pem_files` or
+//! `tls.self_signed`) which we feed into a rustls server config
+//! tagged with the `h3` ALPN.
+//!
+//! Design decisions (from issue #496):
+//! - Effect row stays `[net]` — same gate as `serve` / `serve_fn`.
+//! - 0-RTT is OFF by default — rustls's default is "disabled" so we
+//!   don't need to do anything special. Opting in would require
+//!   `ServerConfig::max_early_data_size` to be set non-zero AND
+//!   per-route replay protection at the handler level (out of scope
+//!   for v1).
+//! - No cert reload in v1 — rotation requires restarting the
+//!   listener.
+//!
+//! Dispatcher shape mirrors the TCP path: one of three modes — a
+//! named handler, a closure, or a routed table — picked at the
+//! dispatch arm in `handler.rs` and threaded through here.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use lex_bytecode::value::Value;
+use lex_bytecode::vm::Vm;
+use lex_bytecode::Program;
+
+use crate::handler::{
+    self, dispatch_route, stamp_path_params, RouteSeg, ServeOpts,
+};
+use crate::policy::Policy;
+use crate::DefaultHandler;
+
+/// PEM-encoded certificate chain + private key as raw bytes. Built
+/// inside `handler.rs` when decoding the opaque Lex `TlsConfig` value
+/// passed to `net.serve_quic`. Held by reference in `serve_*` so the
+/// underlying bytes don't get cloned per-request.
+pub(crate) struct QuicTls {
+    pub cert_pem: Vec<u8>,
+    pub key_pem: Vec<u8>,
+}
+
+pub(crate) enum Dispatcher {
+    Named(String),
+    Closure(Value),
+    Routed {
+        routes: Vec<(String, Vec<RouteSeg>, Value)>,
+        fallback: Value,
+    },
+}
+
+pub(crate) fn serve_http3_named(
+    port: u16,
+    handler_name: String,
+    tls: QuicTls,
+    program: Arc<Program>,
+    policy: Policy,
+    opts: ServeOpts,
+) -> Result<Value, String> {
+    serve_http3(port, tls, program, policy, opts, Dispatcher::Named(handler_name))
+}
+
+pub(crate) fn serve_http3_fn(
+    port: u16,
+    closure: Value,
+    tls: QuicTls,
+    program: Arc<Program>,
+    policy: Policy,
+    opts: ServeOpts,
+) -> Result<Value, String> {
+    serve_http3(port, tls, program, policy, opts, Dispatcher::Closure(closure))
+}
+
+pub(crate) fn serve_http3_routed(
+    port: u16,
+    routes: Vec<(String, Vec<RouteSeg>, Value)>,
+    fallback: Value,
+    tls: QuicTls,
+    program: Arc<Program>,
+    policy: Policy,
+    opts: ServeOpts,
+) -> Result<Value, String> {
+    serve_http3(
+        port,
+        tls,
+        program,
+        policy,
+        opts,
+        Dispatcher::Routed { routes, fallback },
+    )
+}
+
+fn build_server_config(tls: &QuicTls) -> Result<quinn::ServerConfig, String> {
+    // Install ring as the rustls default provider on first call. The
+    // process-global registration is idempotent — ignore "already set"
+    // errors so a second serve_quic call in the same process works.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let mut cert_pem = tls.cert_pem.as_slice();
+    let cert_chain: Vec<rustls::pki_types::CertificateDer<'static>> =
+        rustls_pemfile::certs(&mut cert_pem)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| format!("net.serve_quic: parse cert PEM: {e}"))?;
+    if cert_chain.is_empty() {
+        return Err("net.serve_quic: no certificates found in cert PEM".into());
+    }
+
+    let mut key_pem = tls.key_pem.as_slice();
+    let key_der = rustls_pemfile::private_key(&mut key_pem)
+        .map_err(|e| format!("net.serve_quic: parse key PEM: {e}"))?
+        .ok_or_else(|| "net.serve_quic: no private key found in key PEM".to_string())?;
+
+    let mut crypto = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(cert_chain, key_der)
+        .map_err(|e| format!("net.serve_quic: rustls server config: {e}"))?;
+    // HTTP/3 negotiates via the `h3` ALPN token — clients that don't
+    // advertise it (HTTP/1.1, HTTP/2 over TCP) wouldn't reach this
+    // listener anyway since QUIC is UDP, but rustls still requires
+    // ALPN to be set when serving h3.
+    crypto.alpn_protocols = vec![b"h3".to_vec()];
+
+    let qsc = quinn::crypto::rustls::QuicServerConfig::try_from(crypto)
+        .map_err(|e| format!("net.serve_quic: quic server config: {e}"))?;
+    Ok(quinn::ServerConfig::with_crypto(Arc::new(qsc)))
+}
+
+fn serve_http3(
+    port: u16,
+    tls: QuicTls,
+    program: Arc<Program>,
+    policy: Policy,
+    opts: ServeOpts,
+    dispatcher: Dispatcher,
+) -> Result<Value, String> {
+    let server_config = build_server_config(&tls)?;
+    let host = opts.host.clone();
+    let addr: SocketAddr = format!("{host}:{port}")
+        .parse()
+        .map_err(|e| format!("net.serve_quic: parse {host}:{port}: {e}"))?;
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| format!("net.serve_quic: tokio runtime: {e}"))?;
+
+    let dispatcher = Arc::new(dispatcher);
+
+    rt.block_on(async move {
+        let endpoint = quinn::Endpoint::server(server_config, addr)
+            .map_err(|e| format!("net.serve_quic: bind {addr}: {e}"))?;
+        eprintln!("net.serve_quic: listening on https://{addr} (HTTP/3)");
+
+        while let Some(incoming) = endpoint.accept().await {
+            let program = Arc::clone(&program);
+            let policy = policy.clone();
+            let dispatcher = Arc::clone(&dispatcher);
+            tokio::spawn(async move {
+                let conn = match incoming.await {
+                    Ok(c) => c,
+                    Err(e) => {
+                        eprintln!("net.serve_quic: handshake: {e}");
+                        return;
+                    }
+                };
+                if let Err(e) = handle_quic_conn(conn, program, policy, dispatcher).await {
+                    eprintln!("net.serve_quic: connection: {e}");
+                }
+            });
+        }
+        Ok(Value::Unit)
+    })
+}
+
+async fn handle_quic_conn(
+    conn: quinn::Connection,
+    program: Arc<Program>,
+    policy: Policy,
+    dispatcher: Arc<Dispatcher>,
+) -> Result<(), String> {
+    let h3_conn = h3_quinn::Connection::new(conn);
+    let mut h3 = h3::server::Connection::new(h3_conn)
+        .await
+        .map_err(|e| format!("h3 connection: {e}"))?;
+
+    loop {
+        match h3.accept().await {
+            Ok(Some(resolver)) => {
+                let program = Arc::clone(&program);
+                let policy = policy.clone();
+                let dispatcher = Arc::clone(&dispatcher);
+                tokio::spawn(async move {
+                    let (req, stream) = match resolver.resolve_request().await {
+                        Ok(rs) => rs,
+                        Err(e) => {
+                            eprintln!("net.serve_quic: resolve_request: {e}");
+                            return;
+                        }
+                    };
+                    if let Err(e) =
+                        handle_h3_request(req, stream, program, policy, dispatcher).await
+                    {
+                        eprintln!("net.serve_quic: request: {e}");
+                    }
+                });
+            }
+            Ok(None) => break,
+            Err(e) => {
+                eprintln!("net.serve_quic: h3 accept: {e}");
+                break;
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn handle_h3_request<S>(
+    req: hyper::http::Request<()>,
+    mut stream: h3::server::RequestStream<S, Bytes>,
+    program: Arc<Program>,
+    policy: Policy,
+    dispatcher: Arc<Dispatcher>,
+) -> Result<(), String>
+where
+    S: h3::quic::BidiStream<Bytes> + Send + 'static,
+    <S as h3::quic::BidiStream<Bytes>>::SendStream: Send,
+    <S as h3::quic::BidiStream<Bytes>>::RecvStream: Send,
+{
+    let (parts, _) = req.into_parts();
+
+    // Drain the request body. h3's `recv_data()` returns successive
+    // chunks until the peer finishes; collect into a single Bytes
+    // buffer to feed Lex's body :: Str field.
+    let mut body = Vec::new();
+    while let Some(mut chunk) = stream
+        .recv_data()
+        .await
+        .map_err(|e| format!("h3 recv body: {e}"))?
+    {
+        use bytes::Buf as _;
+        let remaining = chunk.remaining();
+        body.extend_from_slice(chunk.copy_to_bytes(remaining).as_ref());
+    }
+    let body = Bytes::from(body);
+
+    // Build the Lex request record from the same hyper parts shape
+    // the HTTP/1.1+2 path uses — `parts.method`, `parts.uri`,
+    // `parts.headers` are all the `http` crate types, common to
+    // hyper and h3.
+    let lex_req = handler::build_request_value_parts(&parts, &body);
+    let method = parts.method.as_str().to_string();
+    let path = parts
+        .uri
+        .path_and_query()
+        .map(|pq| pq.path().to_string())
+        .unwrap_or_else(|| "/".to_string());
+
+    // Dispatch — pick the closure / fallback / named handler. For the
+    // routed mode also stamp path_params so handlers can read them.
+    let (lex_req, dispatch_kind) = match dispatcher.as_ref() {
+        Dispatcher::Named(name) => (lex_req, DispatchKind::Named(name.clone())),
+        Dispatcher::Closure(c) => (lex_req, DispatchKind::Closure(c.clone())),
+        Dispatcher::Routed { routes, fallback } => {
+            let mut req_val = lex_req;
+            let (closure, params) = match dispatch_route(routes, &method, &path) {
+                Some((c, p)) => (c.clone(), p),
+                None => (fallback.clone(), Default::default()),
+            };
+            stamp_path_params(&mut req_val, params);
+            (req_val, DispatchKind::Closure(closure))
+        }
+    };
+
+    // Run the VM on a blocking worker — same model as serve_http_fn.
+    // The Lex VM is synchronous and may itself do blocking I/O
+    // (file reads, DB calls), so we never run it on a tokio runtime
+    // thread.
+    let resp_result: Result<Value, String> = tokio::task::spawn_blocking(move || {
+        let handler = DefaultHandler::new(policy).with_program(Arc::clone(&program));
+        let mut vm = Vm::with_handler(&program, Box::new(handler));
+        let r = match dispatch_kind {
+            DispatchKind::Named(name) => vm.call(&name, vec![lex_req]),
+            DispatchKind::Closure(c) => vm.invoke_closure_value(c, vec![lex_req]),
+        };
+        r.map_err(|e| format!("{e:?}"))
+    })
+    .await
+    .map_err(|e| format!("h3 vm worker: {e}"))?;
+
+    let lex_resp = match resp_result {
+        Ok(v) => v,
+        Err(e) => {
+            // 500 the request, log the panic — same pattern as TCP.
+            eprintln!("net.serve_quic: handler error: {e}");
+            send_simple_error(&mut stream, 500, &format!("internal error: {e}")).await?;
+            return Ok(());
+        }
+    };
+
+    let (status, body_out, headers) = handler::unpack_response(&lex_resp);
+    let mut resp_builder = hyper::http::Response::builder().status(status);
+    for (k, v) in &headers {
+        resp_builder = resp_builder.header(k, v);
+    }
+    let resp = resp_builder
+        .body(())
+        .map_err(|e| format!("h3 build response: {e}"))?;
+    stream
+        .send_response(resp)
+        .await
+        .map_err(|e| format!("h3 send_response: {e}"))?;
+
+    // Stream bodies aren't supported on the QUIC path yet — for v1 we
+    // collect to a single chunk before sending. Streaming over h3
+    // would mean wiring the Lex stream iterator into a series of
+    // `send_data` calls; deferred to a follow-up.
+    let body_bytes = match body_out {
+        handler::ResponseBodyOut::Str(s) => Bytes::from(s.into_bytes()),
+        handler::ResponseBodyOut::TextChunks(chunks)
+        | handler::ResponseBodyOut::BytesChunks(chunks) => {
+            let mut buf = Vec::new();
+            for c in chunks {
+                buf.extend_from_slice(&c);
+            }
+            Bytes::from(buf)
+        }
+    };
+    if !body_bytes.is_empty() {
+        stream
+            .send_data(body_bytes)
+            .await
+            .map_err(|e| format!("h3 send_data: {e}"))?;
+    }
+    stream
+        .finish()
+        .await
+        .map_err(|e| format!("h3 finish: {e}"))?;
+    Ok(())
+}
+
+enum DispatchKind {
+    Named(String),
+    Closure(Value),
+}
+
+async fn send_simple_error<S>(
+    stream: &mut h3::server::RequestStream<S, Bytes>,
+    status: u16,
+    msg: &str,
+) -> Result<(), String>
+where
+    S: h3::quic::BidiStream<Bytes> + Send + 'static,
+    <S as h3::quic::BidiStream<Bytes>>::SendStream: Send,
+    <S as h3::quic::BidiStream<Bytes>>::RecvStream: Send,
+{
+    let resp = hyper::http::Response::builder()
+        .status(status)
+        .body(())
+        .map_err(|e| format!("h3 build error: {e}"))?;
+    stream
+        .send_response(resp)
+        .await
+        .map_err(|e| format!("h3 send_response: {e}"))?;
+    stream
+        .send_data(Bytes::copy_from_slice(msg.as_bytes()))
+        .await
+        .map_err(|e| format!("h3 send_data: {e}"))?;
+    stream
+        .finish()
+        .await
+        .map_err(|e| format!("h3 finish: {e}"))?;
+    Ok(())
+}
+
+/// Generate a self-signed certificate + private key for the given
+/// hostname (`SubjectAlternativeName`). Returns PEM-encoded bytes for
+/// both, matching `from_pem_files`'s on-disk format. Used by
+/// `tls.self_signed(hostname)` — intended for local development and
+/// integration tests, NOT production.
+pub(crate) fn self_signed_pem(hostname: &str) -> Result<(Vec<u8>, Vec<u8>), String> {
+    let ck = rcgen::generate_simple_self_signed(vec![hostname.to_string()])
+        .map_err(|e| format!("rcgen self-signed: {e}"))?;
+    let cert_pem = ck.cert.pem().into_bytes();
+    let key_pem = ck.key_pair.serialize_pem().into_bytes();
+    Ok((cert_pem, key_pem))
+}

--- a/crates/lex-runtime/tests/net_serve_quic.rs
+++ b/crates/lex-runtime/tests/net_serve_quic.rs
@@ -1,0 +1,202 @@
+//! Integration tests for `net.serve_quic` / `tls.self_signed` (#496).
+//!
+//! Exercises an end-to-end HTTP/3 round-trip: spawn a Lex program that
+//! calls `net.serve_quic` with a self-signed cert, then drive it from a
+//! `quinn` + `h3` client on the same loopback. Gated behind the `quic`
+//! feature — `cargo test -p lex-runtime --features quic` to run.
+
+#![cfg(feature = "quic")]
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::collections::BTreeSet;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+fn spawn_lex_server(src: &str, entry: &str) {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors: {errs:#?}");
+    }
+    let bc = Arc::new(compile_program(&stages));
+    let mut policy = Policy::pure();
+    policy.allow_effects = ["net".to_string()].into_iter().collect::<BTreeSet<_>>();
+    let entry = entry.to_string();
+    thread::spawn(move || {
+        let handler = DefaultHandler::new(policy.clone()).with_program(Arc::clone(&bc));
+        let mut vm = Vm::with_handler(&bc, Box::new(handler));
+        let _ = vm.call(&entry, vec![]);
+    });
+}
+
+/// Trust-all verifier for the self-signed cert we generate inside the
+/// Lex program. The integration test asserts wire-level behaviour, not
+/// PKI correctness, so accepting any cert is correct.
+#[derive(Debug)]
+struct AcceptAll;
+
+impl rustls::client::danger::ServerCertVerifier for AcceptAll {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::pki_types::CertificateDer<'_>,
+        _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+        _server_name: &rustls::pki_types::ServerName<'_>,
+        _ocsp: &[u8],
+        _now: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+    fn verify_tls12_signature(
+        &self,
+        _: &[u8],
+        _: &rustls::pki_types::CertificateDer<'_>,
+        _: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+    fn verify_tls13_signature(
+        &self,
+        _: &[u8],
+        _: &rustls::pki_types::CertificateDer<'_>,
+        _: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        rustls::crypto::ring::default_provider()
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
+async fn h3_get(server_port: u16, path: &str) -> Result<(u16, String), String> {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let mut tls_config = rustls::ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(AcceptAll))
+        .with_no_client_auth();
+    tls_config.alpn_protocols = vec![b"h3".to_vec()];
+    tls_config.enable_early_data = false;
+
+    let qcc = quinn::crypto::rustls::QuicClientConfig::try_from(tls_config)
+        .map_err(|e| format!("quic client config: {e}"))?;
+    let client_cfg = quinn::ClientConfig::new(Arc::new(qcc));
+    let mut endpoint = quinn::Endpoint::client("0.0.0.0:0".parse().unwrap())
+        .map_err(|e| format!("client bind: {e}"))?;
+    endpoint.set_default_client_config(client_cfg);
+
+    let server_addr: SocketAddr = ([127, 0, 0, 1], server_port).into();
+
+    let conn = endpoint
+        .connect(server_addr, "localhost")
+        .map_err(|e| format!("connect: {e}"))?
+        .await
+        .map_err(|e| format!("handshake: {e}"))?;
+
+    let h3_conn = h3_quinn::Connection::new(conn);
+    let (mut driver, mut send_req) =
+        h3::client::new(h3_conn).await.map_err(|e| format!("h3 client: {e}"))?;
+
+    let drive = tokio::spawn(async move {
+        let _ = std::future::poll_fn(|cx| driver.poll_close(cx)).await;
+    });
+
+    let uri: hyper::http::Uri = format!("https://localhost{path}")
+        .parse()
+        .map_err(|e| format!("uri: {e}"))?;
+    let req = hyper::http::Request::builder()
+        .method("GET")
+        .uri(uri)
+        .body(())
+        .map_err(|e| format!("request build: {e}"))?;
+
+    let mut stream = send_req
+        .send_request(req)
+        .await
+        .map_err(|e| format!("send_request: {e}"))?;
+    stream.finish().await.map_err(|e| format!("finish: {e}"))?;
+
+    let resp = stream
+        .recv_response()
+        .await
+        .map_err(|e| format!("recv_response: {e}"))?;
+    let status = resp.status().as_u16();
+
+    let mut body = Vec::new();
+    while let Some(mut chunk) = stream
+        .recv_data()
+        .await
+        .map_err(|e| format!("recv_data: {e}"))?
+    {
+        use bytes::Buf as _;
+        let remaining = chunk.remaining();
+        body.extend_from_slice(chunk.copy_to_bytes(remaining).as_ref());
+    }
+
+    drop(send_req);
+    let _ = drive.await;
+    endpoint.close(0u32.into(), b"done");
+    endpoint.wait_idle().await;
+
+    Ok((status, String::from_utf8_lossy(&body).into_owned()))
+}
+
+async fn wait_for_quic_bind(port: u16, timeout: Duration) {
+    let deadline = std::time::Instant::now() + timeout;
+    let mut backoff = Duration::from_millis(50);
+    loop {
+        // Try a one-shot h3_get; success means the server is up.
+        if let Ok((_status, _)) = h3_get(port, "/__probe").await {
+            return;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("HTTP/3 server on :{port} did not respond within {timeout:?}");
+        }
+        tokio::time::sleep(backoff).await;
+        backoff = (backoff * 2).min(Duration::from_millis(500));
+    }
+}
+
+/// End-to-end smoke test: serve_quic with a self-signed cert, GET via
+/// h3 client, assert handler-returned body comes back. Uses a high
+/// non-reserved port (UDP 18301) to avoid clashing with the TCP serve
+/// tests in net_serve.rs.
+#[test]
+fn serve_quic_self_signed_round_trip() {
+    let src = r#"
+import "std.net" as net
+import "std.tls" as tls
+import "std.str" as str
+
+fn handle(req :: { body :: Str, method :: Str, path :: Str, query :: Str }) -> { body :: Str, status :: Int } {
+  { status: 200, body: str.concat("h3-via-quic: ", req.path) }
+}
+
+fn main() -> [net] Nil {
+  match tls.self_signed("localhost") {
+    Ok(t) => net.serve_quic(18301, t, "handle"),
+    Err(_) => (),
+  }
+}
+"#;
+    spawn_lex_server(src, "main");
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        wait_for_quic_bind(18301, Duration::from_secs(10)).await;
+        let (status, body) = h3_get(18301, "/hello")
+            .await
+            .expect("h3 get succeeds");
+        assert_eq!(status, 200);
+        assert_eq!(body, "h3-via-quic: /hello");
+    });
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -769,6 +769,103 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 Ty::Unit,
             ));
 
+            // serve_quic / serve_quic_fn / serve_quic_routed (#496).
+            // HTTP/3 over QUIC. TlsConfig is an opaque value built by
+            // `tls.from_pem_files` or `tls.self_signed` — it carries the
+            // server certificate chain + private key needed for the
+            // QUIC handshake (TLS is mandatory for HTTP/3). Effect row
+            // stays `[net]` for symmetry with `serve` / `serve_fn`;
+            // policy gates don't distinguish HTTP/1.1+2 (TCP) from
+            // HTTP/3 (UDP) at the effect level.
+            //
+            // serve_quic :: (Int, TlsConfig, Str) -> [net] Unit
+            fields.insert("serve_quic".into(), Ty::function(
+                vec![Ty::int(), Ty::Con("TlsConfig".into(), vec![]), Ty::str()],
+                EffectSet::singleton("net"),
+                Ty::Unit,
+            ));
+
+            // serve_quic_fn[Eff] :: (Int, TlsConfig,
+            //                        (Request) -> [Eff] Response)
+            //                       -> [net, Eff] Unit
+            fields.insert("serve_quic_fn".into(), Ty::function(
+                vec![
+                    Ty::int(),
+                    Ty::Con("TlsConfig".into(), vec![]),
+                    Ty::function(
+                        vec![Ty::Con("Request".into(), vec![])],
+                        EffectSet::open_var(0),
+                        Ty::Con("Response".into(), vec![]),
+                    ),
+                ],
+                EffectSet::open_var(0).union(&EffectSet::singleton("net")),
+                Ty::Unit,
+            ));
+
+            // serve_quic_routed[Eff] :: (
+            //   Int, TlsConfig,
+            //   List[(Str, Str, (Request) -> [Eff] Response)],
+            //   (Request) -> [Eff] Response
+            // ) -> [net, Eff] Unit
+            fields.insert("serve_quic_routed".into(), Ty::function(
+                vec![
+                    Ty::int(),
+                    Ty::Con("TlsConfig".into(), vec![]),
+                    Ty::List(Box::new(Ty::Tuple(vec![
+                        Ty::str(),
+                        Ty::str(),
+                        Ty::function(
+                            vec![Ty::Con("Request".into(), vec![])],
+                            EffectSet::open_var(0),
+                            Ty::Con("Response".into(), vec![]),
+                        ),
+                    ]))),
+                    Ty::function(
+                        vec![Ty::Con("Request".into(), vec![])],
+                        EffectSet::open_var(0),
+                        Ty::Con("Response".into(), vec![]),
+                    ),
+                ],
+                EffectSet::open_var(0).union(&EffectSet::singleton("net")),
+                Ty::Unit,
+            ));
+
+            Some(Ty::Record(fields))
+        }
+        // `tls` — TLS certificate handling for `net.serve_quic` (#496).
+        // `TlsConfig` is opaque to user code; the only ways to obtain
+        // one are these constructors. The runtime keeps the certificate
+        // chain + private key behind that opaque type so we can change
+        // the internal representation (record-of-bytes today, possibly
+        // a Resource handle tomorrow) without breaking source code.
+        "tls" => {
+            let mut fields = IndexMap::new();
+            // from_pem_files :: (Str, Str) -> [fs_read] Result[TlsConfig, Str]
+            //                    cert  key
+            // Load a PEM-encoded certificate chain + private key from
+            // disk. Both paths are read with the `[fs_read]` effect so
+            // policy gates can restrict where certs may come from.
+            fields.insert("from_pem_files".into(), Ty::function(
+                vec![Ty::str(), Ty::str()],
+                EffectSet::singleton("fs_read"),
+                Ty::Con("Result".into(), vec![
+                    Ty::Con("TlsConfig".into(), vec![]),
+                    Ty::str(),
+                ]),
+            ));
+            // self_signed :: Str -> Result[TlsConfig, Str]
+            // Generate a self-signed certificate for the given hostname
+            // (or "localhost"). Pure — no effects needed. Intended for
+            // local development and integration tests only; real
+            // deployments should use a CA-signed cert via from_pem_files.
+            fields.insert("self_signed".into(), Ty::function(
+                vec![Ty::str()],
+                EffectSet::empty(),
+                Ty::Con("Result".into(), vec![
+                    Ty::Con("TlsConfig".into(), vec![]),
+                    Ty::str(),
+                ]),
+            ));
             Some(Ty::Record(fields))
         }
         "chat" => {
@@ -2654,6 +2751,7 @@ pub fn module_for_import(reference: &str) -> Option<&'static str> {
         "env" => "env",
         "bytes" => "bytes",
         "net" => "net",
+        "tls" => "tls",
         "chat" => "chat",
         "math" => "math",
         "map" => "map",

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -192,6 +192,29 @@ fn main() -> [net, io] Nil { net.serve_fn(8080, my_handler) }
 ```
 
 `net.serve_with(port, handler_name, opts)` / `net.serve_fn_with(port, handler, opts)` / `net.serve_routed_with(port, routes, fallback, opts)` — same as the unsuffixed variants but accept a `ServeOpts` record literal (`{ http2: Bool, inline_vm: Bool, host: Str }`) instead of relying on `LEX_NET_HTTP2` / `LEX_NET_INLINE_VM` env vars. `net.default_opts()` returns the defaults (`http2: false, inline_vm: false, host: "0.0.0.0"`); construct your own literal to enable HTTP/2 or bind to a specific host. The legacy `serve` / `serve_fn` / `serve_routed` paths keep honouring the env vars for backwards compatibility — new code should prefer the `*_with` variants (#497).
+
+`net.serve_quic(port, tls, handler_name)` / `net.serve_quic_fn(port, tls, handler)` / `net.serve_quic_routed(port, tls, routes, fallback)` — HTTP/3 over QUIC (#496). TLS is mandatory; `tls` is a `TlsConfig` opaque value built via `std.tls` (see below). Requires the `quic` feature on lex-runtime: `cargo build --features quic` (off by default to keep the dep graph slim). HTTP/3 negotiates via the `h3` ALPN over UDP; existing HTTP/1.1+2 (TCP) listeners aren't affected. Effect row stays `[net]` — same gate as `serve` / `serve_fn`. 0-RTT is disabled by default (replay-attack risk on non-idempotent handlers); cert rotation requires a restart in v1.
+
+```lex
+import "std.net" as net
+import "std.tls" as tls
+
+fn handle(req :: Request) -> Response { ... }
+
+fn main() -> [net] Nil {
+  match tls.self_signed("localhost") {
+    Ok(t) => net.serve_quic(4433, t, "handle"),
+    Err(_) => (),
+  }
+}
+```
+
+### `std.tls`
+`tls.from_pem_files(cert_path, key_path) -> [fs_read] Result[TlsConfig, Str]` — load a PEM-encoded certificate chain + private key from disk. Both paths must be under `--allow-fs-read`.
+`tls.self_signed(hostname) -> Result[TlsConfig, Str]` — generate a self-signed certificate for the given hostname. Pure (no effects). Intended for local development and tests; production should use a CA-signed cert via `from_pem_files`.
+
+`TlsConfig` is opaque — the only ways to obtain one are these two constructors. Pass it to `net.serve_quic*` to set up an HTTP/3 listener.
+
 `net.serve_ws_fn(port, subprotocol, handler)` — WebSocket server:
 ```lex
 fn on_msg(conn :: WsConn, msg :: WsMessage) -> WsAction {


### PR DESCRIPTION
Closes #496. Adds an HTTP/3 server transport behind a new `quic` cargo feature, plus a small `std.tls` namespace for building the `TlsConfig` value that the QUIC handshake requires.

## New surface

```lex
import "std.net" as net
import "std.tls" as tls

fn handle(req :: Request) -> Response { ... }

fn main() -> [net] Nil {
  match tls.self_signed("localhost") {
    Ok(t) => net.serve_quic(4433, t, "handle"),
    Err(_) => (),
  }
}
```

Three serve_quic variants mirror the existing TCP shapes:

- `net.serve_quic(port, tls, handler_name)` — handler by name
- `net.serve_quic_fn(port, tls, closure)` — first-class closure
- `net.serve_quic_routed(port, tls, routes, fallback)` — `:name` routing

Plus a TLS surface:

- `tls.from_pem_files(cert_path, key_path)` — `[fs_read]`
- `tls.self_signed(hostname)` — pure (rcgen)

`TlsConfig` is opaque; the two constructors above are the only ways to build one. Effect row stays `[net]` for symmetry with `serve` / `serve_fn` — policy gates don't distinguish HTTP/1.1+2 (TCP) from HTTP/3 (UDP).

## Design decisions (from the issue's open questions)

- **Effect row** — single `[net]` (not separate `[net_quic]`).
- **0-RTT** — OFF by default. rustls's default is disabled; opt-in would require per-route replay protection, deferred to follow-up.
- **Cert reload** — not supported in v1. Rotation requires restart.

## What changes

**`crates/lex-runtime/Cargo.toml`** — new optional deps `quinn`, `h3`, `h3-quinn`, `rustls`, `rustls-pemfile`, `rcgen` behind `[features] quic`. Off by default so the workspace's default cargo build stays slim.

**`crates/lex-runtime/src/quic.rs`** (new, ~330 LoC) — quinn endpoint + h3 server connection + per-request VM dispatch. Reuses `build_request_value_parts` / `unpack_response` from `handler.rs` so the Lex `Request` / `Response` shape is byte-identical to the TCP path. Self-signed cert helper via rcgen.

**`crates/lex-runtime/src/handler.rs`**:
- `tls.*` intercept before the generic effect gate — maps `from_pem_files` to `[fs_read]` and `self_signed` to pure (same pattern as the `http.{send,get,post}` arms).
- `serve_quic*` dispatch arms gated by `cfg(feature = "quic")`; without the feature they return a clear "compiled without quic" error.
- **Bugfix in `build_request_value_parts`**: use `Uri::path()` instead of `Uri::to_string()`. Absolute-form URIs (which HTTP/2 and HTTP/3 transmit when `:scheme` + `:authority` get folded into the URI) were leaking the scheme+authority into `req.path`. Surfaced against `serve_quic` — `req.path` was `https://localhost/hello` instead of `/hello`. The fix is backwards-compatible for HTTP/1.1 since `Uri::path()` returns the same value there.
- `ServeOpts`, `RouteSeg`, `ResponseBodyOut`, `dispatch_route`, `stamp_path_params`, `build_request_value_parts`, `unpack_response` promoted to `pub(crate)` so the new `quic.rs` module can reuse them.

**`crates/lex-types/src/builtins.rs`** — type-checker signatures for the three `serve_quic*` builtins, the opaque `TlsConfig` type, and the two `tls.*` constructors. Signatures are always present so source code compiles regardless of feature flag; the runtime errors out cleanly if the feature is off.

**`.github/workflows/ci.yml`** — adds `cargo test -p lex-runtime --features quic --test net_serve_quic` as a separate step. Keeps the default workspace test cheap while still verifying H/3 stays working on every PR.

**`docs/AGENT.md`** — documents `serve_quic*`, `std.tls`, and the `quic` cargo feature.

## Test plan

- [x] New `tests/net_serve_quic.rs` — end-to-end: Lex program generates a self-signed cert, binds `net.serve_quic` to UDP :18301, then a real `h3-quinn` client drives a GET and we assert status + body round-trip. Uses an accept-all cert verifier (testing wire behaviour, not PKI).
- [x] `cargo build -p lex-runtime` — clean (no quic feature)
- [x] `cargo build -p lex-runtime --features quic` — clean
- [x] `cargo clippy -p lex-runtime -- -Dwarnings` — clean
- [x] `cargo clippy -p lex-runtime --features quic --tests` — clean
- [x] `cargo test -p lex-runtime --test net_serve` — 11/11 (no regression from the URI-path fix)
- [x] `cargo test -p lex-runtime --test net_serve_with` — 4/4
- [x] `cargo test -p lex-runtime --test net_serve_http2` — 1/1
- [x] `cargo test -p lex-runtime --test net_streaming` — 2/2
- [x] `cargo test -p lex-runtime --features quic --test net_serve_quic` — 1/1 (new)
- [ ] CI green

## Out of scope (deferred follow-ups)

- WebTransport / gRPC over HTTP/3 — separate protocol layers (issue non-goals).
- Server Push — deprecated in HTTP/3.
- 0-RTT opt-in with per-route replay protection.
- Cert rotation (file-watch / SIGHUP).
- Streaming response bodies on the H/3 path (today they get collected and sent as a single `send_data` call; the H/3 spec allows this but it loses the streaming property of the existing TCP `BodyStream` path).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PsrNeuuchvDLFJmY1CskFe)_