### PR TITLE
perf(#461) slice 9: fuse LoadLocal + GetField, read field by reference

### DIFF
--- a/crates/lex-bytecode/src/compiler.rs
+++ b/crates/lex-bytecode/src/compiler.rs
@@ -325,11 +325,21 @@ pub fn compile_program(stages: &[a::Stage]) -> Program {
         // fused op that reads the just-stored local). Must run after
         // slice 5 since it matches on slice 5's output.
         apply_peephole_slice6(&mut f.code);
-        // Slice 7 — fuse `LoadLocal + GetField + IntAdd`, the
-        // accumulator-with-field-read idiom. Disjoint from every
+        // Slice 7/8 — fuse `LoadLocal + GetField + IntAdd|IntSub|IntMul`,
+        // the accumulator-with-field-read idiom. Disjoint from every
         // earlier slice (only this one matches a GetField at slot 1),
-        // so order is independent — placed at the end for chronology.
+        // so order is independent — placed near the end for chronology.
         apply_peephole_slice7(&mut f.code);
+        // Slice 9 — fuse the *remaining* bare `LoadLocal + GetField`
+        // pairs (those slice 7/8 didn't consume): chain-head field
+        // reads (`r.x` in `r.x + r.y`), standalone `r.field` reads
+        // (`r.total`), and field reads feeding non-add/sub/mul ops.
+        // MUST run after slice 7/8 — otherwise it would greedily eat
+        // the `LoadLocal + GetField` prefix of an `acc OP r.field`
+        // triple and prevent the 3-op fusion. Slice 7/8's tombstone
+        // GetFields are preceded by their fused op (not a bare
+        // LoadLocal), so slice 9 never matches them.
+        apply_peephole_slice9(&mut f.code);
     }
 
     // Final pass: stamp every function with its content hash now that
@@ -709,6 +719,49 @@ fn apply_peephole_slice7(code: &mut [Op]) {
                     k += 3;
                     continue;
                 }
+            }
+        }
+        k += 1;
+    }
+}
+
+/// Slice 9: fuse the bare `[LoadLocal(local_idx), GetField{name_idx,
+/// site_idx}]` pair into `LoadLocalGetField { local_idx, name_idx,
+/// site_idx }` — the plain `record.field` read, the most common
+/// field-access shape.
+///
+/// The win is allocation, not just one fewer dispatch: the unfused
+/// pair clones the entire record onto the value stack (a
+/// `Box<IndexMap>` for a heap record) only to read one field; the
+/// fused op reads the field out of the local by reference and clones
+/// only that value. On `response_build` the whole-record clone of the
+/// returned `Response` (`r.total`) was the dominant malloc source.
+///
+/// Order: MUST run after slice 7/8. Those fuse `[LoadLocal, GetField,
+/// IntAdd|IntSub|IntMul]`; if slice 9 ran first it would consume the
+/// `LoadLocal + GetField` prefix and block the 3-op fusion. After
+/// slice 7/8, the only remaining `[LoadLocal, GetField]` pairs are
+/// the ones they didn't want (chain heads, standalone reads, field
+/// reads feeding other ops). Slice 7/8's tombstone GetFields sit
+/// after their fused op, never after a bare `LoadLocal`, so slice 9
+/// won't touch them.
+///
+/// Safety: the trailing slot (the original `GetField`) must not be a
+/// jump target. The first slot can be.
+fn apply_peephole_slice9(code: &mut [Op]) {
+    if code.len() < 2 { return; }
+    let jump_targets = collect_jump_targets(code);
+
+    let n = code.len();
+    let mut k = 0;
+    while k + 1 < n {
+        if let (Op::LoadLocal(local_idx), Op::GetField { name_idx, site_idx })
+            = (code[k], code[k + 1])
+        {
+            if !jump_targets.contains(&(k + 1)) {
+                code[k] = Op::LoadLocalGetField { local_idx, name_idx, site_idx };
+                k += 2;
+                continue;
             }
         }
         k += 1;

--- a/crates/lex-bytecode/src/escape.rs
+++ b/crates/lex-bytecode/src/escape.rs
@@ -455,6 +455,18 @@ fn step(pc: usize, op: &Op, mut s: State) -> (State, Vec<usize>, HashSet<u32>) {
             s.stack.push(Slot::Other);
             return (s, vec![pc + 3], escapes);
         }
+        Op::LoadLocalGetField { .. } => {
+            // #461 slice 9: equivalent to LoadLocal + GetField —
+            // reads a field out of a local record (which does NOT
+            // escape the receiver, matching plain GetField) and
+            // pushes the field value (Other). Net delta +1; skip the
+            // single tombstone (pc+2). (Escape analysis runs before
+            // peephole, so this arm is exercised only if the analysis
+            // is ever re-run on fused code; it's here for exhaustive
+            // matching and forward-correctness.)
+            s.stack.push(Slot::Other);
+            return (s, vec![pc + 2], escapes);
+        }
         Op::LoadLocalGetFieldAdd { .. }
         | Op::LoadLocalGetFieldSub { .. }
         | Op::LoadLocalGetFieldMul { .. } => {

--- a/crates/lex-bytecode/src/op.rs
+++ b/crates/lex-bytecode/src/op.rs
@@ -293,4 +293,28 @@ pub enum Op {
     /// give `acc - field`. The fused dispatch preserves that order.
     LoadLocalGetFieldSub { local_idx: u16, name_idx: u32, site_idx: u32 },
     LoadLocalGetFieldMul { local_idx: u16, name_idx: u32, site_idx: u32 },
+    /// Slice 9 of #461: fuse `LoadLocal(local_idx) + GetField{name_idx,
+    /// site_idx}` — the bare `record.field` read, the single most
+    /// common field-access shape. Unlike slices 7/8 there's no
+    /// arithmetic terminator; this is a 2-op window.
+    ///
+    /// The win is allocation, not just dispatch: the unfused pair
+    /// `LoadLocal` clones the entire record onto the value stack
+    /// (a `Box<IndexMap>` for a heap record), `GetField` pops it,
+    /// reads one field, and drops the rest. The fused op reads the
+    /// field out of the local by reference (`read_local_record_field`)
+    /// and clones only that one value. On the `response_build`
+    /// profile the whole-record clone+drop of the returned `Response`
+    /// (`r.total`) was the dominant malloc source.
+    ///
+    /// Stack delta: +1 (LoadLocal +1, GetField 0). The trailing
+    /// `GetField` stays as a single inert tombstone (delta 0); the
+    /// verifier walks it, leaving depth at pc+2 matching the unfused
+    /// `[LoadLocal, GetField]` pair. `body_hash` decodes to a
+    /// standalone `LoadLocal(local_idx)`; the trailing `GetField`
+    /// hashes normally.
+    ///
+    /// Safety: the trailing slot (the original `GetField`) must not
+    /// be a jump target. The first slot may be.
+    LoadLocalGetField { local_idx: u16, name_idx: u32, site_idx: u32 },
 }

--- a/crates/lex-bytecode/src/program.rs
+++ b/crates/lex-bytecode/src/program.rs
@@ -177,7 +177,8 @@ pub fn compute_body_hash(
             | Op::LoadLocalStoreEqIntConstJumpIfNot { src: local_idx, .. }
             | Op::LoadLocalGetFieldAdd { local_idx, .. }
             | Op::LoadLocalGetFieldSub { local_idx, .. }
-            | Op::LoadLocalGetFieldMul { local_idx, .. } => {
+            | Op::LoadLocalGetFieldMul { local_idx, .. }
+            | Op::LoadLocalGetField { local_idx, .. } => {
                 // Slice 1: this slot was `LoadLocal(local_idx)`.
                 // Slice 2: this slot was *also* `LoadLocal(src)`
                 // — the fused op now owns 4 slots, but the very

--- a/crates/lex-bytecode/src/verify.rs
+++ b/crates/lex-bytecode/src/verify.rs
@@ -264,6 +264,11 @@ fn stack_delta(op: &Op) -> i32 {
         Op::LoadLocalGetFieldAdd { .. }
         | Op::LoadLocalGetFieldSub { .. }
         | Op::LoadLocalGetFieldMul { .. } => 1,
+        // Slice-9 fused op (#461): net +1 (LoadLocal +1, GetField 0),
+        // same as bare LoadLocal. The single trailing GetField
+        // tombstone (delta 0) leaves depth at pc+2 matching the
+        // unfused [LoadLocal, GetField] pair.
+        Op::LoadLocalGetField { .. } => 1,
     }
 }
 

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -1994,18 +1994,30 @@ impl<'a> Vm<'a> {
                     self.stack.push(Value::Int(a * b));
                     self.frames[frame_idx].pc = pc + 3;
                 }
+                Op::LoadLocalGetField { local_idx, name_idx, site_idx } => {
+                    // #461 slice 9: fused `LoadLocal + GetField`. Reads
+                    // the field directly out of the local record by
+                    // reference and pushes it, advancing pc by 2 (one
+                    // tombstone — the original GetField). Avoids the
+                    // unfused pair's whole-record clone onto the value
+                    // stack: the dominant heap-record churn on the
+                    // `response_build` profile (`r.total` field reads).
+                    let base = self.frames[frame_idx].locals_start;
+                    let v = self.read_local_record_field(
+                        base, local_idx, fn_id, name_idx, site_idx, "LoadLocalGetField")?;
+                    self.stack.push(v);
+                    self.frames[frame_idx].pc = pc + 2;
+                }
                 Op::LoadLocalGetFieldAdd { local_idx, name_idx, site_idx } => {
                     // #461 slice 7: fused `LoadLocal + GetField + IntAdd`.
-                    // Pop the prior stack top (the accumulator), read
-                    // `locals[local_idx]`, do the IC-cached field read
-                    // (shared with Op::GetField via `read_record_field`),
-                    // push the sum, advance pc by 3 (skip the two
-                    // tombstones — the original GetField and IntAdd).
+                    // Pop the prior stack top (the accumulator), read the
+                    // field by reference (shared IC via
+                    // `read_local_record_field`), push the sum, advance
+                    // pc by 3 (skip the GetField and IntAdd tombstones).
                     let acc = self.pop()?.as_int();
                     let base = self.frames[frame_idx].locals_start;
-                    let rec = self.locals_storage[base + local_idx as usize].clone();
-                    let b = self.read_record_field(
-                        rec, fn_id, name_idx, site_idx, "LoadLocalGetFieldAdd")?.as_int();
+                    let b = self.read_local_record_field(
+                        base, local_idx, fn_id, name_idx, site_idx, "LoadLocalGetFieldAdd")?.as_int();
                     self.stack.push(Value::Int(acc + b));
                     self.frames[frame_idx].pc = pc + 3;
                 }
@@ -2016,9 +2028,8 @@ impl<'a> Vm<'a> {
                     // unfused form, so the result is `acc - field`.
                     let acc = self.pop()?.as_int();
                     let base = self.frames[frame_idx].locals_start;
-                    let rec = self.locals_storage[base + local_idx as usize].clone();
-                    let b = self.read_record_field(
-                        rec, fn_id, name_idx, site_idx, "LoadLocalGetFieldSub")?.as_int();
+                    let b = self.read_local_record_field(
+                        base, local_idx, fn_id, name_idx, site_idx, "LoadLocalGetFieldSub")?.as_int();
                     self.stack.push(Value::Int(acc - b));
                     self.frames[frame_idx].pc = pc + 3;
                 }
@@ -2028,9 +2039,8 @@ impl<'a> Vm<'a> {
                     // operand order doesn't matter).
                     let acc = self.pop()?.as_int();
                     let base = self.frames[frame_idx].locals_start;
-                    let rec = self.locals_storage[base + local_idx as usize].clone();
-                    let b = self.read_record_field(
-                        rec, fn_id, name_idx, site_idx, "LoadLocalGetFieldMul")?.as_int();
+                    let b = self.read_local_record_field(
+                        base, local_idx, fn_id, name_idx, site_idx, "LoadLocalGetFieldMul")?.as_int();
                     self.stack.push(Value::Int(acc * b));
                     self.frames[frame_idx].pc = pc + 3;
                 }
@@ -2105,108 +2115,128 @@ impl<'a> Vm<'a> {
         self.stack.last().ok_or(VmError::StackUnderflow)
     }
 
-    /// IC-cached field read shared by the slice-7/8 fused field-arith
-    /// superinstructions (`LoadLocalGetField{Add,Sub,Mul}`). `rec` is
-    /// the receiver value (already read out of the local). Uses the
-    /// same `(fn_id, site_idx)` inline-cache slot as the unfused
-    /// `Op::GetField`, so the two paths stay cache-consistent.
+    /// IC-cached field read of `locals[local_idx]`, shared by the
+    /// field-read fusions: slice 9's `LoadLocalGetField` and slice
+    /// 7/8's `LoadLocalGetField{Add,Sub,Mul}`. Uses the same
+    /// `(fn_id, site_idx)` inline-cache slot as the unfused
+    /// `Op::GetField`, so the paths stay cache-consistent.
     /// `op_name` only appears in the non-record error message.
     ///
-    /// `#[inline(always)]`: this is on the hot dispatch path and is
-    /// called from three tight `run_to` arms. Leaving it out-of-line
-    /// measurably regressed the `response_build` profile (the call
-    /// prologue/epilogue showed up as a ~2% standalone frame); forcing
-    /// it back inline keeps the DRY factoring without the call cost.
+    /// Reads the record **by reference** and clones out only the
+    /// selected field — it does *not* clone the whole record. The
+    /// unfused `[LoadLocal, GetField]` pair clones the entire record
+    /// (`Box<IndexMap>` for a heap record) onto the value stack just
+    /// to read one field and drop the rest; on the `response_build`
+    /// profile that whole-record clone+drop of the returned `Response`
+    /// dominated the malloc traffic. Borrowing in place removes it.
+    ///
+    /// Borrow discipline: the inline-cache slot can't be written while
+    /// the record (a borrow of `self.locals_storage`) is live, so the
+    /// match yields `(value, install)` and the `field_ics` write
+    /// happens after the borrow ends.
+    ///
+    /// `#[inline(always)]`: hot dispatch path, called from four tight
+    /// `run_to` arms; leaving it out-of-line showed up as a standalone
+    /// call frame on the profile.
     #[inline(always)]
-    fn read_record_field(
+    fn read_local_record_field(
         &mut self,
-        rec: Value,
+        base: usize,
+        local_idx: u16,
         fn_id: u32,
         name_idx: u32,
         site_idx: u32,
         op_name: &str,
     ) -> Result<Value, VmError> {
-        match rec {
-            Value::Record { fields: r, shape_id } => {
-                if ic_stats_enabled() {
-                    record_ic_hit(fn_id, site_idx, shape_id);
-                }
-                let fid = fn_id as usize;
-                let sid = site_idx as usize;
-                if self.field_ics[fid].is_empty() {
-                    let n = self.program.functions[fid].field_ic_sites as usize;
-                    self.field_ics[fid] = vec![None; n];
-                }
-                let cached = self.field_ics[fid][sid];
-                Ok('ic: {
-                    if let Some((cached_shape, off)) = cached {
+        let fid = fn_id as usize;
+        let sid = site_idx as usize;
+        if self.field_ics[fid].is_empty() {
+            let n = self.program.functions[fid].field_ic_sites as usize;
+            self.field_ics[fid] = vec![None; n];
+        }
+        let cached = self.field_ics[fid][sid];
+        let li = base + local_idx as usize;
+
+        let (value, install): (Value, Option<(u32, usize)>) =
+            match &self.locals_storage[li] {
+                Value::Record { fields: r, shape_id } => {
+                    let shape_id = *shape_id;
+                    if ic_stats_enabled() {
+                        record_ic_hit(fn_id, site_idx, shape_id);
+                    }
+                    let hit = if let Some((cached_shape, off)) = cached {
                         if cached_shape == shape_id {
                             if shape_id != crate::value::NO_SHAPE_ID {
-                                if let Some((_, val)) = r.get_index(off) {
-                                    break 'ic val.clone();
-                                }
+                                r.get_index(off).map(|(_, val)| val.clone())
                             } else if let Some((k, val)) = r.get_index(off) {
-                                if let Const::FieldName(s) =
-                                    &self.program.constants[name_idx as usize]
-                                {
-                                    if s == k { break 'ic val.clone(); }
+                                match &self.program.constants[name_idx as usize] {
+                                    Const::FieldName(s) if s == k => Some(val.clone()),
+                                    _ => None,
                                 }
-                            }
+                            } else { None }
+                        } else { None }
+                    } else { None };
+                    match hit {
+                        Some(v) => (v, None),
+                        None => {
+                            let name = match &self.program.constants[name_idx as usize] {
+                                Const::FieldName(s) => s.as_str(),
+                                _ => return Err(VmError::TypeMismatch(
+                                    "expected FieldName const".into())),
+                            };
+                            let (off, _, val) = r.get_full(name)
+                                .ok_or_else(|| VmError::TypeMismatch(
+                                    format!("missing field `{name}`")))?;
+                            (val.clone(), Some((shape_id, off)))
                         }
                     }
-                    let name = match &self.program.constants[name_idx as usize] {
-                        Const::FieldName(s) => s.as_str(),
-                        _ => return Err(VmError::TypeMismatch(
-                            "expected FieldName const".into())),
-                    };
-                    let (off, _, val) = r.get_full(name)
-                        .ok_or_else(|| VmError::TypeMismatch(
-                            format!("missing field `{name}`")))?;
-                    self.field_ics[fid][sid] = Some((shape_id, off));
-                    val.clone()
-                })
-            }
-            Value::StackRecord { shape_id, slab_start, field_count } => {
-                if ic_stats_enabled() {
-                    record_ic_hit(fn_id, site_idx, shape_id);
                 }
-                let fid = fn_id as usize;
-                let sid = site_idx as usize;
-                if self.field_ics[fid].is_empty() {
-                    let n = self.program.functions[fid].field_ic_sites as usize;
-                    self.field_ics[fid] = vec![None; n];
-                }
-                let cached = self.field_ics[fid][sid];
-                Ok('ic: {
+                &Value::StackRecord { shape_id, slab_start, field_count } => {
+                    if ic_stats_enabled() {
+                        record_ic_hit(fn_id, site_idx, shape_id);
+                    }
                     if let Some((cached_shape, off)) = cached {
                         if cached_shape == shape_id && (off as u16) < field_count {
                             let idx = slab_start as usize + off;
-                            break 'ic self.stack_record_arena[idx].clone();
+                            (self.stack_record_arena[idx].clone(), None)
+                        } else {
+                            let off = self.resolve_stack_field(shape_id, name_idx)?;
+                            (self.stack_record_arena[slab_start as usize + off].clone(),
+                             Some((shape_id, off)))
                         }
+                    } else {
+                        let off = self.resolve_stack_field(shape_id, name_idx)?;
+                        (self.stack_record_arena[slab_start as usize + off].clone(),
+                         Some((shape_id, off)))
                     }
-                    let shape = &self.program.record_shapes[shape_id as usize];
-                    let target_name = match &self.program.constants[name_idx as usize] {
-                        Const::FieldName(s) => s.as_str(),
-                        _ => return Err(VmError::TypeMismatch(
-                            "expected FieldName const".into())),
-                    };
-                    let mut found: Option<usize> = None;
-                    for (i, fn_const_idx) in shape.iter().enumerate() {
-                        if let Const::FieldName(s) =
-                            &self.program.constants[*fn_const_idx as usize]
-                        {
-                            if s == target_name { found = Some(i); break; }
-                        }
-                    }
-                    let off = found.ok_or_else(|| VmError::TypeMismatch(
-                        format!("missing field `{target_name}` on stack record")))?;
-                    self.field_ics[fid][sid] = Some((shape_id, off));
-                    self.stack_record_arena[slab_start as usize + off].clone()
-                })
-            }
-            other => Err(VmError::TypeMismatch(
-                format!("{op_name} on non-record: {other:?}"))),
+                }
+                other => return Err(VmError::TypeMismatch(
+                    format!("{op_name} on non-record: {other:?}"))),
+            };
+        if let Some(entry) = install {
+            self.field_ics[fid][sid] = Some(entry);
         }
+        Ok(value)
+    }
+
+    /// Resolve a field offset within a stack-record shape by name
+    /// (the slow path when the inline cache misses). Factored out so
+    /// `read_local_record_field` doesn't hold the `locals_storage`
+    /// borrow across the `record_shapes` / `constants` walk.
+    #[inline]
+    fn resolve_stack_field(&self, shape_id: u32, name_idx: u32) -> Result<usize, VmError> {
+        let shape = &self.program.record_shapes[shape_id as usize];
+        let target_name = match &self.program.constants[name_idx as usize] {
+            Const::FieldName(s) => s.as_str(),
+            _ => return Err(VmError::TypeMismatch("expected FieldName const".into())),
+        };
+        for (i, fn_const_idx) in shape.iter().enumerate() {
+            if let Const::FieldName(s) = &self.program.constants[*fn_const_idx as usize] {
+                if s == target_name { return Ok(i); }
+            }
+        }
+        Err(VmError::TypeMismatch(
+            format!("missing field `{target_name}` on stack record")))
     }
 
     fn bin_int(&mut self, f: impl Fn(i64, i64) -> Value) -> Result<(), VmError> {

--- a/crates/lex-bytecode/tests/run.rs
+++ b/crates/lex-bytecode/tests/run.rs
@@ -557,3 +557,114 @@ fn pick(flag :: Int, r :: R) -> Int {
     assert_eq!(vm.call("pick", vec![Value::Int(0), mk()]).unwrap(), Value::Int(93));
     assert_eq!(vm.call("pick", vec![Value::Int(1), mk()]).unwrap(), Value::Int(7));
 }
+
+#[test]
+fn slice9_fuses_bare_field_read() {
+    // #461 slice 9: a standalone `r.field` read fuses to
+    // LoadLocalGetField (no whole-record clone).
+    use lex_bytecode::op::Op;
+    let src = "
+type R = { x :: Int, y :: Int }
+fn getx(r :: R) -> Int { r.x }
+";
+    let p = compile(src);
+    let f = &p.functions[0];
+    assert!(matches!(f.code[0], Op::LoadLocalGetField { local_idx: 0, .. }),
+        "slice 9 did not fire; got {:?}", f.code);
+    // The trailing GetField stays as a tombstone (body-hash stability).
+    assert!(matches!(f.code[1], Op::GetField { .. }));
+
+    let mut vm = Vm::new(&p);
+    let r = vm.call("getx", vec![Value::record_dynamic({
+        let mut m = IndexMap::new();
+        m.insert("x".into(), Value::Int(11));
+        m.insert("y".into(), Value::Int(22));
+        m
+    })]).unwrap();
+    assert_eq!(r, Value::Int(11));
+}
+
+#[test]
+fn slice9_fuses_chain_head_alongside_slice7() {
+    // In `r.x + r.y`, slice 7 fuses the `+ r.y` triple and slice 9
+    // fuses the chain-head `r.x` pair — both fire in one function.
+    use lex_bytecode::op::Op;
+    let src = "
+type R = { x :: Int, y :: Int }
+fn add(r :: R) -> Int { r.x + r.y }
+";
+    let p = compile(src);
+    let f = &p.functions[0];
+    let n9 = f.code.iter().filter(|o| matches!(o, Op::LoadLocalGetField { .. })).count();
+    let n7 = f.code.iter().filter(|o| matches!(o, Op::LoadLocalGetFieldAdd { .. })).count();
+    assert_eq!(n9, 1, "expected chain-head fused by slice 9: {:?}", f.code);
+    assert_eq!(n7, 1, "expected `+ r.y` fused by slice 7: {:?}", f.code);
+
+    let mut vm = Vm::new(&p);
+    let r = vm.call("add", vec![Value::record_dynamic({
+        let mut m = IndexMap::new();
+        m.insert("x".into(), Value::Int(30));
+        m.insert("y".into(), Value::Int(12));
+        m
+    })]).unwrap();
+    assert_eq!(r, Value::Int(42));
+}
+
+#[test]
+fn slice9_reads_field_from_returned_heap_record() {
+    // The motivating case: a function returns a record (escapes to
+    // the heap), the caller reads one field. The by-reference read
+    // must produce the right value without cloning the whole record.
+    let src = "
+type Resp = { status :: Int, total :: Int }
+fn handle(n :: Int) -> Resp { { status: 200, total: n } }
+fn drive(n :: Int) -> Int { let r := handle(n) r.total }
+";
+    let p = compile(src);
+    let mut vm = Vm::new(&p);
+    assert_eq!(vm.call("drive", vec![Value::Int(99)]).unwrap(), Value::Int(99));
+}
+
+#[test]
+fn slice9_reads_field_from_stack_record() {
+    // Slice 9 over a stack-allocated record (the by-ref read's
+    // StackRecord branch + resolve_stack_field slow path).
+    let src = r#"
+        fn f() -> Int {
+          let r := { a: 7, b: 9 }
+          r.b
+        }
+    "#;
+    let p = compile(src);
+    use lex_bytecode::op::Op;
+    let f = &p.functions[0];
+    assert!(f.code.iter().any(|o| matches!(o, Op::AllocStackRecord { .. })),
+        "expected stack record");
+    assert!(f.code.iter().any(|o| matches!(o, Op::LoadLocalGetField { .. })),
+        "expected slice 9 fusion");
+    let mut vm = Vm::new(&p);
+    assert_eq!(vm.call("f", vec![]).unwrap(), Value::Int(9));
+}
+
+#[test]
+fn slice9_does_not_fire_across_a_jump_target() {
+    // The trailing GetField must not be a jump target. A match whose
+    // arm entry lands between LoadLocal and GetField would corrupt
+    // the read; verify both arms still produce correct values.
+    let src = "
+type R = { v :: Int }
+fn pick(flag :: Int, r :: R) -> Int {
+  match flag {
+    0 => r.v,
+    _ => 0,
+  }
+}
+";
+    let p = compile(src);
+    let mut vm = Vm::new(&p);
+    let mk = || Value::record_dynamic({
+        let mut m = IndexMap::new(); m.insert("v".into(), Value::Int(5)); m
+    });
+    assert_eq!(vm.call("pick", vec![Value::Int(0), mk()]).unwrap(), Value::Int(5));
+    assert_eq!(vm.call("pick", vec![Value::Int(1), mk()]).unwrap(), Value::Int(0));
+}


### PR DESCRIPTION
## Summary

Adds `Op::LoadLocalGetField` — a 2-op fusion of the bare `record.field` read, the most common field-access shape — and converts the field-read path to **borrow the record in place** instead of cloning it.

**Stacked on #530 (slice 8).** This PR's base is the slice-8 branch; it'll retarget to `main` automatically when #530 merges. The diff here is slice-9-only.

## The win is allocation, not just dispatch

The unfused `[LoadLocal, GetField]` pair clones the *entire* record onto the value stack (a `Box<IndexMap>` for a heap record), pops it in `GetField`, reads one field, and drops the rest. On the `response_build` profile the whole-record clone+drop of the returned `Response` (`r.total` in `drive`) was the dominant malloc source.

`read_record_field` (slice 7/8's helper, which took an already-cloned record) becomes `read_local_record_field`, which borrows `locals[local_idx]` and clones out only the selected field. To satisfy the borrow checker (the IC slot can't be written while the record borrow is live), the match yields `(value, install)` and the `field_ics` write happens after the borrow ends; the stack-record slow path is split into `resolve_stack_field`. Shared by slices 7/8/9, `#[inline(always)]`.

## Ordering & safety

Peephole slice 9 runs **after** slice 7/8 so it only fuses the bare pairs they didn't consume (chain heads like `r.x`, standalone reads like `r.total`, reads feeding non-add/sub/mul ops). Slice 7/8 tombstone `GetField`s sit after their fused op, never after a bare `LoadLocal`, so slice 9 never touches them. Same tombstone / jump-safety / body-hash (decode to `LoadLocal`) / verifier (+1 delta) story. The fused op reads the receiver by reference and does **not** escape it (matching plain `GetField`), so stack-allocation is preserved.

## Result

Callgrind (`response_build`, n=300 ×6): **61.71M → 55.23M instructions (−10.5%)**. `Value::clone` 8.0% → 6.1%, `drop_in_place<Value>` 9.2% → 8.2%.

The `response_build` acceptance speedup narrows from 3.2× to **1.8×** (still ≥ the 1.5× bar) — because the heap-record baseline itself got ~2× faster, so the gap stack records close shrank. That's the optimization working, not a regression.

## Test plan

- [x] `cargo test -p lex-bytecode` — all green, incl. **5 new slice-9 tests**: bare read, chain-head firing alongside slice 7, field read from a returned heap record, field read from a stack record, jump-target safety.
- [x] `cargo test -p lex-runtime --test pure_fn_memo` — 6/6 (no behavioral regression in the field-read path).
- [x] `cargo clippy -p lex-bytecode --all-targets -- -D warnings` — clean.
- [x] `response_build_acceptance` ignored bench — 1.80×, passes.
- [x] Re-profiled under callgrind to confirm the malloc/clone reduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjQc3kQTQXm97YX22kfwsU)_