### PR TITLE
perf(#464): stack-allocate non-escaping tuples (tuple codegen)

### DIFF
--- a/crates/lex-bytecode/src/compiler.rs
+++ b/crates/lex-bytecode/src/compiler.rs
@@ -391,14 +391,25 @@ fn apply_escape_lowering(
     escape_index: &std::collections::HashMap<(String, u32), bool>,
 ) {
     for (pc, op) in code.iter_mut().enumerate() {
-        if let Op::MakeRecord { shape_idx, field_count } = *op {
-            // Look up this (fn, pc) in the escape index. Absent →
-            // analysis didn't observe the site (defensive: leave on
-            // heap path). Present and false → safe to stack-allocate.
-            let key = (fn_name.to_string(), pc as u32);
-            if matches!(escape_index.get(&key), Some(false)) {
+        // Look up this (fn, pc) in the escape index. Absent → analysis
+        // didn't observe the site (defensive: leave on heap path).
+        // Present and false → safe to stack-allocate. Each rewrite is a
+        // single-slot swap preserving pc / stack delta, so jump
+        // targets, downstream peephole passes, and the body-hash
+        // decoder all see the same program shape.
+        let key = (fn_name.to_string(), pc as u32);
+        if !matches!(escape_index.get(&key), Some(false)) {
+            continue;
+        }
+        match *op {
+            Op::MakeRecord { shape_idx, field_count } => {
                 *op = Op::AllocStackRecord { shape_idx, field_count };
             }
+            // #464 tuple codegen: same single-slot swap as records.
+            Op::MakeTuple(arity) => {
+                *op = Op::AllocStackTuple { arity };
+            }
+            _ => {}
         }
     }
 }

--- a/crates/lex-bytecode/src/escape.rs
+++ b/crates/lex-bytecode/src/escape.rs
@@ -327,16 +327,20 @@ fn step(pc: usize, op: &Op, mut s: State) -> (State, Vec<usize>, HashSet<u32>) {
             if let Some(top) = s.stack.pop() {
                 let i = *i as usize;
                 if i >= s.locals.len() { s.locals.resize(i + 1, Slot::Other); }
-                // Round-tripping a Rec through a local is fine; we
-                // keep it tracked. If the local previously held a
-                // different Rec, that one is being overwritten — it
-                // escapes (no remaining reference to it via the
-                // local, but it may still be on the stack elsewhere
-                // — conservatively flag).
-                let prev = s.locals[i];
-                if let Slot::Agg(p_prev) = prev {
-                    if prev != top { escapes.insert(p_prev); }
-                }
+                // Round-tripping an aggregate through a local keeps it
+                // tracked. Overwriting a local that held a *different*
+                // tracked aggregate does NOT make the old one escape:
+                // Lex `let` bindings are immutable, so the compiler
+                // only reuses a slot once its previous occupant is out
+                // of scope (dead). Any real escape of that occupant —
+                // returned, passed to a call, stored into another
+                // aggregate — flows through a `Load → {Return, Call,
+                // MakeRecord/MakeTuple/...}` chain those ops already
+                // leak. Flagging it here was a pure false-positive
+                // that defeated stack-alloc for the common
+                // destructure-then-bind pattern (`compile_match`
+                // rewinds its `__scrut`/`__tuple` temp slots, so the
+                // enclosing `let` reuses them — see #464 tuple codegen).
                 s.locals[i] = top;
             }
         }
@@ -364,6 +368,13 @@ fn step(pc: usize, op: &Op, mut s: State) -> (State, Vec<usize>, HashSet<u32>) {
         // `GetField` does for records.
         Op::MakeTuple(n) => {
             pop_n_leak(&mut s, *n as usize, &mut escapes);
+            s.stack.push(Slot::Agg(pc as u32));
+        }
+        // Post-lowering form of MakeTuple (escape proved). Re-running
+        // the analysis on already-lowered code must classify it the
+        // same way, so treat it identically — mirrors AllocStackRecord.
+        Op::AllocStackTuple { arity } => {
+            pop_n_leak(&mut s, *arity as usize, &mut escapes);
             s.stack.push(Slot::Agg(pc as u32));
         }
         // Lists and variants remain escape sinks for any tracked
@@ -476,12 +487,13 @@ fn step(pc: usize, op: &Op, mut s: State) -> (State, Vec<usize>, HashSet<u32>) {
             s.stack.push(Slot::Other);
         }
         Op::LoadLocalAddIntConstStoreLocal { dest, .. } => {
-            // delta 0; updates a local with an Int.
+            // delta 0; updates a local with an Int. Overwriting a
+            // local doesn't escape its prior aggregate — same rule as
+            // plain StoreLocal above (the dest is Int-typed by this
+            // superinstruction's contract, so prev is never an
+            // aggregate in practice; relaxed for consistency).
             let i = *dest as usize;
             if i >= s.locals.len() { s.locals.resize(i + 1, Slot::Other); }
-            // The local previously may have held a Rec; same logic
-            // as StoreLocal — overwriting it is an escape signal.
-            if let Slot::Agg(p_prev) = s.locals[i] { escapes.insert(p_prev); }
             s.locals[i] = Slot::Other;
             return (s, vec![pc + 4], escapes);
         }
@@ -532,7 +544,8 @@ fn step(pc: usize, op: &Op, mut s: State) -> (State, Vec<usize>, HashSet<u32>) {
             // Other (the scrutinee is an Int per slice-6's contract).
             let i = *dst as usize;
             if i >= s.locals.len() { s.locals.resize(i + 1, Slot::Other); }
-            if let Slot::Agg(p_prev) = s.locals[i] { escapes.insert(p_prev); }
+            // Overwriting a local doesn't escape its prior aggregate
+            // (same rule as plain StoreLocal); dst is Int-typed here.
             s.locals[i] = Slot::Other;
             let target = (pc as i32 + 6 + jump_offset) as usize;
             return (s, vec![pc + 6, target], escapes);
@@ -917,6 +930,43 @@ mod tests {
         assert_eq!((r.sites[0].pc, r.sites[0].kind, r.sites[0].shape_idx), (1, SiteKind::Record, 7));
         assert_eq!((r.sites[1].pc, r.sites[1].kind, r.sites[1].field_count), (5, SiteKind::Tuple, 2));
         assert!(!r.sites[0].escapes && !r.sites[1].escapes);
+    }
+
+    #[test]
+    fn aggregate_overwritten_in_dead_slot_does_not_escape() {
+        // rec1 is stored into local 0, then local 0 is overwritten
+        // with an Int and rec1 is never otherwise used. Lex's
+        // immutable `let` bindings mean a slot is only reused once its
+        // prior occupant is dead, so the overwrite must NOT flag rec1
+        // as escaping (the relaxed StoreLocal rule — #464 tuple
+        // codegen). Pre-relaxation this returned `true`.
+        let f = func("overwrite", 1, 0, vec![
+            Op::PushConst(0),
+            Op::MakeRecord { shape_idx: 0, field_count: 1 }, // rec1 @ pc=1
+            Op::StoreLocal(0),
+            Op::PushConst(0),
+            Op::StoreLocal(0), // overwrite local 0 with an Int
+            Op::PushConst(0),
+            Op::Return,
+        ]);
+        let r = analyze_function(&f);
+        assert_escapes(&r, &[(1, false)]);
+    }
+
+    #[test]
+    fn aggregate_loaded_then_returned_still_escapes() {
+        // Soundness guard for the relaxed overwrite rule: an aggregate
+        // stored in a local, then LOADED and returned, still escapes —
+        // the `Return` leak catches it independent of any overwrite.
+        let f = func("load_then_return", 1, 0, vec![
+            Op::PushConst(0),
+            Op::MakeRecord { shape_idx: 0, field_count: 1 }, // rec1 @ pc=1
+            Op::StoreLocal(0),
+            Op::LoadLocal(0),
+            Op::Return, // returns rec1 → escapes
+        ]);
+        let r = analyze_function(&f);
+        assert_escapes(&r, &[(1, true)]);
     }
 
     #[test]

--- a/crates/lex-bytecode/src/op.rs
+++ b/crates/lex-bytecode/src/op.rs
@@ -66,6 +66,18 @@ pub enum Op {
     /// step-2 lowering.
     AllocStackRecord { shape_idx: u32, field_count: u16 },
     MakeTuple(u16),
+    /// Frame-local tuple (#464 tuple codegen). Stack-alloc analogue of
+    /// `MakeTuple`: pops `arity` values into the VM's stack-record
+    /// arena and pushes a `Value::StackTuple` whose `slab_start`
+    /// indexes the arena. Emitted by the compiler in place of
+    /// `MakeTuple` at sites `escape::build_escape_index` proves do not
+    /// escape the frame. Runtime fallback to the heap `Value::Tuple`
+    /// path when the frame's stack-record budget is exhausted —
+    /// identical observable effect, so stack and heap tuples can mix
+    /// within one function. `body_hash` stability (#222): canonical
+    /// encoding decodes this op back to `MakeTuple(arity)`, so closure
+    /// identity is invariant under the lowering.
+    AllocStackTuple { arity: u16 },
     MakeList(u32),
     MakeVariant { name_idx: u32, arity: u16 },
     /// Record field access. `name_idx` indexes a `Const::FieldName`

--- a/crates/lex-bytecode/src/program.rs
+++ b/crates/lex-bytecode/src/program.rs
@@ -215,6 +215,11 @@ pub fn compute_body_hash(
                 serde_json::to_vec(&LegacyOp::GetField(*name_idx))
                     .expect("Op serialization must succeed")
             }
+            // #464 tuple codegen: AllocStackTuple hashes as MakeTuple
+            // so the stack-vs-heap lowering leaves closure identity
+            // (#222) bit-identical, mirroring AllocStackRecord above.
+            Op::AllocStackTuple { arity } =>
+                serde_json::to_vec(&Op::MakeTuple(*arity)).expect("Op serialization must succeed"),
             Op::IntAdd   | Op::FloatAdd => serde_json::to_vec(&Op::NumAdd).unwrap(),
             Op::IntSub   | Op::FloatSub => serde_json::to_vec(&Op::NumSub).unwrap(),
             Op::IntMul   | Op::FloatMul => serde_json::to_vec(&Op::NumMul).unwrap(),

--- a/crates/lex-bytecode/src/value.rs
+++ b/crates/lex-bytecode/src/value.rs
@@ -133,6 +133,22 @@ pub enum Value {
     /// bytes payload + tag, comfortably inside the 64B `Value`
     /// envelope.
     StackRecord { shape_id: u32, slab_start: u32, field_count: u16 },
+    /// Frame-local tuple (#464 tuple codegen). The stack-alloc
+    /// analogue of `Value::Tuple`, emitted by `Op::AllocStackTuple` at
+    /// sites the escape analysis proved can't outlive the current
+    /// frame. `slab_start` indexes into `Vm::stack_record_arena` (the
+    /// arena is shared with `StackRecord` — both are flat `Value`
+    /// slabs released together on `Op::Return`); the `arity`
+    /// consecutive values starting there are the tuple elements in
+    /// positional order.
+    ///
+    /// Like `StackRecord`, the only consumer that knows how to read
+    /// these is `Op::GetElem` — every other observation point
+    /// (`Return`, `Call`, a `MakeTuple`/`MakeRecord` field value,
+    /// equality, JSON) is an escape op the analysis prevents this
+    /// variant from reaching. An unexpected arrival surfaces as a
+    /// panic at the boundary, not UB (the arena is safe `Vec<Value>`).
+    StackTuple { slab_start: u32, arity: u16 },
     Variant { name: String, args: Vec<Value> },
     /// First-class function value (a lambda + its captured locals). The
     /// function's first `captures.len()` params bind to `captures`; the
@@ -223,6 +239,10 @@ impl PartialEq for Value {
             // get its own opcode with arena-aware comparison.
             (StackRecord { .. }, _) | (_, StackRecord { .. }) =>
                 panic!("BUG(#464): Value::StackRecord reached generic equality \
+                        — escape analysis should have flagged its allocation site"),
+            // Same soundness contract as StackRecord above.
+            (StackTuple { .. }, _) | (_, StackTuple { .. }) =>
+                panic!("BUG(#464): Value::StackTuple reached generic equality \
                         — escape analysis should have flagged its allocation site"),
             (Variant { name: an, args: aa }, Variant { name: bn, args: ba }) =>
                 an == bn && aa == ba,
@@ -341,6 +361,9 @@ impl Value {
             // #464: should never reach JSON serialization. See PartialEq.
             Value::StackRecord { .. } =>
                 panic!("BUG(#464): Value::StackRecord reached to_json — \
+                        escape analysis should have prevented escape to a host boundary"),
+            Value::StackTuple { .. } =>
+                panic!("BUG(#464): Value::StackTuple reached to_json — \
                         escape analysis should have prevented escape to a host boundary"),
             Value::Variant { name, args } => {
                 let mut m = serde_json::Map::new();

--- a/crates/lex-bytecode/src/verify.rs
+++ b/crates/lex-bytecode/src/verify.rs
@@ -162,6 +162,8 @@ fn stack_delta(op: &Op) -> i32 {
         // about the stack-record arena — it walks bytecode shape only.
         Op::AllocStackRecord { field_count, .. } => -(*field_count as i32) + 1,
         Op::MakeTuple(n)  => -(*n as i32) + 1,
+        // #464 tuple codegen: same stack-effect shape as MakeTuple.
+        Op::AllocStackTuple { arity } => -(*arity as i32) + 1,
         Op::MakeList(n)   => -(*n as i32) + 1,
         Op::MakeVariant { arity, .. } => -(*arity as i32) + 1,
 

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -570,6 +570,9 @@ fn hash_value_into<H: std::hash::Hasher>(v: &Value, h: &mut H) {
         Value::StackRecord { .. } =>
             panic!("BUG(#464): Value::StackRecord reached memo hashing — \
                     escape analysis should have prevented escape to a call boundary"),
+        Value::StackTuple { .. } =>
+            panic!("BUG(#464): Value::StackTuple reached memo hashing — \
+                    escape analysis should have prevented escape to a call boundary"),
     }
 }
 
@@ -1312,6 +1315,34 @@ impl<'a> Vm<'a> {
                     for i in (0..n as usize).rev() { items[i] = self.pop()?; }
                     self.stack.push(Value::Tuple(items));
                 }
+                Op::AllocStackTuple { arity } => {
+                    // #464 tuple codegen. Same value-stack contract as
+                    // MakeTuple (pop `arity`, push 1), but the elements
+                    // live in the shared stack-record arena instead of
+                    // a heap Vec. Budget exhaustion falls back to the
+                    // MakeTuple heap path — identical observable result.
+                    let n = arity as usize;
+                    let frame = &mut self.frames[frame_idx];
+                    if frame.stack_record_budget_remaining < arity as u32 {
+                        self.stack_record_heap_fallbacks += 1;
+                        let mut items: Vec<Value> = (0..n).map(|_| Value::Unit).collect();
+                        for i in (0..n).rev() { items[i] = self.pop()?; }
+                        self.stack.push(Value::Tuple(items));
+                    } else {
+                        self.stack_record_allocs += 1;
+                        frame.stack_record_budget_remaining -= arity as u32;
+                        let slab_start = self.stack_record_arena.len();
+                        self.stack_record_arena.resize(slab_start + n, Value::Unit);
+                        for i in (0..n).rev() {
+                            let v = self.pop()?;
+                            self.stack_record_arena[slab_start + i] = v;
+                        }
+                        self.stack.push(Value::StackTuple {
+                            slab_start: slab_start as u32,
+                            arity,
+                        });
+                    }
+                }
                 Op::MakeList(n) => {
                     let mut items: Vec<Value> = (0..n).map(|_| Value::Unit).collect();
                     for i in (0..n as usize).rev() { items[i] = self.pop()?; }
@@ -1464,6 +1495,17 @@ impl<'a> Vm<'a> {
                         Value::Tuple(items) => {
                             let v = items.into_iter().nth(i as usize)
                                 .ok_or_else(|| VmError::TypeMismatch(format!("tuple index {i} out of range")))?;
+                            self.stack.push(v);
+                        }
+                        // #464 tuple codegen: positional read out of a
+                        // frame-local tuple. The arena slot is an O(1)
+                        // index, mirroring the heap path's nth().
+                        Value::StackTuple { slab_start, arity } => {
+                            if i >= arity {
+                                return Err(VmError::TypeMismatch(
+                                    format!("tuple index {i} out of range")));
+                            }
+                            let v = self.stack_record_arena[slab_start as usize + i as usize].clone();
                             self.stack.push(v);
                         }
                         other => return Err(VmError::TypeMismatch(format!("GetElem on non-tuple: {other:?}"))),

--- a/crates/lex-bytecode/tests/stack_tuples.rs
+++ b/crates/lex-bytecode/tests/stack_tuples.rs
@@ -1,0 +1,180 @@
+//! #464 tuple codegen — `Op::AllocStackTuple` end-to-end tests.
+//!
+//! Exercises the escape-analysis-driven lowering of non-escaping
+//! `MakeTuple` to `AllocStackTuple`, the VM's shared stack-record
+//! arena bookkeeping for tuples, `Op::GetElem` dispatch over both
+//! `Value::Tuple` and `Value::StackTuple`, the per-frame budget
+//! fallback, and the body-hash canonicality contract (#222).
+//!
+//! Tuple elements are read via pattern destructuring (`match`), the
+//! only surface construct that emits `GetElem` — and a destructured-
+//! then-dropped tuple is exactly the non-escaping shape the analysis
+//! proves frame-local.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, Op, Value, Vm};
+use lex_syntax::parse_source;
+
+fn compile(src: &str) -> lex_bytecode::Program {
+    let p = parse_source(src).unwrap();
+    let stages = canonicalize_program(&p);
+    compile_program(&stages)
+}
+
+fn fn_code<'a>(prog: &'a lex_bytecode::Program, name: &str) -> &'a [Op] {
+    let idx = prog.function_names[name];
+    &prog.functions[idx as usize].code
+}
+
+fn count<F: Fn(&Op) -> bool>(code: &[Op], pred: F) -> usize {
+    code.iter().filter(|op| pred(op)).count()
+}
+
+/// A tuple built, destructured, and dropped never escapes the frame.
+/// The lowering pass must replace `MakeTuple` with `AllocStackTuple`,
+/// and the program must run with identical semantics.
+#[test]
+fn non_escaping_tuple_lowers_to_alloc_stack_tuple() {
+    let src = r#"
+        fn add_pair() -> Int {
+          match (3, 4) { (a, b) => a + b }
+        }
+    "#;
+    let p = compile(src);
+    let code = fn_code(&p, "add_pair");
+    assert_eq!(count(code, |op| matches!(op, Op::MakeTuple(_))), 0,
+        "MakeTuple should have been lowered: {code:?}");
+    assert_eq!(count(code, |op| matches!(op, Op::AllocStackTuple { .. })), 1,
+        "expected exactly one AllocStackTuple: {code:?}");
+
+    let mut vm = Vm::new(&p);
+    assert_eq!(vm.call("add_pair", vec![]).unwrap(), Value::Int(7));
+    // Prove the stack path actually ran at runtime, not just that the
+    // op was emitted at compile time.
+    assert!(vm.stack_record_allocs > 0, "stack-tuple path should have fired");
+}
+
+/// A tuple that is returned escapes. The lowering pass must leave it
+/// as `MakeTuple` so it lives on the heap as `Value::Tuple`.
+#[test]
+fn escaping_tuple_stays_on_heap() {
+    let src = r#"
+        fn build() -> Tuple[Int, Int] { (1, 2) }
+    "#;
+    let p = compile(src);
+    let code = fn_code(&p, "build");
+    assert_eq!(count(code, |op| matches!(op, Op::AllocStackTuple { .. })), 0,
+        "escaping tuple must not be stack-allocated: {code:?}");
+    assert_eq!(count(code, |op| matches!(op, Op::MakeTuple(_))), 1);
+
+    let mut vm = Vm::new(&p);
+    match vm.call("build", vec![]).unwrap() {
+        Value::Tuple(items) => assert_eq!(items, vec![Value::Int(1), Value::Int(2)]),
+        other => panic!("expected Tuple, got {other:?}"),
+    }
+}
+
+/// A tuple passed to a call escapes (the callee's body is opaque to
+/// the intra-procedural analysis), so it stays on the heap.
+#[test]
+fn tuple_passed_to_call_stays_on_heap() {
+    let src = r#"
+        fn use_pair(p :: Tuple[Int, Int]) -> Int { match p { (a, b) => a + b } }
+        fn caller() -> Int {
+          let t := (5, 6)
+          use_pair(t)
+        }
+    "#;
+    let p = compile(src);
+    let code = fn_code(&p, "caller");
+    assert_eq!(count(code, |op| matches!(op, Op::AllocStackTuple { .. })), 0,
+        "tuple passed to a call must stay on heap: {code:?}");
+    assert_eq!(count(code, |op| matches!(op, Op::MakeTuple(_))), 1);
+
+    let mut vm = Vm::new(&p);
+    assert_eq!(vm.call("caller", vec![]).unwrap(), Value::Int(11));
+}
+
+/// Element reads over a stack-allocated tuple go through the same
+/// `Op::GetElem` the heap path uses — dispatch is polymorphic over
+/// both `Value::Tuple` and `Value::StackTuple`. A 3-tuple exercises
+/// more than one positional index.
+#[test]
+fn stack_tuple_elem_reads_are_polymorphic() {
+    let src = r#"
+        fn sum_triple() -> Int {
+          match (10, 20, 30) { (a, b, c) => a + b + c }
+        }
+    "#;
+    let p = compile(src);
+    let code = fn_code(&p, "sum_triple");
+    assert_eq!(count(code, |op| matches!(op, Op::AllocStackTuple { .. })), 1);
+
+    let mut vm = Vm::new(&p);
+    assert_eq!(vm.call("sum_triple", vec![]).unwrap(), Value::Int(60));
+}
+
+/// Body-hash invariance under the lowering (#222). The canonical
+/// encoding decodes `AllocStackTuple` as `MakeTuple`, so two
+/// source-equivalent functions hash identically whether or not the
+/// escape pass fired.
+#[test]
+fn body_hash_invariant_under_tuple_lowering() {
+    let src_a = r#"
+        fn a() -> Int { match (5, 6) { (x, y) => x + y } }
+    "#;
+    let src_b = r#"
+        fn b() -> Int { match (5, 6) { (x, y) => x + y } }
+    "#;
+    let pa = compile(src_a);
+    let pb = compile(src_b);
+    let fa = &pa.functions[pa.function_names["a"] as usize];
+    let fb = &pb.functions[pb.function_names["b"] as usize];
+    assert_eq!(fa.body_hash, fb.body_hash);
+    assert!(fa.code.iter().any(|op| matches!(op, Op::AllocStackTuple { .. })),
+        "expected the tuple to lower: {:?}", fa.code);
+}
+
+/// The verifier walks `AllocStackTuple` with the same `-(arity)+1`
+/// stack delta as `MakeTuple`, so lowered code still verifies.
+#[test]
+fn verifier_accepts_alloc_stack_tuple() {
+    let src = r#"
+        fn ok() -> Int { match (1, 2, 3) { (a, b, c) => a + b + c } }
+    "#;
+    let p = compile(src);
+    let errs = lex_bytecode::verify_program(&p.functions);
+    assert!(errs.is_empty(), "verifier should accept lowered code: {errs:?}");
+}
+
+/// Budget exhaustion: a frame that allocates more stack-tuple slots
+/// than `STACK_RECORD_BUDGET_SLOTS` allows silently falls back to the
+/// heap `Value::Tuple` path for the overflow. All sites still lower at
+/// compile time; the result is identical regardless of which path each
+/// allocation took, and both the stack and fallback counters fire.
+#[test]
+fn budget_exhaustion_falls_back_for_tuples() {
+    let mut src = String::from("fn many() -> Int {\n");
+    for i in 0..70 {
+        src.push_str(&format!("  let s{i} := match ({i}, 0) {{ (a, b) => a + b }}\n"));
+    }
+    let parts: Vec<String> = (0..70).map(|i| format!("s{i}")).collect();
+    src.push_str("  ");
+    src.push_str(&parts.join(" + "));
+    src.push_str("\n}\n");
+
+    let p = compile(&src);
+    let code = fn_code(&p, "many");
+    assert_eq!(count(code, |op| matches!(op, Op::AllocStackTuple { .. })), 70,
+        "all 70 tuple sites should compile to AllocStackTuple");
+    assert_eq!(count(code, |op| matches!(op, Op::MakeTuple(_))), 0,
+        "no MakeTuple left after lowering");
+
+    let mut vm = Vm::new(&p);
+    let expected: i64 = (0..70).sum();
+    assert_eq!(vm.call("many", vec![]).unwrap(), Value::Int(expected));
+    // 70 tuples × 2 slots = 140 > 64-slot budget: the stack path runs
+    // until the budget is spent, then the heap fallback takes over.
+    assert!(vm.stack_record_allocs > 0, "stack path should have fired");
+    assert!(vm.stack_record_heap_fallbacks > 0, "heap fallback should have fired");
+}

--- a/crates/lex-trace/src/recorder.rs
+++ b/crates/lex-trace/src/recorder.rs
@@ -187,6 +187,10 @@ fn value_to_json(v: &Value) -> serde_json::Value {
         // on Call/EffectCall — both escape sinks the analysis
         // rejects). If we ever do see one, that's an analysis bug.
         Value::StackRecord { .. } => J::String("<stack-record-unreachable>".into()),
+        // #464 tuple codegen: same reasoning as StackRecord above —
+        // the tracer only records args at escape sinks the analysis
+        // rejects, so a frame-local tuple can't reach here.
+        Value::StackTuple { .. } => J::String("<stack-tuple-unreachable>".into()),
         Value::Variant { name, args } => {
             let mut m = serde_json::Map::new();
             m.insert("$variant".into(), J::String(name.clone()));

--- a/crates/lex-trace/tests/m7.rs
+++ b/crates/lex-trace/tests/m7.rs
@@ -83,7 +83,8 @@ fn value_to_json(v: &Value) -> serde_json::Value {
             J::Object(m)
         }
         Value::Map(_) | Value::Set(_) | Value::Deque(_) | Value::Actor(_)
-        | Value::Ticker(_) | Value::ArrowTable(_) | Value::StackRecord { .. } => {
+        | Value::Ticker(_) | Value::ArrowTable(_)
+        | Value::StackRecord { .. } | Value::StackTuple { .. } => {
             // Tests in this file don't exercise these container values;
             // render as a placeholder so the match is exhaustive.
             J::String("<container>".into())


### PR DESCRIPTION
## Summary

Follow-on to the tuple **escape analysis** (landed in #539): actually stack-allocate the non-escaping tuples it identifies. A clean mirror of the record stack-alloc path from #464, with the same panic-guarded safety model.

- **`Op::AllocStackTuple { arity }`** — stack-alloc analogue of `MakeTuple`.
- **`Value::StackTuple { slab_start, arity }`** — frame-local tuple in the shared stack-record arena. Like `StackRecord` it is **panic-guarded**: the escape analysis keeps it away from equality / JSON / memo-hashing / `Return` / `Call`, and an unexpected arrival panics at the boundary (safe `Vec<Value>` arena) rather than UB.
- **VM** — `AllocStackTuple` handler (stack path + per-frame budget fallback to the heap `Value::Tuple` path) and a `Value::StackTuple` arm on `GetElem`; verifier stack-effect; `body_hash` decodes `AllocStackTuple` as `MakeTuple` so closure identity (#222) is invariant under the lowering.
- **Lowering** — `apply_escape_lowering` rewrites non-escaping `MakeTuple → AllocStackTuple` (single-slot swap, same as records).

## Escape-analysis precision fix (the enabler)

Relax the `StoreLocal` *"overwriting a local escapes its prior aggregate"* rule. It was a **pure false-positive** for Lex's immutable `let` bindings — a slot is only reused once its prior occupant is dead, and any *real* escape flows through a `Load → {Return, Call, MakeRecord/MakeTuple/…}` chain those ops already leak.

Without this, the common destructure-then-bind pattern **never lowered**: `compile_match` rewinds its `__scrut`/`__tuple` temp slots, so the enclosing `let` reuses them and the old (dead) tuple got flagged as escaping. Empirically, before the fix a 70-tuple function lowered **0/70**; after, **70/70**. The relaxation also unblocks the **record** path in reused slots.

**Soundness:** verified that `let t := (1,2); t` (returned) still escapes — `Return` catches it independent of the overwrite rule. Two new escape unit tests pin this (overwrite-doesn't-escape + the store-then-return guard).

## Tests

- `crates/lex-bytecode/tests/stack_tuples.rs` (7): lowers / heap-on-escape / escape-via-call / polymorphic `GetElem` over `Tuple`+`StackTuple` / body-hash invariance / verifier acceptance / budget fallback firing **both** paths (allocs=32, fallbacks=38, result correct).
- `escape.rs` (+2 unit tests), `stack_records.rs` (9) green — **no record regression** from the relaxation.
- `lex-trace` updated at the two sites that explicitly match `StackRecord`; its suite green.

## Test plan
- [x] `cargo test -p lex-bytecode` — 39 lib unit + 7 stack_tuples + 9 stack_records + rest green
- [x] `cargo test -p lex-trace` green
- [ ] `cargo test --workspace` — not run in dev container (disk: lex-runtime links the full polars/arrow/tokio graph). CI covers it. Note: lex-runtime has **no** explicit `StackRecord`/`StackTuple` matches (catch-alls), so the new variant flows through there safely.

## Notes
- Builds on the tuple escape analysis from #539 (merged).
- The branch was force-pushed (with lease) to re-base on merged `main` for a clean per-slice diff — prior content was already merged, no work lost.

https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk)_