### PR TITLE
fix: Ollama local-model integration (unicode escapes, io.argv, fs-write path)

### DIFF
--- a/.cli/README.md
+++ b/.cli/README.md
@@ -1,6 +1,6 @@
 # lex
 
-Version: 0.9.4
+Version: 0.9.5
 ACLI version: 0.1.0
 
 ## Commands

--- a/.cli/commands.json
+++ b/.cli/commands.json
@@ -1,6 +1,6 @@
 {
   "name": "lex",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "acli_version": "0.1.0",
   "commands": [
     {

--- a/crates/lex-ast/src/canonicalize.rs
+++ b/crates/lex-ast/src/canonicalize.rs
@@ -184,7 +184,7 @@ fn canonicalize_expr(e: &s::Expr) -> CExpr {
         s::Expr::Var(name) => {
             // A mangled qualified name like `module_hash.Constructor` is a
             // constructor reference if its last component is uppercase.
-            let unqualified = name.split('.').last().unwrap_or(name);
+            let unqualified = name.split('.').next_back().unwrap_or(name);
             if is_constructor_name(unqualified) {
                 CExpr::Constructor { name: unqualified.to_string(), args: Vec::new() }
             } else {
@@ -196,7 +196,7 @@ fn canonicalize_expr(e: &s::Expr) -> CExpr {
             // Special case: a Call whose callee is an uppercase-named Var is a constructor.
             // Also handles mangled qualified names like `module_hash.Constructor`.
             if let s::Expr::Var(name) = callee.as_ref() {
-                let unqualified = name.split('.').last().unwrap_or(name);
+                let unqualified = name.split('.').next_back().unwrap_or(name);
                 if is_constructor_name(unqualified) {
                     return CExpr::Constructor {
                         name: unqualified.to_string(),

--- a/crates/lex-ast/src/canonicalize.rs
+++ b/crates/lex-ast/src/canonicalize.rs
@@ -182,8 +182,11 @@ fn canonicalize_expr(e: &s::Expr) -> CExpr {
     match e {
         s::Expr::Lit(l) => CExpr::Literal { value: canonicalize_lit(l) },
         s::Expr::Var(name) => {
-            if is_constructor_name(name) {
-                CExpr::Constructor { name: name.clone(), args: Vec::new() }
+            // A mangled qualified name like `module_hash.Constructor` is a
+            // constructor reference if its last component is uppercase.
+            let unqualified = name.split('.').last().unwrap_or(name);
+            if is_constructor_name(unqualified) {
+                CExpr::Constructor { name: unqualified.to_string(), args: Vec::new() }
             } else {
                 CExpr::Var { name: name.clone() }
             }
@@ -191,10 +194,12 @@ fn canonicalize_expr(e: &s::Expr) -> CExpr {
         s::Expr::Block(b) => canonicalize_block(b),
         s::Expr::Call { callee, args } => {
             // Special case: a Call whose callee is an uppercase-named Var is a constructor.
+            // Also handles mangled qualified names like `module_hash.Constructor`.
             if let s::Expr::Var(name) = callee.as_ref() {
-                if is_constructor_name(name) {
+                let unqualified = name.split('.').last().unwrap_or(name);
+                if is_constructor_name(unqualified) {
                     return CExpr::Constructor {
-                        name: name.clone(),
+                        name: unqualified.to_string(),
                         args: args.iter().map(canonicalize_expr).collect(),
                     };
                 }

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -565,9 +565,11 @@ fn cmd_run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         )
     } else {
         let path = f.positional.first().ok_or_else(|| anyhow!(
-            "usage: lex run [policy] [--from-canonical] <file> <fn> [args]"))?;
-        let func = f.positional.get(1).ok_or_else(|| anyhow!("missing function name"))?;
-        (path.clone(), func.clone(), 2)
+            "usage: lex run [policy] [--from-canonical] <file> [fn] [args] or <file> -- [program args]"))?;
+        // When `--` was the separator, positional has only the file path;
+        // default to calling `main` with empty vargs and program_args in io.argv().
+        let func = f.positional.get(1).cloned().unwrap_or_else(|| "main".to_string());
+        (path.clone(), func, 2)
     };
     let policy = &f.policy;
     if f.dry_run {
@@ -625,7 +627,9 @@ fn cmd_run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     }
 
     let bc = std::sync::Arc::new(bc);
-    let handler = DefaultHandler::new(f.policy.clone()).with_program(std::sync::Arc::clone(&bc));
+    let handler = DefaultHandler::new(f.policy.clone())
+        .with_program(std::sync::Arc::clone(&bc))
+        .with_program_args(f.program_args.clone());
     let mut vm = Vm::with_handler(&bc, Box::new(handler));
     if let Some(n) = f.max_steps { vm.set_step_limit(n); }
     let recorder = lex_trace::Recorder::new();
@@ -646,14 +650,19 @@ fn cmd_run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         None
     };
 
-    let vargs: Vec<Value> = f.positional[arg_positional_start..]
-        .iter()
-        .map(|a| {
-            let v: serde_json::Value = serde_json::from_str(a)
-                .with_context(|| format!("arg `{a}` must be JSON"))?;
-            Ok(json_to_value(&v))
-        })
-        .collect::<Result<Vec<_>>>()?;
+    // When `--` separator was used, program_args holds the argv and vargs is empty.
+    let vargs: Vec<Value> = if !f.program_args.is_empty() {
+        Vec::new()
+    } else {
+        f.positional[arg_positional_start..]
+            .iter()
+            .map(|a| {
+                let v: serde_json::Value = serde_json::from_str(a)
+                    .with_context(|| format!("arg `{a}` must be JSON"))?;
+                Ok(json_to_value(&v))
+            })
+            .collect::<Result<Vec<_>>>()?
+    };
     let started = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
     let result = vm.call(&func, vargs);
@@ -753,6 +762,8 @@ struct RunFlags {
     require_signed: bool,
     /// Hex Ed25519 public key the stage must be signed by.
     trusted_key: Option<String>,
+    /// Args after `--` separator, passed to `io.argv()` in the program.
+    program_args: Vec<String>,
 }
 
 fn parse_run_flags(args: &[String]) -> Result<RunFlags> {
@@ -822,6 +833,12 @@ fn parse_run_flags(args: &[String]) -> Result<RunFlags> {
                 f.trusted_key = Some(val.clone());
                 f.require_signed = true;
                 i += 2;
+            }
+            "--" => {
+                // Everything after `--` is passed to io.argv() in the program.
+                // `lex run <file> -- [program args]` calls `main()`.
+                f.program_args = args[i + 1..].to_vec();
+                break;
             }
             _ => { f.positional.push(a.clone()); i += 1; }
         }

--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -19,6 +19,7 @@ pub fn is_pure_call(kind: &str, op: &str) -> bool {
         | ("http", "send")
         | ("http", "get")
         | ("http", "post")
+        | ("http", "stream_lines")
         // arrow.read_csv reads from disk → effect-handler path (#426 I/O slice).
         | ("arrow", "read_csv")
         // arrow.{read,write}_parquet + arrow.write_csv — effect-gated I/O (#432).

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -1047,12 +1047,26 @@ impl EffectHandler for DefaultHandler {
                 let path = expect_str(args.first())?.to_string();
                 let contents = expect_str(args.get(1))?.to_string();
                 // Honor write-allowlist if any.
+                // Canonicalize both sides so macOS /tmp → /private/tmp symlinks
+                // and other platform-specific path aliases compare correctly.
                 if !self.policy.allow_fs_write.is_empty() {
-                    let abs = std::env::current_dir()
+                    let raw = std::env::current_dir()
                         .map(|cwd| cwd.join(&path))
                         .unwrap_or_else(|_| std::path::PathBuf::from(&path));
-                    let p = abs.as_path();
-                    if !self.policy.allow_fs_write.iter().any(|a| p.starts_with(a)) {
+                    // canonicalize fails if the file doesn't exist yet (new writes).
+                    // Fall back to canonicalizing the parent so macOS /tmp → /private/tmp
+                    // symlinks still compare correctly against the allowlist.
+                    let p = std::fs::canonicalize(&raw).unwrap_or_else(|_| {
+                        raw.parent()
+                            .and_then(|par| std::fs::canonicalize(par).ok())
+                            .map(|par| par.join(raw.file_name().unwrap_or_default()))
+                            .unwrap_or(raw)
+                    });
+                    let allowed = self.policy.allow_fs_write.iter().any(|a| {
+                        let ca = std::fs::canonicalize(a).unwrap_or_else(|_| a.clone().into());
+                        p.starts_with(&ca)
+                    });
+                    if !allowed {
                         return Err(format!("write to `{path}` outside --allow-fs-write"));
                     }
                 }
@@ -1388,6 +1402,29 @@ impl EffectHandler for DefaultHandler {
                 })?;
                 let policy = self.policy.clone();
                 crate::ws::dial_ws(url, subprotocol, on_open, on_message, program, policy)
+            }
+            ("net", "dial_ws_actor") => {
+                // dial_ws_actor(url, subprotocol, name, on_open, on_message)
+                let url = expect_str(args.first())?.to_string();
+                let subprotocol = expect_str(args.get(1))?.to_string();
+                let name = expect_str(args.get(2))?.to_string();
+                let on_open = match args.get(3).cloned() {
+                    Some(c @ Value::Closure { .. }) => c,
+                    _ => return Err(
+                        "net.dial_ws_actor(url, subprotocol, name, on_open, on_message): on_open must be a closure".into(),
+                    ),
+                };
+                let on_message = match args.into_iter().nth(4) {
+                    Some(c @ Value::Closure { .. }) => c,
+                    _ => return Err(
+                        "net.dial_ws_actor(url, subprotocol, name, on_open, on_message): on_message must be a closure".into(),
+                    ),
+                };
+                let program = self.program.clone().ok_or_else(|| {
+                    "net.dial_ws_actor requires a Program reference; use DefaultHandler::with_program".to_string()
+                })?;
+                let policy = self.policy.clone();
+                crate::ws::dial_ws_actor(url, subprotocol, name, on_open, on_message, program, policy)
             }
             ("chat", "broadcast") => {
                 let registry = self.chat_registry.as_ref()
@@ -3461,15 +3498,16 @@ fn http_request(method: &str, url: &str, body: Option<&str>) -> Value {
     }
 }
 
-/// Build a ureq agent for `http.stream_lines` with a long body-read timeout.
-/// Local models (Ollama, vLLM) can spend several minutes on thinking traces
-/// before closing the stream, so the default 30-second timeout is too short.
+/// Build a ureq agent for `http.stream_lines` with a long timeout.
+/// Local models (Ollama, vLLM) can take minutes to load before they start
+/// responding, and thinking-heavy models can take minutes to finish.
+/// Use timeout_global so the limit applies to the entire operation
+/// (connect + send + recv) rather than individual phases, avoiding the
+/// 10-second default that with_config().read_to_vec() uses for body reads.
 fn http_stream_agent() -> ureq::Agent {
     use std::time::Duration;
     ureq::Agent::config_builder()
-        .timeout_connect(Some(Duration::from_secs(10)))
-        .timeout_recv_body(Some(Duration::from_secs(600)))
-        .timeout_send_body(Some(Duration::from_secs(10)))
+        .timeout_global(Some(Duration::from_secs(600)))
         .http_status_as_error(false)
         .build()
         .into()

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -25,7 +25,9 @@ pub trait IoSink: Send {
 pub struct StdoutSink;
 impl IoSink for StdoutSink {
     fn print_line(&mut self, s: &str) {
-        println!("{s}");
+        use std::io::Write;
+        print!("{s}");
+        let _ = std::io::stdout().flush();
     }
 }
 
@@ -98,6 +100,9 @@ pub struct DefaultHandler {
     /// finds and removes the matching entry. Plain `u64`, not
     /// shared — each handler instance has its own counter.
     next_scope_id: u64,
+    /// Arguments passed after `--` in `lex run <file> -- [args...]`.
+    /// Returned by `io.argv()` so Lex `main` functions can read CLI flags.
+    pub program_args: Vec<String>,
 }
 
 impl DefaultHandler {
@@ -120,6 +125,7 @@ impl DefaultHandler {
             next_stream_id: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             arena_stack: Vec::new(),
             next_scope_id: 1,
+            program_args: Vec::new(),
         }
     }
 
@@ -152,6 +158,10 @@ impl DefaultHandler {
 
     pub fn with_read_root(mut self, root: PathBuf) -> Self {
         self.read_root = Some(root); self
+    }
+
+    pub fn with_program_args(mut self, args: Vec<String>) -> Self {
+        self.program_args = args; self
     }
 
     fn ensure_kind_allowed(&self, kind: &str) -> Result<(), String> {
@@ -1013,12 +1023,35 @@ impl EffectHandler for DefaultHandler {
                     Err(e) => Ok(err(Value::Str(format!("{e}").into()))),
                 }
             }
+            ("io", "readline") => {
+                use std::io::BufRead;
+                let stdin = std::io::stdin();
+                let mut line = String::new();
+                match stdin.lock().read_line(&mut line) {
+                    Ok(0) => Ok(Value::Variant { name: "None".into(), args: vec![] }),
+                    Ok(_) => {
+                        if line.ends_with('\n') { line.pop(); }
+                        if line.ends_with('\r') { line.pop(); }
+                        Ok(Value::Variant { name: "Some".into(), args: vec![Value::Str(line.into())] })
+                    }
+                    Err(_) => Ok(Value::Variant { name: "None".into(), args: vec![] }),
+                }
+            }
+            ("io", "argv") => {
+                let list: Vec<Value> = self.program_args.iter()
+                    .map(|s| Value::Str(s.as_str().into()))
+                    .collect();
+                Ok(Value::List(list.into()))
+            }
             ("io", "write") => {
                 let path = expect_str(args.first())?.to_string();
                 let contents = expect_str(args.get(1))?.to_string();
                 // Honor write-allowlist if any.
                 if !self.policy.allow_fs_write.is_empty() {
-                    let p = std::path::Path::new(&path);
+                    let abs = std::env::current_dir()
+                        .map(|cwd| cwd.join(&path))
+                        .unwrap_or_else(|_| std::path::PathBuf::from(&path));
+                    let p = abs.as_path();
                     if !self.policy.allow_fs_write.iter().any(|a| p.starts_with(a)) {
                         return Err(format!("write to `{path}` outside --allow-fs-write"));
                     }
@@ -2147,6 +2180,7 @@ impl EffectHandler for DefaultHandler {
         // `Arc<Mutex<…>>` so concurrent access is safe.
         fresh.streams = std::sync::Arc::clone(&self.streams);
         fresh.next_stream_id = std::sync::Arc::clone(&self.next_stream_id);
+        fresh.program_args = self.program_args.clone();
         Some(Box::new(fresh))
     }
 }
@@ -3427,6 +3461,20 @@ fn http_request(method: &str, url: &str, body: Option<&str>) -> Value {
     }
 }
 
+/// Build a ureq agent for `http.stream_lines` with a long body-read timeout.
+/// Local models (Ollama, vLLM) can spend several minutes on thinking traces
+/// before closing the stream, so the default 30-second timeout is too short.
+fn http_stream_agent() -> ureq::Agent {
+    use std::time::Duration;
+    ureq::Agent::config_builder()
+        .timeout_connect(Some(Duration::from_secs(10)))
+        .timeout_recv_body(Some(Duration::from_secs(600)))
+        .timeout_send_body(Some(Duration::from_secs(10)))
+        .http_status_as_error(false)
+        .build()
+        .into()
+}
+
 /// Build a ureq agent for `std.http.{send,get,post}` with the given
 /// timeout (None → use the same defaults as the legacy `net.{get,post}`
 /// path). Separate from `http_request` so the rich `http.send` flow
@@ -3662,9 +3710,11 @@ fn err(v: Value) -> Value {
 /// splitting. This means the call blocks until the server closes the connection —
 /// endpoints that hold the connection open indefinitely will hang. True per-line
 /// streaming requires a future HTTP client upgrade.
-fn http_stream_lines_impl(handler: &DefaultHandler, url: &str, headers_val: &Value, body: &str) -> Value {
+fn http_stream_lines_impl(_handler: &DefaultHandler, url: &str, headers_val: &Value, body: &str) -> Value {
     let body_bytes = body.as_bytes().to_vec();
-    let agent = http_agent(None);
+    // Use a 10-minute body-read timeout — local models (Ollama, vLLM) can take
+    // several minutes to generate long thinking traces before closing the stream.
+    let agent = http_stream_agent();
     let mut req = agent.post(url);
     if let Value::Map(headers) = headers_val {
         for (k, v) in headers {
@@ -3683,13 +3733,49 @@ fn http_stream_lines_impl(handler: &DefaultHandler, url: &str, headers_val: &Val
                 Ok(b) => b,
                 Err(e) => return err(Value::Str(format!("http.stream_lines: body read: {e}").into())),
             };
-            let text = String::from_utf8_lossy(&bytes).into_owned();
-            let lines: Vec<String> = text.lines().map(String::from).collect();
-            let handle = handler.register_stream(lines.into_iter());
-            ok(stream_handle_value(handle))
+            let raw_text = String::from_utf8_lossy(&bytes).into_owned();
+            let text = decode_unicode_escapes(&raw_text);
+            let items: std::collections::VecDeque<Value> = text.lines()
+                .map(|l| Value::Str(l.to_string().into()))
+                .collect();
+            let iter_val = Value::Variant {
+                name: "__IterEager".into(),
+                args: vec![Value::List(items), Value::Int(0)],
+            };
+            ok(iter_val)
         }
         Err(e) => err(Value::Str(format!("http.stream_lines: {e}").into())),
     }
+}
+
+fn decode_unicode_escapes(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            result.push(c);
+            continue;
+        }
+        match chars.peek() {
+            Some('u') => {
+                chars.next();
+                let hex: String = (0..4).filter_map(|_| chars.next()).collect();
+                if hex.len() == 4 {
+                    if let Ok(n) = u32::from_str_radix(&hex, 16) {
+                        if let Some(ch) = char::from_u32(n) {
+                            result.push(ch);
+                            continue;
+                        }
+                    }
+                }
+                result.push('\\');
+                result.push('u');
+                result.push_str(&hex);
+            }
+            _ => result.push(c),
+        }
+    }
+    result
 }
 
 /// Build a `SqlError = { message, code, detail }` Lex record (#380).

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -1063,7 +1063,7 @@ impl EffectHandler for DefaultHandler {
                             .unwrap_or(raw)
                     });
                     let allowed = self.policy.allow_fs_write.iter().any(|a| {
-                        let ca = std::fs::canonicalize(a).unwrap_or_else(|_| a.clone().into());
+                        let ca = std::fs::canonicalize(a).unwrap_or_else(|_| a.clone());
                         p.starts_with(&ca)
                     });
                     if !allowed {

--- a/crates/lex-runtime/src/ws.rs
+++ b/crates/lex-runtime/src/ws.rs
@@ -987,6 +987,191 @@ fn stream_for(
     }
 }
 
+// ── dial_ws_actor — outbound-bridge actor for WS clients (#dial-actor) ──────
+//
+// Variant of `dial_ws` that registers the outgoing connection as a named
+// actor in the conc registry, enabling `conc.tell(actor, frame_str)` to push
+// frames into the socket from any other Lex actor (heartbeat timers,
+// meter-value loops, etc.).
+//
+//   net.dial_ws_actor(
+//     url         :: Str,
+//     subprotocol :: Str,
+//     name        :: Str,               — conc registry key ("" to skip)
+//     on_open     :: () -> [E] WsAction,
+//     on_message  :: (WsMessage) -> [E] WsAction
+//   ) -> [net, E] Result[Unit, Str]
+pub fn dial_ws_actor(
+    url: String,
+    subprotocol: String,
+    name: String,
+    on_open: Value,
+    on_message: Value,
+    program: Arc<Program>,
+    policy: Policy,
+) -> Result<Value, String> {
+    use tungstenite::client::IntoClientRequest;
+    use tungstenite::http::HeaderValue;
+
+    let mut req = match url.as_str().into_client_request() {
+        Ok(r) => r,
+        Err(e) => {
+            return Ok(build_dial_result(Err(format!(
+                "net.dial_ws_actor: bad URL `{url}`: {e}"
+            ))));
+        }
+    };
+    if !subprotocol.is_empty() {
+        let header = match HeaderValue::from_str(&subprotocol) {
+            Ok(h) => h,
+            Err(e) => {
+                return Ok(build_dial_result(Err(format!(
+                    "net.dial_ws_actor: invalid subprotocol `{subprotocol}`: {e}"
+                ))));
+            }
+        };
+        req.headers_mut().insert("Sec-WebSocket-Protocol", header);
+    }
+
+    let (mut ws, _resp) = match tungstenite::connect(req) {
+        Ok(pair) => pair,
+        Err(e) => {
+            return Ok(build_dial_result(Err(format!(
+                "net.dial_ws_actor: connect to `{url}`: {e}"
+            ))));
+        }
+    };
+    if let Some(stream) = stream_for(&mut ws) {
+        let _ = stream.set_read_timeout(Some(Duration::from_millis(50)));
+    }
+
+    // Set up the actor bridge — mpsc channel whose Sender end is wrapped in a
+    // native actor cell registered in the conc registry.
+    let (tx, rx) = mpsc::channel::<String>();
+    if !name.is_empty() {
+        let tx_for_bridge = tx.clone();
+        let bridge = lex_bytecode::value::NativeActorHandler {
+            send: Box::new(move |msg: Value| -> Result<Value, String> {
+                match msg {
+                    Value::Str(s) => tx_for_bridge
+                        .send(s.to_string())
+                        .map(|_| Value::Unit)
+                        .map_err(|e| format!("net.dial_ws_actor: outbound channel closed: {e}")),
+                    other => Err(format!(
+                        "net.dial_ws_actor: native bridge accepts Str only, got {other:?}"
+                    )),
+                }
+            }),
+        };
+        let cell = Value::Actor(Arc::new(Mutex::new(lex_bytecode::value::ActorCell {
+            state: Value::Unit,
+            handler: lex_bytecode::value::ActorHandler::Native(Arc::new(bridge)),
+        })));
+        if let Err(e) = lex_bytecode::conc_registry::register(&name, cell) {
+            return Ok(build_dial_result(Err(format!(
+                "net.dial_ws_actor: conc.register({name:?}) failed: {e:?}"
+            ))));
+        }
+    }
+
+    // Fire on_open once, apply its WsAction to the socket.
+    {
+        let handler = crate::handler::DefaultHandler::new(policy.clone())
+            .with_program(Arc::clone(&program));
+        let mut vm = Vm::with_handler(&program, Box::new(handler));
+        match vm.invoke_closure_value(on_open.clone(), vec![]) {
+            Ok(action) => {
+                if let Err(e) = apply_ws_action(&action, &mut ws) {
+                    if !name.is_empty() {
+                        let _ = lex_bytecode::conc_registry::unregister(&name);
+                    }
+                    return Ok(build_dial_result(Err(format!(
+                        "net.dial_ws_actor: on_open action: {e}"
+                    ))));
+                }
+            }
+            Err(e) => {
+                if !name.is_empty() {
+                    let _ = lex_bytecode::conc_registry::unregister(&name);
+                }
+                return Ok(build_dial_result(Err(format!(
+                    "net.dial_ws_actor: on_open: {e}"
+                ))));
+            }
+        }
+    }
+
+    let loop_result = dial_actor_run_loop(&mut ws, &rx, &on_message, &program, &policy);
+    if !name.is_empty() {
+        let _ = lex_bytecode::conc_registry::unregister(&name);
+    }
+    let _ = ws.close(None);
+    Ok(build_dial_result(loop_result))
+}
+
+fn dial_actor_run_loop(
+    ws: &mut tungstenite::WebSocket<tungstenite::stream::MaybeTlsStream<std::net::TcpStream>>,
+    rx: &mpsc::Receiver<String>,
+    on_message: &Value,
+    program: &Arc<Program>,
+    policy: &Policy,
+) -> Result<(), String> {
+    use std::io::ErrorKind;
+    use tungstenite::Message;
+
+    loop {
+        let ws_msg = match ws.read() {
+            Ok(Message::Text(body)) => Some(build_ws_message_text(&body)),
+            Ok(Message::Binary(payload)) => Some(build_ws_message_binary(&payload)),
+            Ok(Message::Ping(_)) => Some(build_ws_message_ping()),
+            Ok(Message::Close(_)) | Err(tungstenite::Error::ConnectionClosed) => {
+                let handler = crate::handler::DefaultHandler::new(policy.clone())
+                    .with_program(Arc::clone(program));
+                let mut vm = Vm::with_handler(program, Box::new(handler));
+                let _ = vm.invoke_closure_value(
+                    on_message.clone(),
+                    vec![build_ws_message_close()],
+                );
+                return Ok(());
+            }
+            Ok(_) => None,
+            Err(tungstenite::Error::Io(ref e))
+                if e.kind() == ErrorKind::WouldBlock || e.kind() == ErrorKind::TimedOut =>
+            {
+                None
+            }
+            Err(e) => return Err(format!("net.dial_ws_actor: read: {e}")),
+        };
+
+        if let Some(msg) = ws_msg {
+            let handler = crate::handler::DefaultHandler::new(policy.clone())
+                .with_program(Arc::clone(program));
+            let mut vm = Vm::with_handler(program, Box::new(handler));
+            match vm.invoke_closure_value(on_message.clone(), vec![msg]) {
+                Ok(action) => {
+                    if let Err(e) = apply_ws_action(&action, ws) {
+                        return Err(format!("net.dial_ws_actor: action: {e}"));
+                    }
+                }
+                Err(e) => return Err(format!("net.dial_ws_actor: on_message: {e}")),
+            }
+        }
+
+        // Drain the actor mailbox — frames enqueued by conc.tell(actor, frame).
+        loop {
+            match rx.try_recv() {
+                Ok(msg) => {
+                    if let Err(e) = ws.send(Message::Text(msg.into())) {
+                        return Err(format!("net.dial_ws_actor: send: {e}"));
+                    }
+                }
+                Err(mpsc::TryRecvError::Empty) => break,
+                Err(mpsc::TryRecvError::Disconnected) => return Ok(()),
+            }
+        }
+    }
+}
+
 fn dial_run_loop(
     ws: &mut tungstenite::WebSocket<tungstenite::stream::MaybeTlsStream<std::net::TcpStream>>,
     on_message: &Value,

--- a/crates/lex-syntax/src/parser.rs
+++ b/crates/lex-syntax/src/parser.rs
@@ -276,7 +276,7 @@ impl<'a> Parser<'a> {
             );
             if last_was_rparen {
                 if let TypeExpr::Named { ref name, .. } = first {
-                    let unqual = name.split('.').last().unwrap_or(name.as_str());
+                    let unqual = name.split('.').next_back().unwrap_or(name.as_str());
                     if unqual.chars().next().map(|c| c.is_ascii_uppercase()).unwrap_or(false) {
                         return Ok(TypeExpr::Union(vec![type_to_variant(first)?]));
                     }

--- a/crates/lex-syntax/src/parser.rs
+++ b/crates/lex-syntax/src/parser.rs
@@ -265,6 +265,23 @@ impl<'a> Parser<'a> {
             }
             Ok(TypeExpr::Union(variants))
         } else {
+            // Single-variant union without `|`: `type Msg = Execute(Str)`.
+            // The `(...)` constructor-payload syntax is distinguishable from
+            // `[...]` type-application by checking the last consumed token.
+            // `Execute(Str)` ends with `)`, `List[Int]` ends with `]`,
+            // `AnotherType` ends with the ident token.
+            let last_was_rparen = self.idx > 0 && matches!(
+                self.tokens.get(self.idx - 1).map(|t| &t.kind),
+                Some(TokenKind::RParen)
+            );
+            if last_was_rparen {
+                if let TypeExpr::Named { ref name, .. } = first {
+                    let unqual = name.split('.').last().unwrap_or(name.as_str());
+                    if unqual.chars().next().map(|c| c.is_ascii_uppercase()).unwrap_or(false) {
+                        return Ok(TypeExpr::Union(vec![type_to_variant(first)?]));
+                    }
+                }
+            }
             Ok(first)
         }
     }
@@ -923,7 +940,14 @@ impl<'a> Parser<'a> {
             Some(TokenKind::LBrace) => self.parse_record_pattern(),
             Some(TokenKind::LParen) => self.parse_tuple_pattern(),
             Some(TokenKind::Ident(_)) => {
-                let name = self.expect_ident("")?;
+                let mut name = self.expect_ident("")?;
+                // Handle module-qualified constructor patterns: `module.Constructor(args)`.
+                // Strip the qualifier and keep only the final name, matching how the
+                // compiler emits MakeVariant with the unqualified constructor name.
+                while matches!(self.peek(), Some(TokenKind::Dot)) {
+                    self.bump();
+                    name = self.expect_ident("after `.` in qualified pattern")?;
+                }
                 if matches!(self.peek(), Some(TokenKind::LParen)) {
                     self.bump();
                     let mut args = Vec::new();

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -31,6 +31,18 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 EffectSet::singleton("io"),
                 Ty::Con("Result".into(), vec![Ty::Unit, Ty::str()]),
             ));
+            // io.readline() -> [io] Option[Str]
+            fields.insert("readline".into(), Ty::function(
+                vec![],
+                EffectSet::singleton("io"),
+                Ty::Con("Option".into(), vec![Ty::str()]),
+            ));
+            // io.argv() -> [io] List[Str]
+            fields.insert("argv".into(), Ty::function(
+                vec![],
+                EffectSet::singleton("io"),
+                Ty::List(Box::new(Ty::str())),
+            ));
             Some(Ty::Record(fields))
         }
         "str" => {

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -652,6 +652,35 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 EffectSet::open_var(0).union(&EffectSet::singleton("net")),
                 Ty::Con("Result".into(), vec![Ty::Unit, Ty::str()]),
             ));
+            // dial_ws_actor[Eff] :: (Str, Str, Str,
+            //                        () -> [Eff] WsAction,
+            //                        (WsMessage) -> [Eff] WsAction)
+            //                        -> [net, Eff] Result[Unit, Str]
+            //
+            // Variant of dial_ws that registers the outgoing connection in the
+            // conc registry under `name`. conc.tell(actor, frame_str) enqueues
+            // a frame for delivery, enabling proactive sends (heartbeats,
+            // meter values) from any other actor without changing the
+            // reactive on_message signature.
+            fields.insert("dial_ws_actor".into(), Ty::function(
+                vec![
+                    Ty::str(), // url
+                    Ty::str(), // subprotocol ("" for none)
+                    Ty::str(), // conc registry name ("" to skip registration)
+                    Ty::function(
+                        vec![],
+                        EffectSet::open_var(0),
+                        Ty::Con("WsAction".into(), vec![]),
+                    ),
+                    Ty::function(
+                        vec![Ty::Con("WsMessage".into(), vec![])],
+                        EffectSet::open_var(0),
+                        Ty::Con("WsAction".into(), vec![]),
+                    ),
+                ],
+                EffectSet::open_var(0).union(&EffectSet::singleton("net")),
+                Ty::Con("Result".into(), vec![Ty::Unit, Ty::str()]),
+            ));
             // serve_fn[Eff] :: (Int, (Request) -> [Eff] Response) -> [net, Eff] Unit
             // Effect-polymorphic variant of serve that accepts a first-class closure
             // instead of a handler name. open_var(0) captures the handler's effect row

--- a/crates/lex-types/src/checker.rs
+++ b/crates/lex-types/src/checker.rs
@@ -1291,6 +1291,11 @@ impl Checker {
                 Ok(())
             }
             a::Pattern::PTuple { items } => {
+                // An empty-tuple pattern `()` is equivalent to Unit.
+                if items.is_empty() {
+                    return self.unify_with_record_coercion(&Ty::Unit, ty)
+                        .map_err(|e| mismatch_err(node_id, e, &self.u, vec!["in unit pattern".into()]));
+                }
                 let resolved = self.u.resolve(ty);
                 let tup = match resolved {
                     Ty::Tuple(t) => t,
@@ -1300,12 +1305,14 @@ impl Checker {
                         self.unify_with_record_coercion(&tup_ty, ty).map_err(|e| mismatch_err(node_id, e, &self.u, vec!["in tuple pattern".into()]))?;
                         fresh
                     }
-                    other => return Err(TypeError::TypeMismatch {
-                        at_node: node_id.into(),
-                        expected: "tuple".into(),
-                        got: other.pretty(),
-                        context: vec!["in tuple pattern".into()],
-                    }),
+                    other => {
+                        return Err(TypeError::TypeMismatch {
+                            at_node: node_id.into(),
+                            expected: "tuple".into(),
+                            got: other.pretty(),
+                            context: vec!["in tuple pattern".into()],
+                        });
+                    }
                 };
                 if tup.len() != items.len() {
                     return Err(TypeError::ArityMismatch {

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -227,6 +227,22 @@ fn main() -> [net] Nil { net.serve_ws_fn(9000, "", on_msg) }
 ```
 Types: `Request`, `Response`, `WsConn`, `WsMessage`, `WsAction` are global (no import needed).
 
+`net.dial_ws(url, subprotocol, on_open, on_message)` — reactive WebSocket client. `on_open` is called once after the handshake; `on_message` is called for each inbound frame. Both return a `WsAction` (`ws.send(frame)` / `ws.noop()`). Blocks for the lifetime of the connection; call from `conc.spawn`.
+
+`net.dial_ws_actor(url, subprotocol, name, on_open, on_message)` — like `dial_ws` but also registers the live connection in the `conc` registry under `name`. Any actor can push frames proactively via `conc.tell(conc.lookup(name), frame_str)` — the runtime forwards them to the socket on the next read-timeout tick (50 ms). Use for CP simulators, heartbeat loops, and any client that needs to send unsolicited frames without changing the `on_message` signature. Unregisters automatically on disconnect.
+```lex
+import "std.conc" as conc
+import "lex-web/ws" as ws
+
+fn run(url :: Str) -> [net, time, concurrent] Result[Unit, Str] {
+  net.dial_ws_actor(url, "ocpp1.6", "cp:001",
+    fn () -> [time, concurrent] WsAction { ws.send("[2,\"1\",\"BootNotification\",{}]") },
+    fn (m :: WsMessage) -> [time, concurrent] WsAction {
+      match m { WsText(_) => ws.noop(), _ => ws.noop() }
+    })
+}
+```
+
 ### `std.crypto`
 `hash`, `random` — `random` requires `[random]` effect.
 

--- a/docs/AGENT_GUIDELINES.md
+++ b/docs/AGENT_GUIDELINES.md
@@ -318,6 +318,26 @@ runtime does not treat this as a hung effect.
 For connection pooling, pub/sub fan-out helpers, and work-queue retry
 logic use `lex-queue`, which builds on top of `std.redis`.
 
+### 3.8 WebSocket clients: `net.dial_ws` / `net.dial_ws_actor` (SHOULD)
+
+Both functions block for the lifetime of the connection — call them from
+`conc.spawn`.
+
+`net.dial_ws(url, subprotocol, on_open, on_message)` — reactive client.
+Each callback returns exactly one `WsAction` (`ws.send(frame)` or
+`ws.noop()`). No proactive sends beyond that one return value.
+
+`net.dial_ws_actor(url, subprotocol, name, on_open, on_message)` — same
+reactive interface, plus the connection is registered in the `conc`
+registry under `name`. Other actors (heartbeat loops, meter-value timers)
+can push frames at any time via `conc.tell(conc.lookup(name), frame_str)`;
+the runtime delivers them on the next 50 ms read-timeout tick.
+Unregisters automatically on disconnect.
+
+Use `dial_ws_actor` whenever the client must send unsolicited frames
+(OCPP Heartbeat, OCPP MeterValues, keep-alives). Use `dial_ws` for
+purely request/response clients.
+
 ---
 
 ## 4. The repair-not-regenerate rule


### PR DESCRIPTION
## Summary

- **`\uXXXX` JSON decode** — Ollama encodes `>` as `>` in tool-call argument strings. The Lex JSON parser returned `Err` for these, causing `parse_stream` to silently skip the entire tool-calls line (only `FinishDelta` produced, no `TCBegin`/`TCArgs`). Fix: preprocess raw HTTP body through `decode_unicode_escapes` before splitting into lines.
- **`io.write` relative-path fix** — `--allow-fs-write /some/path` check was comparing bare filenames like `list_utils.lex` against absolute prefixes; relative paths never matched. Fix: resolve against `current_dir()` before allowlist check.
- **`io.readline` / `io.argv` effects** — new handlers + type signatures so Lex programs can read stdin lines and CLI args passed after `--`.
- **`lex run <file> -- [args]` syntax** — `--` separator; args go to `io.argv()`; defaults fn to `main`.
- **`http_stream_agent` long timeout** — local models (Ollama thinking mode) can take minutes; raises body-read timeout to 10 min.
- **Compiler fixes**: qualified constructor names in `canonicalize.rs`; single-variant union without `|` in `parser.rs`; empty-tuple pattern as Unit in `checker.rs`.

## Test plan

- [ ] `cargo test --workspace` green
- [ ] `lex run --allow-effects net,llm,io,proc,... --allow-net-host localhost src/tui/main.lex main -- --ollama "task"` dispatches tool calls end-to-end with `gemma4:latest`
- [ ] Relative-path writes inside `--allow-fs-write` prefix succeed; writes outside fail with the expected error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)