### PR TITLE
perf: #461 slice B (dispatch) + #464 tuple escape-analysis widening

### DIFF
--- a/crates/lex-bytecode/src/escape.rs
+++ b/crates/lex-bytecode/src/escape.rs
@@ -1,55 +1,61 @@
-//! Escape analysis for `MakeRecord` allocation sites (#464 step 1).
+//! Escape analysis for stack-allocatable aggregate sites —
+//! `Op::MakeRecord` and `Op::MakeTuple` (#464 + tuple widening).
 //!
-//! Walks every function's bytecode to classify each `Op::MakeRecord`
-//! site as either **stack-allocatable** (the record value never
+//! Walks every function's bytecode to classify each aggregate
+//! allocation site as either **stack-allocatable** (the value never
 //! leaves the function frame) or **escapes** (used as a closure
-//! capture, returned, stored in another record, passed to a call,
-//! sent on a channel, etc.). The output is consumed by a follow-on
-//! slice that emits `AllocStackRecord` for the safe sites.
+//! capture, returned, stored in another aggregate, passed to a call,
+//! sent on a channel, etc.). The escape rules are identical for
+//! records and tuples — only the eventual codegen opcode differs —
+//! so a single `Slot::Agg(pc)` lattice value tracks both.
 //!
-//! ## Status: analysis only (step 1 of 3)
+//! ## Status
 //!
-//! This module produces an `EscapeReport` per function but does
-//! NOT yet change codegen — `Op::MakeRecord` is still emitted
-//! everywhere. Steps 2 and 3 introduce `AllocStackRecord` /
-//! `GetStackField` / `SetStackField` and the response-build
-//! micro-bench respectively. See #464.
+//! - **Records** (`MakeRecord`): analysis + codegen complete (#464).
+//!   `compiler::apply_escape_lowering` rewrites non-escaping
+//!   `MakeRecord` to `AllocStackRecord`.
+//! - **Tuples** (`MakeTuple`): analysis only, this slice. Sites are
+//!   classified and reported with `SiteKind::Tuple`, but no codegen
+//!   consumes them yet — `apply_escape_lowering` only rewrites
+//!   `MakeRecord`, so reporting tuple sites is inert until a tuple
+//!   stack-alloc opcode lands. Mirrors how #464 sequenced records
+//!   (analysis → codegen → bench).
 //!
 //! ## Approach
 //!
 //! Abstract interpretation over the bytecode CFG. Each abstract
 //! state tracks:
-//! - per-stack-slot: `Slot::Rec(pc)` (the record allocated at
+//! - per-stack-slot: `Slot::Agg(pc)` (the aggregate allocated at
 //!   `pc`, still local) or `Slot::Other` (anything else — int,
-//!   string, captured value, record we've stopped tracking)
+//!   string, captured value, aggregate we've stopped tracking)
 //! - per-local: same `Slot` lattice, indexed by `locals[i]`
 //!
 //! At each op we update the abstract state and union any newly-
 //! observed escapes into a `HashSet<u32>` keyed by allocation pc.
 //! Worklist fixpoint iterates until no state changes — joins use a
-//! pointwise merge that downgrades `Rec(a) ⊔ Rec(b)` (a ≠ b) and
-//! `Rec(a) ⊔ Other` to `Other`, marking the involved sites as
+//! pointwise merge that downgrades `Agg(a) ⊔ Agg(b)` (a ≠ b) and
+//! `Agg(a) ⊔ Other` to `Other`, marking the involved sites as
 //! escaped (we can no longer prove they stay local from this
 //! merge point forward).
 //!
 //! ## Intra-procedural limit
 //!
 //! Calls (`Call`, `TailCall`, `CallClosure`) escape all argument
-//! records — we can't see the callee's body from here. Inlining
+//! aggregates — we can't see the callee's body from here. Inlining
 //! could recover the cross-fn case but is deliberately out of
-//! scope for #464; the issue's wording ("function frame") matches
+//! scope; the issue's wording ("function frame") matches
 //! intra-procedural.
 //!
 //! ## Conservative defaults
 //!
-//! Whenever the analysis can't prove a record stays local, it
+//! Whenever the analysis can't prove an aggregate stays local, it
 //! defaults to *escaped*. False positives (sites flagged as
 //! escaping when they actually don't) cost a heap allocation per
 //! request — the existing baseline. False negatives (a flagged-
 //! local site that actually escapes) would corrupt memory under
-//! the future stack-alloc codegen, so step 2 will treat the
-//! analysis output as a *necessary* but not sufficient precondition
-//! and pair it with an unconditional runtime fallback.
+//! stack-alloc codegen, so the codegen step treats the analysis
+//! output as a *necessary* but not sufficient precondition and
+//! pairs it with an unconditional runtime fallback.
 
 use std::collections::{HashMap, HashSet};
 
@@ -59,14 +65,18 @@ use crate::program::Function;
 /// Abstract value at a stack or local slot during the analysis.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Slot {
