### PR TITLE
deps: coordinated arrow 55→58 + polars 0.50→0.53 + API adaptation

### DIFF
--- a/crates/lex-bytecode/Cargo.toml
+++ b/crates/lex-bytecode/Cargo.toml
@@ -17,8 +17,8 @@ serde_json.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
 sha2.workspace = true
-arrow-array = "55"
-arrow-schema = "55"
+arrow-array = "58"
+arrow-schema = "58"
 lex-ast = { path = "../lex-ast", version = "0.9.5" }
 lex-types = { path = "../lex-types", version = "0.9.5" }
 

--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -56,14 +56,18 @@ serde_yaml = "0.9"
 csv = "1"
 rusqlite = { version = "0.39", features = ["bundled"] }
 postgres = "0.19"
-arrow-array = "55"
-arrow-schema = "55"
-arrow-select = "55"
-arrow-arith = "55"
-arrow-cast = "55"
-arrow-csv = "55"
-parquet = { version = "55", default-features = false, features = ["arrow", "snap"] }
-polars = { version = "0.50", default-features = false, features = ["lazy", "is_in", "csv", "performant", "strings"] }
+arrow-array = "58"
+arrow-schema = "58"
+arrow-select = "58"
+arrow-arith = "58"
+arrow-cast = "58"
+arrow-csv = "58"
+parquet = { version = "58", default-features = false, features = ["arrow", "snap"] }
+# polars 0.53 split the previously-transitive `polars-time` dep out of
+# `strings`; add `temporal` explicitly so `strings`'s string ops still
+# compile. Found the hard way during the arrow-55→58 / polars-0.50→0.53
+# coordinated bump.
+polars = { version = "0.53", default-features = false, features = ["lazy", "is_in", "csv", "performant", "strings", "temporal"] }
 lex-bytecode = { path = "../lex-bytecode", version = "0.9.5" }
 smol_str = { workspace = true }
 

--- a/crates/lex-runtime/src/df.rs
+++ b/crates/lex-runtime/src/df.rs
@@ -117,7 +117,10 @@ fn to_polars(rb: &RecordBatch) -> Result<DataFrame, String> {
         };
         cols.push(s.into());
     }
-    DataFrame::new(cols).map_err(|e| format!("df: build DataFrame: {e}"))
+    // polars 0.53 switched `DataFrame::new(cols)` to take an explicit
+    // height as the first arg; `new_infer_height` does what the v0.50
+    // `new` did, deriving height from the first column.
+    DataFrame::new_infer_height(cols).map_err(|e| format!("df: build DataFrame: {e}"))
 }
 
 /// Build an arrow-rs `RecordBatch` from a Polars `DataFrame`. Inverse
@@ -128,7 +131,7 @@ fn to_polars(rb: &RecordBatch) -> Result<DataFrame, String> {
 fn from_polars(df: &DataFrame) -> Result<RecordBatch, String> {
     let mut fields: Vec<Field> = Vec::with_capacity(df.width());
     let mut arrays: Vec<arrow_array::ArrayRef> = Vec::with_capacity(df.width());
-    for column in df.get_columns() {
+    for column in df.columns() {
         let name = column.name().as_str();
         let s = column.as_materialized_series();
         let (field, array): (Field, arrow_array::ArrayRef) = match s.dtype() {


### PR DESCRIPTION
## Summary

Supersedes the individual Dependabot PRs that can't land independently:
- #449 arrow-select 55→58
- #451 arrow-arith 55→58
- #452 arrow-csv 55→58
- #453 arrow-array 55→58
- #450 polars 0.50→0.53

`lex-bytecode` and `lex-runtime` both pin the arrow-* family together; bumping one without the others puts two arrow major versions in the dep graph and `RecordBatch` becomes two incompatible types.

## Root cause vs. earlier attempt

This session's earlier triage hit 16 `expected RecordBatch, found arrow_array::record_batch::RecordBatch` errors after bumping only `lex-runtime`'s arrow pins. The hidden culprit was `lex-bytecode/Cargo.toml`'s own `arrow-array = "55"` / `arrow-schema = "55"` pins that Dependabot's per-crate PRs didn't touch. Bumping lex-bytecode's pins unifies the dep graph; `cargo tree -p lex-runtime | grep arrow.*v55` returns empty after this change and the 16 type-mismatch errors vanish.

## Changes

1. `crates/lex-bytecode/Cargo.toml`: arrow-array, arrow-schema 55→58.
2. `crates/lex-runtime/Cargo.toml`: arrow-* + parquet 55→58, polars 0.50→0.53, **added `temporal` to polars features**. 0.53 split the previously-transitive `polars-time` dep out of `strings`; without `temporal`, `polars-expr/dispatch/strings.rs` fails to resolve `polars_time::prelude::StringMethods`.
3. `crates/lex-runtime/src/df.rs`: three polars 0.53 API fixes in arrow ↔ polars round-trip helpers:
   - `DataFrame::new(cols)` → `DataFrame::new_infer_height(cols)` (0.53 added an explicit `height: usize` arg; the helper does the height-from-first-column trick the v0.50 single-arg `new` did).
   - `df.get_columns()` → `df.columns()` (rename).
   - The four `E0282` type-annotation-needed errors in `into_iter().map(...)` chains were downstream of `get_columns()` — fixing the accessor restored the compiler's iterator-item inference.

## Verification

- ✅ `cargo build --workspace` (60 crates, all clean)
- ✅ `cargo tree -p lex-runtime | grep arrow.*v55` empty
- ⚠️ `cargo test -p lex-runtime` did not complete locally — container hit disk exhaustion mid-link. CI is the actual gate.

## Test plan

- [ ] CI green on workspace test (the disk-headroom fixes from #510/#511 should be enough — they were sized exactly for this scale of recompile)
- [ ] Confirm `cargo tree` shows single arrow version
- [ ] After merge, close the superseded Dependabot PRs #449/#450/#451/#452/#453 with a pointer here


---
_Generated by [Claude Code](https://claude.ai/code/session_01NjQc3kQTQXm97YX22kfwsU)_