### PR TITLE
fix(std.redis): open handler effect row for subscribe/psubscribe

### DIFF
--- a/crates/lex-runtime/tests/std_redis.rs
+++ b/crates/lex-runtime/tests/std_redis.rs
@@ -51,6 +51,7 @@ fn unwrap_err_str(v: Value) -> String {
 
 const TYPE_CHECK_SRC: &str = r#"
 import "std.redis" as redis
+import "std.io" as io
 
 fn check_connect(url :: Str) -> [net] Result[ConnRedis, Str] {
   redis.connect(url)
@@ -118,6 +119,20 @@ fn check_hdel(conn :: ConnRedis, key :: Str, field :: Str) -> [net] Unit {
 
 fn check_hgetall(conn :: ConnRedis, key :: Str) -> [net] List[(Str, Str)] {
   redis.hgetall(conn, key)
+}
+
+# subscribe handler carries an open effect row: io.print must type-check here.
+fn check_subscribe(conn :: ConnRedis, ch :: Str) -> [net] Unit {
+  redis.subscribe(conn, ch, fn(channel :: Str, msg :: Str) -> [io] Unit {
+    io.print(msg)
+  })
+}
+
+# psubscribe handler carries an open effect row: io.print must type-check here.
+fn check_psubscribe(conn :: ConnRedis, pat :: Str) -> [net] Unit {
+  redis.psubscribe(conn, pat, fn(pattern :: Str, channel :: Str, msg :: Str) -> [io] Unit {
+    io.print(msg)
+  })
 }
 "#;
 

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -2305,24 +2305,26 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 EffectSet::singleton("net"),
                 Ty::int()));
 
-            // subscribe :: ConnRedis, Str, (Str, Str) -> Unit -> [net] Nil
+            // subscribe :: ConnRedis, Str, (Str, Str ->[E] Unit) -> [net] Nil
             // Blocking loop; handler receives (channel, message) on each message.
             // Uses a dedicated connection — Redis disallows non-Pub/Sub commands
-            // on a subscribed connection.
+            // on a subscribed connection. Handler carries an open effect row so
+            // callers can use io, net, sql, etc. inside the closure.
             let handler2 = Ty::function(
                 vec![Ty::str(), Ty::str()],
-                EffectSet::empty(),
+                EffectSet::open_var(0),
                 Ty::Unit);
             fields.insert("subscribe".into(), Ty::function(
                 vec![conn_t(), Ty::str(), handler2],
                 EffectSet::singleton("net"),
                 Ty::Unit));  // Nil = Unit
 
-            // psubscribe :: ConnRedis, Str, (Str, Str, Str) -> Unit -> [net] Nil
+            // psubscribe :: ConnRedis, Str, (Str, Str, Str ->[E] Unit) -> [net] Nil
             // Pattern-subscribe; handler receives (pattern, channel, message).
+            // Handler carries an open effect row (same rationale as subscribe).
             let handler3 = Ty::function(
                 vec![Ty::str(), Ty::str(), Ty::str()],
-                EffectSet::empty(),
+                EffectSet::open_var(1),
                 Ty::Unit);
             fields.insert("psubscribe".into(), Ty::function(
                 vec![conn_t(), Ty::str(), handler3],


### PR DESCRIPTION
## Summary

- `subscribe` and `psubscribe` handler closures were typed with `EffectSet::empty()`, but the runtime runs handlers in a fresh VM that inherits the parent policy — so callers can legitimately use `io`, `net`, `sql`, etc. inside the closure. The empty effect set was a lie the type checker would enforce but the runtime would silently allow.
- Switch both handler closures to `EffectSet::open_var` (effect polymorphism), consistent with how `std.list.map`, `filter`, and `fold` type their callbacks.
- The §3.7 docs example (`io.print(msg)` inside a `subscribe` handler) now type-checks correctly.

## Files changed

- `crates/lex-types/src/builtins.rs` — `EffectSet::empty()` → `EffectSet::open_var(0/1)` for the `subscribe` and `psubscribe` handler closures.
- `crates/lex-runtime/tests/std_redis.rs` — add `check_subscribe` and `check_psubscribe` to `TYPE_CHECK_SRC` (with `io.print` in the body) so `all_signatures_type_check` catches any future regression.

## Test plan

- [x] `cargo test -p lex-runtime --test std_redis` — all 12 tests green
- [x] `cargo build -p lex-types -p lex-runtime` — clean build

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fhj4FTGNM7B6Yx4Uc57WUr)_