-    /// Holds the record allocated by `Op::MakeRecord` at this pc.
-    /// As long as every consumer reads this slot via `GetField`,
-    /// `Pop`, or a `StoreLocal`/`LoadLocal` round-trip, the site
-    /// stays a stack-alloc candidate.
-    Rec(u32),
-    /// Anything else — primitives, already-escaped records,
+    /// Holds the stack-allocatable aggregate (a record from
+    /// `Op::MakeRecord` or a tuple from `Op::MakeTuple`) allocated at
+    /// this pc. As long as every consumer reads this slot via a field
+    /// / element read (`GetField` / `GetElem`), `Pop`, or a
+    /// `StoreLocal`/`LoadLocal` round-trip, the site stays a
+    /// stack-alloc candidate. The escape rules are identical for both
+    /// aggregate kinds — only the codegen opcode differs — so the
+    /// analysis tracks them with one variant keyed on the alloc pc.
+    Agg(u32),
+    /// Anything else — primitives, already-escaped aggregates,
     /// values produced by ops we don't model precisely. Treated
-    /// as not-a-tracked-record for escape purposes.
+    /// as not-a-tracked-aggregate for escape purposes.
     Other,
 }
 
@@ -77,7 +87,7 @@ impl Slot {
     /// escape set — we lose track of those sites past this merge.
     fn merge(self, other: Slot) -> Slot {
         match (self, other) {
-            (Slot::Rec(a), Slot::Rec(b)) if a == b => Slot::Rec(a),
+            (Slot::Agg(a), Slot::Agg(b)) if a == b => Slot::Agg(a),
             _ => Slot::Other,
         }
     }
@@ -120,14 +130,14 @@ impl State {
             // If a Rec was merged-away (either path had Rec, the
             // result is Other), the corresponding site escapes.
             if merged == Slot::Other {
-                if let Slot::Rec(p) = self.stack[i]  { escaped.insert(p); }
-                if let Slot::Rec(p) = other.stack[i] { escaped.insert(p); }
+                if let Slot::Agg(p) = self.stack[i]  { escaped.insert(p); }
+                if let Slot::Agg(p) = other.stack[i] { escaped.insert(p); }
             }
             stack.push(merged);
         }
         // The dropped tail of the longer stack also leaks any Rec.
         for tail in self.stack.iter().skip(stack_len).chain(other.stack.iter().skip(stack_len)) {
-            if let Slot::Rec(p) = tail { escaped.insert(*p); }
+            if let Slot::Agg(p) = tail { escaped.insert(*p); }
         }
         let local_len = self.locals.len().max(other.locals.len());
         let mut locals = Vec::with_capacity(local_len);
@@ -136,8 +146,8 @@ impl State {
             let b = other.locals.get(i).copied().unwrap_or(Slot::Other);
             let merged = a.merge(b);
             if merged == Slot::Other {
-                if let Slot::Rec(p) = a { escaped.insert(p); }
-                if let Slot::Rec(p) = b { escaped.insert(p); }
+                if let Slot::Agg(p) = a { escaped.insert(p); }
+                if let Slot::Agg(p) = b { escaped.insert(p); }
             }
             locals.push(merged);
         }
@@ -145,25 +155,42 @@ impl State {
     }
 }
 
-/// Per-function escape report — the artifact step 2 will consume
-/// to decide where to emit `AllocStackRecord` vs `MakeRecord`.
+/// Per-function escape report — the artifact codegen consumes to
+/// decide where to emit a stack-alloc opcode vs the heap constructor.
 ///
-/// Each entry is keyed by the allocation pc (the `Op::MakeRecord`
-/// site's index in the function's `code` vec). `escapes = false`
-/// means: across every reachable path through the function, the
-/// record allocated here is only ever read locally (GetField,
-/// dropped via Pop, round-tripped through locals) — never returned,
-/// captured, stored in another aggregate, or passed to a call.
+/// Each entry is keyed by the allocation pc (the `Op::MakeRecord` or
+/// `Op::MakeTuple` site's index in the function's `code` vec) and
+/// tagged with its `SiteKind`. `escapes = false` means: across every
+/// reachable path through the function, the aggregate allocated here
+/// is only ever read locally (`GetField` / `GetElem`, dropped via
+/// `Pop`, round-tripped through locals) — never returned, captured,
+/// stored in another aggregate, or passed to a call.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EscapeReport {
     pub fn_name: String,
-    /// One entry per `MakeRecord` site in the function, in pc order.
+    /// One entry per stack-allocatable aggregate (`MakeRecord` /
+    /// `MakeTuple`) site in the function, in pc order.
     pub sites: Vec<EscapeSite>,
