### PR TITLE
fix(stdlib): http.send supports PUT / PATCH / DELETE / HEAD (#503)

### DIFF
--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -3006,24 +3006,57 @@ fn http_send_full(
     timeout_ms: Option<u64>,
 ) -> Value {
     let agent = http_agent(timeout_ms);
-    let resp = match method {
+    // Normalise method to uppercase before matching. Per RFC 7230, HTTP
+    // methods are case-sensitive, but lex callers naturally write
+    // `"put"` / `"PUT"` interchangeably; uppercasing here keeps the
+    // surface forgiving without compromising the wire format (ureq
+    // sends whatever method name we pass to the per-method builder).
+    let method_upper = method.to_ascii_uppercase();
+    let body_bytes: Vec<u8> = body.unwrap_or_default();
+    let resp = match method_upper.as_str() {
+        // Bodyless methods. PUT/PATCH/DELETE technically allow a body,
+        // but in practice (and per #503's OCPI flows) DELETE is most
+        // often bodyless; if a future caller needs DELETE-with-body
+        // we can split it via a different ureq builder.
         "GET" => {
             let mut req = agent.get(url);
             if !content_type.is_empty() { req = req.header("content-type", content_type); }
             for (k, v) in headers { req = req.header(k.as_str(), v.as_str()); }
             req.call()
         }
+        "HEAD" => {
+            let mut req = agent.head(url);
+            for (k, v) in headers { req = req.header(k.as_str(), v.as_str()); }
+            req.call()
+        }
+        "DELETE" => {
+            let mut req = agent.delete(url);
+            for (k, v) in headers { req = req.header(k.as_str(), v.as_str()); }
+            req.call()
+        }
+        // Methods that carry a request body. `body.unwrap_or_default()`
+        // means a missing body sends an empty payload, which is the
+        // correct default for POST `{}` style requests and matches
+        // curl's `-X POST` (no `-d`) behaviour.
         "POST" => {
-            let body = body.unwrap_or_default();
             let mut req = agent.post(url);
             if !content_type.is_empty() { req = req.header("content-type", content_type); }
             for (k, v) in headers { req = req.header(k.as_str(), v.as_str()); }
-            req.send(&body[..])
+            req.send(&body_bytes[..])
+        }
+        "PUT" => {
+            let mut req = agent.put(url);
+            if !content_type.is_empty() { req = req.header("content-type", content_type); }
+            for (k, v) in headers { req = req.header(k.as_str(), v.as_str()); }
+            req.send(&body_bytes[..])
+        }
+        "PATCH" => {
+            let mut req = agent.patch(url);
+            if !content_type.is_empty() { req = req.header("content-type", content_type); }
+            for (k, v) in headers { req = req.header(k.as_str(), v.as_str()); }
+            req.send(&body_bytes[..])
         }
         m => {
-            // Other methods (PUT, DELETE, PATCH, ...) fall through
-            // here in v1.5; for now surface a structured DecodeError
-            // so the caller can match it.
             return http_decode_err(format!("unsupported method: {m}"));
         }
     };

--- a/crates/lex-runtime/tests/std_http.rs
+++ b/crates/lex-runtime/tests/std_http.rs
@@ -515,3 +515,136 @@ fn fetch(u :: Str) -> [net] Result[HttpResponse, HttpError] { http.get(u) }
         "expected allow-net-host message, got {err}",
     );
 }
+
+// ---- #503 — methods beyond GET/POST ---------------------------------
+//
+// Pre-#503 lex-runtime rejected every method except GET and POST at
+// the `http_send_full` dispatch, returning a `DecodeError("unsupported
+// method: PUT")` before opening the socket. lex-ocpi worked around it
+// by shelling out to `curl` through `[proc]`. These tests pin the
+// fix: each method round-trips through the same `http.send(record)`
+// path, hits the loopback oneshot server, and gets a 200 back.
+//
+// The captured request line is asserted on the wire-level for
+// methods that carry a body, since PUT/PATCH bodies hitting the
+// server is the second half of "this works end-to-end".
+
+const SEND_VIA_RECORD_SRC: &str = r#"
+import "std.bytes" as bytes
+import "std.http"  as http
+import "std.map"   as map
+
+# Caller passes the wire-case method (`"PUT"` etc.) through to the
+# record. The runtime uppercases internally so lowercase also works,
+# but we keep this fixture canonical for the success-path assertions.
+fn send(method :: Str, u :: Str, b :: Str) -> [net] Result[HttpResponse, HttpError] {
+  let req := {
+    method:     method,
+    url:        u,
+    headers:    map.new(),
+    body:       Some(bytes.from_str(b)),
+    timeout_ms: Some(2000),
+  }
+  http.send(req)
+}
+"#;
+
+fn assert_method_round_trip(method: &str, body: &str, expect_body_on_wire: bool) {
+    let (tx, rx) = std::sync::mpsc::channel();
+    let port = spawn_oneshot(
+        "HTTP/1.0 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+        Some(tx),
+    );
+    let url = format!("http://127.0.0.1:{port}/x");
+    let v = run(
+        SEND_VIA_RECORD_SRC,
+        "send",
+        vec![
+            Value::Str(method.into()),
+            Value::Str(url.into()),
+            Value::Str(body.into()),
+        ],
+        allow_net(),
+    );
+    let r = unwrap_ok_record(v);
+    assert_eq!(r.get("status"), Some(&Value::Int(200)), "{method}: expected 200");
+    let captured = rx
+        .recv_timeout(std::time::Duration::from_secs(2))
+        .unwrap_or_else(|_| panic!("{method}: server did not observe a request"));
+    // The Lex surface accepts lowercase / mixed-case methods; ureq
+    // always emits uppercase on the wire (it routes through the
+    // typed per-method builder), so the captured request line is
+    // always the uppercase form.
+    let expected_line = format!("{} /x ", method.to_ascii_uppercase());
+    assert!(
+        captured.starts_with(&expected_line),
+        "{method}: unexpected request line in {captured:?}",
+    );
+    if expect_body_on_wire {
+        assert!(
+            captured.ends_with(body),
+            "{method}: expected body {body:?} at end of {captured:?}",
+        );
+    }
+}
+
+#[test]
+fn http_send_put_round_trips_with_body() {
+    assert_method_round_trip("PUT", r#"{"k":"v"}"#, true);
+}
+
+#[test]
+fn http_send_patch_round_trips_with_body() {
+    assert_method_round_trip("PATCH", r#"{"op":"replace"}"#, true);
+}
+
+#[test]
+fn http_send_delete_round_trips() {
+    // DELETE goes through ureq's WithoutBody builder; the request body
+    // field on the Lex record is ignored on the wire (RFC 7231 allows
+    // DELETE bodies but their semantics are undefined and most servers
+    // ignore them). We still pass a body to confirm the call doesn't
+    // error out on the bodyless path.
+    assert_method_round_trip("DELETE", "", false);
+}
+
+#[test]
+fn http_send_head_returns_200_with_empty_body() {
+    let (tx, rx) = std::sync::mpsc::channel();
+    let port = spawn_oneshot(
+        "HTTP/1.0 200 OK\r\nContent-Length: 7\r\nConnection: close\r\n\r\nIGNORED",
+        Some(tx),
+    );
+    let url = format!("http://127.0.0.1:{port}/probe");
+    let v = run(
+        SEND_VIA_RECORD_SRC,
+        "send",
+        vec![
+            Value::Str("HEAD".into()),
+            Value::Str(url.into()),
+            Value::Str("".into()),
+        ],
+        allow_net(),
+    );
+    let r = unwrap_ok_record(v);
+    assert_eq!(r.get("status"), Some(&Value::Int(200)));
+    // RFC 7231 §4.3.2: HEAD responses MUST NOT include a body. ureq
+    // honours this — `r.body` is empty even though the server wrote
+    // 7 bytes after the headers.
+    if let Some(Value::Bytes(b)) = r.get("body") {
+        assert!(b.is_empty(), "HEAD: expected empty body, got {} bytes", b.len());
+    }
+    let captured = rx
+        .recv_timeout(std::time::Duration::from_secs(2))
+        .expect("HEAD: server should observe the request");
+    assert!(captured.starts_with("HEAD /probe "), "HEAD line: {captured:?}");
+}
+
+#[test]
+fn http_send_method_is_uppercased_before_dispatch() {
+    // #503 reporters typically write `"PUT"` etc., but the spec is
+    // case-sensitive only on the wire — the Lex surface should be
+    // forgiving. `"put"` MUST route to the same builder as `"PUT"`.
+    assert_method_round_trip("put", r#"{"normalised":true}"#, true);
+}
+


### PR DESCRIPTION
Closes #503.

## Diagnosis

`http_send_full` at `crates/lex-runtime/src/handler.rs:3023-3028` had a hard allow-list of GET and POST — every other method hit a fall-through that returned `HttpError::DecodeError("unsupported method: PUT")` before opening the socket. The `m =>` arm carried a comment saying "v1.5" but never got followed up.

Surfaced against lex-ocpi's PUT/PATCH/DELETE write flows (Locations, Sessions, Tariffs, Tokens, Credentials, ChargingProfiles), which had to shell out to `curl` via `[proc]` to compensate ([lex-ocpi#36](https://github.com/alpibrusl/lex-ocpi/pull/36)). This fix unblocks dropping that workaround.

## What changes

- `http_send_full` now dispatches:
  - **WithBody methods** (`POST`, `PUT`, `PATCH`) through `agent.{post,put,patch}(url).send(&body)`.
  - **WithoutBody methods** (`GET`, `HEAD`, `DELETE`) through `agent.{get,head,delete}(url).call()`.
- Method is uppercased before matching so callers can write `method: "put"` interchangeably with `method: "PUT"`. ureq emits the uppercase form on the wire regardless (each per-method builder is typed to its method).
- DELETE goes through ureq's WithoutBody path — RFC 7231 allows DELETE bodies but their semantics are undefined and most servers ignore them. If a future caller needs DELETE-with-body we can wire a different builder; out of scope here.

## Test plan

New tests in `crates/lex-runtime/tests/std_http.rs`:

- [x] `http_send_put_round_trips_with_body` — PUT + body → 200, wire request line is `PUT /x …`
- [x] `http_send_patch_round_trips_with_body` — PATCH + body → 200
- [x] `http_send_delete_round_trips` — DELETE → 200
- [x] `http_send_head_returns_200_with_empty_body` — HEAD → 200, response body empty per RFC 7231 §4.3.2
- [x] `http_send_method_is_uppercased_before_dispatch` — `method: "put"` routes the same as `"PUT"`

Each test uses the existing `spawn_oneshot` TCP server pattern from `std_http.rs`, calls `http.send(record)` from Lex, and asserts both the response status and the wire-level request line.

- [x] `cargo build -p lex-runtime` — clean
- [x] `cargo clippy -p lex-runtime -- -Dwarnings` — clean
- [x] `cargo test -p lex-runtime --test std_http` — 20/20 (5 new + 15 baseline, no regressions)
- [ ] CI green

## Out of scope

- `OPTIONS` / `TRACE` / `CONNECT` — needed less often than PUT/PATCH/DELETE. ureq 3 has `agent.options(url)` but TRACE/CONNECT aren't wrapped. Can be added in the same shape if a caller asks. Today they still hit the fall-through and return a clear `unsupported method: <m>` error rather than silently doing the wrong thing.
- `DELETE` with body — see note above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PsrNeuuchvDLFJmY1CskFe)_