### PR TITLE
perf(#229): replace SHA-256 memo key with fast structural hash

### DIFF
--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -228,10 +228,11 @@ pub struct Vm<'a> {
     pub step_limit: u64,
     pub steps: u64,
     /// Per-Vm memoization cache for pure functions (#229). Keyed by
-    /// `(fn_id, sha256(canonical_json(args))[..16])`. Effectful
-    /// functions never enter this map. The cache lives for the
-    /// lifetime of one `Vm::call` chain — calling `Vm::with_handler`
-    /// again starts a fresh cache.
+    /// `(fn_id, hash_call_args(args))` — a 128-bit structural digest
+    /// of the arguments (see `hash_call_args`). Effectful functions
+    /// never enter this map. The cache lives for the lifetime of one
+    /// `Vm::call` chain — calling `Vm::with_handler` again starts a
+    /// fresh cache.
     pure_memo: std::collections::HashMap<(u32, [u8; 16]), Value>,
     /// Diagnostic counters for `--trace` observability (#229).
     pub pure_memo_hits: u64,
@@ -359,21 +360,184 @@ fn call_budget_cost(f: &crate::program::Function) -> u64 {
 }
 
 /// Hash the argument list for a pure-fn memoization lookup (#229).
-/// Routes through the canonical-JSON path so two semantically-equal
-/// argument lists produce the same hash regardless of how the
-/// containing `Value`s were assembled (Records use IndexMap so field
-/// order is already stable, but canon_json gives the same property
-/// for the inner serde_json shape).
+///
+/// The memo cache (`pure_memo`) is keyed on this 128-bit digest with
+/// no secondary equality check, so the contract is: argument lists
+/// that are equal under `Value`'s `PartialEq` must produce the same
+/// digest, and the 128-bit width keeps the false-collision rate
+/// (which would return a wrong cached result) negligible.
+///
+/// History (#461 follow-up): this used to build a `serde_json::Value`
+/// of every arg, canonicalize it, and SHA-256 the bytes. Profiling
+/// the `response_build` workload showed that path at 27.6% of all
+/// instructions — it dominated the VM, since every effect-free call
+/// pays it whether or not the cache ever hits. The cache is per-`Vm`
+/// and ephemeral, so a cryptographic, cross-process-stable key was
+/// never needed. We now walk the `Value` tree directly into two
+/// domain-separated `SipHash` passes (deterministic fixed-key
+/// `DefaultHasher`), concatenating the two 64-bit outputs into a
+/// 128-bit key. No JSON allocation, no crypto.
+///
+/// The walk mirrors `Value::PartialEq` so the equal-args-equal-key
+/// contract holds: `Record` is hashed order-independently over its
+/// fields (matching `IndexMap`'s order-insensitive equality),
+/// `Closure` on `(body_hash, captures)` not `fn_id` (#222), and
+/// `Actor`/`Ticker` on pointer identity (matching `Arc::ptr_eq`).
 fn hash_call_args(args: &[Value]) -> [u8; 16] {
-    use sha2::{Digest, Sha256};
-    let json = serde_json::Value::Array(args.iter().map(Value::to_json).collect());
-    let canonical = lex_ast::canon_json::hash_canonical(&json);
-    let mut hasher = Sha256::new();
-    hasher.update(canonical);
-    let full = hasher.finalize();
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::Hasher;
+    let mut h0 = DefaultHasher::new();
+    let mut h1 = DefaultHasher::new();
+    // Domain separator: makes the two passes diverge so the
+    // concatenated halves span the full 128-bit space rather than
+    // duplicating one 64-bit value.
+    h1.write_u8(0x9e);
+    h0.write_usize(args.len());
+    h1.write_usize(args.len());
+    for a in args {
+        hash_value_into(a, &mut h0);
+        hash_value_into(a, &mut h1);
+    }
+    let lo = h0.finish();
+    let hi = h1.finish();
     let mut out = [0u8; 16];
-    out.copy_from_slice(&full[..16]);
+    out[..8].copy_from_slice(&lo.to_le_bytes());
+    out[8..].copy_from_slice(&hi.to_le_bytes());
     out
+}
+
+/// Structural hash of a `Value` into `h`, consistent with
+/// `Value::PartialEq`. The leading discriminant byte keeps distinct
+/// variants from colliding (e.g. `Int(0)` vs `Bool(false)`).
+fn hash_value_into<H: std::hash::Hasher>(v: &Value, h: &mut H) {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::Hasher as _;
+    match v {
+        Value::Int(n) => { h.write_u8(0x01); h.write_i64(*n); }
+        // Bit pattern, not value: total and deterministic. NaN==NaN
+        // by bits (a memo hit there is harmless — the callee is pure
+        // and returns the same result for bit-identical args), and
+        // +0.0/-0.0 differ (a harmless extra miss).
+        Value::Float(f) => { h.write_u8(0x02); h.write_u64(f.to_bits()); }
+        Value::Bool(b) => { h.write_u8(0x03); h.write_u8(*b as u8); }
+        Value::Str(s) => {
+            h.write_u8(0x04);
+            h.write_usize(s.len());
+            h.write(s.as_bytes());
+        }
+        Value::Bytes(b) => {
+            h.write_u8(0x05);
+            h.write_usize(b.len());
+            h.write(b);
+        }
+        Value::Unit => { h.write_u8(0x06); }
+        Value::List(items) => {
+            h.write_u8(0x07);
+            h.write_usize(items.len());
+            for it in items { hash_value_into(it, h); }
+        }
+        Value::Tuple(items) => {
+            h.write_u8(0x08);
+            h.write_usize(items.len());
+            for it in items { hash_value_into(it, h); }
+        }
+        Value::Deque(items) => {
+            h.write_u8(0x09);
+            h.write_usize(items.len());
+            for it in items { hash_value_into(it, h); }
+        }
+        // `IndexMap` equality is order-insensitive, so the hash must
+        // be too: combine per-entry sub-hashes with wrapping add (a
+        // commutative mix) rather than feeding them in iteration
+        // order.
+        Value::Record { fields, .. } => {
+            h.write_u8(0x0a);
+            let mut combined: u64 = 0;
+            for (k, val) in fields.iter() {
+                let mut e = DefaultHasher::new();
+                e.write(k.as_bytes());
+                e.write_u8(0xff);
+                hash_value_into(val, &mut e);
+                combined = combined.wrapping_add(e.finish());
+            }
+            h.write_u64(combined);
+            h.write_usize(fields.len());
+        }
+        Value::Variant { name, args } => {
+            h.write_u8(0x0b);
+            h.write_usize(name.len());
+            h.write(name.as_bytes());
+            h.write_usize(args.len());
+            for a in args { hash_value_into(a, h); }
+        }
+        // Identity is `(body_hash, captures)`, not `fn_id` (#222).
+        Value::Closure { body_hash, captures, .. } => {
+            h.write_u8(0x0c);
+            h.write(body_hash);
+            h.write_usize(captures.len());
+            for c in captures { hash_value_into(c, h); }
+        }
+        Value::F64Array { rows, cols, data } => {
+            h.write_u8(0x0d);
+            h.write_u32(*rows);
+            h.write_u32(*cols);
+            for f in data { h.write_u64(f.to_bits()); }
+        }
+        // BTreeMap / BTreeSet iterate in sorted key order — already
+        // canonical, so direct feed is order-independent.
+        Value::Map(m) => {
+            h.write_u8(0x0e);
+            h.write_usize(m.len());
+            for (k, val) in m {
+                hash_mapkey_into(k, h);
+                hash_value_into(val, h);
+            }
+        }
+        Value::Set(s) => {
+            h.write_u8(0x0f);
+            h.write_usize(s.len());
+            for k in s { hash_mapkey_into(k, h); }
+        }
+        // Pointer identity, matching `Arc::ptr_eq` in PartialEq.
+        Value::Actor(a) => {
+            h.write_u8(0x10);
+            h.write_usize(Arc::as_ptr(a) as *const () as usize);
+        }
+        Value::Ticker(t) => {
+            h.write_u8(0x11);
+            h.write_usize(Arc::as_ptr(t) as *const () as usize);
+        }
+        // Coarse summary (schema + dimensions), matching the prior
+        // `to_json` encoding which deliberately omitted the cell data
+        // (tables can be GB-scale). Equal tables share schema + dims
+        // so equal-args-equal-key holds; this is no coarser than the
+        // pre-#461-followup behavior.
+        Value::ArrowTable(t) => {
+            h.write_u8(0x12);
+            h.write_i64(t.num_rows() as i64);
+            h.write_i64(t.num_columns() as i64);
+            for f in t.schema().fields() {
+                h.write(f.name().as_bytes());
+                h.write_u8(0xfe);
+            }
+        }
+        // #464: a StackRecord crossing into the memo path means an
+        // escape the analysis was supposed to reject. Mirror the
+        // PartialEq / to_json panic rather than mint a bogus key.
+        Value::StackRecord { .. } =>
+            panic!("BUG(#464): Value::StackRecord reached memo hashing — \
+                    escape analysis should have prevented escape to a call boundary"),
+    }
+}
+
+/// Hash a `MapKey` into `h` with its own discriminant so a `Str`
+/// key and an `Int` key never collide.
+fn hash_mapkey_into<H: std::hash::Hasher>(k: &crate::value::MapKey, h: &mut H) {
+    use crate::value::MapKey;
+    match k {
+        MapKey::Str(s) => { h.write_u8(0x01); h.write_usize(s.len()); h.write(s.as_bytes()); }
+        MapKey::Int(n) => { h.write_u8(0x02); h.write_i64(*n); }
+    }
 }
 
 /// Evaluate a refinement predicate at runtime against the actual
@@ -2086,5 +2250,103 @@ fn const_to_value(c: &Const) -> Value {
         Const::Bytes(b) => Value::Bytes(b.clone()),
         Const::Unit => Value::Unit,
         Const::FieldName(s) | Const::VariantName(s) | Const::NodeId(s) => Value::Str(s.as_str().into()),
+    }
+}
+
+#[cfg(test)]
+mod memo_hash_tests {
+    //! #461 follow-up: invariants for the structural memo-key hash
+    //! that replaced the SHA-256-over-canonical-JSON path. The memo
+    //! cache keys on this digest with no equality fallback, so the
+    //! load-bearing property is "equal-under-PartialEq args produce
+    //! an equal key" — plus enough discrimination that distinct args
+    //! don't collide in practice.
+    use super::*;
+    use indexmap::IndexMap;
+
+    fn rec(pairs: &[(&str, Value)]) -> Value {
+        let mut m = IndexMap::new();
+        for (k, v) in pairs { m.insert((*k).to_string(), v.clone()); }
+        Value::Record { shape_id: crate::value::NO_SHAPE_ID, fields: Box::new(m) }
+    }
+
+    #[test]
+    fn identical_args_hash_equal() {
+        let a = vec![Value::Int(7), Value::Str("hi".into())];
+        let b = vec![Value::Int(7), Value::Str("hi".into())];
+        assert_eq!(hash_call_args(&a), hash_call_args(&b));
+    }
+
+    #[test]
+    fn distinct_scalars_differ() {
+        assert_ne!(hash_call_args(&[Value::Int(7)]), hash_call_args(&[Value::Int(8)]));
+        assert_ne!(hash_call_args(&[Value::Int(0)]), hash_call_args(&[Value::Bool(false)]));
+        assert_ne!(hash_call_args(&[Value::Int(0)]), hash_call_args(&[Value::Unit]));
+        assert_ne!(hash_call_args(&[Value::Bool(true)]), hash_call_args(&[Value::Bool(false)]));
+    }
+
+    #[test]
+    fn arity_is_part_of_the_key() {
+        assert_ne!(
+            hash_call_args(&[Value::Int(1), Value::Int(2)]),
+            hash_call_args(&[Value::Int(1)]),
+        );
+        // A 2-arg call vs a single Tuple arg of the same elements
+        // must not collide.
+        assert_ne!(
+            hash_call_args(&[Value::Int(1), Value::Int(2)]),
+            hash_call_args(&[Value::Tuple(vec![Value::Int(1), Value::Int(2)])]),
+        );
+    }
+
+    #[test]
+    fn record_hash_is_field_order_independent() {
+        // IndexMap equality ignores insertion order, so the key must
+        // too — otherwise equal records would miss the cache.
+        let r1 = rec(&[("a", Value::Int(1)), ("b", Value::Int(2))]);
+        let r2 = rec(&[("b", Value::Int(2)), ("a", Value::Int(1))]);
+        assert_eq!(r1, r2, "precondition: records compare equal");
+        assert_eq!(hash_call_args(&[r1]), hash_call_args(&[r2]));
+    }
+
+    #[test]
+    fn record_distinguishes_values_and_keys() {
+        let base = rec(&[("a", Value::Int(1)), ("b", Value::Int(2))]);
+        let diff_val = rec(&[("a", Value::Int(1)), ("b", Value::Int(3))]);
+        let diff_key = rec(&[("a", Value::Int(1)), ("c", Value::Int(2))]);
+        assert_ne!(hash_call_args(std::slice::from_ref(&base)), hash_call_args(&[diff_val]));
+        assert_ne!(hash_call_args(&[base]), hash_call_args(&[diff_key]));
+    }
+
+    #[test]
+    fn shape_id_does_not_affect_record_key() {
+        // PartialEq ignores shape_id; the key must too.
+        let mut m = IndexMap::new();
+        m.insert("a".to_string(), Value::Int(1));
+        let r_no_shape = Value::Record { shape_id: crate::value::NO_SHAPE_ID, fields: Box::new(m.clone()) };
+        let r_shaped = Value::Record { shape_id: 3, fields: Box::new(m) };
+        assert_eq!(r_no_shape, r_shaped);
+        assert_eq!(hash_call_args(&[r_no_shape]), hash_call_args(&[r_shaped]));
+    }
+
+    #[test]
+    fn variant_name_and_args_matter() {
+        let some1 = Value::Variant { name: "Some".into(), args: vec![Value::Int(1)] };
+        let some1b = Value::Variant { name: "Some".into(), args: vec![Value::Int(1)] };
+        let some2 = Value::Variant { name: "Some".into(), args: vec![Value::Int(2)] };
+        let none = Value::Variant { name: "None".into(), args: vec![] };
+        assert_eq!(hash_call_args(std::slice::from_ref(&some1)), hash_call_args(&[some1b]));
+        assert_ne!(hash_call_args(std::slice::from_ref(&some1)), hash_call_args(&[some2]));
+        assert_ne!(hash_call_args(&[some1]), hash_call_args(&[none]));
+    }
+
+    #[test]
+    fn float_bit_pattern_keys() {
+        assert_eq!(hash_call_args(&[Value::Float(1.5)]), hash_call_args(&[Value::Float(1.5)]));
+        assert_ne!(hash_call_args(&[Value::Float(1.5)]), hash_call_args(&[Value::Float(2.5)]));
+        // Same NaN bit pattern → same key (harmless: pure callee is
+        // deterministic on bit-identical args).
+        let nan = f64::NAN;
+        assert_eq!(hash_call_args(&[Value::Float(nan)]), hash_call_args(&[Value::Float(nan)]));
     }
 }


