### PR TITLE
perf(#461): superinstructions slice 6 — absorb match-scrutinee dance (1.09x over slice-5; 1.25x cumulative)

### DIFF
--- a/crates/lex-bytecode/src/compiler.rs
+++ b/crates/lex-bytecode/src/compiler.rs
@@ -271,6 +271,11 @@ pub fn compile_program(stages: &[a::Stage]) -> Program {
         // on the same site — order between them is technically free
         // but conventionally slice N runs after slice N-1.
         apply_peephole_slice5(&mut f.code, &pool.pool);
+        // Slice 6 — absorb the match-scrutinee dance
+        // (`LoadLocal + StoreLocal` immediately preceding a slice-5
+        // fused op that reads the just-stored local). Must run after
+        // slice 5 since it matches on slice 5's output.
+        apply_peephole_slice6(&mut f.code);
     }
 
     // Final pass: stamp every function with its content hash now that
@@ -509,6 +514,63 @@ fn apply_peephole_slice5(code: &mut [Op], constants: &[Const]) {
                 code[k] = fused_op;
                 k += 4;
                 continue;
+            }
+        }
+        k += 1;
+    }
+}
+
+/// Slice 6: fuse the match-scrutinee dance preceding a slice-5
+/// pattern-match arm test. 3-slot window
+/// `[LoadLocal(src), StoreLocal(dst),
+///   LoadLocalEqIntConstJumpIfNot { local_idx: dst, ... }]` —
+/// where the slice-5 op's `local_idx` matches the StoreLocal's
+/// destination — rewrites to
+/// `LoadLocalStoreEqIntConstJumpIfNot { src, dst, ... }` at slot k.
+/// The fused op carries `dst` so it can mirror the original
+/// StoreLocal (later arm tests in the same match keep reading
+/// `locals[dst]`).
+///
+/// Trailing tombstones: 5 slots (the original StoreLocal + the
+/// slice-5 fused op itself + slice 5's 3 primitive tombstones).
+/// VM dispatch skips them via `pc + 6`; verifier override pushes
+/// `(pc + 6, ...)` and the branch target `(pc + 6 + jump_offset, ...)`
+/// — the offset is identical to what slice 5 stored (still relative
+/// to the original JumpIfNot's `pc + 1`, now at `k + 5 + 1 = k + 6`).
+///
+/// Safety: slots k+1..=k+5 must not be jump targets — same window
+/// safety as the other slices. Slice 5 already verified k+3..=k+5
+/// weren't jump targets when it fused; slice 6 only needs to re-check
+/// k+1 (the StoreLocal) and k+2 (the slice-5 fused op).
+fn apply_peephole_slice6(code: &mut [Op]) {
+    if code.len() < 3 { return; }
+    let jump_targets = collect_jump_targets(code);
+
+    let n = code.len();
+    let mut k = 0;
+    while k + 2 < n {
+        if let (
+            Op::LoadLocal(src),
+            Op::StoreLocal(dst),
+            Op::LoadLocalEqIntConstJumpIfNot { local_idx, imm_const_idx, jump_offset },
+        ) = (code[k], code[k + 1], code[k + 2]) {
+            // The slice-5 op must read the very local the StoreLocal
+            // just wrote; if it reads some other local this isn't the
+            // match-scrutinee idiom (could be a coincidental sequence).
+            if local_idx == dst {
+                let safe = !jump_targets.contains(&(k + 1))
+                    && !jump_targets.contains(&(k + 2));
+                if safe {
+                    code[k] = Op::LoadLocalStoreEqIntConstJumpIfNot {
+                        src, dst, imm_const_idx, jump_offset,
+                    };
+                    // Skip past this slice-6 window. The slice-5
+                    // tombstones at k+3..=k+5 are already handled by
+                    // slice 5's earlier rewrite; we don't need to
+                    // touch them.
+                    k += 3;
+                    continue;
+                }
             }
         }
         k += 1;

--- a/crates/lex-bytecode/src/op.rs
+++ b/crates/lex-bytecode/src/op.rs
@@ -203,4 +203,27 @@ pub enum Op {
     /// the code stream as tombstones and hash normally — so
     /// closure identity (#222) stays invariant.
     LoadLocalEqIntConstJumpIfNot { local_idx: u16, imm_const_idx: u32, jump_offset: i32 },
+    /// Fused `LoadLocal(src) + StoreLocal(dst) +
+    /// LoadLocalEqIntConstJumpIfNot { local_idx: dst, ... }` (#461
+    /// superinstruction slice 6). Absorbs the match-scrutinee dance
+    /// — the `LoadLocal + StoreLocal` the compiler emits to bind the
+    /// match expression to a fresh local before each arm's pattern
+    /// test reads it back. Reads `locals[src]`, mirrors the original
+    /// `StoreLocal(dst)` by writing the same value into `locals[dst]`
+    /// (so the SECOND and later arm tests in the same match still
+    /// see the scrutinee at the expected slot), then compares against
+    /// the constant. Equal → advance pc by 6 (skip past the 5
+    /// tombstones — original StoreLocal + slice-5 fused op + slice-5's
+    /// 3 trailing tombstones). Not equal → jump to
+    /// `pc + 6 + jump_offset` (the original JumpIfNot's target;
+    /// `jump_offset` is copied unchanged from the slice-5 op).
+    /// Stack delta: 0.
+    ///
+    /// `body_hash` decodes back to a standalone `LoadLocal(src)`;
+    /// the trailing 5 ops (StoreLocal, the slice-5 fused op
+    /// decoded as LoadLocal(dst), PushConst, IntEq, JumpIfNot) stay
+    /// in the code stream as tombstones and hash normally.
+    LoadLocalStoreEqIntConstJumpIfNot {
+        src: u16, dst: u16, imm_const_idx: u32, jump_offset: i32,
+    },
 }

--- a/crates/lex-bytecode/src/program.rs
+++ b/crates/lex-bytecode/src/program.rs
@@ -164,7 +164,8 @@ pub fn compute_body_hash(
             | Op::LoadLocalAddLocal { lhs_idx: local_idx, .. }
             | Op::LoadLocalSubLocal { lhs_idx: local_idx, .. }
             | Op::LoadLocalMulLocal { lhs_idx: local_idx, .. }
-            | Op::LoadLocalEqIntConstJumpIfNot { local_idx, .. } => {
+            | Op::LoadLocalEqIntConstJumpIfNot { local_idx, .. }
+            | Op::LoadLocalStoreEqIntConstJumpIfNot { src: local_idx, .. } => {
                 // Slice 1: this slot was `LoadLocal(local_idx)`.
                 // Slice 2: this slot was *also* `LoadLocal(src)`
                 // — the fused op now owns 4 slots, but the very

--- a/crates/lex-bytecode/src/verify.rs
+++ b/crates/lex-bytecode/src/verify.rs
@@ -123,6 +123,15 @@ pub fn verify_function(func: &Function, errors: &mut Vec<StackError>) {
                 worklist.push((pc + 4, next_depth));
                 worklist.push((target, next_depth));
             }
+            // Slice 6 owns a 6-slot window (this op + 5 tombstones).
+            // Same two-successor shape as slice 5 but with `pc + 6`
+            // arithmetic. Net stack delta is 0 — original was
+            // LoadLocal + StoreLocal + slice5 = +1 + -1 + 0.
+            Op::LoadLocalStoreEqIntConstJumpIfNot { jump_offset, .. } => {
+                let target = (pc as i32 + 6 + jump_offset) as usize;
+                worklist.push((pc + 6, next_depth));
+                worklist.push((target, next_depth));
+            }
             // All other ops: single sequential successor.
             _ => {
                 worklist.push((pc + 1, next_depth));
@@ -241,7 +250,8 @@ fn stack_delta(op: &Op) -> i32 {
         // (original sequence had +1, +1, -1, -1). Worklist override
         // above pushes both fall-through and branch successors with
         // this depth; tombstones are not walked as live.
-        Op::LoadLocalEqIntConstJumpIfNot { .. } => 0,
+        Op::LoadLocalEqIntConstJumpIfNot { .. }
+        | Op::LoadLocalStoreEqIntConstJumpIfNot { .. } => 0,
     }
 }
 

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -1601,6 +1601,30 @@ impl<'a> Vm<'a> {
                     };
                     self.frames[frame_idx].pc = next_pc;
                 }
+                Op::LoadLocalStoreEqIntConstJumpIfNot { src, dst, imm_const_idx, jump_offset } => {
+                    // Slice 6: absorbs LoadLocal + StoreLocal + slice-5 op.
+                    // 6-slot window total (this op + 5 tombstones); fall-
+                    // through is `pc + 6`, branch target is `pc + 6 +
+                    // jump_offset` (the original JumpIfNot was at slot
+                    // pc+5, with offset relative to its own pc+1 = pc+6).
+                    let base = self.frames[frame_idx].locals_start;
+                    let a = self.locals_storage[base + src as usize].as_int();
+                    // Mirror the original `StoreLocal(dst)` — later
+                    // arm tests in the same `match` expect to find
+                    // the scrutinee at `locals[dst]`.
+                    self.locals_storage[base + dst as usize] = Value::Int(a);
+                    let b = match &self.program.constants[imm_const_idx as usize] {
+                        Const::Int(n) => *n,
+                        _ => return Err(VmError::TypeMismatch(
+                            "LoadLocalStoreEqIntConstJumpIfNot expects Const::Int".into())),
+                    };
+                    let next_pc = if a == b {
+                        pc + 6
+                    } else {
+                        ((pc as i32 + 6) + jump_offset) as usize
+                    };
+                    self.frames[frame_idx].pc = next_pc;
+                }
                 Op::LoadLocalAddIntConstStoreLocal { src, imm_const_idx, dest } => {
                     let base = self.frames[frame_idx].locals_start;
                     let a = self.locals_storage[base + src as usize].as_int();

--- a/crates/lex-bytecode/tests/run.rs
+++ b/crates/lex-bytecode/tests/run.rs
@@ -273,6 +273,62 @@ fn classify(n :: Int) -> Int {
 }
 
 #[test]
+fn slice6_absorbs_match_scrutinee_dance() {
+    // #461 slice 6: `match n { 0 => acc; _ => recurse }` compiles to
+    // `LoadLocal(n) + StoreLocal(scrut) + slice5_fused{local_idx:
+    // scrut, ...}`. Slice 6 collapses the leading LoadLocal+StoreLocal
+    // into the fused arm-test, leaving them as tombstones. Verify
+    // both that the fusion fires and that the runtime semantics
+    // remain identical.
+    use lex_bytecode::op::Op;
+    let src = "
+fn sum_to(n :: Int, acc :: Int) -> Int {
+  match n {
+    0 => acc,
+    _ => sum_to(n - 1, acc + n),
+  }
+}";
+    let p = compile(src);
+    let fused = p.functions.iter().flat_map(|f| f.code.iter()).any(|op|
+        matches!(op, Op::LoadLocalStoreEqIntConstJumpIfNot { .. }));
+    assert!(fused, "slice 6 did not fire on sum_to");
+
+    let mut vm = Vm::new(&p);
+    // 1+2+3+4+5 = 15
+    let r = vm.call("sum_to", vec![Value::Int(5), Value::Int(0)]).unwrap();
+    assert_eq!(r, Value::Int(15));
+}
+
+#[test]
+fn slice6_writes_dst_so_subsequent_arms_see_scrutinee() {
+    // Critical correctness check for slice 6: the fused op MUST
+    // mirror the original `StoreLocal(dst)` because the SECOND and
+    // later arm tests in the same match still read `locals[dst]`.
+    // A multi-arm cascade catches this — if the StoreLocal mirror
+    // were dropped, every arm after the first would read garbage.
+    let src = "
+fn classify(n :: Int) -> Int {
+  match n {
+    0 => 100,
+    1 => 200,
+    2 => 300,
+    3 => 400,
+    _ => 999,
+  }
+}";
+    let p = compile(src);
+    let mut vm = Vm::new(&p);
+    // Every arm reads `locals[scrut]`; if slice 6 dropped the
+    // StoreLocal mirror, arms past the first would see undefined
+    // data and either return the wrong constant or hit the `_` arm.
+    assert_eq!(vm.call("classify", vec![Value::Int(0)]).unwrap(), Value::Int(100));
+    assert_eq!(vm.call("classify", vec![Value::Int(1)]).unwrap(), Value::Int(200));
+    assert_eq!(vm.call("classify", vec![Value::Int(2)]).unwrap(), Value::Int(300));
+    assert_eq!(vm.call("classify", vec![Value::Int(3)]).unwrap(), Value::Int(400));
+    assert_eq!(vm.call("classify", vec![Value::Int(99)]).unwrap(), Value::Int(999));
+}
+
+#[test]
 fn slice3_does_not_fire_across_a_jump_target() {
     // Safety check: if the second or third slot of the candidate
     // triple is a jump target, slice 3 must skip the fusion — a


### PR DESCRIPTION
## Summary

Composes on top of #520 the way slice 2 sat on slice 1. Every `match` on an Int scrutinee compiles to `LoadLocal(scrut) + StoreLocal(local_for_match) + slice5_fused{...}` — the leading two ops bind the scrutinee to a fresh local so each arm test can read it. Slice 5 absorbed the arm test; this slice absorbs the binding dance.

Fuses the 3-slot window into `Op::LoadLocalStoreEqIntConstJumpIfNot { src, dst, imm_const_idx, jump_offset }`. The fused op reads `locals[src]`, mirrors the original `StoreLocal(dst)` (so subsequent arm tests still find the scrutinee at `locals[dst]`), then does slice 5's comparison + branch. 6-slot window total (this op + 5 tombstones); `pc + 6` on equal, `pc + 6 + jump_offset` on not-equal.

## Bench

| Bench                | pre-slice-5 | slice 5 only | slice 5+6 |
|----------------------|-------------|--------------|-----------|
| arith_loop / n=10000 | 2.63 ms     | 2.29 ms      | 2.10 ms   |
| vs prior step        | —           | 1.15×        | 1.09×     |
| Cumulative           | —           | 1.15×        | **1.25×** |

## Critical correctness check

The fused op MUST mirror the original `StoreLocal(dst)` — every arm after the first reads `locals[dst]` to do its own test, and dropping the write would silently corrupt multi-arm matches. Covered by `slice6_writes_dst_so_subsequent_arms_see_scrutinee` (a 5-arm cascade that would return wrong constants if the StoreLocal mirror were absent).

## Acceptance per #461

- [x] ≥ 1× speedup on an existing bench: 1.09× on arith_loop
- [x] `cargo test -p lex-bytecode`: 17 pass (incl. `bytecode_is_reproducible` + 2 new slice-6 tests for fusion-fires and multi-arm-scrutinee correctness)
- [x] `cargo test -p lex-runtime --tests`: 81 test binaries green
- [x] No bytecode-format change; body_hash decodes slice-6 op to `LoadLocal(src)`
- [x] Clippy clean

## Followup landscape

Slice 6 is likely the last meaningful superinstruction on the `match` path. Future wins would need different angles:
- Variant-tag fusion (`TestVariant + JumpIfNot` over Variant scrutinees) — same shape as slice 5 but for Variants
- Pop-elision in `_` arm bodies (currently emitted as part of variant cleanup but inert for pattern-match cases)

#465 JIT proper is now the highest-leverage next move; the superinstruction work has done what it can without rewriting the dispatcher itself.

## Test plan

- [x] `cargo test -p lex-bytecode` (17 tests)
- [x] `cargo test -p lex-runtime --tests` (81 binaries, all pass)
- [x] `cargo clippy -p lex-bytecode --all-targets -- -D warnings`
- [ ] CI green on workspace


---
_Generated by [Claude Code](https://claude.ai/code/session_01NjQc3kQTQXm97YX22kfwsU)_