### PR TITLE
perf(#229): adaptive memoization for cold pure functions

### DIFF
--- a/crates/lex-bytecode/examples/profile_response_build.rs
+++ b/crates/lex-bytecode/examples/profile_response_build.rs
@@ -56,7 +56,7 @@ fn main() {
     let p = Arc::new(compile_program(&stages));
 
     let mut acc = 0i64;
-    let (mut hits, mut misses) = (0u64, 0u64);
+    let (mut hits, mut misses, mut skips) = (0u64, 0u64, 0u64);
     for _ in 0..iters {
         let mut vm = Vm::new(&p);
         vm.set_step_limit(u64::MAX);
@@ -65,8 +65,9 @@ fn main() {
         }
         hits += vm.pure_memo_hits;
         misses += vm.pure_memo_misses;
+        skips += vm.pure_memo_skips;
     }
-    eprintln!("pure_memo: hits={hits} misses={misses}");
+    eprintln!("pure_memo: hits={hits} misses={misses} skips={skips}");
     // Keep the result observable so the optimizer can't elide the loop.
     std::process::exit((acc & 0x7f) as i32);
 }

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -101,6 +101,33 @@ pub const MAX_CALL_DEPTH: u32 = 1024;
 /// records) fits well inside this without growing.
 pub const STACK_RECORD_BUDGET_SLOTS: u32 = 64;
 
+/// Adaptive-memoization warmup window (#229 adaptive). A pure
+/// function is given this many cache-probing calls to demonstrate a
+/// hit; if it reaches the window with zero hits, memoization is
+/// disabled for it (its calls stop hashing args). A function that
+/// genuinely benefits — e.g. naive recursive `fib`, where each call
+/// immediately reuses sub-results — accumulates hits well before the
+/// window closes and stays enabled. 64 balances "give real reuse a
+/// chance" against "don't pay the hash forever on always-miss code".
+const MEMO_WARMUP_CALLS: u32 = 64;
+
+/// Per-function adaptive-memoization state (#229 adaptive). `enabled`
+/// starts true; once a function reaches `MEMO_WARMUP_CALLS` cache
+/// probes with `hits == 0`, it flips to false and that function's
+/// calls skip the args hash entirely for the rest of the Vm's life.
+#[derive(Clone, Copy)]
+struct MemoFnState {
+    calls: u32,
+    hits: u32,
+    enabled: bool,
+}
+
+impl Default for MemoFnState {
+    fn default() -> Self {
+        MemoFnState { calls: 0, hits: 0, enabled: true }
+    }
+}
+
 /// Host-side effect dispatch. Implementors decide what `kind`/`op` mean
 /// and how arguments map to side effects.
 pub trait EffectHandler {
@@ -237,6 +264,21 @@ pub struct Vm<'a> {
     /// Diagnostic counters for `--trace` observability (#229).
     pub pure_memo_hits: u64,
     pub pure_memo_misses: u64,
+    /// Number of effect-free calls that skipped the cache entirely
+    /// because adaptive memoization disabled their function (#229
+    /// adaptive). Observability only.
+    pub pure_memo_skips: u64,
+    /// Adaptive-memoization state, one entry per function (indexed by
+    /// `fn_id`), parallel to `field_ics` (#229 adaptive). Memoization
+    /// only pays when a function is called repeatedly with equal args;
+    /// the unconditional `hash_call_args` on every effect-free call is
+    /// pure overhead otherwise (the `response_build` profile: 0 hits /
+    /// 3600 misses, ~12% of instructions). After a warmup window with
+    /// zero hits we stop hashing that function's calls — always safe,
+    /// since the callee is pure and recomputing yields the same value.
+    /// Sticky for the Vm's lifetime: a function that hasn't hit in
+    /// `MEMO_WARMUP_CALLS` calls won't amortize later.
+    memo_fn_state: Vec<MemoFnState>,
     /// Monomorphic inline caches for `Op::GetField` (#462 slice 1 +
     /// shape-keyed verification slice). Indexed by
     /// `[fn_id as usize][site_idx as usize]` — one entry per
@@ -778,6 +820,8 @@ impl<'a> Vm<'a> {
             pure_memo: std::collections::HashMap::new(),
             pure_memo_hits: 0,
             pure_memo_misses: 0,
+            pure_memo_skips: 0,
+            memo_fn_state: vec![MemoFnState::default(); program.functions.len()],
             field_ics: vec![Vec::new(); program.functions.len()],
             // 256 slots handles ~32 frames × 8 locals; grows on demand and
             // retains capacity across consecutive vm.call() invocations.
@@ -1665,14 +1709,25 @@ impl<'a> Vm<'a> {
                     // On hit, push the cached value, emit synthetic
                     // enter+exit trace events (so the trace still shows
                     // the call), and skip the frame push entirely.
+                    //
+                    // Adaptive gate (#229 adaptive): only hash if this
+                    // function still has memoization enabled. A pure
+                    // function whose args never repeat pays the hash for
+                    // nothing; after a warmup window with zero hits we
+                    // disable it and its calls take the plain path below.
                     let f = &self.program.functions[fn_id as usize];
-                    let memo_key: Option<(u32, [u8; 16])> = if f.effects.is_empty() {
-                        Some((fn_id, hash_call_args(&args)))
-                    } else {
-                        None
-                    };
+                    let fid = fn_id as usize;
+                    let memo_key: Option<(u32, [u8; 16])> =
+                        if f.effects.is_empty() && self.memo_fn_state[fid].enabled {
+                            Some((fn_id, hash_call_args(&args)))
+                        } else {
+                            if f.effects.is_empty() { self.pure_memo_skips += 1; }
+                            None
+                        };
                     if let Some(key) = memo_key {
+                        self.memo_fn_state[fid].calls += 1;
                         if let Some(cached) = self.pure_memo.get(&key).cloned() {
+                            self.memo_fn_state[fid].hits += 1;
                             self.pure_memo_hits += 1;
                             self.tracer.enter_call(&node_id, &callee_name, &args);
                             self.tracer.exit_ok(&cached);
@@ -1680,6 +1735,13 @@ impl<'a> Vm<'a> {
                             continue;
                         }
                         self.pure_memo_misses += 1;
+                        // Disable on a cold function: warmup elapsed with
+                        // no hit. Always safe — the callee is pure, so the
+                        // plain path recomputes the identical result.
+                        let st = &mut self.memo_fn_state[fid];
+                        if st.calls >= MEMO_WARMUP_CALLS && st.hits == 0 {
+                            st.enabled = false;
+                        }
                     }
                     self.tracer.enter_call(&node_id, &callee_name, &args);
                     let locals_start = self.locals_storage.len();

--- a/crates/lex-runtime/tests/pure_fn_memo.rs
+++ b/crates/lex-runtime/tests/pure_fn_memo.rs
@@ -29,6 +29,25 @@ fn run_with_counters(src: &str, fn_name: &str, args: Vec<Value>)
     (v, vm.pure_memo_hits, vm.pure_memo_misses)
 }
 
+/// Like `run_with_counters` but also surfaces the adaptive-memo skip
+/// counter (#229 adaptive) — the number of effect-free calls that
+/// bypassed the cache because their function was disabled.
+fn run_with_skips(src: &str, fn_name: &str, args: Vec<Value>)
+    -> (Value, u64, u64, u64)
+{
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors: {errs:#?}");
+    }
+    let bc = Arc::new(compile_program(&stages));
+    let handler = DefaultHandler::new(Policy::permissive())
+        .with_program(Arc::clone(&bc));
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    let v = vm.call(fn_name, args).unwrap_or_else(|e| panic!("{e:?}"));
+    (v, vm.pure_memo_hits, vm.pure_memo_misses, vm.pure_memo_skips)
+}
+
 const PURE_SRC: &str = r#"
 # A pure function (no declared effects). Calling it with the same
 # arg twice should hit the cache the second time.
@@ -142,4 +161,79 @@ fn cache_does_not_persist_across_vm_invocations() {
     let (_, h2, m2) = run_with_counters(CROSS_VM_SRC, "one_call", vec![]);
     assert_eq!(h1, 0); assert_eq!(m1, 1);
     assert_eq!(h2, 0); assert_eq!(m2, 1);
+}
+
+// ---------------------------------------------------------------------------
+// Adaptive memoization (#229 adaptive): a pure function whose args never
+// repeat pays the args-hash on every call for zero benefit. After a warmup
+// window (MEMO_WARMUP_CALLS = 64) with zero hits, the VM disables
+// memoization for that function and its subsequent calls skip the hash.
+// Disabling is always safe — the callee is pure, so the plain path
+// recomputes the identical value.
+// ---------------------------------------------------------------------------
+
+// `leaf` is called once per `drive` recursion level, each time with a
+// distinct argument, so it never hits its own cache. `drive` likewise
+// recurses on a distinct `n` each level. With > 64 levels both functions
+// blow through the warmup window and get disabled, after which their calls
+// register as skips rather than misses.
+const ALWAYS_MISS_SRC: &str = r#"
+fn leaf(n :: Int) -> Int { n + 1 }
+
+fn drive(n :: Int) -> Int {
+  match n {
+    0 => 0,
+    _ => leaf(n) + drive(n - 1),
+  }
+}
+"#;
+
+#[test]
+fn cold_function_is_disabled_after_warmup_and_skips() {
+    // drive(200): 200 distinct-arg calls to `leaf` and ~200 self-calls to
+    // `drive`. Both exceed the 64-call warmup with zero hits, so both get
+    // disabled and the post-warmup calls show up as skips.
+    let (v, hits, _misses, skips) = run_with_skips(ALWAYS_MISS_SRC, "drive", vec![Value::Int(200)]);
+    // sum_{k=1..200} (k+1) = sum k + 200 = 20100 + 200 = 20300
+    assert_eq!(v, Value::Int(20300), "result must be correct despite disabling");
+    assert_eq!(hits, 0, "always-distinct args never hit");
+    assert!(skips > 0, "expected adaptive memo to disable a cold function and skip; got 0 skips");
+}
+
+#[test]
+fn cold_function_result_matches_non_adaptive_recompute() {
+    // Correctness guard: the value must be identical whether memoization
+    // stayed on the whole time (n <= warmup, never disabled) or got
+    // disabled partway (n > warmup). Compute both and compare.
+    let (small, _, _, skips_small) =
+        run_with_skips(ALWAYS_MISS_SRC, "drive", vec![Value::Int(10)]);
+    let (large, _, _, skips_large) =
+        run_with_skips(ALWAYS_MISS_SRC, "drive", vec![Value::Int(100)]);
+    // n=10 stays under warmup → no disabling; n=100 trips it.
+    assert_eq!(skips_small, 0, "under warmup, nothing should be disabled");
+    assert!(skips_large > 0, "over warmup, cold functions should disable");
+    // Closed-form: drive(n) = sum_{k=1..n}(k+1) = n(n+1)/2 + n.
+    assert_eq!(small, Value::Int(10 * 11 / 2 + 10));   // 65
+    assert_eq!(large, Value::Int(100 * 101 / 2 + 100)); // 5150
+}
+
+// Naive recursive fib reuses sub-results heavily, so it hits its cache
+// almost immediately and should NEVER be disabled — memoization is exactly
+// what makes it fast. Verify it accumulates hits and records zero skips.
+const FIB_SRC: &str = r#"
+fn fib(n :: Int) -> Int {
+  match n {
+    0 => 0,
+    1 => 1,
+    _ => fib(n - 1) + fib(n - 2),
+  }
+}
+"#;
+
+#[test]
+fn hot_function_stays_enabled_no_skips() {
+    let (v, hits, _misses, skips) = run_with_skips(FIB_SRC, "fib", vec![Value::Int(25)]);
+    assert_eq!(v, Value::Int(75025), "fib(25)");
+    assert!(hits > 0, "naive fib must hit its memo cache");
+    assert_eq!(skips, 0, "a function that hits should never be disabled");
 }


### PR DESCRIPTION
## Summary

Pure-fn memoization (#229) hashed the args of **every** effect-free call to probe the cache, but the hash only pays off when calls repeat with equal args. On always-miss workloads it's pure overhead — the `response_build` profile showed **0 hits / 3600 misses** with the args hash at ~12% of all VM instructions.

This adds **per-function adaptive memoization**: a function gets a 64-call warmup window to demonstrate a cache hit; if it reaches the window with zero hits, memoization is disabled for it and its subsequent calls skip the args hash entirely.

## Design

- Per-fn `MemoFnState { calls, hits, enabled }`, indexed by `fn_id`, parallel to `field_ics`.
- Gate in the `Op::Call` memo block: only hash if `effects.is_empty() && memo_fn_state[fid].enabled`.
- On a miss, if `calls >= MEMO_WARMUP_CALLS (64) && hits == 0` → disable.
- **Always safe**: the callee is pure, so the plain path recomputes the identical value. **Sticky** for the Vm's lifetime — a function cold for 64 calls won't amortize later.
- Functions that genuinely benefit (e.g. naive recursive `fib`, which reuses sub-results immediately) accumulate hits well before the window closes and stay enabled.
- New `pure_memo_skips` counter for observability; tracing unaffected.

This is the "runtime-adaptive only, zero-hits-after-warmup" variant. It fully fixes the profiled always-miss case without a compiler change.

## Result

Callgrind (`response_build`, n=300 ×6): **61.94M → 51.69M instructions (−16.5%)** off the current main baseline. The SipHash frames drop out of the profile entirely; `Vm::run_to` (genuine dispatch) is now 43%. (Stacks with the slice 8/9 clone-churn work in #530.)

## Test plan

- [x] `cargo test -p lex-runtime --test pure_fn_memo` — **9/9** (6 existing unchanged + 3 new): cold function disables after warmup and skips, result matches the never-disabled small-n run, naive `fib` stays enabled with zero skips.
- [x] `cargo test -p lex-bytecode` — all green.
- [x] `cargo clippy -p lex-bytecode --all-targets -- -D warnings` — clean.
- [x] Re-profiled under callgrind to confirm the SipHash frames are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjQc3kQTQXm97YX22kfwsU)_