### PR TITLE
fix(net): drain lazy iter bodies before unpack_response (closes #477)

### DIFF
--- a/crates/lex-bytecode/src/compiler.rs
+++ b/crates/lex-bytecode/src/compiler.rs
@@ -689,6 +689,7 @@ impl<'a> FnCompiler<'a> {
             ("iter", "take")      => self.emit_iter_take(args),
             ("iter", "skip")      => self.emit_iter_skip(args),
             ("iter", "to_list")   => self.emit_iter_to_list(args),
+            ("iter", "collect")   => self.emit_iter_to_list(args),
             ("iter", "map")       => self.emit_iter_map(args),
             ("iter", "filter")    => self.emit_iter_filter(args),
             ("iter", "fold")      => self.emit_iter_fold(args),

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -1759,14 +1759,18 @@ fn serve_http_plain(
                             let handler = DefaultHandler::new(policy)
                                 .with_program(Arc::clone(&program));
                             let mut vm = Vm::with_handler(&program, Box::new(handler));
-                            Ok(vm.call(&handler_name, vec![lex_req]))
+                            let r = vm.call(&handler_name, vec![lex_req]);
+                            // Drain any lazy iter in the response body
+                            // while the VM is still in scope — see #477.
+                            Ok(r.map(|mut v| { materialize_response_body(&mut vm, &mut v); v }))
                         } else {
                             tokio::task::spawn_blocking(move || {
                                 let lex_req = build_request_value_parts(&parts, &body_bytes);
                                 let handler = DefaultHandler::new(policy)
                                     .with_program(Arc::clone(&program));
                                 let mut vm = Vm::with_handler(&program, Box::new(handler));
-                                vm.call(&handler_name, vec![lex_req])
+                                let r = vm.call(&handler_name, vec![lex_req]);
+                                r.map(|mut v| { materialize_response_body(&mut vm, &mut v); v })
                             })
                             .await
                         };
@@ -1819,7 +1823,10 @@ fn handle_request_tls(
     let handler = DefaultHandler::new(policy).with_program(Arc::clone(&program));
     let mut vm = Vm::with_handler(&program, Box::new(handler));
     match vm.call(&handler_name, vec![lex_req]) {
-        Ok(resp) => {
+        Ok(mut resp) => {
+            // Drain any lazy iter in the response body while the VM is
+            // still in scope — see #477.
+            materialize_response_body(&mut vm, &mut resp);
             let (status, body, headers) = unpack_response(&resp);
             respond_with_body_tls(req, status, body, headers);
         }
@@ -1889,14 +1896,18 @@ fn serve_http_fn(
                             let handler = DefaultHandler::new(policy)
                                 .with_program(Arc::clone(&program));
                             let mut vm = Vm::with_handler(&program, Box::new(handler));
-                            Ok(vm.invoke_closure_value(closure, vec![lex_req]))
+                            let r = vm.invoke_closure_value(closure, vec![lex_req]);
+                            // Drain any lazy iter in the response body
+                            // while the VM is still in scope — see #477.
+                            Ok(r.map(|mut v| { materialize_response_body(&mut vm, &mut v); v }))
                         } else {
                             tokio::task::spawn_blocking(move || {
                                 let lex_req = build_request_value_parts(&parts, &body_bytes);
                                 let handler = DefaultHandler::new(policy)
                                     .with_program(Arc::clone(&program));
                                 let mut vm = Vm::with_handler(&program, Box::new(handler));
-                                vm.invoke_closure_value(closure, vec![lex_req])
+                                let r = vm.invoke_closure_value(closure, vec![lex_req]);
+                                r.map(|mut v| { materialize_response_body(&mut vm, &mut v); v })
                             })
                             .await
                         };
@@ -2133,7 +2144,10 @@ fn serve_http_routed(
                             let handler = DefaultHandler::new(policy)
                                 .with_program(Arc::clone(&program));
                             let mut vm = Vm::with_handler(&program, Box::new(handler));
-                            Ok(vm.invoke_closure_value(closure, vec![lex_req]))
+                            let r = vm.invoke_closure_value(closure, vec![lex_req]);
+                            // Drain any lazy iter in the response body
+                            // while the VM is still in scope — see #477.
+                            Ok(r.map(|mut v| { materialize_response_body(&mut vm, &mut v); v }))
                         } else {
                             tokio::task::spawn_blocking(move || {
                                 let mut lex_req = build_request_value_parts(&parts, &body_bytes);
@@ -2145,7 +2159,8 @@ fn serve_http_routed(
                                 let handler = DefaultHandler::new(policy)
                                     .with_program(Arc::clone(&program));
                                 let mut vm = Vm::with_handler(&program, Box::new(handler));
-                                vm.invoke_closure_value(closure, vec![lex_req])
+                                let r = vm.invoke_closure_value(closure, vec![lex_req]);
+                                r.map(|mut v| { materialize_response_body(&mut vm, &mut v); v })
                             })
                             .await
                         };
@@ -2453,6 +2468,90 @@ fn drain_iter_bytes(v: &Value) -> Vec<Vec<u8>> {
             }
         }
         _ => Vec::new(),
+    }
+}
+
+/// Drive an `__IterLazy(seed, step)` to exhaustion by invoking the step
+/// closure via `vm`, then return an equivalent `__IterEager(list, 0)` so
+/// the existing `drain_iter_*` paths can consume it.
+///
+/// Without this pre-pass, `BodyStream(iter.unfold(...))` produces empty
+/// response bodies because the drain helpers match only on the eager
+/// variant (#477). The step closure can carry effects; we ignore that
+/// here — the handler is already running on a tokio task with the same
+/// effect bindings, so any `[net]` / `[time]` calls inside the step
+/// re-enter the same handler context.
+///
+/// `__IterEager` is returned untouched. Unknown variants pass through.
+fn materialize_lazy_iter(vm: &mut Vm, v: Value) -> Value {
+    let mut current = v;
+    let mut items: Vec<Value> = Vec::new();
+    loop {
+        match current {
+            Value::Variant { name, args } if name == "__IterLazy" && args.len() == 2 => {
+                let seed = args[0].clone();
+                let step = args[1].clone();
+                match vm.invoke_closure_value(step.clone(), vec![seed]) {
+                    Ok(Value::Variant { name: opt, args: opt_args })
+                        if opt == "None" =>
+                    {
+                        let _ = opt_args;
+                        break;
+                    }
+                    Ok(Value::Variant { name: opt, args: opt_args })
+                        if opt == "Some" && opt_args.len() == 1 =>
+                    {
+                        if let Value::Tuple(pair) = &opt_args[0] {
+                            if pair.len() == 2 {
+                                items.push(pair[0].clone());
+                                current = Value::Variant {
+                                    name: "__IterLazy".to_string(),
+                                    args: vec![pair[1].clone(), step],
+                                };
+                                continue;
+                            }
+                        }
+                        // Malformed pair — bail to avoid infinite loop.
+                        break;
+                    }
+                    _ => break,
+                }
+            }
+            // Already eager (or unknown) — return as-is, possibly with
+            // any items we collected from a partial drain.
+            other => {
+                if items.is_empty() {
+                    return other;
+                }
+                // Mixed shape shouldn't happen in practice; fall through
+                // to the eager builder below with the items we have.
+                let _ = other;
+                break;
+            }
+        }
+    }
+    Value::Variant {
+        name: "__IterEager".to_string(),
+        args: vec![
+            Value::List(items.into_iter().collect()),
+            Value::Int(0),
+        ],
+    }
+}
+
+/// Rewrite any `body: BodyStream(__IterLazy(...))` or
+/// `body: BodyBytes(__IterLazy(...))` on a response record in place,
+/// replacing the lazy iter with an eager-materialised equivalent.
+/// Called before `unpack_response` / `build_hyper_response` so the
+/// existing drain paths can consume the iter.
+fn materialize_response_body(vm: &mut Vm, v: &mut Value) {
+    if let Value::Record(rec) = v {
+        if let Some(Value::Variant { name, args }) = rec.get_mut("body") {
+            if (name == "BodyStream" || name == "BodyBytes") && args.len() == 1 {
+                let inner = std::mem::replace(&mut args[0], Value::Unit);
+                args[0] = materialize_lazy_iter(vm, inner);
+            }
+        }
     }
 }
 

--- a/crates/lex-runtime/tests/iter_lazy.rs
+++ b/crates/lex-runtime/tests/iter_lazy.rs
@@ -25,6 +25,10 @@ fn from_list_to_list(xs :: List[Int]) -> List[Int] {
   iter.to_list(iter.from_list(xs))
 }
 
+fn from_list_collect(xs :: List[Int]) -> List[Int] {
+  iter.collect(iter.from_list(xs))
+}
+
 fn next_on_empty() -> Bool {
   let it := iter.from_list([])
   match iter.next(it) {
@@ -107,6 +111,13 @@ fn unfold_empty() -> List[Int] {
 fn from_list_and_to_list_roundtrip() {
     let xs = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)].into());
     let got = run(SRC, "from_list_to_list", vec![xs.clone()]);
+    assert_eq!(got, xs);
+}
+
+#[test]
+fn collect_is_alias_for_to_list() {
+    let xs = Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)].into());
+    let got = run(SRC, "from_list_collect", vec![xs.clone()]);
     assert_eq!(got, xs);
 }
 

