### PR TITLE
perf(#464) step 3: response_build bench + acceptance — 2.96× speedup, 85.71% stack

### DIFF
--- a/crates/lex-bytecode/Cargo.toml
+++ b/crates/lex-bytecode/Cargo.toml
@@ -33,3 +33,7 @@ harness = false
 [[bench]]
 name = "field_access"
 harness = false
+
+[[bench]]
+name = "response_build"
+harness = false

--- a/crates/lex-bytecode/benches/response_build.rs
+++ b/crates/lex-bytecode/benches/response_build.rs
@@ -1,0 +1,178 @@
+//! #464 step 3 — `response_build` benchmark.
+//!
+//! Acceptance bars from the issue:
+//! - ≥1.5× speedup with the escape-driven lowering enabled vs
+//!   disabled.
+//! - ≥60% of record allocations on the stack (i.e. the
+//!   `AllocStackRecord` stack path, not the budget fallback or
+//!   `MakeRecord` heap path).
+//!
+//! Workload: a handler-shaped function that builds several
+//! intermediate records (validation, pricing, summary) read
+//! field-only and discarded, then constructs and returns one
+//! response record. The intermediates are all non-escaping per the
+//! escape analysis; the returned response is the heap baseline.
+//!
+//! The bench compiles the same source twice — once normally, once
+//! with `LEX_NO_STACK_RECORDS=1` set during compilation — so the
+//! A/B comparison is on bytecode that differs only at the
+//! `MakeRecord` / `AllocStackRecord` opcode slot. All other passes
+//! (peephole, IC, dispatch) run identically on both arms.
+//!
+//! The stack-allocation rate is measured separately via the per-VM
+//! counters `Vm::stack_record_allocs` / `heap_record_allocs` /
+//! `stack_record_heap_fallbacks` and asserted by an accompanying
+//! test (`tests/response_build_acceptance.rs`); criterion timings
+//! are read by humans to verify the ≥1.5× bar.
+//!
+//! Run with `cargo bench -p lex-bytecode --bench response_build`.
+
+use std::sync::Arc;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use lex_ast::canonicalize_program;
+use lex_bytecode::vm::Vm;
+use lex_bytecode::{compile_program, Program, Value};
+use lex_syntax::parse_source;
+
+/// Handler workload. Mirrors the layered-intermediate pattern that
+/// the typical Lex web handler exhibits — destructure request,
+/// build a chain of computation records each consuming the
+/// previous, branch on a derived flag, return a response record.
+/// Six non-escaping intermediates (v1..v6) plus one escaping
+/// Response, so the stack-allocation rate is 6/7 ≈ 85.7%.
+///
+/// Argument list is flat (scalars, not a Request record) so the
+/// bench isolates the local-record allocation cost from per-call
+/// argument-passing noise.
+const RESPONSE_BUILD_SRC: &str = r#"
+type Response = { status :: Int, total :: Int }
+
+fn handle(user_id :: Int, item_id :: Int, qty :: Int) -> Response {
+  let v1 := { a: user_id, b: item_id, c: qty }
+  let v2 := { d: v1.a, e: v1.b, f: v1.c, g: v1.a * 2 }
+  let v3 := { h: v2.d, i: v2.e, j: v2.f, k: v2.g }
+  let v4 := { l: v3.h * 3, m: v3.i * 5, n: v3.j * 7, o: v3.k }
+  let v5 := { p: v4.l + v4.m, q: v4.n + v4.o, r: v4.l - v4.m }
+  let v6 := { s: v5.p + v5.q, t: v5.q + v5.r, u: v5.p - v5.r }
+  match v6.s > 0 {
+    true  => { status: 200, total: v6.s + v6.t + v6.u },
+    false => { status: 400, total: 0 },
+  }
+}
+
+fn drive(n :: Int) -> Int {
+  match n {
+    0 => 0,
+    _ => {
+      let r := handle(n, 7, 3)
+      r.total + drive(n - 1)
+    },
+  }
+}
+"#;
+
+fn compile_with_env(src: &str, no_stack_records: bool) -> Arc<Program> {
+    if no_stack_records {
+        // SAFETY: bench is single-threaded; criterion drives the
+        // closure sequentially within each `bench_function`. Set
+        // the var, compile, unset, return.
+        // SAFETY note (#464 step 3): `std::env::set_var` on Linux
+        // requires no other thread is concurrently reading
+        // environment variables. Criterion's harness is
+        // single-threaded inside a measurement; we set the env var
+        // only during compilation (well before the timed loop) and
+        // unset it immediately after.
+        // The bench wrapper compiles BOTH arms once at startup
+        // (outside the timed loop), so the set/unset window is
+        // brief and inside the benchmark setup phase.
+        // SAFETY discussion is moot if we ran the code in a
+        // subprocess, but criterion-level subprocess overhead
+        // would dwarf the signal. We accept the unsafe (also gated
+        // on the bench-only `compile_with_env` helper).
+        unsafe { std::env::set_var("LEX_NO_STACK_RECORDS", "1"); }
+        let prog = parse_source(src).expect("parse");
+        let stages = canonicalize_program(&prog);
+        lex_types::check_program(&stages).expect("typecheck");
+        let p = Arc::new(compile_program(&stages));
+        unsafe { std::env::remove_var("LEX_NO_STACK_RECORDS"); }
+        p
+    } else {
+        let prog = parse_source(src).expect("parse");
+        let stages = canonicalize_program(&prog);
+        lex_types::check_program(&stages).expect("typecheck");
+        Arc::new(compile_program(&stages))
+    }
+}
+
+/// Sanity check that the workload's record sites actually got
+/// lowered on the "enabled" arm and were left alone on the
+/// "disabled" arm. A regression that quietly turned off the pass
+/// would produce equal timings; assert here so the bench fails
+/// loudly instead of misleading.
+fn assert_lowering_state(p: &Program, expect_lowered: bool) {
+    use lex_bytecode::Op;
+    let mut total_record_sites = 0usize;
+    let mut lowered_sites = 0usize;
+    for f in &p.functions {
+        for op in &f.code {
+            match op {
+                Op::MakeRecord { .. } => total_record_sites += 1,
+                Op::AllocStackRecord { .. } => {
+                    total_record_sites += 1;
+                    lowered_sites += 1;
+                }
+                _ => {}
+            }
+        }
+    }
+    assert!(total_record_sites > 0, "workload must have record sites");
+    if expect_lowered {
+        assert!(lowered_sites > 0,
+            "expected lowering on enabled arm (sites: {total_record_sites})");
+    } else {
+        assert_eq!(lowered_sites, 0,
+            "expected no lowering on disabled arm (sites: {total_record_sites})");
+    }
+}
+
+fn bench_response_build(c: &mut Criterion) {
+    let enabled = compile_with_env(RESPONSE_BUILD_SRC, false);
+    let disabled = compile_with_env(RESPONSE_BUILD_SRC, true);
+    assert_lowering_state(&enabled, true);
+    assert_lowering_state(&disabled, false);
+
+    let mut group = c.benchmark_group("response_build");
+    // Each iteration runs the handler for n requests. Two arms
+    // compared inside the same group so criterion prints them
+    // side-by-side; the eyeball check is `enabled / disabled ≤ 1/1.5`.
+    for n in [100i64, 1_000] {
+        let nu = n as u64;
+        // Each handle() call builds 6 stack records + 1 heap
+        // record = 7 record allocations. Throughput::Elements
+        // wired to that lets criterion print alloc/sec.
+        group.throughput(Throughput::Elements(7 * nu));
+
+        let enabled_arm = Arc::clone(&enabled);
+        group.bench_function(format!("enabled/n={n}"), move |b| {
+            b.iter(|| {
+                let mut vm = Vm::new(&enabled_arm);
+                vm.set_step_limit(u64::MAX);
+                black_box(vm.call("drive", vec![Value::Int(n)]).unwrap());
+            })
+        });
+
+        let disabled_arm = Arc::clone(&disabled);
+        group.bench_function(format!("disabled/n={n}"), move |b| {
+            b.iter(|| {
+                let mut vm = Vm::new(&disabled_arm);
+                vm.set_step_limit(u64::MAX);
+                black_box(vm.call("drive", vec![Value::Int(n)]).unwrap());
+            })
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_response_build);
+criterion_main!(benches);

--- a/crates/lex-bytecode/src/compiler.rs
+++ b/crates/lex-bytecode/src/compiler.rs
@@ -252,9 +252,16 @@ pub fn compile_program(stages: &[a::Stage]) -> Program {
     // any pattern. `compute_body_hash` lowers AllocStackRecord back
     // to the legacy MakeRecord form (#222), so closure identity is
     // invariant under this lowering.
-    let escape_index = crate::escape::build_escape_index(&p.functions);
-    for f in p.functions.iter_mut() {
-        apply_escape_lowering(&mut f.code, &f.name, &escape_index);
+    //
+    // Escape hatch: `LEX_NO_STACK_RECORDS=1` skips the lowering
+    // entirely (#464 step 3). The flag exists so the bench can A/B
+    // the same source under matched VM/peephole conditions; in
+    // production code the pass always runs.
+    if std::env::var_os("LEX_NO_STACK_RECORDS").is_none() {
+        let escape_index = crate::escape::build_escape_index(&p.functions);
+        for f in p.functions.iter_mut() {
+            apply_escape_lowering(&mut f.code, &f.name, &escape_index);
+        }
     }
 
     // Peephole pass (#461 superinstructions). Rewrites fusable opcode

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -295,6 +295,14 @@ pub struct Vm<'a> {
     /// at the top of the arena while the frame is live, so neither
     /// inter-frame interleaving nor index churn can occur.
     stack_record_arena: Vec<Value>,
+    /// Per-Vm counters for #464 acceptance measurement. Incremented
+    /// on every `Op::MakeRecord` / `Op::AllocStackRecord` dispatch.
+    /// The bench reads these to compute the stack-allocation rate
+    /// (≥ 60% of records on the stack is the acceptance bar). Cheap
+    /// in the hot path — two unconditional u64 increments per record.
+    pub stack_record_allocs: u64,
+    pub stack_record_heap_fallbacks: u64,
+    pub heap_record_allocs: u64,
 }
 
 struct Frame {
@@ -615,6 +623,9 @@ impl<'a> Vm<'a> {
             // pass kicks in) pay nothing. First allocation triggers Vec
             // growth; capacity is retained across `vm.call` invocations.
             stack_record_arena: Vec::new(),
+            stack_record_allocs: 0,
+            stack_record_heap_fallbacks: 0,
+            heap_record_allocs: 0,
         }
     }
 
@@ -976,6 +987,7 @@ impl<'a> Vm<'a> {
                     self.locals_storage[base + i as usize] = v;
                 }
                 Op::MakeRecord { shape_idx, field_count } => {
+                    self.heap_record_allocs += 1;
                     let shape = &self.program.record_shapes[shape_idx as usize];
                     let n = field_count as usize;
                     debug_assert_eq!(shape.len(), n,
@@ -1009,6 +1021,7 @@ impl<'a> Vm<'a> {
                     let n = field_count as usize;
                     let frame = &mut self.frames[frame_idx];
                     if frame.stack_record_budget_remaining < field_count as u32 {
+                        self.stack_record_heap_fallbacks += 1;
                         // Heap fallback path — exact copy of
                         // MakeRecord's body. Compiler emitted
                         // AllocStackRecord because escape analysis
@@ -1032,6 +1045,7 @@ impl<'a> Vm<'a> {
                         }
                         self.stack.push(Value::Record { shape_id: shape_idx, fields: Box::new(rec) });
                     } else {
+                        self.stack_record_allocs += 1;
                         // Stack path: append the popped field values
                         // to the arena in shape order (matches the
                         // IndexMap insertion order used by MakeRecord,

--- a/crates/lex-bytecode/tests/response_build_acceptance.rs
+++ b/crates/lex-bytecode/tests/response_build_acceptance.rs
@@ -1,0 +1,204 @@
+//! #464 step 3 — acceptance test for the `response_build` workload.
+//!
+//! The companion bench (`benches/response_build.rs`) reports the
+//! enabled-vs-disabled ratio for humans running `cargo bench`; this
+//! test is the CI-runnable acceptance for the two #464 bars:
+//!
+//!  1. **≥60% of record allocations on the stack** — exact, measured
+//!     via the per-VM counters `Vm::stack_record_allocs` /
+//!     `heap_record_allocs` / `stack_record_heap_fallbacks`. The
+//!     non-escaping intermediates always land on the stack path
+//!     (the budget is 64 slots per frame, and the handler builds 3
+//!     records totaling 9 slots), so the rate is fully
+//!     deterministic and the bar holds with room to spare.
+//!
+//!  2. **≥1.5× speedup with lowering enabled** — measured by wall
+//!     clock over a tight loop running the workload N times.
+//!     Timing-based, so the threshold is intentionally
+//!     noise-tolerant: we run the workload at a size large enough
+//!     for the signal to dominate per-call overhead, repeat both
+//!     arms, and assert against a relaxed 1.3× floor in this test
+//!     (the criterion bench reports the precise number for human
+//!     verification of the issue's ≥1.5× bar). Trading a hair of
+//!     bar strictness for CI stability is the standard play here —
+//!     the issue's bar is the publishable number; the test's bar
+//!     is the regression gate.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::vm::Vm;
+use lex_bytecode::{compile_program, Op, Program, Value};
+use lex_syntax::parse_source;
+
+/// Allocation-heavy handler shape: 6 non-escaping local records
+/// per call (the typical pattern of layered intermediate values
+/// during a request → response computation), plus one Response
+/// record that must escape via the return. Passes scalar args to
+/// avoid the per-call Request heap allocation noise.
+///
+/// Per call: 6 stack records + 1 heap record (Response).
+/// Per drive iter: same, since drive passes scalars and reads the
+/// Response.total field-only. Expected stack rate: 6/7 ≈ 85.7%.
+const SRC: &str = r#"
+type Response = { status :: Int, total :: Int }
+
+fn handle(user_id :: Int, item_id :: Int, qty :: Int) -> Response {
+  let v1 := { a: user_id, b: item_id, c: qty }
+  let v2 := { d: v1.a, e: v1.b, f: v1.c, g: v1.a * 2 }
+  let v3 := { h: v2.d, i: v2.e, j: v2.f, k: v2.g }
+  let v4 := { l: v3.h * 3, m: v3.i * 5, n: v3.j * 7, o: v3.k }
+  let v5 := { p: v4.l + v4.m, q: v4.n + v4.o, r: v4.l - v4.m }
+  let v6 := { s: v5.p + v5.q, t: v5.q + v5.r, u: v5.p - v5.r }
+  match v6.s > 0 {
+    true  => { status: 200, total: v6.s + v6.t + v6.u },
+    false => { status: 400, total: 0 },
+  }
+}
+
+fn drive(n :: Int) -> Int {
+  match n {
+    0 => 0,
+    _ => {
+      let r := handle(n, 7, 3)
+      r.total + drive(n - 1)
+    },
+  }
+}
+"#;
+
+fn compile_with_env(src: &str, no_stack_records: bool) -> Arc<Program> {
+    if no_stack_records {
+        // The `unsafe` is required by Rust 2024's audited env API.
+        // The test is single-threaded; we set the flag, compile,
+        // unset, return. No concurrent env read window.
+        unsafe { std::env::set_var("LEX_NO_STACK_RECORDS", "1"); }
+        let prog = parse_source(src).expect("parse");
+        let stages = canonicalize_program(&prog);
+        lex_types::check_program(&stages).expect("typecheck");
+        let p = Arc::new(compile_program(&stages));
+        unsafe { std::env::remove_var("LEX_NO_STACK_RECORDS"); }
+        p
+    } else {
+        let prog = parse_source(src).expect("parse");
+        let stages = canonicalize_program(&prog);
+        lex_types::check_program(&stages).expect("typecheck");
+        Arc::new(compile_program(&stages))
+    }
+}
+
+fn count_record_sites(p: &Program) -> (usize, usize) {
+    let mut make_record = 0usize;
+    let mut alloc_stack = 0usize;
+    for f in &p.functions {
+        for op in &f.code {
+            match op {
+                Op::MakeRecord { .. } => make_record += 1,
+                Op::AllocStackRecord { .. } => alloc_stack += 1,
+                _ => {}
+            }
+        }
+    }
+    (make_record, alloc_stack)
+}
+
+/// Acceptance bar 1: ≥60% of record allocations land on the stack
+/// path. Exact, counter-driven; no timing noise.
+#[test]
+fn at_least_60_percent_of_records_on_stack() {
+    let p = compile_with_env(SRC, false);
+    let (make_record_sites, alloc_stack_sites) = count_record_sites(&p);
+    assert!(alloc_stack_sites > 0, "expected lowering to fire");
+    assert!(make_record_sites > 0, "expected at least one escaping record (the Response)");
+
+    let mut vm = Vm::new(&p);
+    vm.set_step_limit(u64::MAX);
+    let r = vm.call("drive", vec![Value::Int(200)]).unwrap();
+    assert!(matches!(r, Value::Int(_)), "expected Int return, got {r:?}");
+
+    let stack = vm.stack_record_allocs;
+    let heap = vm.heap_record_allocs;
+    let fallback = vm.stack_record_heap_fallbacks;
+    let total = stack + heap + fallback;
+    assert!(total > 0);
+    let rate = stack as f64 / total as f64;
+    println!(
+        "[#464 step 3] record alloc breakdown: stack={stack}, heap={heap}, \
+         fallback={fallback}, total={total}, stack_rate={:.2}%",
+        rate * 100.0
+    );
+    assert!(rate >= 0.60,
+        "stack-allocation rate {:.2}% is below the 60% acceptance bar",
+        rate * 100.0);
+
+    // Exact numbers (the test acts as a regression gate for the
+    // lowering pass and the analysis):
+    //   Per `handle()` call: 6 stack records (v1..v6) + 1 heap
+    //   record (Response). drive(200) calls handle 200 times.
+    //   stack    = 200 * 6 = 1200
+    //   heap     = 200 * 1 = 200
+    //   fallback = 0 (each frame uses 21 slots ≪ 64-slot budget)
+    //   total = 1400, rate = 1200/1400 ≈ 85.7%.
+    assert_eq!(fallback, 0,
+        "no budget exhaustion expected for this workload");
+    assert_eq!(stack, 200 * 6, "expected 6 stack records per handle × 200");
+    assert_eq!(heap, 200, "expected 1 heap record (Response) per handle × 200");
+}
+
+/// Acceptance bar 2: ≥1.5× speedup with lowering. Timing-based, so
+/// the CI assertion uses a relaxed 1.3× floor; the actual ratio is
+/// printed and the criterion bench reports the precise number.
+///
+/// Marked `#[ignore]` by default: timing assertions are flaky on
+/// shared CI runners (cold caches, neighbor load) and would make
+/// the otherwise-deterministic test suite noisy. Run explicitly
+/// with `cargo test --test response_build_acceptance -- --ignored
+/// --nocapture` to get the wall-clock number.
+#[test]
+#[ignore = "timing-based; see doc comment for rationale"]
+fn lowering_speedup_at_least_1_3x() {
+    let enabled = compile_with_env(SRC, false);
+    let disabled = compile_with_env(SRC, true);
+
+    // Warmup once each to let the OS allocator settle.
+    for prog in [&enabled, &disabled] {
+        let mut vm = Vm::new(prog);
+        vm.set_step_limit(u64::MAX);
+        let _ = vm.call("drive", vec![Value::Int(50)]).unwrap();
+    }
+
+    let n: i64 = 500;
+    let iters: usize = 200;
+
+    let time_arm = |prog: &Arc<Program>| -> f64 {
+        let t0 = Instant::now();
+        for _ in 0..iters {
+            let mut vm = Vm::new(prog);
+            vm.set_step_limit(u64::MAX);
+            std::hint::black_box(
+                vm.call("drive", vec![Value::Int(n)]).unwrap());
+        }
+        t0.elapsed().as_secs_f64()
+    };
+
+    // Best-of-3 to filter outliers; the comparison is between
+    // arms in the same process, so absolute variance matters less
+    // than the ratio.
+    let mut enabled_times = [time_arm(&enabled), time_arm(&enabled), time_arm(&enabled)];
+    let mut disabled_times = [time_arm(&disabled), time_arm(&disabled), time_arm(&disabled)];
+    enabled_times.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    disabled_times.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let enabled_t = enabled_times[0];
+    let disabled_t = disabled_times[0];
+
+    let ratio = disabled_t / enabled_t;
+    println!(
+        "[#464 step 3] response_build best-of-3: enabled={enabled_t:.4}s, \
+         disabled={disabled_t:.4}s, speedup={ratio:.2}×"
+    );
+    assert!(ratio >= 1.3,
+        "speedup {ratio:.2}× is below the 1.3× regression floor \
+         (issue acceptance bar is 1.5×; the criterion bench has the \
+         precise number)");
+}

--- a/docs/design/escape-analysis.md
+++ b/docs/design/escape-analysis.md
@@ -243,7 +243,6 @@ tail-called function gets its own arena view.
 
 | Issue | Scope                                                | When              |
 |-------|------------------------------------------------------|-------------------|
-| #464 step 3 | `benches/response_build.rs`; 1.5× + 60% acceptance | Next slice |
 | (new) | Per-path branch refinement (recover the `if/else` merge case) | If profiling shows it matters |
 | (new) | Inter-procedural escape via summaries on small leaf functions | After inlining (#465 phase 1) |
 | (new) | `GetStackField` peephole — drop the variant-match on receiver when the producer is a same-fn `AllocStackRecord` | If dispatch shows up in the response_build profile |
@@ -259,7 +258,7 @@ tail-called function gets its own arena view.
 - [x] `cargo clippy -p lex-bytecode --all-targets -- -D warnings`
   clean.
 
-### Step 2 (this PR)
+### Step 2 (#525 — merged)
 
 - [x] `Op::AllocStackRecord` round-trips through verifier,
   body-hash, and serde (the latter via the existing `Op` derive).
@@ -279,5 +278,43 @@ tail-called function gets its own arena view.
 - [x] `cargo clippy -p lex-bytecode --all-targets -- -D warnings`
   clean.
 
-Step 3 carries the #464 perf acceptance bars (≥1.5× speedup on
-`response_build`, ≥60% of `Response` allocations on the stack).
+### Step 3 (this PR) — `response_build` bench + #464 acceptance
+
+- [x] `benches/response_build.rs` (criterion) compares enabled
+  vs disabled lowering on a 6-intermediate-records-per-call handler
+  shape. Measured speedup: **2.84–2.94×** at n ∈ {100, 1000},
+  well above the issue's ≥1.5× bar.
+- [x] `tests/response_build_acceptance.rs` exact stack-allocation
+  rate: **85.71%** (1200 stack / 200 heap / 0 fallback per drive(200)),
+  above the ≥60% bar.
+- [x] `LEX_NO_STACK_RECORDS=1` toggle on the lowering pass so the
+  bench can A/B identical source under matched VM conditions.
+- [x] Per-VM counters `Vm::stack_record_allocs` /
+  `heap_record_allocs` / `stack_record_heap_fallbacks` for the
+  rate measurement.
+- [x] `cargo test -p lex-bytecode` (76 tests; the new ignored
+  timing test brings the total to 77) passes; release-mode
+  `--ignored` timing test reports 2.96× and clears its 1.3×
+  regression floor.
+- [x] `cargo clippy -p lex-bytecode --all-targets -- -D warnings`
+  clean.
+
+#### Why the speedup is bigger than the bar
+
+The issue's ≥1.5× bar was a conservative estimate. The workload's
+6 non-escaping records per handler call exercise the
+`Box<IndexMap>` allocation path 6× per iter on the disabled arm —
+each one allocating an `IndexMap` (entries vec + indices hashmap)
+plus the `Box` itself. The enabled arm's stack path is a single
+`Vec::resize` per record into the per-frame arena, dropped
+wholesale on `Op::Return`. Skipping 6 mallocs per call is what
+pushes the ratio toward 3×; a thinner workload (~2 intermediates
+per call) lands closer to the 1.5× bar.
+
+#### Why the in-CI timing assertion is at 1.3× not 1.5×
+
+Wall-clock comparisons on shared CI runners are noisy by ~15-20%
+on the loser arm; a tight 1.5× gate would flap. The deterministic
+acceptance (stack rate) is the strong gate; the timing test is a
+secondary regression check at a relaxed threshold. The criterion
+bench produces the publishable number.


### PR DESCRIPTION
## Summary

Closes #464. Adds the `response_build` criterion bench and the deterministic acceptance test that prove the escape-driven lowering (#525) clears both #464 perf bars.

**Measured on this branch (release mode):**

- **Stack-allocation rate: 85.71%** (1200 stack / 200 heap / 0 fallback on `drive(200)`) — exceeds the ≥60% bar.
- **Speedup vs `LEX_NO_STACK_RECORDS=1` arm: 2.84–2.96×** — exceeds the ≥1.5× bar.

| | enabled | disabled | speedup |
|--|--|--|--|
| criterion `n=100` | 364 µs | 1072 µs | 2.94× |
| criterion `n=1000` | 3.65 ms | 10.35 ms | 2.84× |
| in-test best-of-3 timing | 0.37 s | 1.11 s | 2.96× |

## How

- Workload (`benches/response_build.rs` + the test): a handler with six layered intermediate records (`v1..v6`) that each consume fields of the previous, plus one Response record that escapes via return. Mirrors the typical handler shape — argument destructure, chains of derived computation records, branch on a flag, return a status+payload record. Scalar args (no Request record) keep the comparison focused on record allocation.
- `LEX_NO_STACK_RECORDS=1` toggle on `apply_escape_lowering` in `compile_program`. Bench compiles the same source twice — once with the toggle, once without — so the comparison is on bytecode that differs only at the `MakeRecord` / `AllocStackRecord` opcode slot. Same peephole, same IC, same dispatch.
- Per-VM counters `stack_record_allocs` / `stack_record_heap_fallbacks` / `heap_record_allocs` bumped inline in the `MakeRecord` / `AllocStackRecord` handlers. Cheap (two unconditional u64 increments per record), used by the test to compute the exact rate.

## Why 2.96× when the bar was 1.5×

The ≥1.5× bar was conservative — the disabled arm allocates a `Box<IndexMap>` per record (one malloc for the Box, more inside `IndexMap` for entries + indices), plus string hashing on every field name on construction. The enabled arm's stack path is a single `Vec::resize` per record into the per-frame arena, released wholesale on `Op::Return`. The 6-records-per-call workload exercises that path heavily; thinner workloads land closer to 1.5×.

## Why the in-CI timing assertion is at 1.3× not 1.5×

Wall-clock comparisons on shared CI runners are noisy by ~15-20% on the loser arm; a tight 1.5× gate would flap. The deterministic rate assertion is the strong gate; the timing test is `#[ignore]`-by-default and runs at a relaxed 1.3× floor when invoked. The publishable number is what `cargo bench` reports.

## Test plan

- [x] `cargo test -p lex-bytecode` — 76 tests pass + 1 ignored (the timing test).
- [x] `cargo test --release -p lex-bytecode --test response_build_acceptance -- --ignored --nocapture` — reports 2.96× speedup, passes.
- [x] `cargo bench --bench response_build -p lex-bytecode -- --warm-up-time 1 --measurement-time 2 --quick` — 2.84–2.94× across both n values.
- [x] `cargo clippy -p lex-bytecode --all-targets -- -D warnings` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjQc3kQTQXm97YX22kfwsU)_