### PR TITLE
perf(#461): superinstructions slice 4 — LoadLocalSubLocal + LoadLocalMulLocal (1.8x sub, 1.87x mul)

### DIFF
--- a/crates/lex-bytecode/benches/dispatch.rs
+++ b/crates/lex-bytecode/benches/dispatch.rs
@@ -235,6 +235,8 @@ criterion_group!(
     bench_straight_arith_no_dispatch,
     bench_pure_dispatch,
     bench_two_local_arith,
+    bench_two_local_sub_arith,
+    bench_two_local_mul_arith,
 );
 criterion_main!(benches);
 
@@ -289,6 +291,69 @@ fn bench_two_local_arith(c: &mut Criterion) {
         });
     }
     group.finish();
+}
+
+/// Sibling of `bench_two_local_arith` for the `IntSub` shape
+/// (#461 slice 4). Same source pattern but with `-` instead of `+`,
+/// so each let-binding compiles to `LoadLocal + LoadLocal + IntSub +
+/// StoreLocal`; slice 4 collapses the first three into
+/// `LoadLocalSubLocal`. Isolated bench so the slice-4 dispatch saving
+/// is the only superinstruction that fires.
+fn bench_two_local_sub_arith(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dispatch/two_local_sub_arith");
+    for n in [100usize, 1_000, 5_000] {
+        let prog = compile(&make_two_local_binop_source(n, "-"));
+        group.throughput(Throughput::Elements((4 * n) as u64));
+        group.bench_function(format!("n={n}"), |b| {
+            b.iter(|| {
+                let mut vm = Vm::new(&prog);
+                vm.set_step_limit(u64::MAX);
+                black_box(
+                    vm.call("two_local_binop", vec![Value::Int(0), Value::Int(0)])
+                        .expect("call two_local_binop (-)"),
+                )
+            })
+        });
+    }
+    group.finish();
+}
+
+/// Sibling of `bench_two_local_arith` for the `IntMul` shape
+/// (#461 slice 4). Seeded with `1, 1` so the running product stays
+/// `1` and we don't overflow — the dispatch shape is the same
+/// regardless of the values, and that's what we're measuring.
+fn bench_two_local_mul_arith(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dispatch/two_local_mul_arith");
+    for n in [100usize, 1_000, 5_000] {
+        let prog = compile(&make_two_local_binop_source(n, "*"));
+        group.throughput(Throughput::Elements((4 * n) as u64));
+        group.bench_function(format!("n={n}"), |b| {
+            b.iter(|| {
+                let mut vm = Vm::new(&prog);
+                vm.set_step_limit(u64::MAX);
+                black_box(
+                    vm.call("two_local_binop", vec![Value::Int(1), Value::Int(1)])
+                        .expect("call two_local_binop (*)"),
+                )
+            })
+        });
+    }
+    group.finish();
+}
+
+/// Generalised version of `make_two_local_arith_source` for slice 4
+/// — emits the same chain shape (each `a{i}` := previous-local OP
+/// step), parameterised on the binary operator string.
+fn make_two_local_binop_source(n: usize, op: &str) -> String {
+    let mut s = String::with_capacity(48 * n);
+    s.push_str("fn two_local_binop(start :: Int, step :: Int) -> Int {\n");
+    s.push_str("  let a0 := start\n");
+    for i in 1..=n {
+        s.push_str(&format!("  let a{i} := a{} {op} step\n", i - 1));
+    }
+    s.push_str(&format!("  a{n}\n"));
+    s.push_str("}\n");
+    s
 }
 
 /// Pure-dispatch microbench: hand-built `Program` whose body is N