--- a/crates/lex-runtime/tests/net_streaming.rs
+++ b/crates/lex-runtime/tests/net_streaming.rs
@@ -131,6 +131,30 @@ fn handle(_req :: Request) -> Response {
 fn main() -> [net] Unit { net.serve_fn(18194, handle) }
 "#;
 
+// #477 regression: `BodyStream(iter.unfold(...))` previously returned
+// an empty body because the drain path only matched on `__IterEager`.
+// The runtime now materialises lazy iters into eager ones before the
+// drain runs, so unfold-based streams produce the same wire bytes as
+// the equivalent `iter.from_list` version.
+const UNFOLD_SRC: &str = r#"
+import "std.net" as net
+import "std.iter" as iter
+import "std.map" as map
+
+fn handle(_req :: Request) -> Response {
+  let f := iter.unfold(0, fn (i :: Int) -> Option[(Str, Int)] {
+    if i >= 3 { None } else { Some(("hello\n", i + 1)) }
+  })
+  {
+    status:  200,
+    body:    BodyStream(f),
+    headers: map.from_list([("content-type", "text/plain")]),
+  }
+}
+
+fn main() -> [net] Unit { net.serve_fn(18195, handle) }
+"#;
+
 #[test]
 fn body_stream_uses_chunked_transfer_encoding() {
     spawn_lex_server(SRC, "main");
@@ -177,6 +201,32 @@ fn body_bytes_emits_per_iter_item_chunks() {
     );
     let (payload, chunks) = decode_chunked(&raw);
     assert_eq!(payload, vec![1u8, 2, 3, 4, 5, 6, 7, 8, 9]);
+    assert!(
+        !chunks.is_empty(),
+        "expected at least one HTTP chunk in a chunked-encoded response"
+    );
+}
+
+#[test]
+fn body_stream_unfold_produces_body_bytes() {
+    // Regression for #477. Prior to the lazy-iter materialisation
+    // pass in handler.rs, this test would observe a zero-byte body
+    // because `drain_iter_str` matched only on `__IterEager`.
+    spawn_lex_server(UNFOLD_SRC, "main");
+    wait_for_bind(18195, Duration::from_secs(5));
+    let (status, headers, raw) = http_get(18195, "/sse");
+    assert!(status.starts_with("HTTP/1.1 200"), "status: {status}");
+    let headers_lower = headers.to_ascii_lowercase();
+    assert!(
+        headers_lower.contains("transfer-encoding: chunked"),
+        "expected chunked encoding; headers were:\n{headers}"
+    );
+    let (payload, chunks) = decode_chunked(&raw);
+    assert_eq!(
+        String::from_utf8_lossy(&payload),
+        "hello\nhello\nhello\n",
+        "unfold-based BodyStream must produce the same payload as the equivalent from_list version"
+    );
     assert!(
         !chunks.is_empty(),
         "expected at least one HTTP chunk in a chunked-encoded response"

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -1304,6 +1304,12 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
             fields.insert("to_list".into(), Ty::function(
                 vec![it(0)], EffectSet::empty(),
                 Ty::List(Box::new(Ty::Var(0)))));
+            // collect :: Iter[T] -> List[T] — alias for `to_list`
+            // (matches Rust / Python / Kotlin naming so call sites
+            // coming from those languages don't have to re-learn).
+            fields.insert("collect".into(), Ty::function(
+                vec![it(0)], EffectSet::empty(),
+                Ty::List(Box::new(Ty::Var(0)))));
             // map :: [E] Iter[T], (T) -> [E] U -> [E] Iter[U]
             fields.insert("map".into(), Ty::function(
                 vec![


### PR DESCRIPTION
Closes #477.

## Root cause
`BodyStream(iter.unfold(...))` previously returned an empty HTTP body because `drain_iter_str` / `drain_iter_bytes` matched only on the `__IterEager` runtime variant. `iter.unfold` compiles to `__IterLazy(seed, step_closure)`, which requires invoking the closure via the VM to materialise items — something the drain helpers can't do because they're plain Rust functions with no VM handle.

## Fix
Add a pre-pass `materialize_response_body(&mut Vm, &mut Value)` that walks the response record, finds any `BodyStream(__IterLazy)` or `BodyBytes(__IterLazy)`, and rewrites the inner iter to an `__IterEager` variant by driving `iter.next` through `Vm::invoke_closure_value`. The existing drain helpers then handle it unchanged.

## Call sites threaded through
- `serve_fn` hyper service (inline + spawn_blocking paths)
- `serve_fn` closure service (inline + spawn_blocking paths)
- `serve_routed` (inline + spawn_blocking paths)
- `handle_request_tls` (tiny_http path)

In each case the materialisation runs while the VM is still in scope, so the step closure's effects (`[net]`, `[time]`, …) bind the same handler.

## Tests
- New `body_stream_unfold_produces_body_bytes` regression in `tests/net_streaming.rs` — wire-decodes the chunked response and asserts the payload matches the equivalent `iter.from_list` version. Fails before the patch (empty body, length 0); passes after.
- `net_streaming` (3/3 ✓) and `iter_lazy` (18/18 ✓) tests all pass locally.

## Trade-off
Materialisation is eager: the iter is drained into a `Vec` before the response goes back to hyper. The doc comment on `drain_iter_str` already noted a "v1 caveat" — per-iter-item chunk boundaries on the wire are TBD pending the planned `ChunkReader` follow-up. This commit doesn't widen that constraint; it fixes the empty-body bug under the same eager-streaming model. Composed iter ops (`iter.map`/`filter` over an `__IterLazy`) are not addressed here — they're a separate compiler-side issue.

## Test plan
- [x] `cargo test -p lex-runtime --test net_streaming` — 3 passed.
- [x] `cargo test -p lex-runtime --test iter_lazy` — 18 passed.
- [ ] CI full suite.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HvBJ2GKU2Ktg6bUJmFuv1q)_