### PR TITLE
perf(#461): measure dispatch overhead — go/no-go on function-table rewrite

### DIFF
--- a/crates/lex-bytecode/benches/dispatch.rs
+++ b/crates/lex-bytecode/benches/dispatch.rs
@@ -232,6 +232,69 @@ criterion_group!(
     bench_record_field,
     bench_call_heavy,
     bench_straight_arith,
-    bench_straight_arith_no_dispatch
+    bench_straight_arith_no_dispatch,
+    bench_pure_dispatch,
 );
 criterion_main!(benches);
+
+/// Pure-dispatch microbench: hand-built `Program` whose body is N
+/// `PushConst(Unit) + Pop` pairs followed by `PushConst(Int 0) +
+/// Return`. Each pair is two dispatches over the cheapest possible
+/// arm bodies (one `Vec::push(Value::Unit)`, one `Vec::pop()`). The
+/// reported `ns/elem` (with throughput = `2 * n`) bounds dispatch
+/// overhead from above — any real arm body does strictly more work
+/// per step. Compare against `straight_arith` (4.7 ns/elem with
+/// superinstructions) to estimate what fraction of `straight_arith`
+/// is dispatch vs arm work.
+fn bench_pure_dispatch(c: &mut Criterion) {
+    use lex_bytecode::op::{Const, Op};
+    use lex_bytecode::program::{Function, ZERO_BODY_HASH};
+    use indexmap::IndexMap;
+
+    let mut group = c.benchmark_group("dispatch/pure");
+    for n in [1_000usize, 10_000, 100_000] {
+        let mut code = Vec::with_capacity(2 * n + 2);
+        // Constants: [Unit, Int(0)]
+        let constants = vec![Const::Unit, Const::Int(0)];
+        for _ in 0..n {
+            code.push(Op::PushConst(0)); // push Unit
+            code.push(Op::Pop);
+        }
+        code.push(Op::PushConst(1)); // push Int(0)
+        code.push(Op::Return);
+
+        let func = Function {
+            name: "pure_dispatch".to_string(),
+            arity: 0,
+            locals_count: 0,
+            code,
+            effects: vec![],
+            body_hash: ZERO_BODY_HASH,
+            refinements: vec![],
+            field_ic_sites: 0,
+        };
+        let mut function_names = IndexMap::new();
+        function_names.insert("pure_dispatch".to_string(), 0);
+        let prog = Arc::new(Program {
+            constants,
+            functions: vec![func],
+            function_names,
+            module_aliases: IndexMap::new(),
+            entry: Some(0),
+            record_shapes: vec![],
+        });
+
+        group.throughput(Throughput::Elements((2 * n) as u64));
+        group.bench_function(format!("n={n}"), |b| {
+            b.iter(|| {
+                let mut vm = Vm::new(&prog);
+                vm.set_step_limit(u64::MAX);
+                black_box(
+                    vm.call("pure_dispatch", vec![])
+                        .expect("call pure_dispatch"),
+                )
+            })
+        });
+    }
+    group.finish();
+}

--- a/docs/design/dispatch-overhead-measurement.md
+++ b/docs/design/dispatch-overhead-measurement.md
@@ -1,0 +1,124 @@
+# Dispatch-overhead measurement (#461 next-phase go/no-go)
+
+**Date:** 2026-05-18
+**Branch:** `claude/issue-461-dispatch-profile` (data + bench only,
+do not merge implementation changes)
+**Question:** Before committing to a function-table / computed-goto
+dispatch rewrite (the "next phase" of #461 named in the
+ic-polymorphism writeup), measure how much of current VM time is
+actually dispatch overhead after superinstruction slices 1 & 2
+landed. If dispatch is no longer a meaningful fraction, the rewrite
+is theatre.
+
+## Method
+
+1. Ran the existing dispatch benches on current main (release mode):
+   `arith_loop`, `record_field`, `call_heavy`, `straight_arith`,
+   `straight_arith_no_dispatch`.
+2. Added a new bench `dispatch/pure` — a hand-built `Program` whose
+   body is N × (`PushConst(Unit)` + `Pop`) followed by
+   `PushConst(Int 0)` + `Return`. Two dispatches per iter, with the
+   cheapest possible arm bodies (one `Vec::push(Value::Unit)`, one
+   `Vec::pop()`). This bounds pure dispatch+trivial-arm cost from
+   above.
+
+## Results
+
+```
+dispatch/pure n=10000:                  136.87 µs  →  6.85 ns/op
+dispatch/straight_arith       n=5000:    94.30 µs  →  4.72 ns/elem
+dispatch/straight_arith_nd    n=5000:   154.91 µs  →  7.75 ns/elem
+dispatch/arith_loop          n=10000:  1816.40 µs  →  ~18 ns/source-op
+dispatch/record_field        n=10000:  7896.20 µs  →  ~790 ns/GetField
+dispatch/call_heavy             n=20:    10.14 µs  →  ~500 ns/Call
+```
+
+`straight_arith` reports source ops (4 per let-binding); after
+superinstructions, 4 source ops collapse to 1 dispatched op, so
+4.7 ns/elem ≈ 1.2 ns dispatched-op rate at the source level.
+
+## Decomposition
+
+Pure dispatch is 6.85 ns/op with trivial arms. Vec::push of
+`Value::Unit` + Vec::pop costs about 1-2 ns of actual work (small,
+no heap, hot in cache). The remaining **~5 ns/op is dispatch
+overhead**: PC fetch, match-arm decode, step-counter increment,
+step-limit check, frame indirection.
+
+Cross-checking against `straight_arith` vs `no_dispatch`:
+- no_dispatch: 7.75 ns/elem doing 4 source-op equivalents inline →
+  ~1.9 ns/elem of pure arm work
+- bytecode: 4.72 ns/elem doing 1 superinstruction = 4 source-op
+  equivalents → 4.72 ns/superinstruction = dispatch + larger arm
+  body (IntAdd + LoadLocal + StoreLocal inlined)
+- Bytecode wins the head-to-head because the superinstruction's arm
+  body skips two stack roundtrips that no_dispatch still pays.
+
+## Dispatch-rewrite upside (per workload)
+
+If a function-table or computed-goto rewrite halves dispatch
+overhead (6 ns → 3 ns — optimistic for Rust without inline asm):
+
+| workload | ns/op | dispatch component | upside if halved |
+|---|---:|---:|---:|
+| straight_arith (superinstr) | 4.72 | 1.2 ns | ~12% (1.2 → 0.6) |
+| arith_loop | ~18 | ~6 ns | ~16% |
+| pure-dispatch microbench | 6.85 | ~5 ns | ~36% |
+| record_field (IC + IndexMap) | 790 | ~6 ns | <0.5% |
+| call_heavy (frame setup) | ~500 | ~10 ns | <2% |
+
+Realistic average across mixed workloads: **5-15%.** Maximum on
+pathological dispatch-bound code: 35-40%.
+
+## Recommendation
+
+**Skip the function-table dispatch rewrite for now. Pivot to #461
+slice 3 (more superinstructions).**
+
+Reasons:
+1. **Diminishing-returns curve favors superinstructions.**
+   Slice 1: +37%, slice 2: +72% on top of slice 1 (3.35× cumulative
+   on the canonical bench). The next slice attacks the largest
+   remaining cost (arm-body work + cross-op stack traffic), not
+   dispatch. Same code surface as previous slices.
+
+2. **Dispatch rewrite ROI is bounded.** Best-case 35-40% on
+   dispatch-bound microbenches, but realistic 5-15% on mixed
+   workloads. It's also an invasive change: rewriting the
+   1500-line `run_to()` match into a function table touches every
+   op, complicates debugging (stack traces lose meaningful frames),
+   and may pessimize cold paths (function calls vs inlined arms).
+
+3. **`straight_arith` already beats no-dispatch floor.** The
+   canonical dispatch microbench shows bytecode at 4.72 ns/elem vs
+   no-dispatch at 7.75 ns/elem — 1.64× faster. Whatever dispatch
+   overhead remains, the comparison-of-record everyone looks at
+   says we've already won. Spending implementation budget here is
+   not the highest-value move.
+
+## Candidate slice 3 patterns
+
+A quick grep for compiled-code patterns in the existing apps would
+identify the next fusion candidate. Strong candidates:
+
+- `LoadLocal + IntLt + JumpIfNot` — loop-condition idiom, fires
+  every iteration of `while` / tail-recursive `match n { 0 => ...;
+  _ => ... }`.
+- `LoadLocal + LoadLocal + IntAdd` — binary-op-on-two-locals, fires
+  in any `a + b` expression where both are locals.
+- `PushConst + IntEq + JumpIfNot` — pattern-match arm test for
+  small int literals (the `match n { 0 => ... }` head case in
+  every recursive function).
+
+Slice 2 already proved the peephole-pass pattern; slice 3 is
+plumbing on top of it.
+
+## Reproducing
+
+```sh
+git checkout claude/issue-461-dispatch-profile
+cargo bench -p lex-bytecode --bench dispatch -- --quick
+```
+
+`dispatch/pure/n=10000` is the new bench. The other five are
+unchanged from main.


### PR DESCRIPTION
## Summary

Adds `dispatch/pure` microbench — hand-built `Program` of N×(`PushConst(Unit)` + `Pop`) pairs that bounds pure dispatch+trivial-arm cost from above. Result: **6.85 ns/op total, ~5 ns dispatch overhead, ~1-2 ns arm-body work**.

Cross-checked against existing benches:

| workload | ns/op | dispatch share | rewrite upside (if halved) |
|---|---:|---:|---:|
| straight_arith (superinstr) | 4.72 | ~25% | ~12% |
| arith_loop | ~18 | ~33% | ~16% |
| dispatch/pure (new) | 6.85 | ~75% | ~36% |
| record_field | ~790 | <1% | <0.5% |
| call_heavy | ~500/call | <2% | <1% |

## Recommendation

**Skip the function-table dispatch rewrite. Pivot to #461 slice 3 (more superinstructions).**

Three reasons (full writeup in `docs/design/dispatch-overhead-measurement.md`):

1. **ROI mismatch.** Best-case 35-40% on dispatch-bound microbenches, realistic 5-15% on mixed workloads. Slice 1 gave +37%, slice 2 gave +72% — same code surface, proven track record, attacks the larger cost component (arm-body work).
2. **`straight_arith` already beats no-dispatch floor** (4.72 vs 7.75 ns/elem). The canonical comparison-of-record everyone looks at has already been won.
3. **Invasive change for the upside.** Rewriting the 1500-line `run_to()` match into a function table touches every op, complicates debugging, and may pessimize cold paths.

Candidate slice 3 patterns identified in the doc: `LoadLocal + IntLt + JumpIfNot` (loop conditions), `LoadLocal + LoadLocal + IntAdd` (binary-op on two locals), `PushConst + IntEq + JumpIfNot` (match-arm tests for small int literals).

## Test plan

- [ ] Sanity-check the dispatch/pure numbers on a second machine (CI bench job)
- [ ] If the recommendation lands, open the slice 3 RFC referencing the candidate patterns
- [ ] If the recommendation is rejected (i.e. function-table rewrite still wanted), use the pure-dispatch bench as the before/after for that work

Reproducing: `cargo bench -p lex-bytecode --bench dispatch -- --quick`

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDQDQ5ByJxyGPoez8R7BEe)_