### PR TITLE
perf(#461): intern record field-name keys (String -> SmolStr)

### DIFF
--- a/crates/lex-bytecode/src/value.rs
+++ b/crates/lex-bytecode/src/value.rs
@@ -110,7 +110,7 @@ pub enum Value {
     /// `PartialEq` below): two records with identical fields must
     /// compare equal regardless of provenance, so a JSON-decoded
     /// record equals a compile-time-built one with the same fields.
-    Record { shape_id: u32, fields: Box<IndexMap<String, Value>> },
+    Record { shape_id: u32, fields: Box<IndexMap<SmolStr, Value>> },
     /// Frame-local record (#464 step 2). Emitted by
     /// `Op::AllocStackRecord` at sites the escape analysis proved
     /// can't outlive the current call frame. `slab_start` indexes
@@ -335,7 +335,7 @@ impl Value {
             Value::Tuple(items) => J::Array(items.iter().map(Value::to_json).collect()),
             Value::Record { fields, .. } => {
                 let mut m = serde_json::Map::new();
-                for (k, v) in fields.iter() { m.insert(k.clone(), v.to_json()); }
+                for (k, v) in fields.iter() { m.insert(k.to_string(), v.to_json()); }
                 J::Object(m)
             }
             // #464: should never reach JSON serialization. See PartialEq.
@@ -483,7 +483,24 @@ impl Value {
     /// measurement found at exactly zero occurrences) would still
     /// be correct under the IC's shape-keyed verifier — they'd just
     /// churn the cache.
+    /// Build a `Record` from a String-keyed host map (JSON decode, SQL
+    /// rows, builtins). Keys are re-collected into interned `SmolStr`
+    /// (#461 field-name interning). The hot bytecode `MakeRecord` path
+    /// builds `SmolStr`-keyed maps directly and never routes through
+    /// here; callers that already hold an interned map use
+    /// `record_interned`.
     pub fn record_dynamic(fields: IndexMap<String, Value>) -> Value {
+        let shape_id = crate::shape_registry::intern(fields.keys());
+        let fields: IndexMap<SmolStr, Value> =
+            fields.into_iter().map(|(k, v)| (SmolStr::from(k), v)).collect();
+        Value::Record { shape_id, fields: Box::new(fields) }
+    }
+
+    /// Build a `Record` from an already-interned `SmolStr`-keyed map —
+    /// used by the http builder chain, which threads `SmolStr` keys
+    /// through `with_header`/`with_query`/… without round-tripping back
+    /// to `String` (#461).
+    pub fn record_interned(fields: IndexMap<SmolStr, Value>) -> Value {
         let shape_id = crate::shape_registry::intern(fields.keys());
         Value::Record { shape_id, fields: Box::new(fields) }
     }

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -5,6 +5,7 @@ use crate::program::*;
 use crate::value::{ActorCell, Value};
 use std::sync::{Arc, Mutex, OnceLock};
 use indexmap::IndexMap;
+use smol_str::SmolStr;
 use std::collections::{HashMap, VecDeque};
 
 // ── IC polymorphism instrumentation (throwaway, env-gated) ─────────
@@ -873,7 +874,7 @@ impl<'a> Vm<'a> {
                 args: vec![value],
             }),
             Err((pos, msg)) => {
-                let mut e = indexmap::IndexMap::new();
+                let mut e: IndexMap<String, Value> = IndexMap::new();
                 e.insert("pos".into(), Value::Int(pos as i64));
                 e.insert("message".into(), Value::Str(msg.into()));
                 Ok(Value::Variant {
@@ -1204,10 +1205,10 @@ impl<'a> Vm<'a> {
                     for i in (0..n).rev() {
                         values[i] = self.pop()?;
                     }
-                    let mut rec = IndexMap::new();
+                    let mut rec: IndexMap<SmolStr, Value> = IndexMap::with_capacity(n);
                     for (i, val) in values.into_iter().enumerate() {
-                        let name = match &self.program.constants[shape[i] as usize] {
-                            Const::FieldName(s) => s.clone(),
+                        let name: SmolStr = match &self.program.constants[shape[i] as usize] {
+                            Const::FieldName(s) => s.as_str().into(),
                             _ => return Err(VmError::TypeMismatch("expected FieldName const".into())),
                         };
                         rec.insert(name, val);
@@ -1243,10 +1244,10 @@ impl<'a> Vm<'a> {
                         for i in (0..n).rev() {
                             values[i] = self.pop()?;
                         }
-                        let mut rec = IndexMap::new();
+                        let mut rec: IndexMap<SmolStr, Value> = IndexMap::with_capacity(n);
                         for (i, val) in values.into_iter().enumerate() {
-                            let name = match &self.program.constants[shape[i] as usize] {
-                                Const::FieldName(s) => s.clone(),
+                            let name: SmolStr = match &self.program.constants[shape[i] as usize] {
+                                Const::FieldName(s) => s.as_str().into(),
                                 _ => return Err(VmError::TypeMismatch("expected FieldName const".into())),
                             };
                             rec.insert(name, val);
@@ -2394,8 +2395,8 @@ mod memo_hash_tests {
     use indexmap::IndexMap;
 
     fn rec(pairs: &[(&str, Value)]) -> Value {
-        let mut m = IndexMap::new();
-        for (k, v) in pairs { m.insert((*k).to_string(), v.clone()); }
+        let mut m: IndexMap<SmolStr, Value> = IndexMap::new();
+        for (k, v) in pairs { m.insert((*k).into(), v.clone()); }
         Value::Record { shape_id: crate::value::NO_SHAPE_ID, fields: Box::new(m) }
     }
 
@@ -2450,8 +2451,8 @@ mod memo_hash_tests {
     #[test]
     fn shape_id_does_not_affect_record_key() {
         // PartialEq ignores shape_id; the key must too.
-        let mut m = IndexMap::new();
-        m.insert("a".to_string(), Value::Int(1));
+        let mut m: IndexMap<SmolStr, Value> = IndexMap::new();
+        m.insert("a".into(), Value::Int(1));
         let r_no_shape = Value::Record { shape_id: crate::value::NO_SHAPE_ID, fields: Box::new(m.clone()) };
         let r_shaped = Value::Record { shape_id: 3, fields: Box::new(m) };
         assert_eq!(r_no_shape, r_shaped);

--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -1495,14 +1495,14 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             let req = expect_record_pure(args.first())?.clone();
             let k = expect_str(args.get(1))?;
             let v = expect_str(args.get(2))?;
-            Ok(Value::record_dynamic(http_set_header(req, &k, &v)))
+            Ok(Value::record_interned(http_set_header(req, &k, &v)))
         }
         ("http", "with_auth") => {
             let req = expect_record_pure(args.first())?.clone();
             let scheme = expect_str(args.get(1))?;
             let token = expect_str(args.get(2))?;
             let value = format!("{scheme} {token}");
-            Ok(Value::record_dynamic(http_set_header(req, "Authorization", &value)))
+            Ok(Value::record_interned(http_set_header(req, "Authorization", &value)))
         }
         ("http", "with_query") => {
             let req = expect_record_pure(args.first())?.clone();
@@ -1512,7 +1512,7 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
                     "http.with_query: params must be Map[Str, Str], got {other:?}")),
                 None => return Err("http.with_query: missing params argument".into()),
             };
-            Ok(Value::record_dynamic(http_append_query(req, &params)))
+            Ok(Value::record_interned(http_append_query(req, &params)))
         }
         ("http", "with_timeout_ms") => {
             let req = expect_record_pure(args.first())?.clone();
@@ -1522,7 +1522,7 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
                 name: "Some".into(),
                 args: vec![Value::Int(ms)],
             });
-            Ok(Value::record_dynamic(out))
+            Ok(Value::record_interned(out))
         }
         ("http", "json_body") => {
             let resp = expect_record_pure(args.first())?;
@@ -1872,7 +1872,7 @@ fn rng_decode(v: Option<&Value>) -> Result<u64, String> {
 
 // -- helpers for `std.http` builders / decoders --
 
-fn expect_record_pure(v: Option<&Value>) -> Result<&indexmap::IndexMap<String, Value>, String> {
+fn expect_record_pure(v: Option<&Value>) -> Result<&indexmap::IndexMap<smol_str::SmolStr, Value>, String> {
     match v {
         Some(Value::Record { fields: r, .. }) => Ok(r),
         Some(other) => Err(format!("expected Record, got {other:?}")),
@@ -1893,10 +1893,10 @@ fn http_decode_err_pure(msg: String) -> Value {
 /// case-insensitivity; an existing entry under any casing is
 /// overwritten by the new value.
 fn http_set_header(
-    mut req: indexmap::IndexMap<String, Value>,
+    mut req: indexmap::IndexMap<smol_str::SmolStr, Value>,
     name: &str,
     value: &str,
-) -> indexmap::IndexMap<String, Value> {
+) -> indexmap::IndexMap<smol_str::SmolStr, Value> {
     use lex_bytecode::MapKey;
     let mut headers = match req.shift_remove("headers") {
         Some(Value::Map(m)) => m,
@@ -1921,9 +1921,9 @@ fn http_set_header(
 /// order (`BTreeMap` → sorted by key) so the produced URL is
 /// deterministic.
 fn http_append_query(
-    mut req: indexmap::IndexMap<String, Value>,
+    mut req: indexmap::IndexMap<smol_str::SmolStr, Value>,
     params: &std::collections::BTreeMap<lex_bytecode::MapKey, Value>,
-) -> indexmap::IndexMap<String, Value> {
+) -> indexmap::IndexMap<smol_str::SmolStr, Value> {
     use lex_bytecode::MapKey;
     let url = match req.get("url") {
         Some(Value::Str(s)) => s.clone(),
@@ -2343,9 +2343,9 @@ fn resolve_tz_to_components(n: i64, tz: &TzArg) -> Result<Value, String> {
 }
 
 
-fn instant_from_components(rec: &indexmap::IndexMap<String, Value>) -> Result<i64, String> {
+fn instant_from_components(rec: &indexmap::IndexMap<smol_str::SmolStr, Value>) -> Result<i64, String> {
     use chrono::TimeZone;
-    fn get_int(rec: &indexmap::IndexMap<String, Value>, k: &str) -> Result<i64, String> {
+    fn get_int(rec: &indexmap::IndexMap<smol_str::SmolStr, Value>, k: &str) -> Result<i64, String> {
         match rec.get(k) {
             Some(Value::Int(n)) => Ok(*n),
             other => Err(format!("from_components: missing or non-int field `{k}`: {other:?}")),

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -3263,7 +3263,7 @@ fn collect_response_headers(
 /// Pull the standard `HttpRequest` shape out of a `Value::Record`
 /// and dispatch through `http_send_full`. The handler verifies
 /// `--allow-net-host` for the URL before sending.
-fn http_send_record(handler: &DefaultHandler, req: &indexmap::IndexMap<String, Value>) -> Value {
+fn http_send_record(handler: &DefaultHandler, req: &indexmap::IndexMap<smol_str::SmolStr, Value>) -> Value {
     let method = match req.get("method") {
         Some(Value::Str(s)) => s.to_string(),
         _ => return http_decode_err("HttpRequest.method must be Str".into()),
@@ -3303,7 +3303,7 @@ fn http_send_record(handler: &DefaultHandler, req: &indexmap::IndexMap<String, V
     http_send_full(&method, &url, body, "", &headers, timeout_ms)
 }
 
-fn expect_record(v: Option<&Value>) -> Result<&indexmap::IndexMap<String, Value>, String> {
+fn expect_record(v: Option<&Value>) -> Result<&indexmap::IndexMap<smol_str::SmolStr, Value>, String> {
     match v {
         Some(Value::Record { fields: r, .. }) => Ok(r),
         Some(other) => Err(format!("expected Record, got {other:?}")),

--- a/crates/lex-runtime/tests/proc_effect.rs
+++ b/crates/lex-runtime/tests/proc_effect.rs
@@ -29,7 +29,7 @@ fn run(src: &str, func: &str, args: Vec<Value>, policy: Policy) -> Result<Value,
     vm.call(func, args).map_err(|e| format!("{e}"))
 }
 
-fn unwrap_record(v: &Value) -> &indexmap::IndexMap<String, Value> {
+fn unwrap_record(v: &Value) -> &indexmap::IndexMap<smol_str::SmolStr, Value> {
     match v {
         Value::Record { fields: r, .. } => r,
         other => panic!("expected Record, got {other:?}"),

--- a/crates/lex-runtime/tests/std_http.rs
+++ b/crates/lex-runtime/tests/std_http.rs
@@ -109,7 +109,8 @@ fn unwrap_ok_record(v: Value) -> indexmap::IndexMap<String, Value> {
         other => panic!("expected Ok, got {other:?}"),
     };
     match args.into_iter().next() {
-        Some(Value::Record { fields: r, .. }) => *r,
+        Some(Value::Record { fields: r, .. }) =>
+            r.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
         other => panic!("expected Record inside Ok, got {other:?}"),
     }
 }

--- a/crates/lex-trace/src/recorder.rs
+++ b/crates/lex-trace/src/recorder.rs
@@ -179,7 +179,7 @@ fn value_to_json(v: &Value) -> serde_json::Value {
         Value::Tuple(items) => J::Array(items.iter().map(value_to_json).collect()),
         Value::Record { fields, .. } => {
             let mut m = serde_json::Map::new();
-            for (k, v) in fields.iter() { m.insert(k.clone(), value_to_json(v)); }
+            for (k, v) in fields.iter() { m.insert(k.to_string(), value_to_json(v)); }
             J::Object(m)
         }
         // #464 step 2: escape analysis prevents this variant from

--- a/crates/lex-trace/tests/m7.rs
+++ b/crates/lex-trace/tests/m7.rs
@@ -60,7 +60,7 @@ fn value_to_json(v: &Value) -> serde_json::Value {
         Value::Tuple(items) => J::Array(items.iter().map(value_to_json).collect()),
         Value::Record { fields, .. } => {
             let mut m = serde_json::Map::new();
-            for (k, v) in fields.iter() { m.insert(k.clone(), value_to_json(v)); }
+            for (k, v) in fields.iter() { m.insert(k.to_string(), value_to_json(v)); }
             J::Object(m)
         }
         Value::Variant { name, args } => {

--- a/crates/spec-checker/src/checker.rs
+++ b/crates/spec-checker/src/checker.rs
@@ -268,8 +268,8 @@ fn eval(
             // also hold for randomly-sampled records of the same shape.
             let v = eval(value, bindings, bc, policy)?;
             match v {
-                Value::Record { fields, .. } => fields.get(field).cloned().ok_or_else(|| {
-                    let known: Vec<&str> = fields.keys().map(String::as_str).collect();
+                Value::Record { fields, .. } => fields.get(field.as_str()).cloned().ok_or_else(|| {
+                    let known: Vec<&str> = fields.keys().map(|k| k.as_str()).collect();
                     format!("field `{field}` missing on record (have: {})", known.join(", "))
                 }),
                 other => Err(format!("field access `.{field}` on non-record: {other:?}")),

--- a/crates/spec-checker/src/gate.rs
+++ b/crates/spec-checker/src/gate.rs
@@ -270,8 +270,8 @@ fn eval_body(
             // wants to know about, not silently default.
             let v = eval_body(value, bindings, bc, policy, new_tracer)?;
             match v {
-                Value::Record { fields, .. } => fields.get(field).cloned().ok_or_else(|| {
-                    let known: Vec<&str> = fields.keys().map(String::as_str).collect();
+                Value::Record { fields, .. } => fields.get(field.as_str()).cloned().ok_or_else(|| {
+                    let known: Vec<&str> = fields.keys().map(|k| k.as_str()).collect();
                     format!("field `{field}` missing on record (have: {})", known.join(", "))
                 }),
                 other => Err(format!(


### PR DESCRIPTION
## Summary

Field-name interning for records, the small self-contained win identified in the #461 profile write-up. `Value::Record` fields were keyed by `String`, so every `MakeRecord` deep-cloned a fresh heap `String` per field name and grew the `IndexMap` from empty (rehashing as it went). The `response_build` profile showed this as `String::clone` + hashbrown `reserve_rehash` on every record build, plus the matching malloc/free churn.

This switches the record key type to `SmolStr` (already the backing type for `Value::Str`). Short field names (`status`, `headers`, `body`, …) store inline, so a key becomes a stack copy with no heap allocation.

## Changes

- `Value::Record { fields: Box<IndexMap<String, Value>> }` → `Box<IndexMap<SmolStr, Value>>`.
- Hot path (bytecode `MakeRecord` / `AllocStackRecord` heap-fallback): build with `IndexMap::with_capacity(field_count)` and intern names straight from the constant pool via `s.as_str().into()` — kills both the per-field `String` alloc and the rehash-on-grow.
- Cold builders (JSON decode, SQL rows, builtins) keep String-keyed maps and route through `Value::record_dynamic`, which now re-keys to `SmolStr` on the way in. **No cold-site edits.**
- The http builder chain (`with_header`/`with_query`/…) threads `SmolStr` keys end-to-end and constructs via a new `Value::record_interned`, avoiding a `String` round-trip.
- Read sites unchanged — `SmolStr: Borrow<str>` keeps `fields.get("name")` working.

## Result

Callgrind (`response_build`, n=300 ×6): **44.94M → 43.29M I-refs (−3.7%)**, behavior identical (memo counters unchanged).

`String::clone` and `reserve_rehash` drop out of the profile entirely; libc `free` shrinks. `drop_in_place<Value>` is unchanged **as expected** — that's structural value-tree teardown, which the #461 write-up identified as arena/escape-analysis territory (#463/#464), not key interning.

## Test plan

- [x] `cargo test --workspace` — **1738 passed, 0 failed**
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] Re-profiled under callgrind to confirm the targeted frames (`String::clone`, `reserve_rehash`) are eliminated

Context + the profile analysis that motivated this: https://github.com/alpibrusl/lex-lang/issues/461#issuecomment-4508261230

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjQc3kQTQXm97YX22kfwsU)_