### PR TITLE
ci: strip test-binary debuginfo entirely to clear rust-lld SIGBUS margin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,19 +9,21 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-      # Drop full DWARF debuginfo from test binaries on CI. Each
-      # lex-runtime test binary re-links arrow + polars + the whole
-      # stdlib runtime; with debuginfo=2 (cargo's default for the
-      # test profile) they land ~250 MB stripped / ~1 GB with full
-      # symbols. `line-tables-only` keeps enough info for `panic`
-      # backtraces to be useful (file:line) but drops the variable
-      # / type / lexical-scope DWARF that bloats the binary, giving
-      # roughly 50% reduction per test binary => 4-6 GB headroom
-      # across the ~30 lex-runtime test binaries. Complements the
-      # `free-disk-space` step below, which buys cleanup-side
-      # headroom but doesn't change the per-binary footprint. Local
-      # `cargo test` keeps full debuginfo (env var is CI-scoped).
-      CARGO_PROFILE_TEST_DEBUG: line-tables-only
+      # Drop test-binary debuginfo entirely on CI. `line-tables-only`
+      # wasn't enough — rust-lld still SIGBUS'd inside LLVM's
+      # parallelFor during the workspace test link (post-#510, hit
+      # on `iter_lazy` and `policy_per_capability`). With debuginfo=0
+      # each lex-runtime test binary shrinks another ~30-40% on top
+      # of the line-tables-only reduction; across the ~30 test
+      # binaries that's the headroom needed to stop the parallel
+      # link workers from racing each other for mmap space.
+      # Tradeoff: panic backtraces from CI lose the `file:line`
+      # frames and surface raw addresses + symbol names only. That's
+      # tolerable because (a) tests still fail loudly with the
+      # assertion message, (b) reproducing locally restores full
+      # debuginfo, and (c) the default test profile is otherwise
+      # unaffected — env var is CI-scoped.
+      CARGO_PROFILE_TEST_DEBUG: "0"
     steps:
       - uses: actions/checkout@v6
       # std.arrow + std.df pull in arrow-rs + Polars, which roughly


### PR DESCRIPTION
## Summary

Follow-up to #510. Post-merge CI still hit `rust-lld` SIGBUS inside LLVM's `parallelFor` during the workspace test link — this time on `iter_lazy` and `policy_per_capability` (vs `ws_chat` pre-#510). Different test binaries failing each run is the signature of a marginal-disk failure where the parallel linker workers race for mmap space.

Bumps `CARGO_PROFILE_TEST_DEBUG` from `line-tables-only` (#510) to `0` — cuts another ~30-40% off each test binary on top of the previous reduction.

## Tradeoff

CI panic backtraces lose `file:line` frames (raw symbols + addresses only). Acceptable because:
- assertion messages still print
- local repro keeps full debuginfo (env var is CI-scoped)
- the alternative levers cost more — serializing rust-lld is ~5 min wall-clock, splitting the workspace into per-crate steps is most invasive.

## Test plan

- [ ] CI green on this PR (the test is whether the workspace test link completes without SIGBUS)
- [ ] If still failing, escalate to `CARGO_BUILD_JOBS=2` to serialize the parallel linker workers


---
_Generated by [Claude Code](https://claude.ai/code/session_01NjQc3kQTQXm97YX22kfwsU)_