+}
+
+/// Which aggregate constructor an escape site is — determines which
+/// stack-alloc opcode a future codegen slice would emit for it
+/// (`AllocStackRecord` for records; tuple stack-alloc is not yet
+/// implemented, so `Tuple` sites are reported but not lowered).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SiteKind {
+    /// `Op::MakeRecord`: `shape_idx` is meaningful, `field_count` is
+    /// the record's field count.
+    Record,
+    /// `Op::MakeTuple`: `shape_idx` is unused (`0`), `field_count` is
+    /// the tuple arity.
+    Tuple,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct EscapeSite {
     pub pc: u32,
+    pub kind: SiteKind,
     pub shape_idx: u32,
     pub field_count: u16,
     pub escapes: bool,
@@ -189,13 +216,16 @@ pub fn analyze_function(func: &Function) -> EscapeReport {
     // Inventory the MakeRecord sites first. If there are none,
     // skip the whole fixpoint — the function can't benefit from
     // stack allocation anyway.
-    let sites: Vec<(u32, u32, u16)> = func
+    let sites: Vec<(u32, SiteKind, u32, u16)> = func
         .code
         .iter()
         .enumerate()
         .filter_map(|(pc, op)| match op {
             Op::MakeRecord { shape_idx, field_count } => {
-                Some((pc as u32, *shape_idx, *field_count))
+                Some((pc as u32, SiteKind::Record, *shape_idx, *field_count))
+            }
+            Op::MakeTuple(arity) => {
+                Some((pc as u32, SiteKind::Tuple, 0, *arity))
             }
             _ => None,
         })
@@ -244,8 +274,9 @@ pub fn analyze_function(func: &Function) -> EscapeReport {
 
     let report_sites = sites
         .into_iter()
-        .map(|(pc, shape_idx, field_count)| EscapeSite {
+        .map(|(pc, kind, shape_idx, field_count)| EscapeSite {
             pc,
+            kind,
             shape_idx,
             field_count,
             escapes: escaped.contains(&pc),
@@ -264,7 +295,7 @@ fn step(pc: usize, op: &Op, mut s: State) -> (State, Vec<usize>, HashSet<u32>) {
 
     // Helper closures for the common pop-n / push patterns.
     let leak = |slot: Slot, into: &mut HashSet<u32>| {
-        if let Slot::Rec(p) = slot { into.insert(p); }
+        if let Slot::Agg(p) = slot { into.insert(p); }
     };
     let pop_n_leak = |state: &mut State, n: usize, esc: &mut HashSet<u32>| {
         for _ in 0..n {
@@ -303,7 +334,7 @@ fn step(pc: usize, op: &Op, mut s: State) -> (State, Vec<usize>, HashSet<u32>) {
                 // local, but it may still be on the stack elsewhere
                 // — conservatively flag).
                 let prev = s.locals[i];
-                if let Slot::Rec(p_prev) = prev {
+                if let Slot::Agg(p_prev) = prev {
                     if prev != top { escapes.insert(p_prev); }
                 }
                 s.locals[i] = top;
@@ -316,24 +347,30 @@ fn step(pc: usize, op: &Op, mut s: State) -> (State, Vec<usize>, HashSet<u32>) {
             // any of them is itself a tracked Rec, it escapes (now
             // referenced from inside the parent).
             pop_n_leak(&mut s, *field_count as usize, &mut escapes);
-            s.stack.push(Slot::Rec(pc as u32));
+            s.stack.push(Slot::Agg(pc as u32));
         }
         // #464 step 2: post-lowering form of MakeRecord (escape
         // proved). Re-running the analysis on already-lowered code
         // must produce the same shape, so treat it identically.
         Op::AllocStackRecord { field_count, .. } => {
             pop_n_leak(&mut s, *field_count as usize, &mut escapes);
-            s.stack.push(Slot::Rec(pc as u32));
+            s.stack.push(Slot::Agg(pc as u32));
         }
-        // Other aggregate constructors are escape sinks for any Rec
-        // operand. They don't create new tracked records (the
-        // analysis is record-shape-driven; lists/tuples/variants
-        // would need their own machinery, out of scope for #464).
-        Op::MakeList(n) => {
-            pop_n_leak(&mut s, *n as usize, &mut escapes);
-            s.stack.push(Slot::Other);
-        }
+        // A tuple is a stack-allocatable aggregate, tracked the same
+        // way as a record: its field operands leak (any tracked
+        // aggregate stored inside it escapes), and the tuple itself
+        // becomes a tracked candidate keyed on this pc. `GetElem`
+        // reads an element without escaping the tuple, exactly as
+        // `GetField` does for records.
         Op::MakeTuple(n) => {
+            pop_n_leak(&mut s, *n as usize, &mut escapes);
+            s.stack.push(Slot::Agg(pc as u32));
+        }
+        // Lists and variants remain escape sinks for any tracked
+        // aggregate operand and don't create new tracked candidates —
+        // list stack-allocation needs variable-length arena handling
+        // (a later slice), and variants aren't a stack-alloc target.
+        Op::MakeList(n) => {
             pop_n_leak(&mut s, *n as usize, &mut escapes);
             s.stack.push(Slot::Other);
         }
@@ -444,7 +481,7 @@ fn step(pc: usize, op: &Op, mut s: State) -> (State, Vec<usize>, HashSet<u32>) {
             if i >= s.locals.len() { s.locals.resize(i + 1, Slot::Other); }
             // The local previously may have held a Rec; same logic
             // as StoreLocal — overwriting it is an escape signal.
-            if let Slot::Rec(p_prev) = s.locals[i] { escapes.insert(p_prev); }
+            if let Slot::Agg(p_prev) = s.locals[i] { escapes.insert(p_prev); }
             s.locals[i] = Slot::Other;
             return (s, vec![pc + 4], escapes);
         }
@@ -495,7 +532,7 @@ fn step(pc: usize, op: &Op, mut s: State) -> (State, Vec<usize>, HashSet<u32>) {
             // Other (the scrutinee is an Int per slice-6's contract).
             let i = *dst as usize;
             if i >= s.locals.len() { s.locals.resize(i + 1, Slot::Other); }
-            if let Slot::Rec(p_prev) = s.locals[i] { escapes.insert(p_prev); }
+            if let Slot::Agg(p_prev) = s.locals[i] { escapes.insert(p_prev); }
             s.locals[i] = Slot::Other;
             let target = (pc as i32 + 6 + jump_offset) as usize;
             return (s, vec![pc + 6, target], escapes);
@@ -758,5 +795,145 @@ mod tests {
         ]);
         let idx = build_escape_index(&[f]);
         assert_eq!(idx.get(&("idx_test".into(), 1)), Some(&false));
+    }
+
+    // ---- tuple widening (#464 tuple analysis slice) ----
+
+    #[test]
+    fn tuple_built_and_dropped_does_not_escape() {
+        let f = func("tup_drop", 0, 0, vec![
+            Op::PushConst(0),
+            Op::PushConst(1),
+            Op::MakeTuple(2), // pc=2
+            Op::Pop,
+            Op::PushConst(0),
+            Op::Return,
+        ]);
+        let r = analyze_function(&f);
+        assert_escapes(&r, &[(2, false)]);
+        assert_eq!(r.sites[0].kind, SiteKind::Tuple);
+        assert_eq!(r.sites[0].field_count, 2);
+    }
+
+    #[test]
+    fn tuple_returned_escapes() {
+        let f = func("tup_ret", 0, 0, vec![
+            Op::PushConst(0),
+            Op::PushConst(1),
+            Op::MakeTuple(2), // pc=2
+            Op::Return,
+        ]);
+        let r = analyze_function(&f);
+        assert_escapes(&r, &[(2, true)]);
+    }
+
+    #[test]
+    fn tuple_elem_read_only_does_not_escape() {
+        // Reading an element (GetElem) consumes the tuple locally,
+        // mirroring GetField on a record — the tuple stays a candidate.
+        let f = func("tup_read", 0, 0, vec![
+            Op::PushConst(0),
+            Op::PushConst(1),
+            Op::MakeTuple(2), // pc=2
+            Op::GetElem(0),
+            Op::Return,
+        ]);
+        let r = analyze_function(&f);
+        assert_escapes(&r, &[(2, false)]);
+    }
+
+    #[test]
+    fn tuple_round_tripped_through_local_does_not_escape() {
+        let f = func("tup_rt", 1, 0, vec![
+            Op::PushConst(0),
+            Op::PushConst(1),
+            Op::MakeTuple(2), // pc=2
+            Op::StoreLocal(0),
+            Op::LoadLocal(0),
+            Op::GetElem(1),
+            Op::Return,
+        ]);
+        let r = analyze_function(&f);
+        assert_escapes(&r, &[(2, false)]);
+    }
+
+    #[test]
+    fn tuple_passed_to_call_escapes() {
+        let f = func("tup_call", 0, 0, vec![
+            Op::PushConst(0),
+            Op::PushConst(1),
+            Op::MakeTuple(2), // pc=2
+            Op::Call { fn_id: 1, arity: 1, node_id_idx: 0 },
+            Op::Return,
+        ]);
+        let r = analyze_function(&f);
+        assert_escapes(&r, &[(2, true)]);
+    }
+
+    #[test]
+    fn record_stored_into_tuple_escapes_tuple_stays_local() {
+        // Build a record, wrap it in a tuple, drop the tuple. The
+        // record escapes into the tuple; the tuple itself is local.
+        let f = func("rec_in_tup", 0, 0, vec![
+            Op::PushConst(0),
+            Op::MakeRecord { shape_idx: 0, field_count: 1 }, // rec @ pc=1
+            Op::MakeTuple(1),                                // tup @ pc=2 holds rec
+            Op::Pop,
+            Op::PushConst(0),
+            Op::Return,
+        ]);
+        let r = analyze_function(&f);
+        assert_escapes(&r, &[(1, true), (2, false)]);
+    }
+
+    #[test]
+    fn tuple_stored_into_record_escapes() {
+        let f = func("tup_in_rec", 0, 0, vec![
+            Op::PushConst(0),
+            Op::PushConst(1),
+            Op::MakeTuple(2),                                // tup @ pc=2
+            Op::MakeRecord { shape_idx: 0, field_count: 1 }, // rec @ pc=3 holds tup
+            Op::Return,
+        ]);
+        let r = analyze_function(&f);
+        assert_escapes(&r, &[(2, true), (3, true)]);
+    }
+
+    #[test]
+    fn tuple_and_record_sites_carry_distinct_kinds() {
+        let f = func("mixed_kinds", 0, 0, vec![
+            Op::PushConst(0),
+            Op::MakeRecord { shape_idx: 7, field_count: 1 }, // pc=1 record
+            Op::Pop,
+            Op::PushConst(0),
+            Op::PushConst(1),
+            Op::MakeTuple(2), // pc=5 tuple
+            Op::Pop,
+            Op::PushConst(0),
+            Op::Return,
+        ]);
+        let r = analyze_function(&f);
+        assert_eq!(r.sites.len(), 2);
+        assert_eq!((r.sites[0].pc, r.sites[0].kind, r.sites[0].shape_idx), (1, SiteKind::Record, 7));
+        assert_eq!((r.sites[1].pc, r.sites[1].kind, r.sites[1].field_count), (5, SiteKind::Tuple, 2));
+        assert!(!r.sites[0].escapes && !r.sites[1].escapes);
+    }
+
+    #[test]
+    fn tuple_only_function_now_produces_report() {
+        // Pre-widening this function had no tracked sites and was
+        // omitted from analyze_program; now its tuple site is reported.
+        let f = func("tuponly", 0, 0, vec![
+            Op::PushConst(0),
+            Op::PushConst(1),
+            Op::MakeTuple(2),
+            Op::Pop,
+            Op::PushConst(0),
+            Op::Return,
+        ]);
+        let reports = analyze_program(&[f]);
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].sites.len(), 1);
+        assert_eq!(reports[0].sites[0].kind, SiteKind::Tuple);
     }
 }

--- a/crates/lex-bytecode/src/lib.rs
+++ b/crates/lex-bytecode/src/lib.rs
@@ -17,4 +17,4 @@ pub use program::{Function, Program};
 pub use value::{MapKey, Value};
 pub use vm::{Vm, VmError, MAX_CALL_DEPTH};
 pub use verify::{verify_program, StackError};
-pub use escape::{analyze_program as analyze_escapes, EscapeReport, EscapeSite};
+pub use escape::{analyze_program as analyze_escapes, EscapeReport, EscapeSite, SiteKind};

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -1153,11 +1153,26 @@ impl<'a> Vm<'a> {
     /// already-running `run()` must return when *its* frame returns,
     /// not when the entire frame stack empties (#221).
     fn run_to(&mut self, base_depth: usize) -> Result<Value, VmError> {
+        // #461 slice A: cache the executing function's code slice across
+        // ops instead of re-deriving `program.functions[fn_id].code` on
+        // every iteration. The program is borrowed (`&'a Program`) and is
+        // never mutated during a run, so the slice reference is valid for
+        // the whole run and — crucially — is independent of the `&mut self`
+        // borrow the op handlers take: it points into the caller-owned
+        // `Program`, not into `*self`. Re-resolve only when `fn_id`
+        // changes, which is exactly the frame-transition set (Call /
+        // CallClosure / TailCall / Return); recursion into the same
+        // `fn_id` correctly keeps the cached slice. `frame_idx` / `fn_id`
+        // stay recomputed per op (cheap field reads), so the op handlers
+        // are untouched and their `fn_id` bindings shadow as before.
+        let program: &'a Program = self.program;
+        let mut code: &'a [Op] = &[];
+        let mut code_fn_id: u32 = u32::MAX;
         loop {
             if self.steps > self.step_limit {
                 let frame_idx = self.frames.len() - 1;
                 let fn_id = self.frames[frame_idx].fn_id;
-                let fn_name = &self.program.functions[fn_id as usize].name;
+                let fn_name = &program.functions[fn_id as usize].name;
                 return Err(VmError::Panic(format!(
                     "step limit exceeded in `{fn_name}` ({} > {})",
                     self.steps, self.step_limit,
@@ -1167,9 +1182,12 @@ impl<'a> Vm<'a> {
             let frame_idx = self.frames.len() - 1;
             let pc = self.frames[frame_idx].pc;
             let fn_id = self.frames[frame_idx].fn_id;
-            let code = &self.program.functions[fn_id as usize].code;
+            if fn_id != code_fn_id {
+                code = &program.functions[fn_id as usize].code;
+                code_fn_id = fn_id;
+            }
             if pc >= code.len() {
-                let fn_name = &self.program.functions[fn_id as usize].name;
+                let fn_name = &program.functions[fn_id as usize].name;
                 return Err(VmError::Panic(format!("ran past end of code in `{fn_name}`")));
             }
             let op = code[pc];

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -1186,10 +1186,22 @@ impl<'a> Vm<'a> {
                 code = &program.functions[fn_id as usize].code;
                 code_fn_id = fn_id;
             }
-            if pc >= code.len() {
-                let fn_name = &program.functions[fn_id as usize].name;
-                return Err(VmError::Panic(format!("ran past end of code in `{fn_name}`")));
-            }
+            // #461 slice B: the bytecode verifier (#366) proves pc stays
+            // in bounds for every reachable op — every path through a
+            // function ends in Return / Jump / TailCall, so execution
+            // never falls off the end of `code`. The per-op
+            // `pc >= code.len()` guard is therefore redundant for verified
+            // programs; demote it to a debug-only assertion. The `code[pc]`
+            // index below stays bounds-checked, so a malformed program in
+            // a release build still panics (loudly, just without the
+            // bespoke message) rather than reading out of bounds — no
+            // `unsafe`, no UB, only the cold error-return path leaves the
+            // hot loop.
+            debug_assert!(
+                pc < code.len(),
+                "ran past end of code in `{}`",
+                program.functions[fn_id as usize].name,
+            );
             let op = code[pc];
             self.frames[frame_idx].pc = pc + 1;
 

--- a/docs/design/dispatch-overhead-measurement.md
+++ b/docs/design/dispatch-overhead-measurement.md
@@ -193,3 +193,37 @@ Each slice re-runs `cargo bench -p lex-bytecode --bench dispatch`
 --workspace` must stay green — same discipline as superinstruction
 slices 1–9. Slice A is the one with the measured 48% behind it;
 B and C are follow-ons.
+
+### Slice A landed — measured result (2026-05-22)
+
+First increment of slice A: cache the executing function's code
+slice (`program.functions[fn_id].code`) across ops, re-resolving
+only when `fn_id` changes (the frame-transition set). Works because
+`program` is a borrowed `&'a Program` — the slice reference is
+independent of the `&mut self` the op handlers take, so it can live
+across the dispatch arms with no `unsafe`, no `Arc`, no serialization
+change. `frame_idx` / `fn_id` stay recomputed per op, so the 70+ op
+handlers are untouched.
+
+Measured with the deterministic tool, not wall-clock: criterion on
+this shared VM has a ~4–5% run-to-run noise floor (the
+`straight_arith_no_dispatch` control — native Rust that never enters
+`run_to` — drifts that much between back-to-back runs), which swamps
+a slice-A-sized effect. callgrind I-refs are drift-immune, so they
+are the gate for changes this small. `profile_response_build 120 3`:
+
+| | I-refs | `run_to` I-refs |
+|---|---|---|
+| before | 11,073,057 | 4,344,448 (39.2%) |
+| after  | 10,946,101 | 4,206,062 (38.4%) |
+| Δ | **−1.15%** total | **−3.2%** in `run_to` |
+
+A modest, real reduction in the dominant VM function, in the
+single-digit range the table above predicted. The larger win still
+lives in slice C (threaded dispatch); slice A's lasting value is
+that the cached code slice is the structural precondition for it.
+`cargo test -p lex-bytecode` is green; `--workspace` could not be
+run to completion in the dev container (disk: each lex-runtime
+integration binary statically links the full polars/arrow/tokio
+graph and the set overflows the volume), but the reentrant-path
+coverage (`list_sort_by`) and the full bytecode suite pass.

--- a/docs/design/dispatch-overhead-measurement.md
+++ b/docs/design/dispatch-overhead-measurement.md
@@ -227,3 +227,34 @@ run to completion in the dev container (disk: each lex-runtime
 integration binary statically links the full polars/arrow/tokio
 graph and the set overflows the volume), but the reentrant-path
 coverage (`list_sort_by`) and the full bytecode suite pass.
+
+### Slice B landed — measured result (2026-05-22)
+
+Demote the per-op `pc >= code.len()` guard to a `debug_assert!`. The
+verifier (#366) proves pc stays in bounds for every reachable op
+(every path ends in Return / Jump / TailCall), so the explicit guard
+is redundant for verified programs. The `code[pc]` index stays
+bounds-checked, so a malformed program in release still panics rather
+than reading out of bounds — **no `unsafe`, no UB**; only the cold
+error-return path (and its `format!`) leaves the hot loop.
+
+Deterministic callgrind, `profile_response_build 120 3`, baseline =
+main post-slice-A:
+
+| | I-refs | `run_to` I-refs |
+|---|---|---|
+| before (slice A) | 10,934,935 | 4,206,062 |
+| after  (slice B) | 10,875,216 | 4,196,378 |
+| Δ | **−0.55%** total | **−0.23%** in `run_to` |
+
+Marginal, as expected — the explicit guard was nearly redundant with
+the index check LLVM keeps. The honest read: slice B is safe cleanup
+that shaves a cold path, not a real lever. The remaining dispatch
+win lives in slice C (threaded dispatch), which is **blocked on
+stable Rust** (computed-goto / tail-call `become` are nightly-only)
+and is an architectural decision given the project's stable-toolchain
+pin (INVARIANTS.md), not a free slice. Cumulative slice A + B:
+`run_to` 4,344,448 → 4,196,378 (**−3.4%**). The higher-ROI next
+lever per the #461 profile is the ~15% alloc churn (`drop_in_place`
++ `free`), i.e. arena (#463) / wider escape analysis (#464), not
+more dispatch micro-slices.

--- a/docs/design/dispatch-overhead-measurement.md
+++ b/docs/design/dispatch-overhead-measurement.md
@@ -122,3 +122,74 @@ cargo bench -p lex-bytecode --bench dispatch -- --quick
 
 `dispatch/pure/n=10000` is the new bench. The other five are
 unchanged from main.
+
+## Update 2026-05-22 — recommendation reversed to GO
+
+The "skip the rewrite" recommendation above was correct **for the
+workloads it measured** (arithmetic microbenches), but it is now
+stale. New data flips it.
+
+### What changed
+
+The decomposition above measured *arith* shapes, where
+superinstructions had already collapsed 4 source ops into 1 dispatch
+and `straight_arith` beat the no-dispatch floor. On those shapes the
+residual dispatch upside really is 5–15%, and skipping was right.
+
+But the workload that matters for real Lex deployments is
+*record-heavy* (HTTP handlers, SQL row decoders), and there
+superinstructions don't collapse the op stream the same way. The
+2026-05-21 callgrind profile of `response_build` (in #461's issue
+comment), taken after slices 5–9, the memo-key rework (#529), and
+adaptive memoization (#532) all landed, shows:
+
+```
+21.58M (48.0%)  Vm::run_to        <- dispatch (this issue)
+ 4.45M ( 9.9%)  drop_in_place<Value>
+ 3.24M ( 7.2%)  <Value as Clone>::clone
+```
+
+`run_to` is **48% of I-refs** on a record-heavy workload. The other
+levers that used to compete with dispatch (memo hashing, value
+clone) have been knocked down by the recent perf arc, so dispatch is
+now the single largest remaining cost — exactly the condition under
+which this rewrite stops being theatre.
+
+### Revised recommendation: **GO**, but bench-gated and sliced
+
+Caveat that the original doc's skepticism still holds in part: a
+naïve `fn(&mut Vm)` handler table can *regress* in Rust, because the
+current `match` over a small `Op` enum already lowers to a jump
+table and inlines arm bodies, whereas a function-pointer table adds
+an indirect call and de-inlines. So the rewrite is **not** "swap the
+match for a table" — it is the set of changes that actually remove
+per-op work:
+
+1. **Slice A — hoist per-op loop invariants.** Today the prologue
+   re-derives `frame_idx = frames.len()-1`, re-borrows
+   `code = &program.functions[fn_id].code`, and re-checks
+   `pc >= code.len()` on *every* op. `fn_id`/`code` only change at
+   Call / CallClosure / TailCall / Return. Restructure `run_to` into
+   an outer (per-frame) / inner (per-op) loop so the code slice is
+   fetched once per frame-entry, not once per op. The borrow-checker
+   constraint (can't hold `&[Op]` across `&mut self` arm bodies) is
+   the real design decision: candidates are `Function.code:
+   Arc<[Op]>` (clone the Arc per frame-entry — one refcount bump per
+   Call, not per op) or a contained `unsafe` raw-slice pointer
+   refreshed at the 5 frame-transition sites. **Note INVARIANTS.md:**
+   confirm an `Arc<[Op]>` change does not perturb bytecode
+   serialization / SigId before committing to it.
+2. **Slice B — drop verifier-discharged checks.** The
+   `pc >= code.len()` guard is redundant given #366 (the slice index
+   panics on OOB anyway); demote to `debug_assert!`. Small, but free.
+3. **Slice C (optional, feature-flagged) — threaded dispatch.**
+   computed-goto via `asm!` or tail-call `become` once stable. This
+   is where the C-interpreter literature's gains actually live; keep
+   behind `#[cfg(feature = "computed_goto")]` with the match loop as
+   the portable default, same as #461 originally proposed.
+
+Each slice re-runs `cargo bench -p lex-bytecode --bench dispatch`
+**and** the `response_build` bench before/after, and `cargo test
+--workspace` must stay green — same discipline as superinstruction
+slices 1–9. Slice A is the one with the measured 48% behind it;
+B and C are follow-ons.

--- a/docs/design/jit-roadmap.md
+++ b/docs/design/jit-roadmap.md
@@ -4,6 +4,15 @@
 **Status:** Design doc — closes the architectural-decisions
 acceptance criterion of #465. No implementation yet.
 
+> **Re-scope 2026-05-22 — see [Status update](#status-update-2026-05-22--re-scope)
+> at the bottom.** Two measurements that landed after this doc was
+> written change the phase-0 priority order: (1) the dispatch-loop
+> rewrite (#461) is promoted from "deferred" to *next development*,
+> and (2) the value-rep / NaN-boxing rework is demoted off the JIT
+> critical path pending a JIT-specific measurement. The original
+> analysis below is left intact; the re-scope section records what
+> changed and why.
+
 ## Why this doc
 
 #465 is the long-horizon JIT tracking issue. It explicitly lists
@@ -280,3 +289,78 @@ the audit in #465 already confirmed JIT-safe:
 
 No Lex concept needs to be sacrificed. The cost is engineering,
 not language design.
+
+## Status update (2026-05-22) — re-scope
+
+Per #465's "scope re-evaluation triggers" (above), the prereq order
+is revised based on two measurements that landed *after* this doc.
+
+### Phase-0 prereq scorecard
+
+| Prereq | Issue | State (2026-05-22) |
+|--------|-------|--------------------|
+| Dispatch | #461 | **Partial** — superinstruction slices 1–9 + typed lowering + field-name interning landed; the **function-table / computed-goto dispatch-loop rewrite itself is not done**. |
+| Inline caches | #462 | **Effectively done** — `(fn_id, site_idx)` key, `shape_id` IC, dynamic-shape interning. Polymorphic slice 2b **skipped**: measured 0% polymorphism (`ic-polymorphism-measurement.md`). |
+| Per-request arena | #463 | **Scaffolding only** — `lex-runtime/src/arena.rs` exists but is not plumbed into the VM. |
+| Stack-alloc records | #464 | **Done / closed.** `AllocStackRecord` + escape-driven lowering. |
+| Value-rep (NaN-boxing) | new | **Not started — and de-prioritized, see below.** |
+
+### What changed since 2026-05-20
+
+**1. Dispatch is the dominant cost again on real workloads.** The
+2026-05-18 go/no-go (`dispatch-overhead-measurement.md`) recommended
+*skipping* the function-table rewrite — but that call was made on
+*arithmetic* microbenches, where superinstructions already beat the
+no-dispatch floor. The 2026-05-21 callgrind profile of
+`response_build` (a *record-heavy* workload, representative of real
+HTTP/SQL handlers) puts `Vm::run_to` back at **~48% of I-refs** after
+all recent perf work landed. On the workloads that matter, dispatch
+is once again the single largest cost — and it is a hard JIT prereq.
+The earlier "skip it" decision is therefore **stale**; the rewrite is
+promoted to next.
+
+**2. Value-rep's interpreter-throughput ROI is ~3%, not the enabler
+of 3–5×.** This doc (and #465/#480) treated NaN-boxing as the hidden
+make-or-break prereq. A throwaway prototype (recorded in #461's
+2026-05-21 comment) measured the cheapest version — `Arc`-wrapping
+`Record.fields` — at **−2.8%**, with `drop_in_place<Value>`
+*unchanged*. The churn is **linear-use** value trees: built, read
+once, dropped, so refcount stays 1 and NaN-boxing only shrinks the
+move/envelope cost, not the build/teardown of the underlying maps.
+Estimated NaN-boxing upside on record-heavy interpreter throughput:
+**~3%.**
+
+This does **not** mean value-rep is worthless for the JIT — the
+original §"value-rep rework" argument is about the JIT inlining
+`as_int()` to a mask and unboxing arithmetic into native registers,
+which is a *different* win than interpreter throughput. But that
+JIT-specific ROI is **unmeasured**, and the interpreter-throughput
+case that this doc leaned on is now falsified. So: NaN-boxing comes
+**off the critical path** until its JIT-specific win is measured
+(prototype: a hand-lowered unboxed arith loop vs the boxed one). Do
+not start the 2–3 month rework on the strength of the old assumption.
+
+### Revised next-development order
+
+1. **#461 — function-table / computed-goto dispatch-loop rewrite.**
+   Highest value on three independent axes: biggest single
+   interpreter win (~48% of time; ~5 ns/op pure dispatch overhead),
+   a hard JIT prereq, and no preconditions of its own. Caveat for
+   implementers: a naïve `fn(&mut Vm)` table can *regress* in Rust
+   (indirect call + non-inlined arms vs. the current `match`, which
+   already lowers to a jump table). The genuine levers are (a)
+   hoisting per-op loop invariants out of the prologue
+   (`code`-slice refetch, `frame_idx` recompute, bounds checks that
+   the verifier already discharges) and (b) threaded dispatch
+   (computed-goto / tail-call `become`), the latter behind a
+   feature flag. **Re-confirm with the dispatch bench before and
+   after each slice** — same discipline as slices 1–9.
+2. **#463 — plumb the per-request arena + widen #464 escape
+   analysis** (lists/tuples/deeper nesting). Targets the ~15% in
+   `drop_in_place` + libc `free` directly. Bigger, riskier change
+   (lifetime tied to effect scope), so it follows the dispatch work.
+3. **Value-rep / NaN-boxing — measure first, then decide.** Blocked
+   on a JIT-specific micro-measurement (see above), not scheduled.
+
+What explicitly should **not** be next: NaN-boxing (de-motivated),
+or #462 slice 2b polymorphic ICs (0% measured polymorphism).


### PR DESCRIPTION
Two small, independent perf-track changes that ended up on the same development branch. Both are isolated and well-tested; happy to split if preferred.

---

## 1. #461 slice B — demote per-op end-of-code guard to `debug_assert!`

Demote the per-op `pc >= code.len()` guard in the dispatch loop to a `debug_assert!`. The verifier (#366) proves `pc` stays in bounds for every reachable op (every path ends in `Return` / `Jump` / `TailCall`), so the explicit guard is redundant for verified programs. The `code[pc]` index stays bounds-checked — a malformed program in release still panics rather than reading out of bounds (**no `unsafe`, no UB**); only the cold error path leaves the hot loop.

Deterministic callgrind, `profile_response_build 120 3` (baseline = main post-slice-A):

| | I-refs | `run_to` I-refs |
|---|---|---|
| before (slice A) | 10,934,935 | 4,206,062 |
| after  (slice B) | 10,875,216 | 4,196,378 |
| Δ | **−0.55%** total | **−0.23%** in `run_to` |

Marginal, as expected — safe cleanup shaving a cold path. Cumulative slice A+B: `run_to` −3.4%. This ends the cheap dispatch wins; slice C (threaded dispatch) is nightly-only and an architectural call.

## 2. #464 — widen escape analysis to classify non-escaping tuples

Extend the escape pass to track tuples (`Op::MakeTuple`) alongside records, mirroring how #464 sequenced records (analysis → codegen → bench). The escape rules are identical for both aggregate kinds, so a single `Slot::Agg(pc)` lattice value tracks both (renamed from `Slot::Rec`). `EscapeSite` now carries a `SiteKind` (Record | Tuple) so a future codegen slice picks the right opcode.

**Analysis-only**, by design: `apply_escape_lowering` still rewrites only `MakeRecord`, so reporting tuple sites is inert until a tuple stack-alloc opcode lands. **No `Value`/VM/verifier/body_hash change; no runtime behavior change.** The codegen step (new `AllocStackTuple` + `Value::StackTuple`) is the riskier follow-on, best validated against the full `--workspace` suite in CI.

## Test plan
- [x] `cargo test -p lex-bytecode` green — 37 lib unit tests including 9 new tuple escape tests (drop / return / elem-read / round-trip / pass-to-call + record↔tuple nesting); no regressions in existing record tests
- [ ] `cargo test --workspace` — not run locally (disk: lex-runtime integration binaries link the full polars/arrow/tokio graph and overflow the dev container). CI covers it.

## Notes
- Builds on slice A (#538) and the docs re-scope (#537), both merged.
- slice B: ~12 lines in `vm.rs`; tuple analysis: confined to `escape.rs` + a re-export.

https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk