### PR TITLE
perf(#462): IC verification keyed on shape_id, drops per-hit string compare

### DIFF
--- a/crates/lex-bytecode/benches/dispatch.rs
+++ b/crates/lex-bytecode/benches/dispatch.rs
@@ -105,6 +105,49 @@ fn bench_record_field(c: &mut Criterion) {
     group.finish();
 }
 
+/// Wider sibling of `bench_record_field` (#462). 10 GetFields per
+/// iteration instead of 3, on a 10-field record — amplifies the
+/// IC's per-hit verification cost relative to the iteration's
+/// TailCall frame setup. With shape_id-keyed verification the hot
+/// path is `cached_shape == record.shape_id` (single u32 compare)
+/// instead of `field_name_at(offset) == requested_name_const`
+/// (IndexMap lookup + Const::FieldName unwrap + SmolStr cmp).
+fn bench_record_field_wide(c: &mut Criterion) {
+    let src = r#"
+type Wide = { a :: Int, b :: Int, c :: Int, d :: Int, e :: Int,
+               f :: Int, g :: Int, h :: Int, i :: Int, j :: Int }
+
+fn sum_wide(w :: Wide, n :: Int, acc :: Int) -> Int {
+  match n {
+    0 => acc,
+    _ => sum_wide(w, n - 1, acc + w.a + w.b + w.c + w.d + w.e
+                                + w.f + w.g + w.h + w.i + w.j),
+  }
+}
+
+fn bench(n :: Int) -> Int {
+  let w :: Wide := { a: 1, b: 2, c: 3, d: 4, e: 5,
+                     f: 6, g: 7, h: 8, i: 9, j: 10 }
+  sum_wide(w, n, 0)
+}
+"#;
+    let prog = compile(src);
+    let mut group = c.benchmark_group("dispatch/record_field_wide");
+    for n in [100i64, 1_000, 10_000] {
+        group.bench_function(format!("n={n}"), |b| {
+            b.iter(|| {
+                let mut vm = Vm::new(&prog);
+                vm.set_step_limit(u64::MAX);
+                black_box(
+                    vm.call("bench", vec![Value::Int(n)])
+                        .expect("call bench"),
+                )
+            })
+        });
+    }
+    group.finish();
+}
+
 fn bench_call_heavy(c: &mut Criterion) {
     let prog = compile(CALL_HEAVY_SRC);
     let mut group = c.benchmark_group("dispatch/call_heavy");
@@ -237,6 +280,7 @@ criterion_group!(
     bench_two_local_arith,
     bench_two_local_sub_arith,
     bench_two_local_mul_arith,
+    bench_record_field_wide,
 );
 criterion_main!(benches);
 

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -199,14 +199,30 @@ pub struct Vm<'a> {
     /// Diagnostic counters for `--trace` observability (#229).
     pub pure_memo_hits: u64,
     pub pure_memo_misses: u64,
-    /// Monomorphic inline caches for `Op::GetField` (#462 slice 1).
-    /// Indexed by `[fn_id as usize][site_idx as usize]` — one entry
-    /// per field-access site within each function. `site_idx` is
-    /// assigned at compile time by `FnCompiler::field_get_sites` so
-    /// every emit produces a stable identifier independent of pc.
-    /// The cache survives the planned dispatch rewrite (#461) and a
-    /// future JIT (#465). Replaces the pre-#462 monomorphic
-    /// `HashMap<(fn_id << 32 | pc), usize>`.
+    /// Monomorphic inline caches for `Op::GetField` (#462 slice 1 +
+    /// shape-keyed verification slice). Indexed by
+    /// `[fn_id as usize][site_idx as usize]` — one entry per
+    /// field-access site within each function. `site_idx` is assigned
+    /// at compile time by `FnCompiler::field_get_sites` so every emit
+    /// produces a stable identifier independent of pc. The cache
+    /// survives the planned dispatch rewrite (#461) and a future
+    /// JIT (#465).
+    ///
+    /// Slot shape: `(shape_id, offset)`. The pre-shape-keyed slice
+    /// stored only the offset and re-verified each hit by walking
+    /// `IndexMap::get_index(off)` and string-comparing the field name
+    /// against the requested `name_idx`. After this slice, hits
+    /// against compile-time records (real `shape_id`) verify with a
+    /// single `u32` compare and skip the string compare entirely —
+    /// per the #462 slice-2b measurement that observed 0% polymorphism
+    /// and 86% of hits going to records with a real shape_id.
+    ///
+    /// `NO_SHAPE_ID` records (JSON / SQL / HTTP-built — 14% of measured
+    /// hits, 100% of inbox/gateway traffic) fall through to the
+    /// pre-slice name-compare verification. Distinct dynamic shapes
+    /// both carry `NO_SHAPE_ID` and would otherwise alias on a
+    /// pure-shape-keyed IC; keeping the name compare on that path
+    /// preserves correctness without a separate cache for them.
     ///
     /// Outer Vec is pre-sized to `program.functions.len()`; each inner
     /// Vec is empty until the first GetField in that function runs,
@@ -214,7 +230,7 @@ pub struct Vm<'a> {
     /// `field_ic_sites` size and never resize again. Lazy on the inner
     /// side so VMs created for short-lived scripts don't eagerly
     /// allocate IC slots for functions they never enter.
-    field_ics: Vec<Vec<Option<usize>>>,
+    field_ics: Vec<Vec<Option<(u32, usize)>>>,
     /// Stack allocator for function locals (#389 slice 3).
     ///
     /// Every function frame claims `locals_count` contiguous slots from
@@ -913,18 +929,22 @@ impl<'a> Vm<'a> {
                             if ic_stats_enabled() {
                                 record_ic_hit(fn_id, site_idx, shape_id);
                             }
-                            // Inline cache keyed by (fn_id, site_idx) — #462
-                            // slice 1. Direct array index instead of the
-                            // pre-#462 `HashMap<(fn_id << 32 | pc), usize>`.
-                            // The inner Vec is empty until first GetField in
-                            // this function runs; we one-shot allocate it to
-                            // the compiler-recorded site count and never
-                            // resize again. After init, the hot path is two
-                            // array dereferences. On hit: verify the cached
-                            // offset still points at the requested field
-                            // (name compare — shape_id propagation is the
-                            // next slice). On miss: walk the IndexMap by
-                            // name, populate.
+                            // Inline cache keyed by (fn_id, site_idx) with
+                            // shape_id-keyed verification (#462). Slot stores
+                            // (shape_id_at_install, offset). Hit verification:
+                            // - real shape_id (!= NO_SHAPE_ID) matches: offset
+                            //   is guaranteed valid (records with the same
+                            //   shape_id share the same field-name ordering
+                            //   from the compile-time `record_shapes` table).
+                            //   One u32 compare; no string work.
+                            // - NO_SHAPE_ID matches NO_SHAPE_ID: distinct
+                            //   dynamic shapes both carry this sentinel and
+                            //   would otherwise alias, so we fall back to
+                            //   verifying via name compare against the field
+                            //   at the cached offset — the pre-slice
+                            //   correctness path.
+                            // On any mismatch we walk by name and reinstall
+                            // (shape_id, offset).
                             let fid = fn_id as usize;
                             let sid = site_idx as usize;
                             if self.field_ics[fid].is_empty() {
@@ -933,16 +953,25 @@ impl<'a> Vm<'a> {
                             }
                             let cached = self.field_ics[fid][sid];
                             let value = 'ic: {
-                                if let Some(off) = cached {
-                                    if let Some((k, val)) = r.get_index(off) {
-                                        if let Const::FieldName(s) =
-                                            &self.program.constants[name_idx as usize]
-                                        {
-                                            if s == k { break 'ic val.clone(); } // cache hit
+                                if let Some((cached_shape, off)) = cached {
+                                    if cached_shape == shape_id {
+                                        if shape_id != crate::value::NO_SHAPE_ID {
+                                            // Real shape match: offset is sound.
+                                            if let Some((_, val)) = r.get_index(off) {
+                                                break 'ic val.clone();
+                                            }
+                                        } else if let Some((k, val)) = r.get_index(off) {
+                                            // Dynamic shape: verify by name.
+                                            if let Const::FieldName(s) =
+                                                &self.program.constants[name_idx as usize]
+                                            {
+                                                if s == k { break 'ic val.clone(); }
+                                            }
                                         }
                                     }
                                 }
-                                // Cache miss: resolve by name, populate IC.
+                                // Cache miss: resolve by name, install
+                                // (shape_id, offset).
                                 let name = match &self.program.constants[name_idx as usize] {
                                     Const::FieldName(s) => s.as_str(),
                                     _ => return Err(VmError::TypeMismatch(
@@ -951,7 +980,7 @@ impl<'a> Vm<'a> {
                                 let (off, _, val) = r.get_full(name)
                                     .ok_or_else(|| VmError::TypeMismatch(
                                         format!("missing field `{name}`")))?;
-                                self.field_ics[fid][sid] = Some(off);
+                                self.field_ics[fid][sid] = Some((shape_id, off));
                                 val.clone()
                             };
                             self.stack.push(value);


### PR DESCRIPTION
## Summary

First active slice on #462 since slice 2a wired the `shape_id` field. The IC has been carrying `Value::Record.shape_id` since #502 but **ignoring it on hit verification** — every IC hit pays a `r.get_index(off)` + `Const::FieldName` unwrap + `SmolStr` compare to validate the cached offset.

This slice switches verification to a single `u32` compare on `shape_id`, with a name-compare fallback for `NO_SHAPE_ID` (dynamic) records since distinct dynamic shapes alias on the sentinel.

## Why now

The slice-2b measurement found:
- 0% polymorphism (monomorphic IC is the right shape — no need for polymorphic slots yet)
- 86% of hits go to records with a real `shape_id` (compile-time `MakeRecord`)
- 14% land on NO_SHAPE_ID (JSON / SQL / HTTP-built dynamic records)

So a monomorphic IC keyed on shape_id captures the majority case directly, and the NO_SHAPE_ID fallback preserves correctness for the rest until slice 3 (dynamic shape interning) ships.

## Bench

New `dispatch/record_field_wide` (10 GetFields per iteration on a 10-field record) — the existing `bench_record_field` was TailCall-dominated and hid the IC delta:

| Bench                        | Baseline (main) | This branch | Speedup |
|------------------------------|-----------------|-------------|---------|
| record_field_wide / n=10000  | 60.40 ms        | 58.92 ms    | **1.025×** |

~15 ns saved per IC hit. Modest on this bench shape but consistent — the real value is infrastructural (see Followups).

## Correctness

IC slot now stores `(shape_id, offset)`:
- `cached_shape == shape_id && shape_id != NO_SHAPE_ID` → fast path, offset sound.
- `cached_shape == shape_id == NO_SHAPE_ID` → name-compare fallback (pre-slice path).
- Mismatch → walk by name, reinstall `(shape_id, offset)`.

`cargo test -p lex-runtime --tests` exercises the NO_SHAPE_ID fallback through every JSON/SQL/HTTP dynamic-record path — all green.

## Followups (not in this PR)

- **Slice 3: dynamic shape interning.** Process-global shape registry; `Value::record_dynamic` / JSON decode / SQL row → record / HTTP body → record all consult it. The IC immediately starts hitting on the 14% of hits that currently fall back to name compare. No VM change needed once the registry lands.
- **Slice 2b polymorphic IC.** Becomes trivial once any workload shows real >5% polymorphism — the measurement doc has the trigger threshold.

## Test plan

- [x] `cargo test -p lex-bytecode` (12 tests, includes `bytecode_is_reproducible`)
- [x] `cargo test -p lex-runtime --tests` (all integration binaries green, exercises dynamic-record paths)
- [x] `cargo clippy -p lex-bytecode --all-targets -- -D warnings`
- [ ] CI green on workspace


---
_Generated by [Claude Code](https://claude.ai/code/session_01NjQc3kQTQXm97YX22kfwsU)_