### PR TITLE
perf(#462): dynamic shape interning — registry-backed shape_id for record_dynamic

### DIFF
--- a/crates/lex-bytecode/benches/dispatch.rs
+++ b/crates/lex-bytecode/benches/dispatch.rs
@@ -148,6 +148,64 @@ fn bench(n :: Int) -> Int {
     group.finish();
 }
 
+/// Slice-3 sibling of `bench_record_field_wide` (#462). Reads the
+/// same fields off a record built via `Value::record_dynamic`
+/// instead of an `Op::MakeRecord` site — i.e. the shape every
+/// HTTP / JSON / SQL record carries. Before slice 3 all such
+/// records aliased on `NO_SHAPE_ID` and the IC fell through to a
+/// per-hit name compare on every access. After slice 3 they share
+/// a real (registry-interned) `shape_id` and the IC fast path
+/// fires.
+fn bench_record_field_dynamic(c: &mut Criterion) {
+    use indexmap::IndexMap;
+    // Same hot loop as `_wide`, but `sum_wide` takes a parameter
+    // of opaque (untyped) `Record`-ish shape — the caller passes
+    // in the dynamic record directly so `Op::MakeRecord` doesn't
+    // run and the record's `shape_id` comes solely from the
+    // registry.
+    let src = r#"
+type Wide = { a :: Int, b :: Int, c :: Int, d :: Int, e :: Int,
+               f :: Int, g :: Int, h :: Int, i :: Int, j :: Int }
+
+fn sum_wide(w :: Wide, n :: Int, acc :: Int) -> Int {
+  match n {
+    0 => acc,
+    _ => sum_wide(w, n - 1, acc + w.a + w.b + w.c + w.d + w.e
+                                + w.f + w.g + w.h + w.i + w.j),
+  }
+}
+"#;
+    let prog = compile(src);
+    // Build the dynamic record once. The IC measures steady-state
+    // GetField cost on dynamic-flavored records; including registry
+    // interning + IndexMap alloc per iteration would swamp the IC
+    // delta.
+    let dyn_rec = {
+        let mut fields: IndexMap<String, Value> = IndexMap::new();
+        for (k, v) in [
+            ("a", 1i64), ("b", 2), ("c", 3), ("d", 4), ("e", 5),
+            ("f", 6), ("g", 7), ("h", 8), ("i", 9), ("j", 10),
+        ] {
+            fields.insert(k.into(), Value::Int(v));
+        }
+        Value::record_dynamic(fields)
+    };
+    let mut group = c.benchmark_group("dispatch/record_field_dynamic");
+    for n in [100i64, 1_000, 10_000] {
+        group.bench_function(format!("n={n}"), |b| {
+            b.iter(|| {
+                let mut vm = Vm::new(&prog);
+                vm.set_step_limit(u64::MAX);
+                black_box(
+                    vm.call("sum_wide", vec![dyn_rec.clone(), Value::Int(n), Value::Int(0)])
+                        .expect("call sum_wide"),
+                )
+            })
+        });
+    }
+    group.finish();
+}
+
 fn bench_call_heavy(c: &mut Criterion) {
     let prog = compile(CALL_HEAVY_SRC);
     let mut group = c.benchmark_group("dispatch/call_heavy");
@@ -281,6 +339,7 @@ criterion_group!(
     bench_two_local_sub_arith,
     bench_two_local_mul_arith,
     bench_record_field_wide,
+    bench_record_field_dynamic,
 );
 criterion_main!(benches);
 

--- a/crates/lex-bytecode/src/lib.rs
+++ b/crates/lex-bytecode/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod op;
 pub mod program;
 pub mod value;
+pub mod shape_registry;
 pub mod compiler;
 pub mod conc_registry;
 pub mod parser_runtime;

--- a/crates/lex-bytecode/src/shape_registry.rs
+++ b/crates/lex-bytecode/src/shape_registry.rs
@@ -1,0 +1,109 @@
+//! Process-global record-shape registry (#462 slice 3).
+//!
+//! Maps sorted field-name lists to stable `u32` shape IDs for records
+//! built at runtime — JSON decode, SQL row, HTTP body, host effect
+//! handlers, builtin returns. Anywhere `Value::record_dynamic` is
+//! called.
+//!
+//! Why: the slice-2b measurement (`docs/design/ic-polymorphism-measurement.md`)
+//! found 14% of GetField IC hits — and 100% of inbox/gateway/std_http
+//! traffic — landed on records carrying `NO_SHAPE_ID`. Those records
+//! all aliased on the sentinel, so the IC's shape-keyed verification
+//! (added in #517) couldn't distinguish them and fell through to the
+//! name-compare path on every hit. With this registry, dynamic records
+//! built from the same field set share a real `shape_id` and the IC
+//! hits cleanly amongst them.
+//!
+//! ## Disjoint ID spaces
+//!
+//! Compile-time `Op::MakeRecord` shape IDs come from
+//! `Program::record_shapes` and are per-program indices (0, 1, 2, …).
+//! Runtime registry IDs come from this module and live in the high
+//! half of the `u32` range starting at [`DYNAMIC_SHAPE_ID_BASE`].
+//! `NO_SHAPE_ID` (`u32::MAX`) is reserved.
+//!
+//! Disjoint spaces are required for IC correctness: the shape-keyed
+//! verifier in `vm.rs` treats `cached_shape == incoming_shape` as
+//! "offset is sound" for non-`NO_SHAPE_ID` cases. If a compile-time
+//! ID collided with a dynamic ID for a different field set, the IC
+//! would return values from the wrong field.
+//!
+//! ## Cost
+//!
+//! One `RwLock<IndexMap>` lookup per `record_dynamic` call. The map
+//! grows monotonically (shapes are never freed) but is small in
+//! practice — tens of distinct shapes per workload. Lookups are
+//! read-lock + hash; misses take the write lock once per new shape.
+//!
+//! ## Sorting
+//!
+//! The key is the sorted field-name vec — two records with the same
+//! fields in different insertion order share a `shape_id`. Matches
+//! the existing `Value::Record` `PartialEq` (which compares `IndexMap`
+//! contents structurally, ignoring `shape_id`), so equality and IC
+//! sharing line up.
+
+use indexmap::IndexMap;
+use std::sync::{OnceLock, RwLock};
+
+/// Base for dynamically-interned shape IDs. Chosen so that
+/// `Program::record_shapes` indices (which start at 0 and grow up)
+/// cannot collide with dynamic IDs even for pathologically large
+/// programs.  Compile-time records will hit a different IC slot
+/// outcome than dynamic records with the same field set — that's
+/// the cost of keeping ID spaces disjoint; the slice-2b
+/// measurement found 0 mixed-flavor sites in real workloads.
+pub const DYNAMIC_SHAPE_ID_BASE: u32 = 0x8000_0000;
+
+fn registry() -> &'static RwLock<IndexMap<Vec<String>, u32>> {
+    static REGISTRY: OnceLock<RwLock<IndexMap<Vec<String>, u32>>> = OnceLock::new();
+    REGISTRY.get_or_init(|| RwLock::new(IndexMap::new()))
+}
+
+/// Look up (or assign) the shape ID for the given field-name list.
+/// Same set of names — in any insertion order — yields the same ID
+/// for the lifetime of the process.
+pub fn intern(field_names: impl IntoIterator<Item = impl AsRef<str>>) -> u32 {
+    let mut key: Vec<String> = field_names.into_iter().map(|s| s.as_ref().to_string()).collect();
+    key.sort();
+    // Fast path: read-only lookup.
+    if let Some(&id) = registry().read().unwrap().get(&key) {
+        return id;
+    }
+    // Slow path: write-lock, re-check, insert.
+    let mut w = registry().write().unwrap();
+    if let Some(&id) = w.get(&key) {
+        return id;
+    }
+    let id = DYNAMIC_SHAPE_ID_BASE + w.len() as u32;
+    w.insert(key, id);
+    id
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_fields_yield_same_id_regardless_of_order() {
+        let a = intern(["x", "y", "z"]);
+        let b = intern(["z", "y", "x"]);
+        let c = intern(["y", "x", "z"]);
+        assert_eq!(a, b);
+        assert_eq!(b, c);
+    }
+
+    #[test]
+    fn distinct_fields_yield_distinct_ids() {
+        let a = intern(["a", "b"]);
+        let b = intern(["a", "c"]);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn ids_are_in_the_dynamic_range() {
+        let id = intern(["only_for_this_test"]);
+        assert!(id >= DYNAMIC_SHAPE_ID_BASE);
+        assert!(id < u32::MAX);
+    }
+}

--- a/crates/lex-bytecode/src/value.rs
+++ b/crates/lex-bytecode/src/value.rs
@@ -430,13 +430,25 @@ impl Value {
 
     /// Build a `Value::Record` whose fields don't come from an
     /// `Op::MakeRecord` site — JSON decode, SQL row → record, host
-    /// effect handlers, test fixtures, etc. The IC unconditionally
-    /// misses against `NO_SHAPE_ID`, which is the correct behavior
-    /// for records with no compile-time shape. Prefer this over
-    /// hand-rolling `Value::Record { shape_id: NO_SHAPE_ID, fields }`
-    /// so a future shape-interning slice has one place to retrofit.
+    /// effect handlers, test fixtures, etc. Interns the field-name
+    /// set in the process-global shape registry (#462 slice 3) so
+    /// records with the same set of field names share a stable
+    /// `shape_id` and hit the same IC slot. Two records with the
+    /// same fields in different insertion order share a `shape_id`
+    /// (the registry sorts the field-name vec before lookup),
+    /// matching the existing `Value::Record` structural-equality
+    /// semantics.
+    ///
+    /// Dynamic shape IDs live in the high half of the `u32` range
+    /// (see `crate::shape_registry::DYNAMIC_SHAPE_ID_BASE`) so they
+    /// can't collide with the per-program shape indices emitted by
+    /// `Op::MakeRecord`. Mixed-flavor IC sites (which the slice-2b
+    /// measurement found at exactly zero occurrences) would still
+    /// be correct under the IC's shape-keyed verifier — they'd just
+    /// churn the cache.
     pub fn record_dynamic(fields: IndexMap<String, Value>) -> Value {
-        Value::Record { shape_id: NO_SHAPE_ID, fields: Box::new(fields) }
+        let shape_id = crate::shape_registry::intern(fields.keys());
+        Value::Record { shape_id, fields: Box::new(fields) }
     }
 }
 


### PR DESCRIPTION
## Summary

Slice 3 of #462, follow-on to #517. The previous slice keyed IC verification on `shape_id` for the 86% of hits with real shape IDs (compile-time `Op::MakeRecord`); the 14% on `NO_SHAPE_ID` (dynamic records — JSON decode, SQL row, HTTP body, builtin returns) still fell through to per-hit name-compare.

This slice adds a process-global `shape_registry` keyed on sorted field-name vec. `Value::record_dynamic` consults it on every call and assigns a stable `u32` shape_id. Two dynamic records with the same field set (any insertion order) share an ID for the lifetime of the process. All 51 existing call sites of `record_dynamic` pick up the behavior with zero call-site churn.

## Disjoint ID spaces

- Dynamic IDs: `0x8000_0000..u32::MAX-1`
- Compile-time IDs: `0..0x8000_0000` (`Program::record_shapes` indices)
- `NO_SHAPE_ID = u32::MAX` reserved

Disjoint spaces are required for IC correctness: the cached-shape fast path doesn't re-verify field names. The slice-2b measurement found zero mixed-flavor IC sites in real workloads; if any appear, polymorphic IC (slice 2b proper) is the answer.

## Bench (honest framing)

`dispatch/record_field_dynamic` (new) — 10 GetFields per iteration on a pre-built `Value::record_dynamic` record:

| Bench                            | Baseline | This branch |
|----------------------------------|----------|-------------|
| record_field_dynamic / n=10000   | 59.22 ms | 58.80 ms    |

~0.7%, inside criterion noise on this synthetic shape. The slice is **infrastructural not perf-headline**:

1. Dynamic records of the same shape now share IC slots (direct improvement on HTTP/SQL workloads not in the synthetic suite).
2. Precondition for polymorphic IC (slice 2b proper).
3. Removes the `record_dynamic` → `NO_SHAPE_ID` asymmetry.

## Test plan

- [x] `cargo test -p lex-bytecode` — 15 tests pass (incl 3 new shape_registry tests)
- [x] `cargo test -p lex-runtime --tests` — all integration binaries green (exercises JSON/SQL/HTTP dynamic-record paths)
- [x] `cargo clippy -p lex-bytecode --all-targets -- -D warnings`
- [ ] CI green on workspace

## Followups

- Slice 2b polymorphic IC once any workload measures >5% polymorphism.
- Registry growth is unbounded in pathological cases (unique-field-set per request). Fixed-size LRU is a one-PR upgrade if needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NjQc3kQTQXm97YX22kfwsU)_