### PR TITLE
perf(#464) step 2: AllocStackRecord opcode + escape-driven lowering

### DIFF
--- a/crates/lex-bytecode/src/compiler.rs
+++ b/crates/lex-bytecode/src/compiler.rs
@@ -240,6 +240,23 @@ pub fn compile_program(stages: &[a::Stage]) -> Program {
         p.functions[pl.fn_id as usize].locals_count = peak;
     }
 
+    // #464 step 2: escape-analysis-driven lowering. Rewrites
+    // `MakeRecord` at non-escaping sites to `AllocStackRecord`, which
+    // the VM allocates in the frame's stack-record arena instead of
+    // on the heap. Runs on raw bytecode (before the peephole passes)
+    // so the escape analysis — which itself walks raw bytecode — sees
+    // exactly the program it was designed for.
+    //
+    // The peephole passes that follow do not match on MakeRecord /
+    // AllocStackRecord, so swapping one for the other doesn't disturb
+    // any pattern. `compute_body_hash` lowers AllocStackRecord back
+    // to the legacy MakeRecord form (#222), so closure identity is
+    // invariant under this lowering.
+    let escape_index = crate::escape::build_escape_index(&p.functions);
+    for f in p.functions.iter_mut() {
+        apply_escape_lowering(&mut f.code, &f.name, &escape_index);
+    }
+
     // Peephole pass (#461 superinstructions). Rewrites fusable opcode
     // patterns into single dispatch steps. Runs before `body_hash`
     // computation, but `compute_body_hash` decomposes each fused op
@@ -310,6 +327,35 @@ pub fn compile_program(stages: &[a::Stage]) -> Program {
 /// tombstone instead of the live op the source intended. The
 /// pre-pass below collects every jump target in the function and
 /// skips fusion sites whose tombstones overlap one.
+/// #464 step 2 — rewrite `MakeRecord` to `AllocStackRecord` at sites
+/// the escape analysis (`crate::escape::build_escape_index`) proved
+/// non-escaping. Each rewrite is a single-slot swap that preserves
+/// pc, stack delta, and shape semantics — jump targets, the peephole
+/// passes downstream, and the body-hash decoder all see the same
+/// program shape they would have seen for the unlowered code.
+///
+/// Sites that escape are left as-is and still incur the
+/// IndexMap-backed heap allocation. Step 3 of #464 carries the
+/// bench acceptance bars (≥1.5× speedup on `response_build`); this
+/// pass is the precondition.
+fn apply_escape_lowering(
+    code: &mut [Op],
+    fn_name: &str,
+    escape_index: &std::collections::HashMap<(String, u32), bool>,
+) {
+    for (pc, op) in code.iter_mut().enumerate() {
+        if let Op::MakeRecord { shape_idx, field_count } = *op {
+            // Look up this (fn, pc) in the escape index. Absent →
+            // analysis didn't observe the site (defensive: leave on
+            // heap path). Present and false → safe to stack-allocate.
+            let key = (fn_name.to_string(), pc as u32);
+            if matches!(escape_index.get(&key), Some(false)) {
+                *op = Op::AllocStackRecord { shape_idx, field_count };
+            }
+        }
+    }
+}
+
 fn apply_peephole(code: &mut [Op], constants: &[Const]) {
     if code.len() < 3 { return; }
     let jump_targets = collect_jump_targets(code);

--- a/crates/lex-bytecode/src/escape.rs
+++ b/crates/lex-bytecode/src/escape.rs
@@ -318,6 +318,13 @@ fn step(pc: usize, op: &Op, mut s: State) -> (State, Vec<usize>, HashSet<u32>) {
             pop_n_leak(&mut s, *field_count as usize, &mut escapes);
             s.stack.push(Slot::Rec(pc as u32));
         }
+        // #464 step 2: post-lowering form of MakeRecord (escape
+        // proved). Re-running the analysis on already-lowered code
+        // must produce the same shape, so treat it identically.
+        Op::AllocStackRecord { field_count, .. } => {
+            pop_n_leak(&mut s, *field_count as usize, &mut escapes);
+            s.stack.push(Slot::Rec(pc as u32));
+        }
         // Other aggregate constructors are escape sinks for any Rec
         // operand. They don't create new tracked records (the
         // analysis is record-shape-driven; lists/tuples/variants

--- a/crates/lex-bytecode/src/op.rs
+++ b/crates/lex-bytecode/src/op.rs
@@ -43,6 +43,28 @@ pub enum Op {
     /// (`code[pc]` becomes a register-sized read instead of an
     /// every-step `Vec` clone).
     MakeRecord { shape_idx: u32, field_count: u16 },
+    /// Stack-allocated record (#464). Same shape semantics as
+    /// `MakeRecord` — pops `field_count` field values and pairs them
+    /// with `Program.record_shapes[shape_idx]` — but the field values
+    /// are stored in the current frame's slab inside the VM's
+    /// `stack_record_arena`, not in a heap-allocated `IndexMap`. The
+    /// stack pushes a `Value::StackRecord` whose `slab_start` indexes
+    /// into the arena.
+    ///
+    /// Emitted by the compiler in place of `MakeRecord` at sites that
+    /// `escape::build_escape_index` proves do not escape the frame
+    /// (returned, captured, stored into another aggregate, or passed
+    /// to a call). Runtime fallback: when the frame's
+    /// `stack_record_budget_remaining` is exhausted, the op silently
+    /// degrades to the heap path (identical observable effect to
+    /// `MakeRecord`), so a single function can mix stack and heap
+    /// records without compile-time partitioning.
+    ///
+    /// `body_hash` stability (#222): canonical encoding decodes this
+    /// op back to the historical `{"MakeRecord":{"field_name_indices":
+    /// [...]}}` form, so closure identity is invariant under the
+    /// step-2 lowering.
+    AllocStackRecord { shape_idx: u32, field_count: u16 },
     MakeTuple(u16),
     MakeList(u32),
     MakeVariant { name_idx: u32, arity: u16 },

--- a/crates/lex-bytecode/src/program.rs
+++ b/crates/lex-bytecode/src/program.rs
@@ -137,7 +137,16 @@ pub fn compute_body_hash(
     // hash bytes stay bit-identical to pre-#461 builds.
     for op in code {
         let bytes = match op {
-            Op::MakeRecord { shape_idx, .. } => {
+            // Both `MakeRecord` and its #464 step-2 sibling
+            // `AllocStackRecord` hash as the historical inline
+            // `{"MakeRecord":{"field_name_indices":[...]}}` form so
+            // closure identity (#222) is bit-identical to pre-#464
+            // builds — the stack-vs-heap lowering is a performance
+            // detail that mustn't perturb body hashes (otherwise the
+            // same closure literal would hash differently after the
+            // escape pass fires).
+            Op::MakeRecord { shape_idx, .. }
+            | Op::AllocStackRecord { shape_idx, .. } => {
                 let shape = &record_shapes[*shape_idx as usize];
                 #[derive(Serialize)]
                 struct LegacyMakeRecord<'a> {

--- a/crates/lex-bytecode/src/value.rs
+++ b/crates/lex-bytecode/src/value.rs
@@ -111,6 +111,28 @@ pub enum Value {
     /// compare equal regardless of provenance, so a JSON-decoded
     /// record equals a compile-time-built one with the same fields.
     Record { shape_id: u32, fields: Box<IndexMap<String, Value>> },
+    /// Frame-local record (#464 step 2). Emitted by
+    /// `Op::AllocStackRecord` at sites the escape analysis proved
+    /// can't outlive the current call frame. `slab_start` indexes
+    /// into `Vm::stack_record_arena`; the `field_count` consecutive
+    /// values starting there are the record's fields, in
+    /// `Program.record_shapes[shape_id]` order (same insertion order
+    /// as `Op::MakeRecord` uses, so the polymorphic-IC offset is
+    /// interoperable with `Value::Record`).
+    ///
+    /// `Op::GetField` is the only consumer that knows how to read
+    /// these — every other observation point (`Op::Return`,
+    /// `Op::Call`, `Op::MakeRecord` as a field value, …) is an
+    /// escape op that the analysis prevents this variant from
+    /// reaching. If a `StackRecord` ever does reach an unexpected
+    /// site (escape-analysis bug), it surfaces as a panic at the
+    /// boundary, not undefined behavior — the arena is plain
+    /// `Vec<Value>` in safe Rust.
+    ///
+    /// Size: 4 (shape_id) + 4 (slab_start) + 2 (field_count) = 10
+    /// bytes payload + tag, comfortably inside the 64B `Value`
+    /// envelope.
+    StackRecord { shape_id: u32, slab_start: u32, field_count: u16 },
     Variant { name: String, args: Vec<Value> },
     /// First-class function value (a lambda + its captured locals). The
     /// function's first `captures.len()` params bind to `captures`; the
@@ -191,6 +213,17 @@ impl PartialEq for Value {
             (List(a), List(b)) => a == b,
             (Tuple(a), Tuple(b)) => a == b,
             (Record { fields: a, .. }, Record { fields: b, .. }) => a == b,
+            // #464 step 2: a `Value::StackRecord` can only reach
+            // generic equality if it crossed an escape boundary the
+            // analysis was supposed to reject. Treat as a soundness
+            // bug: panic rather than silently lie about equality (a
+            // wrong answer would cascade into mis-routed match arms).
+            // Well-typed Lex source never compares records with
+            // `==` via `bin_eq` — record equality, if added, will
+            // get its own opcode with arena-aware comparison.
+            (StackRecord { .. }, _) | (_, StackRecord { .. }) =>
+                panic!("BUG(#464): Value::StackRecord reached generic equality \
+                        — escape analysis should have flagged its allocation site"),
             (Variant { name: an, args: aa }, Variant { name: bn, args: ba }) =>
                 an == bn && aa == ba,
             (Closure { body_hash: ah, captures: ac, .. },
@@ -305,6 +338,10 @@ impl Value {
                 for (k, v) in fields.iter() { m.insert(k.clone(), v.to_json()); }
                 J::Object(m)
             }
+            // #464: should never reach JSON serialization. See PartialEq.
+            Value::StackRecord { .. } =>
+                panic!("BUG(#464): Value::StackRecord reached to_json — \
+                        escape analysis should have prevented escape to a host boundary"),
             Value::Variant { name, args } => {
                 let mut m = serde_json::Map::new();
                 m.insert("$variant".into(), J::String(name.clone()));

--- a/crates/lex-bytecode/src/verify.rs
+++ b/crates/lex-bytecode/src/verify.rs
@@ -157,6 +157,10 @@ fn stack_delta(op: &Op) -> i32 {
 
         // Record / tuple / list construction
         Op::MakeRecord { field_count, .. } => -(*field_count as i32) + 1,
+        // #464 step 2: same stack-effect shape as MakeRecord (pops
+        // field_count, pushes 1). The verifier doesn't need to know
+        // about the stack-record arena — it walks bytecode shape only.
+        Op::AllocStackRecord { field_count, .. } => -(*field_count as i32) + 1,
         Op::MakeTuple(n)  => -(*n as i32) + 1,
         Op::MakeList(n)   => -(*n as i32) + 1,
         Op::MakeVariant { arity, .. } => -(*arity as i32) + 1,

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -91,6 +91,16 @@ pub enum VmError {
 /// the OS stack limit at any per-frame size we use.
 pub const MAX_CALL_DEPTH: u32 = 1024;
 
+/// Per-frame stack-record budget (#464 step 2). Counts the number of
+/// `Value` slots a frame may consume from `Vm::stack_record_arena`
+/// before further `Op::AllocStackRecord` requests fall back to the
+/// heap path. 64 slots at the current `size_of::<Value>() = 64B`
+/// gives ~4 KiB per frame, matching the design-doc proposal in
+/// `docs/design/escape-analysis.md`. A handler-shaped function
+/// (one outer record of ≤8 fields, plus a handful of small inner
+/// records) fits well inside this without growing.
+pub const STACK_RECORD_BUDGET_SLOTS: u32 = 64;
+
 /// Host-side effect dispatch. Implementors decide what `kind`/`op` mean
 /// and how arguments map to side effects.
 pub trait EffectHandler {
@@ -272,6 +282,19 @@ pub struct Vm<'a> {
     /// again but its capacity is retained, so the next request incurs
     /// zero allocations for locals up to the high-water mark.
     locals_storage: Vec<Value>,
+    /// Stack-record arena (#464 step 2). Each `Op::AllocStackRecord`
+    /// at a non-escaping site appends its `field_count` field values
+    /// here; the produced `Value::StackRecord` carries `slab_start =
+    /// arena.len() - field_count` so reads are an O(1) slab index.
+    /// On `Op::Return` the arena is truncated back to
+    /// `frame.stack_record_arena_start`, releasing every record the
+    /// frame allocated in O(1) — same lifetime story as
+    /// `locals_storage` for frame locals.
+    ///
+    /// LIFO frame discipline guarantees a frame's records always sit
+    /// at the top of the arena while the frame is live, so neither
+    /// inter-frame interleaving nor index churn can occur.
+    stack_record_arena: Vec<Value>,
 }
 
 struct Frame {
@@ -292,6 +315,18 @@ struct Frame {
     /// `None` means "don't memoize" — either the function isn't pure,
     /// the call wasn't through Op::Call, or memoization is disabled.
     memo_key: Option<(u32, [u8; 16])>,
+    /// #464 step 2: start index of this frame's records in
+    /// `Vm::stack_record_arena`. On `Op::Return`, the arena is
+    /// truncated back here. Identical lifetime discipline to
+    /// `locals_start`.
+    stack_record_arena_start: usize,
+    /// Remaining stack-record budget for this frame, in Value-slot
+    /// units (#464 step 2). Initial value: `STACK_RECORD_BUDGET_SLOTS`.
+    /// When an `Op::AllocStackRecord` would consume more slots than
+    /// remain, the VM falls back to the heap path silently (same
+    /// observable effect as `Op::MakeRecord`), so the budget never
+    /// surfaces as a user-visible error.
+    stack_record_budget_remaining: u32,
 }
 
 /// Sum of `[budget(N)]` declarations on a function's signature
@@ -575,6 +610,11 @@ impl<'a> Vm<'a> {
             // 256 slots handles ~32 frames × 8 locals; grows on demand and
             // retains capacity across consecutive vm.call() invocations.
             locals_storage: Vec::with_capacity(256),
+            // #464 step 2: zero capacity at construction — handlers that
+            // never AllocStackRecord (most code today, until the lowering
+            // pass kicks in) pay nothing. First allocation triggers Vec
+            // growth; capacity is retained across `vm.call` invocations.
+            stack_record_arena: Vec::new(),
         }
     }
 
@@ -870,6 +910,8 @@ impl<'a> Vm<'a> {
             stack_base: self.stack.len(),
             trace_kind: FrameKind::Entry,
             memo_key: None,
+            stack_record_arena_start: self.stack_record_arena.len(),
+            stack_record_budget_remaining: STACK_RECORD_BUDGET_SLOTS,
         })?;
         self.run_to(base_depth)
     }
@@ -952,6 +994,66 @@ impl<'a> Vm<'a> {
                     }
                     self.stack.push(Value::Record { shape_id: shape_idx, fields: Box::new(rec) });
                 }
+                Op::AllocStackRecord { shape_idx, field_count } => {
+                    // #464 step 2. Same value-stack contract as
+                    // MakeRecord (pop `field_count`, push 1), but the
+                    // fields live in the VM's stack-record arena
+                    // instead of a heap-allocated IndexMap.
+                    //
+                    // Budget check: if this frame's remaining
+                    // allocation budget can't cover `field_count`
+                    // slots, fall back to MakeRecord behavior. The
+                    // observable result is identical (a record
+                    // value) so the compiler doesn't need to know
+                    // ahead of time whether the budget will hold.
+                    let n = field_count as usize;
+                    let frame = &mut self.frames[frame_idx];
+                    if frame.stack_record_budget_remaining < field_count as u32 {
+                        // Heap fallback path — exact copy of
+                        // MakeRecord's body. Compiler emitted
+                        // AllocStackRecord because escape analysis
+                        // proved the record can stay frame-local;
+                        // the budget exhaustion is a runtime cost
+                        // ceiling, not a correctness issue.
+                        let shape = &self.program.record_shapes[shape_idx as usize];
+                        debug_assert_eq!(shape.len(), n,
+                            "AllocStackRecord field_count must match record_shapes[shape_idx].len()");
+                        let mut values: Vec<Value> = (0..n).map(|_| Value::Unit).collect();
+                        for i in (0..n).rev() {
+                            values[i] = self.pop()?;
+                        }
+                        let mut rec = IndexMap::new();
+                        for (i, val) in values.into_iter().enumerate() {
+                            let name = match &self.program.constants[shape[i] as usize] {
+                                Const::FieldName(s) => s.clone(),
+                                _ => return Err(VmError::TypeMismatch("expected FieldName const".into())),
+                            };
+                            rec.insert(name, val);
+                        }
+                        self.stack.push(Value::Record { shape_id: shape_idx, fields: Box::new(rec) });
+                    } else {
+                        // Stack path: append the popped field values
+                        // to the arena in shape order (matches the
+                        // IndexMap insertion order used by MakeRecord,
+                        // so the polymorphic GetField IC sees the same
+                        // offset for either variant).
+                        frame.stack_record_budget_remaining -= field_count as u32;
+                        let slab_start = self.stack_record_arena.len();
+                        // Reserve all slots upfront so we can write in
+                        // shape order while popping in reverse —
+                        // matches MakeRecord's idiom.
+                        self.stack_record_arena.resize(slab_start + n, Value::Unit);
+                        for i in (0..n).rev() {
+                            let v = self.pop()?;
+                            self.stack_record_arena[slab_start + i] = v;
+                        }
+                        self.stack.push(Value::StackRecord {
+                            shape_id: shape_idx,
+                            slab_start: slab_start as u32,
+                            field_count,
+                        });
+                    }
+                }
                 Op::MakeTuple(n) => {
                     let mut items: Vec<Value> = (0..n).map(|_| Value::Unit).collect();
                     for i in (0..n as usize).rev() { items[i] = self.pop()?; }
@@ -1031,6 +1133,71 @@ impl<'a> Vm<'a> {
                                         format!("missing field `{name}`")))?;
                                 self.field_ics[fid][sid] = Some((shape_id, off));
                                 val.clone()
+                            };
+                            self.stack.push(value);
+                        }
+                        Value::StackRecord { shape_id, slab_start, field_count } => {
+                            // #464 step 2: dispatch over a stack-allocated
+                            // record. The IC slot stored
+                            // (shape_id, offset_in_shape) is interoperable
+                            // with the heap path because MakeRecord builds
+                            // the IndexMap in shape order — offset N means
+                            // the same field in either representation. So
+                            // we share `field_ics` with the heap path; no
+                            // per-variant cache pollution.
+                            if ic_stats_enabled() {
+                                record_ic_hit(fn_id, site_idx, shape_id);
+                            }
+                            let fid = fn_id as usize;
+                            let sid = site_idx as usize;
+                            if self.field_ics[fid].is_empty() {
+                                let n = self.program.functions[fid].field_ic_sites as usize;
+                                self.field_ics[fid] = vec![None; n];
+                            }
+                            let cached = self.field_ics[fid][sid];
+                            let value = 'ic: {
+                                if let Some((cached_shape, off)) = cached {
+                                    if cached_shape == shape_id && (off as u16) < field_count {
+                                        // Shape-keyed verification is sound
+                                        // here for the same reason as the
+                                        // heap path — compile-time shape
+                                        // IDs are issued by
+                                        // `Program::record_shapes` and
+                                        // their field order is fixed.
+                                        // Stack records always carry a
+                                        // compile-time shape_id (NO_SHAPE_ID
+                                        // is impossible — AllocStackRecord
+                                        // is only emitted at compile time
+                                        // with a known shape_idx).
+                                        let idx = slab_start as usize + off;
+                                        break 'ic self.stack_record_arena[idx].clone();
+                                    }
+                                }
+                                // Cache miss: walk the shape's field-name
+                                // vec to find the slot for `name_idx`. The
+                                // miss path is O(field_count) like the
+                                // heap path, but the hot retrieval after
+                                // install is one array index — cheaper
+                                // than IndexMap::get_index.
+                                let shape =
+                                    &self.program.record_shapes[shape_id as usize];
+                                let target_name = match &self.program.constants[name_idx as usize] {
+                                    Const::FieldName(s) => s.as_str(),
+                                    _ => return Err(VmError::TypeMismatch(
+                                        "expected FieldName const".into())),
+                                };
+                                let mut found: Option<usize> = None;
+                                for (i, fn_const_idx) in shape.iter().enumerate() {
+                                    if let Const::FieldName(s) =
+                                        &self.program.constants[*fn_const_idx as usize]
+                                    {
+                                        if s == target_name { found = Some(i); break; }
+                                    }
+                                }
+                                let off = found.ok_or_else(|| VmError::TypeMismatch(
+                                    format!("missing field `{target_name}` on stack record")))?;
+                                self.field_ics[fid][sid] = Some((shape_id, off));
+                                self.stack_record_arena[slab_start as usize + off].clone()
                             };
                             self.stack.push(value);
                         }
@@ -1191,6 +1358,8 @@ impl<'a> Vm<'a> {
                         // hashing strategy that includes the captures.
                         // Direct Op::Call is the v1 surface.
                         memo_key: None,
+                        stack_record_arena_start: self.stack_record_arena.len(),
+                        stack_record_budget_remaining: STACK_RECORD_BUDGET_SLOTS,
                     })?;
                 }
                 Op::SortByKey { node_id_idx: _ } => {
@@ -1346,6 +1515,8 @@ impl<'a> Vm<'a> {
                         stack_base: self.stack.len(),
                         trace_kind: FrameKind::Call(node_id),
                         memo_key,
+                        stack_record_arena_start: self.stack_record_arena.len(),
+                        stack_record_budget_remaining: STACK_RECORD_BUDGET_SLOTS,
                     })?;
                 }
                 Op::TailCall { fn_id, arity, node_id_idx } => {
@@ -1402,11 +1573,20 @@ impl<'a> Vm<'a> {
                     for (i, v) in args.into_iter().enumerate() {
                         self.locals_storage[old_locals_start + i] = v;
                     }
+                    // #464 step 2: a tail-called function gets a fresh
+                    // stack-record arena view. Release any records the
+                    // pre-tail-call code allocated (they can't be live
+                    // — the args have already been popped off the
+                    // value stack) and refill the budget for the
+                    // callee.
+                    let arena_start = self.frames.last().unwrap().stack_record_arena_start;
+                    self.stack_record_arena.truncate(arena_start);
                     let frame = self.frames.last_mut().unwrap();
                     frame.fn_id = fn_id;
                     frame.pc = 0;
                     frame.locals_len = new_locals_len;
                     frame.trace_kind = FrameKind::Call(node_id);
+                    frame.stack_record_budget_remaining = STACK_RECORD_BUDGET_SLOTS;
                 }
                 Op::EffectCall { kind_idx, op_idx, arity, node_id_idx } => {
                     let mut args: Vec<Value> = (0..arity).map(|_| Value::Unit).collect();
@@ -1457,6 +1637,14 @@ impl<'a> Vm<'a> {
                     // Release this frame's locals back to the arena (#389 slice 3).
                     // LIFO frame ordering guarantees this frame's slots are at the top.
                     self.locals_storage.truncate(frame.locals_start);
+                    // #464 step 2: release this frame's stack-record
+                    // slab. LIFO frame discipline guarantees its
+                    // records sit at the top of the arena. The
+                    // returned value `v` is escape-proven not to be
+                    // one of them — the compiler only emits
+                    // AllocStackRecord at sites that don't reach
+                    // `Return`.
+                    self.stack_record_arena.truncate(frame.stack_record_arena_start);
                     if matches!(frame.trace_kind, FrameKind::Call(_)) {
                         self.tracer.exit_ok(&v);
                     }

--- a/crates/lex-bytecode/tests/stack_records.rs
+++ b/crates/lex-bytecode/tests/stack_records.rs
@@ -1,0 +1,236 @@
+//! #464 step 2 — `Op::AllocStackRecord` end-to-end tests.
+//!
+//! Exercises the compiler's escape-analysis-driven lowering pass,
+//! the VM's stack-record arena bookkeeping, the polymorphic
+//! `Op::GetField` IC dispatch over both `Value::Record` and
+//! `Value::StackRecord`, the per-frame budget fallback, and the
+//! body-hash canonicality contract.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, Op, Value, Vm};
+use lex_syntax::parse_source;
+
+fn compile(src: &str) -> lex_bytecode::Program {
+    let p = parse_source(src).unwrap();
+    let stages = canonicalize_program(&p);
+    compile_program(&stages)
+}
+
+fn fn_code<'a>(prog: &'a lex_bytecode::Program, name: &str) -> &'a [Op] {
+    let idx = prog.function_names[name];
+    &prog.functions[idx as usize].code
+}
+
+fn count<F: Fn(&Op) -> bool>(code: &[Op], pred: F) -> usize {
+    code.iter().filter(|op| pred(op)).count()
+}
+
+/// A record that is allocated and then field-read and dropped never
+/// escapes the frame. The lowering pass must replace `MakeRecord`
+/// with `AllocStackRecord`, and the program must still run with the
+/// same semantics.
+#[test]
+fn non_escaping_record_lowers_to_alloc_stack_record() {
+    let src = r#"
+        fn drop_and_read() -> Int {
+          let r := { x: 7, y: 9 }
+          r.x
+        }
+    "#;
+    let p = compile(src);
+    let code = fn_code(&p, "drop_and_read");
+    assert_eq!(count(code, |op| matches!(op, Op::MakeRecord { .. })), 0,
+        "MakeRecord should have been lowered: {code:?}");
+    assert_eq!(count(code, |op| matches!(op, Op::AllocStackRecord { .. })), 1,
+        "expected exactly one AllocStackRecord: {code:?}");
+
+    let mut vm = Vm::new(&p);
+    let r = vm.call("drop_and_read", vec![]).unwrap();
+    assert_eq!(r, Value::Int(7));
+}
+
+/// A record that is returned escapes. The lowering pass must leave
+/// it as `MakeRecord` so it lives on the heap.
+#[test]
+fn escaping_record_stays_on_heap() {
+    let src = r#"
+        fn build() -> { x :: Int, y :: Int } {
+          { x: 1, y: 2 }
+        }
+    "#;
+    let p = compile(src);
+    let code = fn_code(&p, "build");
+    assert_eq!(count(code, |op| matches!(op, Op::AllocStackRecord { .. })), 0,
+        "escaping record must not be stack-allocated: {code:?}");
+    assert_eq!(count(code, |op| matches!(op, Op::MakeRecord { .. })), 1);
+
+    let mut vm = Vm::new(&p);
+    let r = vm.call("build", vec![]).unwrap();
+    match r {
+        Value::Record { fields, .. } => {
+            assert_eq!(fields.get("x"), Some(&Value::Int(1)));
+            assert_eq!(fields.get("y"), Some(&Value::Int(2)));
+        }
+        other => panic!("expected Record, got {other:?}"),
+    }
+}
+
+/// A stack-allocated record's field read goes through the same
+/// `Op::GetField` opcode the heap path uses — the dispatch is
+/// polymorphic over both `Value::Record` and `Value::StackRecord`.
+/// Multiple field reads on the same record exercise the inline cache.
+#[test]
+fn stack_record_field_reads_use_polymorphic_ic() {
+    let src = r#"
+        fn sum_fields() -> Int {
+          let r := { a: 10, b: 20, c: 30 }
+          r.a + r.b + r.c
+        }
+    "#;
+    let p = compile(src);
+    let code = fn_code(&p, "sum_fields");
+    assert_eq!(count(code, |op| matches!(op, Op::AllocStackRecord { .. })), 1);
+
+    let mut vm = Vm::new(&p);
+    let r = vm.call("sum_fields", vec![]).unwrap();
+    assert_eq!(r, Value::Int(60));
+}
+
+/// Two non-escaping `MakeRecord` sites in the same function lower
+/// independently. The arena is shared, but the per-record
+/// `slab_start` differs.
+#[test]
+fn two_stack_records_in_one_frame() {
+    let src = r#"
+        fn two_records() -> Int {
+          let r1 := { x: 100 }
+          let r2 := { y: 25 }
+          r1.x + r2.y
+        }
+    "#;
+    let p = compile(src);
+    let code = fn_code(&p, "two_records");
+    assert_eq!(count(code, |op| matches!(op, Op::AllocStackRecord { .. })), 2,
+        "both records should lower: {code:?}");
+
+    let mut vm = Vm::new(&p);
+    assert_eq!(vm.call("two_records", vec![]).unwrap(), Value::Int(125));
+}
+
+/// A record allocated inside a helper call must NOT be lowered if
+/// the helper returns it — that's an escape. Verifies the
+/// inter-procedural conservatism the design doc commits to.
+#[test]
+fn record_returned_from_helper_is_not_lowered() {
+    let src = r#"
+        fn make_point() -> { x :: Int, y :: Int } { { x: 3, y: 4 } }
+        fn caller() -> Int {
+          let p := make_point()
+          p.x + p.y
+        }
+    "#;
+    let p = compile(src);
+    let make_point_code = fn_code(&p, "make_point");
+    assert_eq!(count(make_point_code, |op| matches!(op, Op::AllocStackRecord { .. })), 0,
+        "helper-returned record must stay on heap: {make_point_code:?}");
+    assert_eq!(count(make_point_code, |op| matches!(op, Op::MakeRecord { .. })), 1);
+
+    let mut vm = Vm::new(&p);
+    assert_eq!(vm.call("caller", vec![]).unwrap(), Value::Int(7));
+}
+
+/// Body-hash invariance under the lowering pass (#222). The
+/// canonical encoding decodes `AllocStackRecord` as the historical
+/// `MakeRecord` form, so two source-equivalent functions hash
+/// identically regardless of whether the analysis fired.
+#[test]
+fn body_hash_invariant_under_lowering() {
+    let src_a = r#"
+        fn a() -> Int {
+          let r := { x: 5 }
+          r.x
+        }
+    "#;
+    let src_b = r#"
+        fn b() -> Int {
+          let r := { x: 5 }
+          r.x
+        }
+    "#;
+    let pa = compile(src_a);
+    let pb = compile(src_b);
+    let fa = &pa.functions[pa.function_names["a"] as usize];
+    let fb = &pb.functions[pb.function_names["b"] as usize];
+    assert_eq!(fa.body_hash, fb.body_hash);
+    assert!(fa.code.iter().any(|op| matches!(op, Op::AllocStackRecord { .. })));
+}
+
+/// Stack delta is unchanged by the lowering. The verifier walks
+/// `AllocStackRecord` with the same -(n)+1 delta as `MakeRecord`.
+#[test]
+fn verifier_accepts_alloc_stack_record() {
+    let src = r#"
+        fn ok() -> Int {
+          let r := { p: 1, q: 2, s: 3 }
+          r.q
+        }
+    "#;
+    let p = compile(src);
+    let errs = lex_bytecode::verify_program(&p.functions);
+    assert!(errs.is_empty(), "verifier should accept lowered code: {errs:?}");
+}
+
+/// Budget exhaustion: when a frame allocates more stack records
+/// than `STACK_RECORD_BUDGET_SLOTS` allows, further allocations
+/// fall back to the heap path silently. Observable result is
+/// identical.
+#[test]
+fn budget_exhaustion_falls_back_to_heap_without_changing_result() {
+    let mut src = String::from("fn many() -> Int {\n");
+    for i in 0..70 {
+        src.push_str(&format!("  let r{i} := {{ v: {i} }}\n"));
+    }
+    src.push_str("  ");
+    let parts: Vec<String> = (0..70).map(|i| format!("r{i}.v")).collect();
+    src.push_str(&parts.join(" + "));
+    src.push_str("\n}\n");
+
+    let p = compile(&src);
+    let code = fn_code(&p, "many");
+    assert_eq!(count(code, |op| matches!(op, Op::AllocStackRecord { .. })), 70,
+        "all 70 sites should compile to AllocStackRecord");
+    assert_eq!(count(code, |op| matches!(op, Op::MakeRecord { .. })), 0,
+        "no MakeRecord left after lowering");
+
+    let mut vm = Vm::new(&p);
+    let expected: i64 = (0..70).sum();
+    assert_eq!(vm.call("many", vec![]).unwrap(), Value::Int(expected));
+}
+
+/// Mixed escape pattern: in the same function, one site escapes
+/// and another doesn't. Lowering must be per-site, not all-or-nothing.
+#[test]
+fn per_site_lowering_in_mixed_function() {
+    let src = r#"
+        fn mix() -> { z :: Int } {
+          let temp := { a: 1, b: 2 }
+          let _ := temp.a
+          { z: 99 }
+        }
+    "#;
+    let p = compile(src);
+    let code = fn_code(&p, "mix");
+    assert_eq!(count(code, |op| matches!(op, Op::AllocStackRecord { .. })), 1,
+        "the dropped {{a,b}} record should lower");
+    assert_eq!(count(code, |op| matches!(op, Op::MakeRecord { .. })), 1,
+        "the returned {{z}} record should stay on heap");
+
+    let mut vm = Vm::new(&p);
+    let r = vm.call("mix", vec![]).unwrap();
+    match r {
+        Value::Record { fields, .. } => {
+            assert_eq!(fields.get("z"), Some(&Value::Int(99)));
+        }
+        other => panic!("expected Record, got {other:?}"),
+    }
+}

--- a/crates/lex-trace/src/recorder.rs
+++ b/crates/lex-trace/src/recorder.rs
@@ -182,6 +182,11 @@ fn value_to_json(v: &Value) -> serde_json::Value {
             for (k, v) in fields.iter() { m.insert(k.clone(), value_to_json(v)); }
             J::Object(m)
         }
+        // #464 step 2: escape analysis prevents this variant from
+        // reaching a trace boundary (the tracer only records args
+        // on Call/EffectCall — both escape sinks the analysis
+        // rejects). If we ever do see one, that's an analysis bug.
+        Value::StackRecord { .. } => J::String("<stack-record-unreachable>".into()),
         Value::Variant { name, args } => {
             let mut m = serde_json::Map::new();
             m.insert("$variant".into(), J::String(name.clone()));

--- a/crates/lex-trace/tests/m7.rs
+++ b/crates/lex-trace/tests/m7.rs
@@ -83,7 +83,7 @@ fn value_to_json(v: &Value) -> serde_json::Value {
             J::Object(m)
         }
         Value::Map(_) | Value::Set(_) | Value::Deque(_) | Value::Actor(_)
-        | Value::Ticker(_) | Value::ArrowTable(_) => {
+        | Value::Ticker(_) | Value::ArrowTable(_) | Value::StackRecord { .. } => {
             // Tests in this file don't exercise these container values;
             // render as a placeholder so the match is exhaustive.
             J::String("<container>".into())

--- a/docs/design/escape-analysis.md
+++ b/docs/design/escape-analysis.md
@@ -184,24 +184,100 @@ EscapeSite}`. Step 2's compiler integration will call
 `build_escape_index` once per program and consult it at each
 `MakeRecord` emit site.
 
+## Step 2 — `AllocStackRecord` + polymorphic `GetField`
+
+The step-2 slice (this PR's sibling commits) lowers proven-local
+`MakeRecord` sites to a new opcode `Op::AllocStackRecord` and a
+new `Value` variant `Value::StackRecord { shape_id, slab_start,
+field_count }`. The slab lives in a VM-wide
+`stack_record_arena: Vec<Value>` truncated on every `Op::Return`,
+mirroring the `locals_storage` lifetime discipline from #389.
+
+### What we did NOT add (vs the future-work table)
+
+Initial design notes mentioned `GetStackField` / `SetStackField`
+opcodes. We dropped both:
+
+- **`SetStackField`**: Lex records are immutable — there is no
+  existing `SetField` op for either heap or stack records, and the
+  AST has no field-assignment syntax. The opcode would have nothing
+  to lower from.
+
+- **`GetStackField`**: `Op::GetField` already dispatches over the
+  `Value::Record` variant via an inline-cache slot keyed by
+  `(fn_id, site_idx)` and verified by `(shape_id, offset)`. Stack
+  records carry the same `shape_id` (issued from
+  `Program::record_shapes`) and store their fields in shape order
+  (matching `MakeRecord`'s IndexMap insertion order), so the
+  existing IC slot is interoperable — one new match arm in the
+  `GetField` handler replaces what would have been a whole new op.
+  A dedicated `GetStackField` is still on the table as a peephole
+  optimization once we have a static "this GetField receiver was
+  just stack-allocated" pass, but it would compete on dispatch
+  overhead at the µs scale and is deferred.
+
+### Budget
+
+Per-frame budget pinned at `STACK_RECORD_BUDGET_SLOTS = 64` Value
+cells (= 4 KiB at the current `size_of::<Value>() == 64`). The
+budget is tracked on `Frame::stack_record_budget_remaining` and
+checked inside the VM at every `AllocStackRecord`; on overflow
+the op falls back to the heap path (an exact MakeRecord) with no
+user-visible difference. A `TailCall` refills the budget — the
+tail-called function gets its own arena view.
+
+### What step 2 ships
+
+- `Op::AllocStackRecord { shape_idx, field_count }` (op.rs)
+- `Value::StackRecord { shape_id, slab_start, field_count }` (value.rs)
+- VM arena (`stack_record_arena`) with per-frame start markers and
+  budget (vm.rs)
+- Compiler pass `apply_escape_lowering` (compiler.rs) — consults
+  `escape::build_escape_index` and rewrites non-escaping
+  `MakeRecord` sites in place
+- Body-hash invariance: `AllocStackRecord` decodes as the legacy
+  `MakeRecord` form (#222), so closure identity survives the
+  lowering bit-identically
+
 ## Future work
 
 | Issue | Scope                                                | When              |
 |-------|------------------------------------------------------|-------------------|
-| #464 step 2 | `AllocStackRecord`, `GetStackField`, `SetStackField`; compiler integration; per-frame stack-record budget | Next slice |
-| #464 step 3 | `benches/response_build.rs`; 1.5× + 60% acceptance | After step 2 |
+| #464 step 3 | `benches/response_build.rs`; 1.5× + 60% acceptance | Next slice |
 | (new) | Per-path branch refinement (recover the `if/else` merge case) | If profiling shows it matters |
 | (new) | Inter-procedural escape via summaries on small leaf functions | After inlining (#465 phase 1) |
+| (new) | `GetStackField` peephole — drop the variant-match on receiver when the producer is a same-fn `AllocStackRecord` | If dispatch shows up in the response_build profile |
 
-## Acceptance for this slice (step 1)
+## Acceptance
+
+### Step 1 (#524 — merged)
 
 - [x] `analyze_program` returns one `EscapeReport` per function
   with at least one `MakeRecord` site.
 - [x] All 15 lattice unit tests pass.
-- [x] No regression on `cargo test -p lex-bytecode --tests` (70
-  passing).
+- [x] No regression on `cargo test -p lex-bytecode --tests`.
 - [x] `cargo clippy -p lex-bytecode --all-targets -- -D warnings`
   clean.
 
-Steps 2 and 3 carry the full #464 acceptance bars (≥1.5× speedup
-on `response_build`, ≥60% of `Response` allocations on the stack).
+### Step 2 (this PR)
+
+- [x] `Op::AllocStackRecord` round-trips through verifier,
+  body-hash, and serde (the latter via the existing `Op` derive).
+- [x] Compiler lowers exactly the non-escaping `MakeRecord` sites
+  per the per-PC escape index.
+- [x] Per-frame budget falls back to heap with identical observable
+  output when exhausted.
+- [x] Polymorphic `GetField` dispatches over both `Value::Record`
+  and `Value::StackRecord` with shared IC slot.
+- [x] 9 new integration tests in
+  `crates/lex-bytecode/tests/stack_records.rs` pass.
+- [x] `cargo test -p lex-bytecode` (75 tests), `-p lex-trace`,
+  `-p lex-runtime --lib` (46), `-p core-compiler --test m9/m9_phase2`
+  (19), and runtime integration `std_http` / `analytics_app` /
+  `closed_pydantic_issues` / `conc_registry` / `arena_lifecycle`
+  all pass.
+- [x] `cargo clippy -p lex-bytecode --all-targets -- -D warnings`
+  clean.
+
+Step 3 carries the #464 perf acceptance bars (≥1.5× speedup on
+`response_build`, ≥60% of `Response` allocations on the stack).


### PR DESCRIPTION
## Summary

Step 2 of #464. Step 1 (#524) gave us a per-`(fn, pc)` index of `MakeRecord` sites the escape analysis proved frame-local. This slice consumes the index: a new `Op::AllocStackRecord` allocates into a VM-wide arena instead of the heap, the compiler swaps `MakeRecord → AllocStackRecord` at non-escaping PCs, and `Op::GetField` polymorphically reads from either representation.

- `Op::AllocStackRecord { shape_idx, field_count }` — same value-stack contract as `MakeRecord` (pop N, push 1).
- `Value::StackRecord { shape_id, slab_start, field_count }` — 12-byte payload referring into `Vm::stack_record_arena`.
- `apply_escape_lowering` pass in `compiler.rs` consults `escape::build_escape_index` and rewrites in place. Runs before peephole; the peephole patterns don't match either opcode so order is free.
- Per-frame budget = `STACK_RECORD_BUDGET_SLOTS = 64` (≈4 KiB at `size_of::<Value>() == 64`); on overflow the op falls back to the heap path silently with identical observable behavior.
- `Op::GetField` gets a `Value::StackRecord` arm; the existing `(shape_id, offset)` inline cache is interoperable because `MakeRecord` builds the `IndexMap` in shape-order — offset N means the same field in either representation.
- `Op::Return` truncates the arena to `frame.stack_record_arena_start`; `Op::TailCall` refills the budget for the tail-called function.
- `body_hash` decodes `AllocStackRecord` as the legacy `MakeRecord` form, so closure identity (#222) is bit-identical under the lowering.

Design notes are in `docs/design/escape-analysis.md` (updated in this PR). Notable narrowing vs. the original step-2 sketch: `GetStackField` and `SetStackField` aren't shipped — Lex records are immutable (no `SetField` exists), and the polymorphic `GetField` arm is cheaper than introducing a new opcode while the IC handles both representations.

## What's NOT in this PR

Step 3 (next slice): `benches/response_build.rs` and the #464 perf acceptance bars (≥1.5× speedup on response build, ≥60% of `Response` allocations on the stack).

## Test plan

- [x] `cargo test -p lex-bytecode` — 75 tests pass (9 new in `tests/stack_records.rs`: non-escaping lowers, escaping stays on heap, multi-record same frame, helper-returned record not lowered, body-hash invariance, verifier accepts new op, polymorphic IC dispatch, budget exhaustion fallback, mixed per-site lowering)
- [x] `cargo test -p lex-trace` — passes (with `Value::StackRecord` placeholder added to the trace JSON renderer; never reached in practice — escape analysis prevents it)
- [x] `cargo test -p lex-runtime --lib` — 46/46 pass
- [x] `cargo test -p lex-runtime --test analytics_app --test std_http --test closed_pydantic_issues --test conc_registry --test arena_lifecycle` — all pass (record-heavy integration paths)
- [x] `cargo test -p core-compiler --test m9 --test m9_phase2` — 19 pass
- [x] `cargo clippy -p lex-bytecode --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjQc3kQTQXm97YX22kfwsU)_