### PR DESCRIPTION
## Summary

`hash_call_args` (the pure-fn memoization key, #229) built a `serde_json::Value` of every argument, canonicalized it, and SHA-256'd the bytes — on **every** effect-free call. Profiling the `response_build` workload (PR #528) put that path at **27.6% of all VM instructions**: it dominated dispatch, and every call pays it whether or not the cache ever hits. On that workload it scored 0 hits / 3600 misses.

The memo cache is per-`Vm` and ephemeral, so a cryptographic, cross-process-stable key was never required. This walks the `Value` tree directly into two domain-separated SipHash passes (deterministic fixed-key `DefaultHasher`) concatenated into a 128-bit key. No JSON allocation, no crypto.

## Correctness

The cache keys on the digest with no secondary equality check, so the load-bearing invariant is "args equal under `Value::PartialEq` → equal key." The walk mirrors `PartialEq`:

- **Record** — hashed order-independently over fields (IndexMap equality is order-insensitive); `shape_id` excluded (PartialEq ignores it).
- **Closure** — keyed on `(body_hash, captures)`, not `fn_id` (#222).
- **Actor/Ticker** — `Arc` pointer identity (matches `Arc::ptr_eq`).
- **ArrowTable** — schema + dimensions (matches the prior `to_json` summary, which deliberately omitted cell data).
- **StackRecord** — panics, mirroring `PartialEq`/`to_json` (#464).
- **Float** — bit pattern (total, deterministic).

## Result

Callgrind (`response_build`, n=300 ×6 iters):

| | Before | After |
|---|---|---|
| Total instructions | 88.75M | **61.94M (−30%)** |
| `sha2::sha256::compress` | 27.6% | **0%** |
| `Vm::run_to` (dispatch) | 25.1% | 36.0% (now the legitimate top frame) |

The #229 memo acceptance suite is unchanged (hit/miss behavior identical).

## Test plan

- [x] `cargo test -p lex-bytecode` — 28 lib tests incl. **8 new `memo_hash_tests`** (identity, distinctness, arity, record order-independence, shape_id exclusion, variant, float bit-pattern), all green.
- [x] `cargo test -p lex-runtime --test pure_fn_memo` — 6/6 pass (hit/miss behavior preserved, incl. the Record-arg determinism case).
- [x] `cargo clippy -p lex-bytecode --all-targets -- -D warnings` — clean.
- [x] Re-profiled under callgrind to confirm the SHA-256 frame is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjQc3kQTQXm97YX22kfwsU)_