### PR TITLE
feat(stdlib): add `iter.collect` as alias for `iter.to_list` (closes #500)

### DIFF
--- a/crates/lex-bytecode/src/compiler.rs
+++ b/crates/lex-bytecode/src/compiler.rs
@@ -689,6 +689,7 @@ impl<'a> FnCompiler<'a> {
             ("iter", "take")      => self.emit_iter_take(args),
             ("iter", "skip")      => self.emit_iter_skip(args),
             ("iter", "to_list")   => self.emit_iter_to_list(args),
+            ("iter", "collect")   => self.emit_iter_to_list(args),
             ("iter", "map")       => self.emit_iter_map(args),
             ("iter", "filter")    => self.emit_iter_filter(args),
             ("iter", "fold")      => self.emit_iter_fold(args),

--- a/crates/lex-runtime/tests/iter_lazy.rs
+++ b/crates/lex-runtime/tests/iter_lazy.rs
@@ -25,6 +25,10 @@ fn from_list_to_list(xs :: List[Int]) -> List[Int] {
   iter.to_list(iter.from_list(xs))
 }
 
+fn from_list_collect(xs :: List[Int]) -> List[Int] {
+  iter.collect(iter.from_list(xs))
+}
+
 fn next_on_empty() -> Bool {
   let it := iter.from_list([])
   match iter.next(it) {
@@ -107,6 +111,13 @@ fn unfold_empty() -> List[Int] {
 fn from_list_and_to_list_roundtrip() {
     let xs = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)].into());
     let got = run(SRC, "from_list_to_list", vec![xs.clone()]);
+    assert_eq!(got, xs);
+}
+
+#[test]
+fn collect_is_alias_for_to_list() {
+    let xs = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)].into());
+    let got = run(SRC, "from_list_collect", vec![xs.clone()]);
     assert_eq!(got, xs);
 }
 

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -1304,6 +1304,12 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
             fields.insert("to_list".into(), Ty::function(
                 vec![it(0)], EffectSet::empty(),
                 Ty::List(Box::new(Ty::Var(0)))));
+            // collect :: Iter[T] -> List[T] — alias for `to_list`
+            // (matches Rust / Python / Kotlin naming so call sites
+            // coming from those languages don't have to re-learn).
+            fields.insert("collect".into(), Ty::function(
+                vec![it(0)], EffectSet::empty(),
+                Ty::List(Box::new(Ty::Var(0)))));
             // map :: [E] Iter[T], (T) -> [E] U -> [E] Iter[U]
             fields.insert("map".into(), Ty::function(
                 vec![


### PR DESCRIPTION
Closes #500.

Drains an `Iter[T]` into a `List[T]` under the name people coming from Rust / Python / Kotlin / etc. reach for first. Same signature, same compile path as `iter.to_list` — the compiler dispatches both to the same `emit_iter_to_list` emitter, so there's no runtime cost or behavioural difference.

## Changes
- `crates/lex-types/src/builtins.rs`: register `collect :: Iter[T] -> List[T]` alongside `to_list` on the `iter` builtin record.
- `crates/lex-bytecode/src/compiler.rs`: route `("iter", "collect")` to the existing `emit_iter_to_list`.
- `crates/lex-runtime/tests/iter_lazy.rs`: new test `collect_is_alias_for_to_list` asserts equivalence end-to-end.

## Test plan
- [x] `cargo test -p lex-runtime --test iter_lazy` — **18 passed, 0 failed** (new test included).
- [x] `cargo test -p lex-types` / `cargo test -p lex-bytecode` — no regressions.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HvBJ2GKU2Ktg6bUJmFuv1q)_