### PR TITLE
test(m8): poll /v1/health for server readiness instead of 20ms sleep

### DIFF
--- a/crates/lex-api/tests/m8.rs
+++ b/crates/lex-api/tests/m8.rs
@@ -36,9 +36,34 @@ fn start_server() -> (Server, TempDir) {
     let join = thread::spawn(move || {
         lex_api::serve_on(server, state);
     });
-    // Give the OS a moment to actually start listening.
-    thread::sleep(Duration::from_millis(20));
+    // The kernel listener is already bound when `Server::http` returns,
+    // so `connect()` succeeds immediately — but the serve thread may
+    // not yet be inside its `recv()` loop. Under fresh-compile +
+    // parallel test launch the spawned thread can stay CPU-starved
+    // past the 5s client read timeout, leaving the test panicking at
+    // `s.read_to_string(&mut buf).unwrap()`. Sleeping a fixed 20ms
+    // didn't survive heavy CI load; poll `/v1/health` until it
+    // actually responds.
+    wait_until_serving(&addr);
     (Server { addr, _join: Some(join), _server_holder: Arc::new(()) }, tmp)
+}
+
+fn wait_until_serving(addr: &SocketAddr) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    let probe = b"GET /v1/health HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n";
+    while std::time::Instant::now() < deadline {
+        if let Ok(mut s) = TcpStream::connect_timeout(addr, Duration::from_millis(200)) {
+            s.set_read_timeout(Some(Duration::from_millis(200))).ok();
+            if s.write_all(probe).is_ok() {
+                let mut buf = [0u8; 16];
+                if s.read(&mut buf).is_ok() && buf.starts_with(b"HTTP/1.1 200") {
+                    return;
+                }
+            }
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+    panic!("test server never became ready within 10s");
 }
 
 fn http(addr: &SocketAddr, method: &str, path: &str, body: &str) -> (u16, String) {


### PR DESCRIPTION
## Summary

Follow-up promised on #509: replaces the brittle 20ms warm-up sleep in `m8.rs::start_server` with a `/v1/health` poll, so heavy CI launches stop tripping the 5s client read timeout.

## Diagnosis

`tiny_http::Server::http(...)` returns the moment the kernel listener is bound, so `TcpStream::connect()` from the test client succeeds immediately. The spawned thread that actually drains `recv()` and dispatches handlers, though, isn't guaranteed to be scheduled — under fresh-compile + 4-way parallel test launch on GHA it can stay CPU-starved for several seconds. The client's 5s read timeout fires first, surfacing as:

```
thread 'merge_commit_advances_dst_branch_after_take_theirs' panicked at
crates/lex-api/tests/m8.rs:53:32:
called `Result::unwrap()` on an `Err` value: Os { code: 11, kind: WouldBlock, message: "Resource temporarily unavailable" }
```

Reproducible (intermittently) on `main` under fresh `cargo clean` + parallel launch. Four tests have been observed flaking:
- `merge_commit_advances_dst_branch_after_take_theirs`
- `merge_commit_with_custom_resolution_lands_agent_supplied_stage`
- `merge_commit_rejects_custom_op_targeting_wrong_sig`
- `agent_loop_publish_run_trace_diff`

## Fix

`wait_until_serving(addr)`: connect-with-timeout + write a `GET /v1/health` + read until the response starts with `HTTP/1.1 200`. 20ms back-off, 10s overall deadline. Panics with a clear message if the deadline lapses (so a real "server never came up" stays detectable, doesn't get masked).

Same pattern as the lex-search fix in #498 (9694cb0).

## Test plan

- [x] `cargo test -p lex-api --test m8 -- --test-threads=4` — 29/29 pass locally in 4.11s
- [ ] CI green


---
_Generated by [Claude Code](https://claude.ai/code/session_01NjQc3kQTQXm97YX22kfwsU)_