--- a/crates/lex-bytecode/src/compiler.rs
+++ b/crates/lex-bytecode/src/compiler.rs
@@ -251,11 +251,15 @@ pub fn compile_program(stages: &[a::Stage]) -> Program {
     // (LoadLocal + LoadLocal + IntAdd) is disjoint from both — its
     // second slot is LoadLocal, not PushConst — so it can run in
     // either order. Run it last to keep the slice 1/2 contract
-    // (slice 2 expects to see slice-1 output) untouched.
+    // (slice 2 expects to see slice-1 output) untouched. Slice 4 is
+    // slice 3 for IntSub / IntMul (same pattern, different terminator);
+    // disjoint from every prior slice because the terminator op
+    // disambiguates, so order between slice 3 and slice 4 is free.
     for f in p.functions.iter_mut() {
         apply_peephole(&mut f.code, &pool.pool);
         apply_peephole_slice2(&mut f.code);
         apply_peephole_slice3(&mut f.code);
+        apply_peephole_slice4(&mut f.code);
     }
 
     // Final pass: stamp every function with its content hash now that
@@ -399,6 +403,46 @@ fn apply_peephole_slice3(code: &mut [Op]) {
                 code[k] = Op::LoadLocalAddLocal { lhs_idx, rhs_idx };
                 k += 3;
                 continue;
+            }
+        }
+        k += 1;
+    }
+}
+
+/// Slice 4: slice 3 for `IntSub` and `IntMul`. Fuses
+/// `[LoadLocal(lhs), LoadLocal(rhs), IntSub]` to
+/// `LoadLocalSubLocal { lhs_idx, rhs_idx }` and the `IntMul` shape
+/// to `LoadLocalMulLocal`. Same tombstone, jump-safety, and
+/// body-hash story as slice 3 — the trailing two slots stay as
+/// inert primitives with cancelling stack deltas.
+///
+/// Disjoint from every prior slice: slice 1/2 require a `PushConst`
+/// at slot 2 (here it's `LoadLocal`), and slice 3's terminator is
+/// `IntAdd` (here it's `IntSub` / `IntMul`). A given site matches at
+/// most one slice.
+fn apply_peephole_slice4(code: &mut [Op]) {
+    if code.len() < 3 { return; }
+    let jump_targets = collect_jump_targets(code);
+
+    let n = code.len();
+    let mut k = 0;
+    while k + 2 < n {
+        if let (Op::LoadLocal(lhs_idx), Op::LoadLocal(rhs_idx), terminator)
+            = (code[k], code[k + 1], code[k + 2])
+        {
+            let fused = match terminator {
+                Op::IntSub => Some(Op::LoadLocalSubLocal { lhs_idx, rhs_idx }),
+                Op::IntMul => Some(Op::LoadLocalMulLocal { lhs_idx, rhs_idx }),
+                _ => None,
+            };
+            if let Some(fused_op) = fused {
+                let safe = !jump_targets.contains(&(k + 1))
+                    && !jump_targets.contains(&(k + 2));
+                if safe {
+                    code[k] = fused_op;
+                    k += 3;
+                    continue;
+                }
             }
         }
         k += 1;

--- a/crates/lex-bytecode/src/op.rs
+++ b/crates/lex-bytecode/src/op.rs
@@ -166,4 +166,19 @@ pub enum Op {
     /// (+1 LoadLocal, -1 IntAdd) cancel, matching the unfused depth
     /// at pc+3.
     LoadLocalAddLocal { lhs_idx: u16, rhs_idx: u16 },
+    /// Fused `LoadLocal(lhs_idx) + LoadLocal(rhs_idx) + IntSub`
+    /// (#461 superinstruction slice 4). Sibling of `LoadLocalAddLocal`
+    /// for the typed `Int` subtraction binop — fires on any `a - b`
+    /// where both operands are `Int` locals. Reads `locals[lhs_idx]`
+    /// and `locals[rhs_idx]`, pushes `lhs - rhs`, advances pc by 3.
+    /// Stack delta: +1. Tombstone + body-hash story matches
+    /// `LoadLocalAddLocal` exactly.
+    LoadLocalSubLocal { lhs_idx: u16, rhs_idx: u16 },
+    /// Fused `LoadLocal(lhs_idx) + LoadLocal(rhs_idx) + IntMul`
+    /// (#461 superinstruction slice 4). Sibling of `LoadLocalAddLocal`
+    /// for the typed `Int` multiplication binop. Same shape: reads
+    /// the two Int locals, pushes `lhs * rhs`, advances pc by 3.
+    /// Stack delta: +1. Tombstone + body-hash story matches
+    /// `LoadLocalAddLocal` exactly.
+    LoadLocalMulLocal { lhs_idx: u16, rhs_idx: u16 },
 }

--- a/crates/lex-bytecode/src/program.rs
+++ b/crates/lex-bytecode/src/program.rs
@@ -161,16 +161,19 @@ pub fn compute_body_hash(
             // stays invariant across peephole rewrites.
             Op::LoadLocalAddIntConst { local_idx, .. }
             | Op::LoadLocalAddIntConstStoreLocal { src: local_idx, .. }
-            | Op::LoadLocalAddLocal { lhs_idx: local_idx, .. } => {
+            | Op::LoadLocalAddLocal { lhs_idx: local_idx, .. }
+            | Op::LoadLocalSubLocal { lhs_idx: local_idx, .. }
+            | Op::LoadLocalMulLocal { lhs_idx: local_idx, .. } => {
                 // Slice 1: this slot was `LoadLocal(local_idx)`.
                 // Slice 2: this slot was *also* `LoadLocal(src)`
                 // — the fused op now owns 4 slots, but the very
                 // first one was originally `LoadLocal`. Slice 3:
-                // ditto for `LoadLocal(lhs_idx)`. The trailing
-                // primitive ops (PushConst / IntAdd / StoreLocal /
-                // LoadLocal) remain in the code stream as tombstones
-                // and hash normally, so the total byte stream
-                // matches pre-fusion.
+                // ditto for `LoadLocal(lhs_idx)`. Slice 4: same
+                // shape as slice 3, just with IntSub / IntMul as
+                // terminator. The trailing primitive ops (PushConst
+                // / IntAdd / IntSub / IntMul / StoreLocal / LoadLocal)
+                // remain in the code stream as tombstones and hash
+                // normally, so the total byte stream matches pre-fusion.
                 serde_json::to_vec(&Op::LoadLocal(*local_idx))
                     .expect("Op serialization must succeed")
             }

--- a/crates/lex-bytecode/src/verify.rs
+++ b/crates/lex-bytecode/src/verify.rs
@@ -219,6 +219,10 @@ fn stack_delta(op: &Op) -> i32 {
         // (LoadLocal + IntAdd) have deltas +1 and -1 — they cancel
         // when walked as live, mirroring slice 1's shape.
         Op::LoadLocalAddLocal { .. } => 1,
+        // Slice-4 fused ops: identical shape to slice 3, just with
+        // IntSub / IntMul as terminator. Net delta +1; trailing
+        // LoadLocal + IntSub|IntMul tombstones cancel when walked.
+        Op::LoadLocalSubLocal { .. } | Op::LoadLocalMulLocal { .. } => 1,
     }
 }
 

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -1536,6 +1536,20 @@ impl<'a> Vm<'a> {
                     // pass left in place for body-hash stability.
                     self.frames[frame_idx].pc = pc + 3;
                 }
+                Op::LoadLocalSubLocal { lhs_idx, rhs_idx } => {
+                    let base = self.frames[frame_idx].locals_start;
+                    let a = self.locals_storage[base + lhs_idx as usize].as_int();
+                    let b = self.locals_storage[base + rhs_idx as usize].as_int();
+                    self.stack.push(Value::Int(a - b));
+                    self.frames[frame_idx].pc = pc + 3;
+                }
+                Op::LoadLocalMulLocal { lhs_idx, rhs_idx } => {
+                    let base = self.frames[frame_idx].locals_start;
+                    let a = self.locals_storage[base + lhs_idx as usize].as_int();
+                    let b = self.locals_storage[base + rhs_idx as usize].as_int();
+                    self.stack.push(Value::Int(a * b));
+                    self.frames[frame_idx].pc = pc + 3;
+                }
                 Op::LoadLocalAddIntConstStoreLocal { src, imm_const_idx, dest } => {
                     let base = self.frames[frame_idx].locals_start;
                     let a = self.locals_storage[base + src as usize].as_int();

--- a/crates/lex-bytecode/tests/run.rs
+++ b/crates/lex-bytecode/tests/run.rs
@@ -143,6 +143,68 @@ fn slice3_fuses_two_local_add_and_runs_correctly() {
 }
 
 #[test]
+fn slice4_fuses_two_local_sub_and_runs_correctly() {
+    // #461 slice 4: same shape as slice 3 but for `IntSub`. Must
+    // rewrite to `Op::LoadLocalSubLocal`, leave tombstones in place,
+    // and compute lhs - rhs.
+    use lex_bytecode::op::Op;
+    let src = "fn sub_them(a :: Int, b :: Int) -> Int { a - b }\n";
+    let p = compile(src);
+    let f = &p.functions[0];
+    assert!(
+        matches!(f.code[0], Op::LoadLocalSubLocal { lhs_idx: 0, rhs_idx: 1 }),
+        "slice 4 (sub) did not fire; got {:?}", f.code[0],
+    );
+    assert!(matches!(f.code[1], Op::LoadLocal(1)));
+    assert!(matches!(f.code[2], Op::IntSub));
+    assert!(matches!(f.code[3], Op::Return));
+
+    let mut vm = Vm::new(&p);
+    let r = vm.call("sub_them", vec![Value::Int(42), Value::Int(7)]).unwrap();
+    assert_eq!(r, Value::Int(35));
+}
+
+#[test]
+fn slice4_fuses_two_local_mul_and_runs_correctly() {
+    use lex_bytecode::op::Op;
+    let src = "fn mul_them(a :: Int, b :: Int) -> Int { a * b }\n";
+    let p = compile(src);
+    let f = &p.functions[0];
+    assert!(
+        matches!(f.code[0], Op::LoadLocalMulLocal { lhs_idx: 0, rhs_idx: 1 }),
+        "slice 4 (mul) did not fire; got {:?}", f.code[0],
+    );
+    assert!(matches!(f.code[1], Op::LoadLocal(1)));
+    assert!(matches!(f.code[2], Op::IntMul));
+    assert!(matches!(f.code[3], Op::Return));
+
+    let mut vm = Vm::new(&p);
+    let r = vm.call("mul_them", vec![Value::Int(6), Value::Int(7)]).unwrap();
+    assert_eq!(r, Value::Int(42));
+}
+
+#[test]
+fn slice4_does_not_fire_across_a_jump_target() {
+    // Mirror of `slice3_does_not_fire_across_a_jump_target` for sub/mul.
+    // A `match`-arm body straddles a JumpIfNot target, so if the
+    // jump-safety check ever regressed the call would panic or return
+    // junk.
+    let src = "
+fn pick(flag :: Int, a :: Int, b :: Int) -> Int {
+  match flag {
+    0 => a - b,
+    1 => a * b,
+    _ => a,
+  }
+}";
+    let p = compile(src);
+    let mut vm = Vm::new(&p);
+    assert_eq!(vm.call("pick", vec![Value::Int(0), Value::Int(10), Value::Int(3)]).unwrap(), Value::Int(7));
+    assert_eq!(vm.call("pick", vec![Value::Int(1), Value::Int(10), Value::Int(3)]).unwrap(), Value::Int(30));
+    assert_eq!(vm.call("pick", vec![Value::Int(9), Value::Int(10), Value::Int(3)]).unwrap(), Value::Int(10));
+}
+
+#[test]
 fn slice3_does_not_fire_across_a_jump_target() {
     // Safety check: if the second or third slot of the candidate
     // triple is a jump target, slice 3 must skip the fusion — a


### PR DESCRIPTION
## Summary

Slice 4 of the #461 superinstruction series. Mirrors slice 3 (#509) for the other typed Int binops: fuses `LoadLocal(lhs) + LoadLocal(rhs) + IntSub` into `Op::LoadLocalSubLocal`, and the `IntMul` shape into `Op::LoadLocalMulLocal`. Same tombstone + body-hash strategy, same jump-safety check.

Disjoint from every prior slice:
- slice 1/2 require `PushConst` at slot 2 (here it's `LoadLocal`)
- slice 3's terminator is `IntAdd` (here it's `IntSub` / `IntMul`)

A site matches at most one slice; runs after slice 3 to keep the existing pipeline shape.

## Bench

Two new sibling benches (`dispatch/two_local_sub_arith`, `dispatch/two_local_mul_arith`), built off a `make_two_local_binop_source` helper parameterised on the operator. Measured by toggling slice 4 off/on:

| Bench                       | Baseline  | Slice 4   | Speedup |
|-----------------------------|-----------|-----------|---------|
| two_local_sub_arith / n=5k  | 292.37 µs | 162.80 µs | **1.80×** |
| two_local_mul_arith / n=5k  | 304.44 µs | 162.59 µs | **1.87×** |

Both above slice 3's reference 1.69× — same dispatch saving, slightly cleaner variance. With slice 4 on, all three two-local-binop ops land within ~0.6% of each other (~163 µs / ~123 Melem/s), confirming dispatch is now the floor for this shape.

## Acceptance per #461

- [x] ≥ 1× speedup on a new microbench: 1.80× sub, 1.87× mul
- [x] No regression on `cargo test -p lex-bytecode`: 12 passed including `bytecode_is_reproducible` and the new slice-4 fusion + jump-safety tests
- [x] No regression on `cargo test -p lex-runtime`: all integration test binaries green (only ignored tests are the pre-existing WS server-registration race)
- [x] No bytecode-format change; `compute_body_hash` decomposes both new ops to `LoadLocal(lhs_idx)`, total bytes match pre-fusion form
- [x] Clippy clean

## Followups (not in this PR)

From `docs/design/dispatch-overhead-measurement.md`, still uncovered:
- `LoadLocal + IntLt + JumpIfNot` (loop-condition idiom) — needs jump-aware fusion; deferred.
- `PushConst + IntEq + JumpIfNot` (pattern-match arm test) — blocked on lowering `NumEq → IntEq` in `compile_pattern_test`.
- Slice-2-style companion fusing `[LoadLocalAddLocal, _, _, StoreLocal]` and siblings for sub/mul — composes on top of slices 3/4 the way slice 2 sits on slice 1.

## Test plan

- [x] `cargo test -p lex-bytecode` (12 tests, includes bytecode_is_reproducible)
- [x] `cargo test -p lex-runtime` (all integration test binaries green)
- [x] `cargo clippy -p lex-bytecode --all-targets -- -D warnings`
- [ ] CI green on workspace


---
_Generated by [Claude Code](https://claude.ai/code/session_01NjQc3kQTQXm97YX22kfwsU)_