### PR TITLE
perf(#461) slice 7: fuse LoadLocal + GetField + IntAdd

### DIFF
--- a/crates/lex-bytecode/src/compiler.rs
+++ b/crates/lex-bytecode/src/compiler.rs
@@ -152,6 +152,22 @@ pub fn compile_program(stages: &[a::Stage]) -> Program {
     let function_names = p.function_names.clone();
     let module_aliases = p.module_aliases.clone();
     let mut pending_lambdas: Vec<PendingLambda> = Vec::new();
+    // #461 slice 7: collect `type Foo = { ... }` aliases so
+    // `record_field_types` can resolve a parameter's named record
+    // type to its field layout. Without this, `r :: R` where
+    // `type R = { x :: Int, y :: Int }` falls through to Unknown
+    // and the typed-Add lowering misses on `r.x + r.y`.
+    let mut type_aliases: IndexMap<String, a::TypeExpr> = IndexMap::new();
+    for s in stages {
+        if let a::Stage::TypeDecl(td) = s {
+            // Parameterized type aliases (`type Box[T] = ...`) are
+            // out of scope for this slice — without monomorphization
+            // we can't know what T resolves to. Skip them.
+            if td.params.is_empty() {
+                type_aliases.insert(td.name.clone(), td.definition.clone());
+            }
+        }
+    }
 
     for s in stages {
         if let a::Stage::FnDecl(_) = s {
@@ -165,6 +181,7 @@ pub fn compile_program(stages: &[a::Stage]) -> Program {
                 next_local: 0,
                 peak_local: 0,
                 local_types: IndexMap::new(),
+                local_record_field_types: IndexMap::new(),
                 field_get_sites: 0,
                 pool: &mut pool,
                 function_names: &function_names,
@@ -177,6 +194,13 @@ pub fn compile_program(stages: &[a::Stage]) -> Program {
                 let i = fc.next_local;
                 fc.locals.insert(param.name.clone(), i);
                 fc.local_types.insert(param.name.clone(), classify_type_expr(&param.ty));
+                // #461 slice 7: inline-record parameter (`r ::
+                // { x :: Int, y :: Int }`) — populate the per-local
+                // field-type map so `r.x + r.y` classifies as
+                // Int+Int → IntAdd, which slice 7 then fuses.
+                if let Some(ftypes) = record_field_types(&param.ty, &type_aliases) {
+                    fc.local_record_field_types.insert(param.name.clone(), ftypes);
+                }
                 fc.next_local += 1;
                 fc.peak_local = fc.next_local;
             }
@@ -203,6 +227,7 @@ pub fn compile_program(stages: &[a::Stage]) -> Program {
             next_local: 0,
             peak_local: 0,
             local_types: IndexMap::new(),
+            local_record_field_types: IndexMap::new(),
             field_get_sites: 0,
             pool: &mut pool,
             function_names: &function_names,
@@ -300,6 +325,11 @@ pub fn compile_program(stages: &[a::Stage]) -> Program {
         // fused op that reads the just-stored local). Must run after
         // slice 5 since it matches on slice 5's output.
         apply_peephole_slice6(&mut f.code);
+        // Slice 7 — fuse `LoadLocal + GetField + IntAdd`, the
+        // accumulator-with-field-read idiom. Disjoint from every
+        // earlier slice (only this one matches a GetField at slot 1),
+        // so order is independent — placed at the end for chronology.
+        apply_peephole_slice7(&mut f.code);
     }
 
     // Final pass: stamp every function with its content hash now that
@@ -630,6 +660,52 @@ fn apply_peephole_slice6(code: &mut [Op]) {
     }
 }
 
+/// Slice 7: fuse `[LoadLocal(local_idx), GetField{name_idx, site_idx},
+/// IntAdd]` into `LoadLocalGetFieldAdd { local_idx, name_idx, site_idx }`.
+///
+/// Fires on the `acc + r.field` accumulator-with-field-read idiom —
+/// the bytecode the compiler emits for `prev_expr + record.field`
+/// once `prev_expr` is on the stack. Common in handler-shaped code
+/// like `r.x + r.y + r.z` (the LHS of each `+` after the first
+/// matches this pattern) and `acc + items[i].weight` reductions.
+///
+/// Disjoint from every prior slice: slice 1 wants `PushConst` at
+/// slot 1; slices 3-4 want `LoadLocal` at slot 1; slice 5 wants
+/// a 4-slot window with `IntEq + JumpIfNot` terminator. Only this
+/// slice matches a `GetField` at slot 1.
+///
+/// Order: must run after slice 4 (so the disjointness analysis
+/// holds — slice 3/4 patterns with a trailing IntAdd / IntSub /
+/// IntMul never carry a GetField at slot 1 and don't compete);
+/// must run before / independent of slice 5/6, which don't match
+/// any slot in this window.
+///
+/// Safety: trailing two slots (the original `GetField` and
+/// `IntAdd`) must not be jump targets. The first slot can be.
+fn apply_peephole_slice7(code: &mut [Op]) {
+    if code.len() < 3 { return; }
+    let jump_targets = collect_jump_targets(code);
+
+    let n = code.len();
+    let mut k = 0;
+    while k + 2 < n {
+        if let (
+            Op::LoadLocal(local_idx),
+            Op::GetField { name_idx, site_idx },
+            Op::IntAdd,
+        ) = (code[k], code[k + 1], code[k + 2]) {
+            let safe = !jump_targets.contains(&(k + 1))
+                && !jump_targets.contains(&(k + 2));
+            if safe {
+                code[k] = Op::LoadLocalGetFieldAdd { local_idx, name_idx, site_idx };
+                k += 3;
+                continue;
+            }
+        }
+        k += 1;
+    }
+}
+
 fn collect_jump_targets(code: &[Op]) -> std::collections::HashSet<usize> {
     let mut targets = std::collections::HashSet::new();
     for (pc, op) in code.iter().enumerate() {
@@ -675,6 +751,21 @@ struct FnCompiler<'a> {
     /// slot index so shadowed bindings are handled correctly via
     /// `IndexMap`'s insertion-order semantics.
     local_types: IndexMap<String, NumTy>,
+    /// Per-local map of statically-known field types (#461 slice 7).
+    /// Populated when a local is bound from a `RecordLit` whose
+    /// fields all classify to non-`Unknown` `NumTy`s. Lets
+    /// `classify_expr(FieldAccess { value: Var(name), field })`
+    /// return a precise `NumTy` instead of falling back to
+    /// `Unknown` — which in turn unlocks the typed-Add lowering
+    /// (`+` over two Ints → `IntAdd`) on `r.field + r.field`
+    /// chains, which slice 7 then fuses into
+    /// `LoadLocalGetFieldAdd`.
+    ///
+    /// Only the literal-binding case is tracked here; annotated
+    /// `let r :: R := ...` would require resolving the type alias
+    /// `R` to its field-type map, which the compiler doesn't yet
+    /// have. Future slice work.
+    local_record_field_types: IndexMap<String, IndexMap<String, NumTy>>,
     /// Per-function counter for `Op::GetField` site indices (#462
     /// slice 1). Each `Op::GetField` emit allocates the next index
     /// here, giving every field-access site within this function a
@@ -702,6 +793,33 @@ struct FnCompiler<'a> {
 /// of these returns `Unknown` and falls back to the polymorphic op.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum NumTy { Int, Float, Unknown }
+
+/// #461 slice 7: extract a `field_name -> NumTy` map from a record
+/// type expression. Resolves named types (`r :: R`) via
+/// `type_aliases` and returns `None` if the type ultimately isn't
+/// a record literal.
+fn record_field_types(
+    ty: &a::TypeExpr,
+    type_aliases: &IndexMap<String, a::TypeExpr>,
+) -> Option<IndexMap<String, NumTy>> {
+    match ty {
+        a::TypeExpr::Record { fields } => {
+            let mut m = IndexMap::new();
+            for f in fields {
+                m.insert(f.name.clone(), classify_type_expr(&f.ty));
+            }
+            Some(m)
+        }
+        a::TypeExpr::Refined { base, .. } => record_field_types(base, type_aliases),
+        a::TypeExpr::Named { name, args } if args.is_empty() => {
+            // Resolve the alias and recurse. Cycle protection isn't
+            // needed here — a cyclic type alias would have been
+            // rejected by `lex-types::check_program` upstream.
+            type_aliases.get(name).and_then(|t| record_field_types(t, type_aliases))
+        }
+        _ => None,
+    }
+}
 
 fn classify_type_expr(ty: &a::TypeExpr) -> NumTy {
     match ty {
@@ -756,6 +874,19 @@ impl<'a> FnCompiler<'a> {
                     Some(t) => classify_type_expr(t),
                     None => self.classify_expr(value),
                 };
+                // #461 slice 7: when the RHS is a record literal,
+                // remember the field types so `name.field` accesses
+                // downstream can classify precisely. Without this,
+                // `r.x + r.y` falls through to `NumAdd`, blocking
+                // the slice-7 fusion.
+                if let a::CExpr::RecordLit { fields } = value.as_ref() {
+                    let mut ftypes = IndexMap::new();
+                    for f in fields {
+                        let fty = self.classify_expr(&f.value);
+                        ftypes.insert(f.name.clone(), fty);
+                    }
+                    self.local_record_field_types.insert(name.clone(), ftypes);
+                }
                 self.compile_expr(value, false);
                 let slot = self.alloc_local(name);
                 self.local_types.insert(name.clone(), nty);
@@ -984,6 +1115,20 @@ impl<'a> FnCompiler<'a> {
                 }
             }
             a::CExpr::UnaryOp { op, expr } if op == "-" => self.classify_expr(expr),
+            // #461 slice 7: `r.field` access where `r` is a local
+            // bound from a record literal. Reads the per-local
+            // field-type map populated at the let-binding site.
+            // Unknown otherwise (record argument with `:: R`
+            // annotation, helper-returned record, etc.) — those
+            // would need type-alias resolution to classify.
+            a::CExpr::FieldAccess { value, field } => {
+                if let a::CExpr::Var { name } = value.as_ref() {
+                    if let Some(ftypes) = self.local_record_field_types.get(name) {
+                        return ftypes.get(field).copied().unwrap_or(NumTy::Unknown);
+                    }
+                }
+                NumTy::Unknown
+            }
             // Let-expressions: the let-binding mutates `local_types`
             // *during* compile_expr; classifying ahead of time would
             // require simulating that. Conservative fallback.

--- a/crates/lex-bytecode/src/escape.rs
+++ b/crates/lex-bytecode/src/escape.rs
@@ -455,6 +455,19 @@ fn step(pc: usize, op: &Op, mut s: State) -> (State, Vec<usize>, HashSet<u32>) {
             s.stack.push(Slot::Other);
             return (s, vec![pc + 3], escapes);
         }
+        Op::LoadLocalGetFieldAdd { .. } => {
+            // #461 slice 7: net delta on the value stack is 0 (pops
+            // prior Int top, pushes Int sum). The receiver is read
+            // from a local — the analysis tracks locals separately,
+            // and reading a local doesn't escape its Rec slot (the
+            // round-trip-through-local rule from StoreLocal applies
+            // here too: the value stays referenced). We pop the
+            // existing top (the accumulator) and push a fresh Other
+            // (the sum). Skip past the two tombstones.
+            s.stack.pop();
+            s.stack.push(Slot::Other);
+            return (s, vec![pc + 3], escapes);
+        }
         Op::LoadLocalEqIntConstJumpIfNot { jump_offset, .. } => {
             // delta 0; two successors (fall-through past tombstones,
             // and the branch target relative to the original

--- a/crates/lex-bytecode/src/op.rs
+++ b/crates/lex-bytecode/src/op.rs
@@ -248,4 +248,37 @@ pub enum Op {
     LoadLocalStoreEqIntConstJumpIfNot {
         src: u16, dst: u16, imm_const_idx: u32, jump_offset: i32,
     },
+    /// Fused `LoadLocal(local_idx) + GetField{name_idx, site_idx} +
+    /// IntAdd` (#461 superinstruction slice 7). Fires on the
+    /// `acc + r.field` accumulator-with-field-read idiom — the
+    /// shape any `expr + record.field` lowers to when the LHS is
+    /// already on the stack and the RHS is a same-frame record
+    /// field. After #464 step 2 dropped the IndexMap allocation
+    /// from hot-path records, this fusion is the next dispatch-
+    /// overhead bottleneck on the `response_build` profile.
+    ///
+    /// Dispatch: pops the prior stack top (an Int), reads
+    /// `locals[local_idx]`, performs the polymorphic-IC GetField
+    /// lookup keyed by `(fn_id, site_idx)` against `name_idx`,
+    /// adds the field value to the popped Int, pushes the result,
+    /// advances pc by 3.
+    ///
+    /// Stack delta: +1 (matches a bare `LoadLocal`). The trailing
+    /// `GetField` (delta 0) and `IntAdd` (delta -1) stay in the
+    /// code stream as inert tombstones; the verifier walks them as
+    /// live and their cancelling deltas leave depth at pc+3
+    /// matching the unfused form.
+    ///
+    /// `body_hash` stability (#222): canonical encoding decomposes
+    /// to a standalone `LoadLocal(local_idx)`; the unchanged
+    /// `GetField` and `IntAdd` at pc+1 and pc+2 hash normally, so
+    /// the total bytes match pre-fusion. The trailing `GetField`'s
+    /// own body-hash decoding (which strips `site_idx`) means the
+    /// hash is unchanged across recompiles where IC-site numbering
+    /// differs.
+    ///
+    /// Safety: the trailing two slots must not be jump targets
+    /// (standard tombstone rule). The first slot may be a target —
+    /// the fused op there is live.
+    LoadLocalGetFieldAdd { local_idx: u16, name_idx: u32, site_idx: u32 },
 }

--- a/crates/lex-bytecode/src/program.rs
+++ b/crates/lex-bytecode/src/program.rs
@@ -174,7 +174,8 @@ pub fn compute_body_hash(
             | Op::LoadLocalSubLocal { lhs_idx: local_idx, .. }
             | Op::LoadLocalMulLocal { lhs_idx: local_idx, .. }
             | Op::LoadLocalEqIntConstJumpIfNot { local_idx, .. }
-            | Op::LoadLocalStoreEqIntConstJumpIfNot { src: local_idx, .. } => {
+            | Op::LoadLocalStoreEqIntConstJumpIfNot { src: local_idx, .. }
+            | Op::LoadLocalGetFieldAdd { local_idx, .. } => {
                 // Slice 1: this slot was `LoadLocal(local_idx)`.
                 // Slice 2: this slot was *also* `LoadLocal(src)`
                 // — the fused op now owns 4 slots, but the very

--- a/crates/lex-bytecode/src/verify.rs
+++ b/crates/lex-bytecode/src/verify.rs
@@ -256,6 +256,12 @@ fn stack_delta(op: &Op) -> i32 {
         // this depth; tombstones are not walked as live.
         Op::LoadLocalEqIntConstJumpIfNot { .. }
         | Op::LoadLocalStoreEqIntConstJumpIfNot { .. } => 0,
+        // Slice-7 fused op (#461): net +1, same as bare LoadLocal.
+        // Trailing GetField (delta 0) + IntAdd (delta -1) tombstones
+        // cancel to -1 when walked, leaving depth at pc+3 matching
+        // the unfused [LoadLocal, GetField, IntAdd] sequence's
+        // overall delta of 0.
+        Op::LoadLocalGetFieldAdd { .. } => 1,
     }
 }
 

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -1830,6 +1830,113 @@ impl<'a> Vm<'a> {
                     self.stack.push(Value::Int(a * b));
                     self.frames[frame_idx].pc = pc + 3;
                 }
+                Op::LoadLocalGetFieldAdd { local_idx, name_idx, site_idx } => {
+                    // #461 slice 7: fused `LoadLocal + GetField + IntAdd`.
+                    // Pop the prior stack top (the accumulator), read
+                    // `locals[local_idx]`, do the IC-cached field read,
+                    // push the sum, advance pc by 3 (skip the two
+                    // tombstones — the original GetField and IntAdd).
+                    //
+                    // The IC slot is shared with the unfused Op::GetField
+                    // path: same `(fn_id, site_idx)` key, same
+                    // `(shape_id, offset)` value. A function with both
+                    // fused and unfused GetFields against the same site
+                    // would observe a consistent cache — though in
+                    // practice the peephole pass either fires at a
+                    // site or not, so the slot only ever sees one
+                    // dispatch path.
+                    let acc = self.pop()?.as_int();
+                    let base = self.frames[frame_idx].locals_start;
+                    let rec = self.locals_storage[base + local_idx as usize].clone();
+                    let field_val = match rec {
+                        Value::Record { fields: r, shape_id } => {
+                            if ic_stats_enabled() {
+                                record_ic_hit(fn_id, site_idx, shape_id);
+                            }
+                            let fid = fn_id as usize;
+                            let sid = site_idx as usize;
+                            if self.field_ics[fid].is_empty() {
+                                let n = self.program.functions[fid].field_ic_sites as usize;
+                                self.field_ics[fid] = vec![None; n];
+                            }
+                            let cached = self.field_ics[fid][sid];
+                            'ic: {
+                                if let Some((cached_shape, off)) = cached {
+                                    if cached_shape == shape_id {
+                                        if shape_id != crate::value::NO_SHAPE_ID {
+                                            if let Some((_, val)) = r.get_index(off) {
+                                                break 'ic val.clone();
+                                            }
+                                        } else if let Some((k, val)) = r.get_index(off) {
+                                            if let Const::FieldName(s) =
+                                                &self.program.constants[name_idx as usize]
+                                            {
+                                                if s == k { break 'ic val.clone(); }
+                                            }
+                                        }
+                                    }
+                                }
+                                let name = match &self.program.constants[name_idx as usize] {
+                                    Const::FieldName(s) => s.as_str(),
+                                    _ => return Err(VmError::TypeMismatch(
+                                        "expected FieldName const".into())),
+                                };
+                                let (off, _, val) = r.get_full(name)
+                                    .ok_or_else(|| VmError::TypeMismatch(
+                                        format!("missing field `{name}`")))?;
+                                self.field_ics[fid][sid] = Some((shape_id, off));
+                                val.clone()
+                            }
+                        }
+                        Value::StackRecord { shape_id, slab_start, field_count } => {
+                            // Same polymorphic path as Op::GetField for
+                            // stack records — shared IC, shape gives
+                            // the field-name vec.
+                            if ic_stats_enabled() {
+                                record_ic_hit(fn_id, site_idx, shape_id);
+                            }
+                            let fid = fn_id as usize;
+                            let sid = site_idx as usize;
+                            if self.field_ics[fid].is_empty() {
+                                let n = self.program.functions[fid].field_ic_sites as usize;
+                                self.field_ics[fid] = vec![None; n];
+                            }
+                            let cached = self.field_ics[fid][sid];
+                            'ic: {
+                                if let Some((cached_shape, off)) = cached {
+                                    if cached_shape == shape_id && (off as u16) < field_count {
+                                        let idx = slab_start as usize + off;
+                                        break 'ic self.stack_record_arena[idx].clone();
+                                    }
+                                }
+                                let shape =
+                                    &self.program.record_shapes[shape_id as usize];
+                                let target_name = match &self.program.constants[name_idx as usize] {
+                                    Const::FieldName(s) => s.as_str(),
+                                    _ => return Err(VmError::TypeMismatch(
+                                        "expected FieldName const".into())),
+                                };
+                                let mut found: Option<usize> = None;
+                                for (i, fn_const_idx) in shape.iter().enumerate() {
+                                    if let Const::FieldName(s) =
+                                        &self.program.constants[*fn_const_idx as usize]
+                                    {
+                                        if s == target_name { found = Some(i); break; }
+                                    }
+                                }
+                                let off = found.ok_or_else(|| VmError::TypeMismatch(
+                                    format!("missing field `{target_name}` on stack record")))?;
+                                self.field_ics[fid][sid] = Some((shape_id, off));
+                                self.stack_record_arena[slab_start as usize + off].clone()
+                            }
+                        }
+                        other => return Err(VmError::TypeMismatch(
+                            format!("LoadLocalGetFieldAdd on non-record: {other:?}"))),
+                    };
+                    let b = field_val.as_int();
+                    self.stack.push(Value::Int(acc + b));
+                    self.frames[frame_idx].pc = pc + 3;
+                }
                 Op::LoadLocalEqIntConstJumpIfNot { local_idx, imm_const_idx, jump_offset } => {
                     // First jump-aware fusion (#461 slice 5). The
                     // JumpIfNot's offset is relative to its own

--- a/crates/lex-bytecode/tests/run.rs
+++ b/crates/lex-bytecode/tests/run.rs
@@ -356,6 +356,94 @@ fn pick(flag :: Int, a :: Int, b :: Int) -> Int {
 }
 
 #[test]
+fn slice7_fuses_load_local_get_field_add() {
+    // Pattern: a chain of `expr + r.field` reads. The first term
+    // is a bare LoadLocal+GetField, the second-and-onward terms
+    // each form a `[LoadLocal(r), GetField(field, ic_site),
+    // IntAdd]` triple that slice 7 fuses. Verify at least one
+    // fusion fires in the chain.
+    use lex_bytecode::op::Op;
+    let src = "
+type R = { x :: Int, y :: Int, z :: Int }
+fn sum_fields(r :: R) -> Int { r.x + r.y + r.z }
+";
+    let p = compile(src);
+    let f = &p.functions[0];
+    let fused_count = f.code.iter()
+        .filter(|op| matches!(op, Op::LoadLocalGetFieldAdd { .. }))
+        .count();
+    assert!(fused_count >= 2,
+        "expected ≥2 slice-7 fusions in y+z chain, got {fused_count}: {:?}",
+        f.code);
+
+    let mut vm = Vm::new(&p);
+    let r = vm.call("sum_fields",
+        vec![Value::record_dynamic({
+            let mut m = IndexMap::new();
+            m.insert("x".into(), Value::Int(10));
+            m.insert("y".into(), Value::Int(20));
+            m.insert("z".into(), Value::Int(30));
+            m
+        })]).unwrap();
+    assert_eq!(r, Value::Int(60));
+}
+
+#[test]
+fn slice7_works_on_stack_records_too() {
+    // The slice-7 dispatch handler is polymorphic over Value::Record
+    // and Value::StackRecord — the same path GetField uses. A
+    // non-escaping record (lowered to AllocStackRecord by #464
+    // step 2) chained through field-add should produce the right
+    // answer.
+    let src = r#"
+        fn inline_sum() -> Int {
+          let r := { a: 5, b: 11, c: 13 }
+          r.a + r.b + r.c
+        }
+    "#;
+    let p = compile(src);
+    // Sanity: both lowerings should have fired in this function.
+    use lex_bytecode::op::Op;
+    let f = &p.functions[0];
+    assert!(f.code.iter().any(|op| matches!(op, Op::AllocStackRecord { .. })),
+        "expected escape lowering to fire");
+    assert!(f.code.iter().any(|op| matches!(op, Op::LoadLocalGetFieldAdd { .. })),
+        "expected slice 7 fusion to fire");
+
+    let mut vm = Vm::new(&p);
+    assert_eq!(vm.call("inline_sum", vec![]).unwrap(), Value::Int(29));
+}
+
+#[test]
+fn slice7_does_not_fire_across_a_jump_target() {
+    // Same safety story as slice 3/4: a `match`-arm body whose
+    // entry point straddles the candidate triple's second or
+    // third slot must skip the fusion. A regression would corrupt
+    // the stack on the jump-into path. Check by running both arms
+    // of a function shaped to put a GetField+IntAdd at an arm
+    // boundary.
+    let src = r#"
+type R = { v :: Int }
+fn pick(flag :: Int, r :: R) -> Int {
+  match flag {
+    0 => 100 + r.v,
+    _ => r.v,
+  }
+}
+"#;
+    let p = compile(src);
+    let mut vm = Vm::new(&p);
+    let r1 = vm.call("pick", vec![Value::Int(0), Value::record_dynamic({
+        let mut m = IndexMap::new(); m.insert("v".into(), Value::Int(7)); m
+    })]).unwrap();
+    assert_eq!(r1, Value::Int(107));
+    let r2 = vm.call("pick", vec![Value::Int(1), Value::record_dynamic({
+        let mut m = IndexMap::new(); m.insert("v".into(), Value::Int(7)); m
+    })]).unwrap();
+    assert_eq!(r2, Value::Int(7));
+}
+
+#[test]
 fn record_field_access() {
     let src = "fn xof(r :: Record) -> Int { r.x }\n".replace(
         "Record",
@@ -369,3 +457,4 @@ fn record_field_access() {
     let r = vm.call("xof", vec![Value::record_dynamic(m)]).unwrap();
     assert_eq!(r, Value::Int(11));
 }
+


### PR DESCRIPTION
## Summary

Adds `Op::LoadLocalGetFieldAdd { local_idx, name_idx, site_idx }` — fuses the `[LoadLocal, GetField, IntAdd]` triple that the compiler emits for `acc + record.field` chains. After #464 lowered record allocation off the heap, GetField dispatch is the new hot spot on the response_build profile; this slice eats two dispatches per accumulated field.

## Two parts

**1. Bytecode peephole + dispatch + body-hash + verifier.** Same shape as slices 3-6:
- Peephole rewrites `[LoadLocal(local_idx), GetField{name_idx, site_idx}, IntAdd]` → `LoadLocalGetFieldAdd{local_idx, name_idx, site_idx}` when the trailing two slots aren't jump targets.
- Dispatch handler reuses the shared `(fn_id, site_idx)` inline-cache slot — fully interoperable with the unfused `Op::GetField` path. Polymorphic over `Value::Record` and `Value::StackRecord` (the latter from #464).
- `body_hash` decodes back to `LoadLocal(local_idx)`; trailing `GetField` and `IntAdd` stay live and hash normally. Closure identity (#222) is bit-identical to pre-fusion.
- Verifier walks the fused op with net delta `+1` (matches bare `LoadLocal`); trailing tombstones `GetField(0) + IntAdd(-1) = -1` cancel to the unfused total of `0` at `pc+3`.

**2. Compiler type propagation.** The peephole needs `IntAdd` at slot 2, but `r.x + r.y` produced `NumAdd` because `classify_expr` returned `Unknown` for `FieldAccess`. Two new binding sites populate a per-local `field_name → NumTy` map:
- `let r := { x: 10, y: 20 }` — types read directly from the literal's field values.
- `fn handle(r :: R)` where `type R = { x :: Int, ... }` — resolved via a new top-level type-aliases registry built once per `compile_program`.

This unlocks slice 7 firing on both the inline-record idiom (common after #464 step 2 lowers intermediates) and on named-record parameters.

## Numbers

- response_build acceptance timing: **2.96× → 3.07×** (small additional bump; slice 7's bigger payoff is on workloads dominated by the GetField+arith pattern).
- field_access/mono_chain bench post-slice: 3.49–3.59 Melem/s across n ∈ {100, 1000, 5000}.

## Test plan

- [x] `cargo test -p lex-bytecode` — 77 tests pass + 1 ignored.
  - 3 new in `tests/run.rs`: fusion on named-record param, fusion on stack records, jump-safety regression gate.
- [x] `cargo test -p lex-runtime --lib` — 46/46 pass.
- [x] `cargo test -p lex-runtime --test analytics_app --test std_http --test closed_pydantic_issues` — record-heavy integration paths, all pass.
- [x] `cargo test -p core-compiler --test m9 --test m9_phase2` — 19/19 pass.
- [x] `cargo bench --bench field_access -p lex-bytecode -- mono_chain --quick` — clean output.
- [x] `cargo clippy -p lex-bytecode --all-targets -- -D warnings` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjQc3kQTQXm97YX22kfwsU)_