### PR TITLE
perf(#461) slice A: cache code slice across the dispatch loop

### DIFF
--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -1153,11 +1153,26 @@ impl<'a> Vm<'a> {
     /// already-running `run()` must return when *its* frame returns,
     /// not when the entire frame stack empties (#221).
     fn run_to(&mut self, base_depth: usize) -> Result<Value, VmError> {
+        // #461 slice A: cache the executing function's code slice across
+        // ops instead of re-deriving `program.functions[fn_id].code` on
+        // every iteration. The program is borrowed (`&'a Program`) and is
+        // never mutated during a run, so the slice reference is valid for
+        // the whole run and — crucially — is independent of the `&mut self`
+        // borrow the op handlers take: it points into the caller-owned
+        // `Program`, not into `*self`. Re-resolve only when `fn_id`
+        // changes, which is exactly the frame-transition set (Call /
+        // CallClosure / TailCall / Return); recursion into the same
+        // `fn_id` correctly keeps the cached slice. `frame_idx` / `fn_id`
+        // stay recomputed per op (cheap field reads), so the op handlers
+        // are untouched and their `fn_id` bindings shadow as before.
+        let program: &'a Program = self.program;
+        let mut code: &'a [Op] = &[];
+        let mut code_fn_id: u32 = u32::MAX;
         loop {
             if self.steps > self.step_limit {
                 let frame_idx = self.frames.len() - 1;
                 let fn_id = self.frames[frame_idx].fn_id;
-                let fn_name = &self.program.functions[fn_id as usize].name;
+                let fn_name = &program.functions[fn_id as usize].name;
                 return Err(VmError::Panic(format!(
                     "step limit exceeded in `{fn_name}` ({} > {})",
                     self.steps, self.step_limit,
@@ -1167,9 +1182,12 @@ impl<'a> Vm<'a> {
             let frame_idx = self.frames.len() - 1;
             let pc = self.frames[frame_idx].pc;
             let fn_id = self.frames[frame_idx].fn_id;
-            let code = &self.program.functions[fn_id as usize].code;
+            if fn_id != code_fn_id {
+                code = &program.functions[fn_id as usize].code;
+                code_fn_id = fn_id;
+            }
             if pc >= code.len() {
-                let fn_name = &self.program.functions[fn_id as usize].name;
+                let fn_name = &program.functions[fn_id as usize].name;
                 return Err(VmError::Panic(format!("ran past end of code in `{fn_name}`")));
             }
             let op = code[pc];

--- a/docs/design/dispatch-overhead-measurement.md
+++ b/docs/design/dispatch-overhead-measurement.md
@@ -193,3 +193,37 @@ Each slice re-runs `cargo bench -p lex-bytecode --bench dispatch`
 --workspace` must stay green — same discipline as superinstruction
 slices 1–9. Slice A is the one with the measured 48% behind it;
 B and C are follow-ons.
+
+### Slice A landed — measured result (2026-05-22)
+
+First increment of slice A: cache the executing function's code
+slice (`program.functions[fn_id].code`) across ops, re-resolving
+only when `fn_id` changes (the frame-transition set). Works because
+`program` is a borrowed `&'a Program` — the slice reference is
+independent of the `&mut self` the op handlers take, so it can live
+across the dispatch arms with no `unsafe`, no `Arc`, no serialization
+change. `frame_idx` / `fn_id` stay recomputed per op, so the 70+ op
+handlers are untouched.
+
+Measured with the deterministic tool, not wall-clock: criterion on
+this shared VM has a ~4–5% run-to-run noise floor (the
+`straight_arith_no_dispatch` control — native Rust that never enters
+`run_to` — drifts that much between back-to-back runs), which swamps
+a slice-A-sized effect. callgrind I-refs are drift-immune, so they
+are the gate for changes this small. `profile_response_build 120 3`:
+
+| | I-refs | `run_to` I-refs |
+|---|---|---|
+| before | 11,073,057 | 4,344,448 (39.2%) |
+| after  | 10,946,101 | 4,206,062 (38.4%) |
+| Δ | **−1.15%** total | **−3.2%** in `run_to` |
+
+A modest, real reduction in the dominant VM function, in the
+single-digit range the table above predicted. The larger win still
+lives in slice C (threaded dispatch); slice A's lasting value is
+that the cached code slice is the structural precondition for it.
+`cargo test -p lex-bytecode` is green; `--workspace` could not be
+run to completion in the dev container (disk: each lex-runtime
+integration binary statically links the full polars/arrow/tokio
+graph and the set overflows the volume), but the reentrant-path
+coverage (`list_sort_by`) and the full bytecode suite pass.

--- a/docs/design/dispatch-overhead-measurement.md
+++ b/docs/design/dispatch-overhead-measurement.md
@@ -122,3 +122,74 @@ cargo bench -p lex-bytecode --bench dispatch -- --quick
 
 `dispatch/pure/n=10000` is the new bench. The other five are
 unchanged from main.
+
+## Update 2026-05-22 — recommendation reversed to GO
+
+The "skip the rewrite" recommendation above was correct **for the
+workloads it measured** (arithmetic microbenches), but it is now
+stale. New data flips it.
+
+### What changed
+
+The decomposition above measured *arith* shapes, where
+superinstructions had already collapsed 4 source ops into 1 dispatch
+and `straight_arith` beat the no-dispatch floor. On those shapes the
+residual dispatch upside really is 5–15%, and skipping was right.
+
+But the workload that matters for real Lex deployments is
+*record-heavy* (HTTP handlers, SQL row decoders), and there
+superinstructions don't collapse the op stream the same way. The
+2026-05-21 callgrind profile of `response_build` (in #461's issue
+comment), taken after slices 5–9, the memo-key rework (#529), and
+adaptive memoization (#532) all landed, shows:
+
+```
+21.58M (48.0%)  Vm::run_to        <- dispatch (this issue)
+ 4.45M ( 9.9%)  drop_in_place<Value>
+ 3.24M ( 7.2%)  <Value as Clone>::clone
+```
+
+`run_to` is **48% of I-refs** on a record-heavy workload. The other
+levers that used to compete with dispatch (memo hashing, value
+clone) have been knocked down by the recent perf arc, so dispatch is
+now the single largest remaining cost — exactly the condition under
+which this rewrite stops being theatre.
+
+### Revised recommendation: **GO**, but bench-gated and sliced
+
+Caveat that the original doc's skepticism still holds in part: a
+naïve `fn(&mut Vm)` handler table can *regress* in Rust, because the
+current `match` over a small `Op` enum already lowers to a jump
+table and inlines arm bodies, whereas a function-pointer table adds
+an indirect call and de-inlines. So the rewrite is **not** "swap the
+match for a table" — it is the set of changes that actually remove
+per-op work:
+
+1. **Slice A — hoist per-op loop invariants.** Today the prologue
+   re-derives `frame_idx = frames.len()-1`, re-borrows
+   `code = &program.functions[fn_id].code`, and re-checks
+   `pc >= code.len()` on *every* op. `fn_id`/`code` only change at
+   Call / CallClosure / TailCall / Return. Restructure `run_to` into
+   an outer (per-frame) / inner (per-op) loop so the code slice is
+   fetched once per frame-entry, not once per op. The borrow-checker
+   constraint (can't hold `&[Op]` across `&mut self` arm bodies) is
+   the real design decision: candidates are `Function.code:
+   Arc<[Op]>` (clone the Arc per frame-entry — one refcount bump per
+   Call, not per op) or a contained `unsafe` raw-slice pointer
+   refreshed at the 5 frame-transition sites. **Note INVARIANTS.md:**
+   confirm an `Arc<[Op]>` change does not perturb bytecode
+   serialization / SigId before committing to it.
+2. **Slice B — drop verifier-discharged checks.** The
+   `pc >= code.len()` guard is redundant given #366 (the slice index
+   panics on OOB anyway); demote to `debug_assert!`. Small, but free.
+3. **Slice C (optional, feature-flagged) — threaded dispatch.**
+   computed-goto via `asm!` or tail-call `become` once stable. This
+   is where the C-interpreter literature's gains actually live; keep
+   behind `#[cfg(feature = "computed_goto")]` with the match loop as
+   the portable default, same as #461 originally proposed.
+
+Each slice re-runs `cargo bench -p lex-bytecode --bench dispatch`
+**and** the `response_build` bench before/after, and `cargo test
+--workspace` must stay green — same discipline as superinstruction
+slices 1–9. Slice A is the one with the measured 48% behind it;
+B and C are follow-ons.

--- a/docs/design/jit-roadmap.md
+++ b/docs/design/jit-roadmap.md
@@ -4,6 +4,15 @@
 **Status:** Design doc — closes the architectural-decisions
 acceptance criterion of #465. No implementation yet.
 
+> **Re-scope 2026-05-22 — see [Status update](#status-update-2026-05-22--re-scope)
+> at the bottom.** Two measurements that landed after this doc was
+> written change the phase-0 priority order: (1) the dispatch-loop
+> rewrite (#461) is promoted from "deferred" to *next development*,
+> and (2) the value-rep / NaN-boxing rework is demoted off the JIT
+> critical path pending a JIT-specific measurement. The original
+> analysis below is left intact; the re-scope section records what
+> changed and why.
+
 ## Why this doc
 
 #465 is the long-horizon JIT tracking issue. It explicitly lists
@@ -280,3 +289,78 @@ the audit in #465 already confirmed JIT-safe:
 
 No Lex concept needs to be sacrificed. The cost is engineering,
 not language design.
+
+## Status update (2026-05-22) — re-scope
+
+Per #465's "scope re-evaluation triggers" (above), the prereq order
+is revised based on two measurements that landed *after* this doc.
+
+### Phase-0 prereq scorecard
+
+| Prereq | Issue | State (2026-05-22) |
+|--------|-------|--------------------|
+| Dispatch | #461 | **Partial** — superinstruction slices 1–9 + typed lowering + field-name interning landed; the **function-table / computed-goto dispatch-loop rewrite itself is not done**. |
+| Inline caches | #462 | **Effectively done** — `(fn_id, site_idx)` key, `shape_id` IC, dynamic-shape interning. Polymorphic slice 2b **skipped**: measured 0% polymorphism (`ic-polymorphism-measurement.md`). |
+| Per-request arena | #463 | **Scaffolding only** — `lex-runtime/src/arena.rs` exists but is not plumbed into the VM. |
+| Stack-alloc records | #464 | **Done / closed.** `AllocStackRecord` + escape-driven lowering. |
+| Value-rep (NaN-boxing) | new | **Not started — and de-prioritized, see below.** |
+
+### What changed since 2026-05-20
+
+**1. Dispatch is the dominant cost again on real workloads.** The
+2026-05-18 go/no-go (`dispatch-overhead-measurement.md`) recommended
+*skipping* the function-table rewrite — but that call was made on
+*arithmetic* microbenches, where superinstructions already beat the
+no-dispatch floor. The 2026-05-21 callgrind profile of
+`response_build` (a *record-heavy* workload, representative of real
+HTTP/SQL handlers) puts `Vm::run_to` back at **~48% of I-refs** after
+all recent perf work landed. On the workloads that matter, dispatch
+is once again the single largest cost — and it is a hard JIT prereq.
+The earlier "skip it" decision is therefore **stale**; the rewrite is
+promoted to next.
+
+**2. Value-rep's interpreter-throughput ROI is ~3%, not the enabler
+of 3–5×.** This doc (and #465/#480) treated NaN-boxing as the hidden
+make-or-break prereq. A throwaway prototype (recorded in #461's
+2026-05-21 comment) measured the cheapest version — `Arc`-wrapping
+`Record.fields` — at **−2.8%**, with `drop_in_place<Value>`
+*unchanged*. The churn is **linear-use** value trees: built, read
+once, dropped, so refcount stays 1 and NaN-boxing only shrinks the
+move/envelope cost, not the build/teardown of the underlying maps.
+Estimated NaN-boxing upside on record-heavy interpreter throughput:
+**~3%.**
+
+This does **not** mean value-rep is worthless for the JIT — the
+original §"value-rep rework" argument is about the JIT inlining
+`as_int()` to a mask and unboxing arithmetic into native registers,
+which is a *different* win than interpreter throughput. But that
+JIT-specific ROI is **unmeasured**, and the interpreter-throughput
+case that this doc leaned on is now falsified. So: NaN-boxing comes
+**off the critical path** until its JIT-specific win is measured
+(prototype: a hand-lowered unboxed arith loop vs the boxed one). Do
+not start the 2–3 month rework on the strength of the old assumption.
+
+### Revised next-development order
+
+1. **#461 — function-table / computed-goto dispatch-loop rewrite.**
+   Highest value on three independent axes: biggest single
+   interpreter win (~48% of time; ~5 ns/op pure dispatch overhead),
+   a hard JIT prereq, and no preconditions of its own. Caveat for
+   implementers: a naïve `fn(&mut Vm)` table can *regress* in Rust
+   (indirect call + non-inlined arms vs. the current `match`, which
+   already lowers to a jump table). The genuine levers are (a)
+   hoisting per-op loop invariants out of the prologue
+   (`code`-slice refetch, `frame_idx` recompute, bounds checks that
+   the verifier already discharges) and (b) threaded dispatch
+   (computed-goto / tail-call `become`), the latter behind a
+   feature flag. **Re-confirm with the dispatch bench before and
+   after each slice** — same discipline as slices 1–9.
+2. **#463 — plumb the per-request arena + widen #464 escape
+   analysis** (lists/tuples/deeper nesting). Targets the ~15% in
+   `drop_in_place` + libc `free` directly. Bigger, riskier change
+   (lifetime tied to effect scope), so it follows the dispatch work.
+3. **Value-rep / NaN-boxing — measure first, then decide.** Blocked
+   on a JIT-specific micro-measurement (see above), not scheduled.
+
+What explicitly should **not** be next: NaN-boxing (de-motivated),
+or #462 slice 2b polymorphic ICs (0% measured polymorphism).


### PR DESCRIPTION
## Summary

First increment of #461 **slice A** (per the go/no-go reversal in `docs/design/dispatch-overhead-measurement.md`): cache the executing function's code slice across the dispatch loop instead of re-deriving `program.functions[fn_id].code` on every op.

The change is enabled by a property of the VM: `program` is a borrowed `&'a Program` that is never mutated during a run, so a `&'a [Op]` into a function's code is valid for the whole run **and independent of the `&mut self` borrow** the op handlers take (it points into the caller-owned `Program`, not into `*self`). That lets the slice be held across the 76 dispatch arms with **no `unsafe`, no `Arc`, no serialization change**. It re-resolves only when `fn_id` changes (the frame-transition set: Call / CallClosure / TailCall / Return); recursion into the same `fn_id` correctly keeps the cache. `frame_idx` / `fn_id` stay recomputed per op, so the op handlers — and their shadowing `fn_id` bindings — are completely untouched.

## Measurement (deterministic — callgrind, not wall-clock)

Criterion wall-clock is unusable for an effect this size in the dev container: the `straight_arith_no_dispatch` control (native Rust that never enters `run_to`) drifts ~4–5% run-to-run, swamping the signal. callgrind I-refs are drift-immune. `profile_response_build 120 3`:

| | I-refs | `run_to` I-refs |
|---|---|---|
| before | 11,073,057 | 4,344,448 (39.2%) |
| after  | 10,946,101 | 4,206,062 (38.4%) |
| Δ | **−1.15%** total | **−3.2%** in `run_to` |

A modest, real reduction in the dominant VM function — the single-digit range the go/no-go predicted for slice A. Its lasting value is structural: the cached code slice is the precondition for slice C (threaded dispatch), where the larger win lives.

## Test plan
- [x] `cargo test -p lex-bytecode` green (recursion, tailcalls, closures, stack records, effects, memo, all superinstruction slices)
- [x] reentrant-path coverage: `list_sort_by` (SortByKey → `invoke_closure_value`) green
- [ ] `cargo test --workspace` — **could not finish in the dev container**: each `lex-runtime` integration binary statically links the full polars/arrow/tokio/postgres graph and the set overflows the disk volume. Worth running in CI where disk is not constrained.

## Notes
- Builds on the merged docs PR #537 (roadmap re-scope + go/no-go flip).
- Diff is 24 lines in `vm.rs`, confined to the loop prologue.

https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk)_