### PR TITLE
perf(#461): superinstructions slice 3 — LoadLocalAddLocal (1.69× on two-local arith)

### DIFF
--- a/crates/lex-bytecode/benches/dispatch.rs
+++ b/crates/lex-bytecode/benches/dispatch.rs
@@ -234,8 +234,62 @@ criterion_group!(
     bench_straight_arith,
     bench_straight_arith_no_dispatch,
     bench_pure_dispatch,
+    bench_two_local_arith,
 );
 criterion_main!(benches);
+
+/// Build a `two_local_arith` source: each let-binding sums two
+/// already-bound locals (no constant operand), so each compiles to
+/// `LoadLocal + LoadLocal + IntAdd + StoreLocal`. The first two slots
+/// are exactly slice 3's pattern (`LoadLocalAddLocal`) and the trailing
+/// `StoreLocal` would be slice 3's natural follow-on if it ever grew
+/// a `StoreLocal`-absorbing companion (mirroring slice 2's relation
+/// to slice 1). Sibling to `straight_arith` — same shape, but with a
+/// LoadLocal as the second operand instead of a PushConst, so slice 3
+/// is the only superinstruction that fires here.
+fn make_two_local_arith_source(n: usize) -> String {
+    // a0 = start, a1 = start, a{i} = a{i-1} + a{i-2}-equivalent
+    // pattern (the second-operand local cycles between the two
+    // seeds so we don't overflow into a useless big number — we
+    // just want consistent LoadLocal+LoadLocal+IntAdd dispatch shape).
+    let mut s = String::with_capacity(48 * n);
+    s.push_str("fn two_local_arith(start :: Int, step :: Int) -> Int {\n");
+    s.push_str("  let a0 := start\n");
+    for i in 1..=n {
+        // Always: a{i} := a{i-1} + step. Both operands are Int locals,
+        // so compile_binop emits IntAdd (typed lowering) and the
+        // peephole slice 3 fuses the LoadLocal+LoadLocal+IntAdd triple.
+        s.push_str(&format!("  let a{i} := a{} + step\n", i - 1));
+    }
+    s.push_str(&format!("  a{n}\n"));
+    s.push_str("}\n");
+    s
+}
+
+fn bench_two_local_arith(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dispatch/two_local_arith");
+    for n in [100usize, 1_000, 5_000] {
+        let prog = compile(&make_two_local_arith_source(n));
+        // 4 dispatch steps per let-binding without superinstructions:
+        // LoadLocal + LoadLocal + IntAdd + StoreLocal. With slice 3 the
+        // first three collapse to one dispatched op (the trailing two
+        // are tombstones the VM steps past in one `pc + 3` update).
+        // Throughput count uses the unfused-equivalent step count so
+        // ns/elem numbers are comparable to `straight_arith`.
+        group.throughput(Throughput::Elements((4 * n) as u64));
+        group.bench_function(format!("n={n}"), |b| {
+            b.iter(|| {
+                let mut vm = Vm::new(&prog);
+                vm.set_step_limit(u64::MAX);
+                black_box(
+                    vm.call("two_local_arith", vec![Value::Int(0), Value::Int(1)])
+                        .expect("call two_local_arith"),
+                )
+            })
+        });
+    }
+    group.finish();
+}
 
 /// Pure-dispatch microbench: hand-built `Program` whose body is N
 /// `PushConst(Unit) + Pop` pairs followed by `PushConst(Int 0) +

--- a/crates/lex-bytecode/src/compiler.rs
+++ b/crates/lex-bytecode/src/compiler.rs
@@ -247,10 +247,15 @@ pub fn compile_program(stages: &[a::Stage]) -> Program {
     // is invariant under this pass and the order doesn't matter.
     //
     // Slices run sequentially: slice 2 looks for slice-1 output
-    // followed by a StoreLocal, so it must follow slice 1.
+    // followed by a StoreLocal, so it must follow slice 1. Slice 3
+    // (LoadLocal + LoadLocal + IntAdd) is disjoint from both — its
+    // second slot is LoadLocal, not PushConst — so it can run in
+    // either order. Run it last to keep the slice 1/2 contract
+    // (slice 2 expects to see slice-1 output) untouched.
     for f in p.functions.iter_mut() {
         apply_peephole(&mut f.code, &pool.pool);
         apply_peephole_slice2(&mut f.code);
+        apply_peephole_slice3(&mut f.code);
     }
 
     // Final pass: stamp every function with its content hash now that
@@ -354,6 +359,45 @@ fn apply_peephole_slice2(code: &mut [Op]) {
                     dest,
                 };
                 k += 4;
+                continue;
+            }
+        }
+        k += 1;
+    }
+}
+
+/// Slice 3: fuse `[LoadLocal(lhs), LoadLocal(rhs), IntAdd]` into
+/// `LoadLocalAddLocal { lhs_idx, rhs_idx }`. The binary-op-on-two-
+/// locals idiom: any `a + b` where both operands compile to a
+/// `LoadLocal` (typed `Int`). Mirrors slice 1's shape exactly — the
+/// trailing `LoadLocal` + `IntAdd` stay in place as inert tombstones
+/// with cancelling stack deltas (+1, -1), so the verifier and
+/// body-hash decoder both keep walking them as live.
+///
+/// Disjoint from slice 1: the second slot disambiguates (LoadLocal
+/// vs PushConst), so a site can match at most one of the two. Runs
+/// after slice 2 so we don't accidentally consume a `LoadLocal` slot
+/// that slice 2 was about to fuse into a `*StoreLocal` superop (and
+/// to keep slice 2's input contract — slice-1 output followed by
+/// StoreLocal — untouched).
+///
+/// Safety: like slice 1, the trailing two slots must not be jump
+/// targets. The first slot can be a target (it stays a live op).
+fn apply_peephole_slice3(code: &mut [Op]) {
+    if code.len() < 3 { return; }
+    let jump_targets = collect_jump_targets(code);
+
+    let n = code.len();
+    let mut k = 0;
+    while k + 2 < n {
+        if let (Op::LoadLocal(lhs_idx), Op::LoadLocal(rhs_idx), Op::IntAdd)
+            = (code[k], code[k + 1], code[k + 2])
+        {
+            let safe = !jump_targets.contains(&(k + 1))
+                && !jump_targets.contains(&(k + 2));
+            if safe {
+                code[k] = Op::LoadLocalAddLocal { lhs_idx, rhs_idx };
+                k += 3;
                 continue;
             }
         }

--- a/crates/lex-bytecode/src/op.rs
+++ b/crates/lex-bytecode/src/op.rs
@@ -151,4 +151,19 @@ pub enum Op {
     /// both treat the 3 following slots as tombstones owned by
     /// this op.
     LoadLocalAddIntConstStoreLocal { src: u16, imm_const_idx: u32, dest: u16 },
+    /// Fused `LoadLocal(lhs_idx) + LoadLocal(rhs_idx) + IntAdd`
+    /// (#461 superinstruction slice 3). The binary-op-on-two-locals
+    /// idiom — fires on any `a + b` where both operands are
+    /// statically-typed `Int` locals (e.g. `acc + n` in tail-recursive
+    /// accumulator loops). Reads `locals[lhs_idx]` and `locals[rhs_idx]`,
+    /// pushes the sum, advances pc by 3. Stack delta: +1.
+    ///
+    /// `body_hash` stability (#222): canonical encoding decomposes
+    /// back to a standalone `LoadLocal(lhs_idx)`. The unchanged
+    /// `LoadLocal(rhs_idx)` + `IntAdd` tombstones at pc+1 and pc+2
+    /// hash normally, so the total bytes match the pre-fusion form.
+    /// Verifier walks the tombstones as if live: their deltas
+    /// (+1 LoadLocal, -1 IntAdd) cancel, matching the unfused depth
+    /// at pc+3.
+    LoadLocalAddLocal { lhs_idx: u16, rhs_idx: u16 },
 }

--- a/crates/lex-bytecode/src/program.rs
+++ b/crates/lex-bytecode/src/program.rs
@@ -160,14 +160,17 @@ pub fn compute_body_hash(
             // match the pre-fusion form — closure identity (#222)
             // stays invariant across peephole rewrites.
             Op::LoadLocalAddIntConst { local_idx, .. }
-            | Op::LoadLocalAddIntConstStoreLocal { src: local_idx, .. } => {
+            | Op::LoadLocalAddIntConstStoreLocal { src: local_idx, .. }
+            | Op::LoadLocalAddLocal { lhs_idx: local_idx, .. } => {
                 // Slice 1: this slot was `LoadLocal(local_idx)`.
                 // Slice 2: this slot was *also* `LoadLocal(src)`
                 // — the fused op now owns 4 slots, but the very
-                // first one was originally `LoadLocal`. The other
-                // 3 (PushConst / IntAdd / StoreLocal) remain in
-                // the code stream as tombstones and hash normally,
-                // so the total byte stream matches pre-fusion.
+                // first one was originally `LoadLocal`. Slice 3:
+                // ditto for `LoadLocal(lhs_idx)`. The trailing
+                // primitive ops (PushConst / IntAdd / StoreLocal /
+                // LoadLocal) remain in the code stream as tombstones
+                // and hash normally, so the total byte stream
+                // matches pre-fusion.
                 serde_json::to_vec(&Op::LoadLocal(*local_idx))
                     .expect("Op serialization must succeed")
             }

--- a/crates/lex-bytecode/src/verify.rs
+++ b/crates/lex-bytecode/src/verify.rs
@@ -214,6 +214,11 @@ fn stack_delta(op: &Op) -> i32 {
         // Tombstones at the next 3 slots are *not* walked (see the
         // control-flow successor logic in `verify_function`).
         Op::LoadLocalAddIntConstStoreLocal { .. } => 0,
+        // Slice-3 fused op: LoadLocal(lhs) + LoadLocal(rhs) + IntAdd.
+        // Net delta +1 (pushes the sum). The trailing tombstones
+        // (LoadLocal + IntAdd) have deltas +1 and -1 — they cancel
+        // when walked as live, mirroring slice 1's shape.
+        Op::LoadLocalAddLocal { .. } => 1,
     }
 }
 

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -1525,6 +1525,17 @@ impl<'a> Vm<'a> {
                     // left in place for body-hash stability.
                     self.frames[frame_idx].pc = pc + 3;
                 }
+                Op::LoadLocalAddLocal { lhs_idx, rhs_idx } => {
+                    let base = self.frames[frame_idx].locals_start;
+                    let a = self.locals_storage[base + lhs_idx as usize].as_int();
+                    let b = self.locals_storage[base + rhs_idx as usize].as_int();
+                    self.stack.push(Value::Int(a + b));
+                    // Override the default `pc + 1`: skip past the
+                    // two inert primitive ops (the original
+                    // LoadLocal(rhs_idx) + IntAdd) that the peephole
+                    // pass left in place for body-hash stability.
+                    self.frames[frame_idx].pc = pc + 3;
+                }
                 Op::LoadLocalAddIntConstStoreLocal { src, imm_const_idx, dest } => {
                     let base = self.frames[frame_idx].locals_start;
                     let a = self.locals_storage[base + src as usize].as_int();

--- a/crates/lex-bytecode/tests/run.rs
+++ b/crates/lex-bytecode/tests/run.rs
@@ -113,6 +113,63 @@ fn match_with_literal_int() {
 }
 
 #[test]
+fn slice3_fuses_two_local_add_and_runs_correctly() {
+    // #461 slice 3: `LoadLocal + LoadLocal + IntAdd` over two
+    // Int-typed locals must (a) be rewritten to
+    // `Op::LoadLocalAddLocal` by the peephole pass, (b) leave the
+    // trailing two slots as untouched primitive tombstones (so the
+    // body hash stays bit-identical to the unfused form), and
+    // (c) produce the same numeric result as the unfused triple.
+    use lex_bytecode::op::Op;
+    let src = "fn add_them(a :: Int, b :: Int) -> Int { a + b }\n";
+    let p = compile(src);
+    let f = &p.functions[0];
+
+    // The body should be exactly:
+    //   [LoadLocalAddLocal{a,b}, LoadLocal(b) tombstone, IntAdd tombstone, Return]
+    // — slice 3 rewrites slot 0; slots 1+2 stay live for body-hash
+    // stability and are skipped by the dispatch loop via pc+=3.
+    assert!(
+        matches!(f.code[0], Op::LoadLocalAddLocal { lhs_idx: 0, rhs_idx: 1 }),
+        "slice 3 did not fire; got {:?}", f.code[0],
+    );
+    assert!(matches!(f.code[1], Op::LoadLocal(1)));
+    assert!(matches!(f.code[2], Op::IntAdd));
+    assert!(matches!(f.code[3], Op::Return));
+
+    let mut vm = Vm::new(&p);
+    let r = vm.call("add_them", vec![Value::Int(40), Value::Int(2)]).unwrap();
+    assert_eq!(r, Value::Int(42));
+}
+
+#[test]
+fn slice3_does_not_fire_across_a_jump_target() {
+    // Safety check: if the second or third slot of the candidate
+    // triple is a jump target, slice 3 must skip the fusion — a
+    // jump landing on what looks like a `LoadLocal` is in fact a
+    // live entry point, not an inert tombstone. `match` in the
+    // body forces a JumpIfNot whose target sits between operations,
+    // so we can construct a function where the LoadLocal+LoadLocal+
+    // IntAdd triple straddles the arm boundary and verify no
+    // fusion happens. Easier route: just check that running such
+    // a function still produces the right answer (defensive — if
+    // the safety check ever regressed, a wrong jump-target rewrite
+    // would corrupt the stack and the call would either panic or
+    // return junk).
+    let src = "
+fn pick(flag :: Int, a :: Int, b :: Int) -> Int {
+  match flag {
+    0 => a + b,
+    _ => a,
+  }
+}";
+    let p = compile(src);
+    let mut vm = Vm::new(&p);
+    assert_eq!(vm.call("pick", vec![Value::Int(0), Value::Int(10), Value::Int(5)]).unwrap(), Value::Int(15));
+    assert_eq!(vm.call("pick", vec![Value::Int(1), Value::Int(10), Value::Int(5)]).unwrap(), Value::Int(10));
+}
+
+#[test]
 fn record_field_access() {
     let src = "fn xof(r :: Record) -> Int { r.x }\n".replace(
         "Record",


### PR DESCRIPTION
## Summary

Slice 3 of the #461 superinstruction series, picking up where the
dispatch-overhead measurement
(`docs/design/dispatch-overhead-measurement.md`) recommended pivoting:
attack arm-body work via more peephole fusions instead of the
function-table dispatch rewrite.

Fuses `LoadLocal(lhs) + LoadLocal(rhs) + IntAdd` into a single
`Op::LoadLocalAddLocal { lhs_idx, rhs_idx }` — the binary-op-on-two-
locals idiom (e.g. `acc + n` in tail-recursive accumulator loops,
`x + y` in coordinate arithmetic). Mirrors slice 1 exactly: the
trailing two slots stay as inert tombstones with cancelling stack
deltas (+1, -1), so the verifier walks them as live and the
body-hash decoder hashes the fused slot as the original
`LoadLocal(lhs_idx)`. Closure identity (#222) is invariant.

Disjoint from slices 1/2: the second slot disambiguates (LoadLocal
vs PushConst), so a fusion site matches at most one pattern. Runs
after slice 2 so the slice-1/2 contract (slice-1 output followed
by StoreLocal) stays untouched.

## Bench

New `dispatch/two_local_arith` microbench — sibling to
`straight_arith`, but with a `LoadLocal` as the second operand
instead of `PushConst`, so slice 3 is the only superinstruction
that fires. Measured on this branch by toggling
`apply_peephole_slice3` off/on:

| Stage                          | Wall      | Thrpt          |
|--------------------------------|-----------|----------------|
| pre-slice 3 (slice 1 + 2 only) | 234.82 µs |  85.2 Melem/s  |
| this branch (slice 1 + 2 + 3)  | 138.96 µs | 144.0 Melem/s  |

**1.69× on the two-local-arith pattern** (≈40% wall-time
reduction).

`arith_loop` (sum_to) moves only ~2% because its hot path is
dominated by TailCall frame setup (~500 ns/Call per the dispatch
overhead doc), not the dispatch work slice 3 absorbs. The isolated
bench is the right signal here.

## Acceptance per #461

- [x] ≥ 1× speedup on a new microbench: **1.69×** on
  `two_local_arith`
- [x] No regression on `cargo test -p lex-bytecode`: 9 passed
  including `bytecode_is_reproducible`, `canonical_format_e2e`
  (closure identity), and all integration fixtures
- [x] Representative app suites green: `inbox_app`, `gateway_app`,
  `analytics_app`, `ml_app`, `list_sort_by`,
  `canonical_format_e2e`
- [x] No bytecode-format change; body_hash bit-identical to the
  pre-fusion form
- [x] Clippy clean (`cargo clippy -p lex-bytecode --all-targets
  -- -D warnings`)

## Test plan

- [ ] Run `cargo test --workspace` on CI (local disk constraints
  required running it in slices)
- [ ] Confirm the dispatch bench numbers reproduce on a clean
  runner

## Followups (not in this PR)

Slice 3 candidates from
`docs/design/dispatch-overhead-measurement.md` not yet covered:

- `LoadLocal + IntLt + JumpIfNot` (loop-condition idiom) — needs
  jump-aware fusion; deferred.
- `PushConst + IntEq + JumpIfNot` (pattern-match arm test) —
  blocked on lowering `NumEq → IntEq` in `compile_pattern_test`
  first; separate slice.
- `LoadLocal + LoadLocal + IntSub` / `IntMul`: same shape as this
  slice but for the other typed binops; natural follow-on.
- A slice-2-style companion that fuses
  `[LoadLocalAddLocal, _, _, StoreLocal]` into a single op (mirroring
  slice 2's relation to slice 1).

https://claude.ai/code/session_01NjQc3kQTQXm97YX22kfwsU

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjQc3kQTQXm97YX22kfwsU)_