### PR TITLE
perf(#464): measure tuple stack-alloc win (bench + acceptance + callgrind)

### DIFF
--- a/crates/lex-bytecode/Cargo.toml
+++ b/crates/lex-bytecode/Cargo.toml
@@ -37,3 +37,7 @@ harness = false
 [[bench]]
 name = "response_build"
 harness = false
+
+[[bench]]
+name = "tuple_build"
+harness = false

--- a/crates/lex-bytecode/benches/tuple_build.rs
+++ b/crates/lex-bytecode/benches/tuple_build.rs
@@ -1,0 +1,124 @@
+//! #464 tuple codegen — `tuple_build` benchmark.
+//!
+//! Tuple analogue of `response_build`: a handler-shaped function that
+//! builds and destructures several non-escaping intermediate tuples,
+//! returning a scalar. Compiles the same source twice — normally and
+//! with `LEX_NO_STACK_RECORDS=1` (which gates the whole escape
+//! lowering, tuples included) — so the A/B differs only at the
+//! `MakeTuple` / `AllocStackTuple` opcode slot.
+//!
+//! The deterministic instruction count comes from the callgrind
+//! harness (`examples/profile_tuple_build.rs`); the stack-allocation
+//! count and a relaxed timing floor are asserted by
+//! `tests/tuple_build_acceptance.rs`. Criterion timings here are read
+//! by humans.
+//!
+//! Run with `cargo bench -p lex-bytecode --bench tuple_build`.
+
+use std::sync::Arc;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use lex_ast::canonicalize_program;
+use lex_bytecode::vm::Vm;
+use lex_bytecode::{compile_program, Program, Value};
+use lex_syntax::parse_source;
+
+/// Six non-escaping intermediate tuples per `handle`, each built and
+/// destructured via `match`. `drive` passes/reads scalars, so no
+/// tuple escapes — every intermediate lands on the stack path.
+const TUPLE_BUILD_SRC: &str = r#"
+fn handle(a :: Int, b :: Int) -> Int {
+  let s1 := match (a, b)   { (x, y) => x + y }
+  let s2 := match (a, b)   { (x, y) => x * y }
+  let s3 := match (s1, s2) { (x, y) => x + y }
+  let s4 := match (s1, s2) { (x, y) => x - y }
+  let s5 := match (s3, s4) { (x, y) => x * 2 + y }
+  let s6 := match (s4, s3) { (x, y) => x + y * 3 }
+  s1 + s2 + s3 + s4 + s5 + s6
+}
+
+fn drive(n :: Int) -> Int {
+  match n {
+    0 => 0,
+    _ => {
+      let r := handle(n, 7)
+      r + drive(n - 1)
+    },
+  }
+}
+"#;
+
+fn compile_with_env(src: &str, no_stack: bool) -> Arc<Program> {
+    // SAFETY: bench is single-threaded; the env var is set only during
+    // compilation (outside the timed loop) and unset immediately after.
+    if no_stack {
+        unsafe { std::env::set_var("LEX_NO_STACK_RECORDS", "1"); }
+    }
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    lex_types::check_program(&stages).expect("typecheck");
+    let p = Arc::new(compile_program(&stages));
+    if no_stack {
+        unsafe { std::env::remove_var("LEX_NO_STACK_RECORDS"); }
+    }
+    p
+}
+
+/// Fail loudly if the pass quietly stopped firing (which would make
+/// the two arms identical and the comparison meaningless).
+fn assert_lowering_state(p: &Program, expect_lowered: bool) {
+    use lex_bytecode::Op;
+    let mut total = 0usize;
+    let mut lowered = 0usize;
+    for f in &p.functions {
+        for op in &f.code {
+            match op {
+                Op::MakeTuple(_) => total += 1,
+                Op::AllocStackTuple { .. } => { total += 1; lowered += 1; }
+                _ => {}
+            }
+        }
+    }
+    assert!(total > 0, "workload must have tuple sites");
+    if expect_lowered {
+        assert!(lowered > 0, "expected lowering on enabled arm");
+    } else {
+        assert_eq!(lowered, 0, "expected no lowering on disabled arm");
+    }
+}
+
+fn bench_tuple_build(c: &mut Criterion) {
+    let enabled = compile_with_env(TUPLE_BUILD_SRC, false);
+    let disabled = compile_with_env(TUPLE_BUILD_SRC, true);
+    assert_lowering_state(&enabled, true);
+    assert_lowering_state(&disabled, false);
+
+    let mut group = c.benchmark_group("tuple_build");
+    for n in [100i64, 1_000] {
+        let nu = n as u64;
+        // 6 tuple allocations per handle() call.
+        group.throughput(Throughput::Elements(6 * nu));
+
+        let enabled_arm = Arc::clone(&enabled);
+        group.bench_function(format!("enabled/n={n}"), move |b| {
+            b.iter(|| {
+                let mut vm = Vm::new(&enabled_arm);
+                vm.set_step_limit(u64::MAX);
+                black_box(vm.call("drive", vec![Value::Int(n)]).unwrap());
+            })
+        });
+
+        let disabled_arm = Arc::clone(&disabled);
+        group.bench_function(format!("disabled/n={n}"), move |b| {
+            b.iter(|| {
+                let mut vm = Vm::new(&disabled_arm);
+                vm.set_step_limit(u64::MAX);
+                black_box(vm.call("drive", vec![Value::Int(n)]).unwrap());
+            })
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_tuple_build);
+criterion_main!(benches);

--- a/crates/lex-bytecode/examples/profile_tuple_build.rs
+++ b/crates/lex-bytecode/examples/profile_tuple_build.rs
@@ -1,0 +1,75 @@
+//! Callgrind-targeted profiling harness for a tuple-heavy workload
+//! (#464 tuple codegen measurement). Mirrors `profile_response_build`
+//! but exercises non-escaping *tuples* (built and destructured via
+//! `match`) rather than records, so callgrind attributes the
+//! `AllocStackTuple` stack path vs the `MakeTuple` heap path cleanly.
+//!
+//! A/B the same source under matched VM/peephole conditions with the
+//! `LEX_NO_STACK_RECORDS` escape hatch (it gates the whole escape
+//! lowering, tuples included):
+//!
+//!   cargo build --release --example profile_tuple_build -p lex-bytecode
+//!   # stack-tuple path (lowering on):
+//!   valgrind --tool=callgrind --callgrind-out-file=cg.on \
+//!     target/release/examples/profile_tuple_build 400 30
+//!   # heap-tuple baseline (lowering off):
+//!   LEX_NO_STACK_RECORDS=1 valgrind --tool=callgrind \
+//!     --callgrind-out-file=cg.off \
+//!     target/release/examples/profile_tuple_build 400 30
+//!
+//! Args: <n> <iters>. Defaults 400 30.
+
+use std::sync::Arc;
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::vm::Vm;
+use lex_bytecode::{compile_program, Value};
+use lex_syntax::parse_source;
+
+const SRC: &str = r#"
+fn handle(a :: Int, b :: Int) -> Int {
+  let s1 := match (a, b)   { (x, y) => x + y }
+  let s2 := match (a, b)   { (x, y) => x * y }
+  let s3 := match (s1, s2) { (x, y) => x + y }
+  let s4 := match (s1, s2) { (x, y) => x - y }
+  let s5 := match (s3, s4) { (x, y) => x * 2 + y }
+  let s6 := match (s4, s3) { (x, y) => x + y * 3 }
+  s1 + s2 + s3 + s4 + s5 + s6
+}
+
+fn drive(n :: Int) -> Int {
+  match n {
+    0 => 0,
+    _ => {
+      let r := handle(n, 7)
+      r + drive(n - 1)
+    },
+  }
+}
+"#;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let n: i64 = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(400);
+    let iters: u64 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(30);
+
+    let prog = parse_source(SRC).expect("parse");
+    let stages = canonicalize_program(&prog);
+    lex_types::check_program(&stages).expect("typecheck");
+    let p = Arc::new(compile_program(&stages));
+
+    let mut acc = 0i64;
+    let (mut stack, mut fallback) = (0u64, 0u64);
+    for _ in 0..iters {
+        let mut vm = Vm::new(&p);
+        vm.set_step_limit(u64::MAX);
+        if let Value::Int(v) = vm.call("drive", vec![Value::Int(n)]).unwrap() {
+            acc = acc.wrapping_add(v);
+        }
+        stack += vm.stack_record_allocs;
+        fallback += vm.stack_record_heap_fallbacks;
+    }
+    eprintln!("stack_tuples: stack={stack} fallback={fallback}");
+    // Keep the result observable so the optimizer can't elide the loop.
+    std::process::exit((acc & 0x7f) as i32);
+}

--- a/crates/lex-bytecode/tests/tuple_build_acceptance.rs
+++ b/crates/lex-bytecode/tests/tuple_build_acceptance.rs
@@ -1,0 +1,161 @@
+//! #464 tuple codegen — acceptance test for a tuple-heavy workload.
+//!
+//! The companion harness (`examples/profile_tuple_build.rs`) reports
+//! the callgrind instruction delta for humans; this test is the
+//! CI-runnable regression gate:
+//!
+//!  1. **Every non-escaping tuple lowers and runs on the stack path**
+//!     — exact, measured via static op-site counts plus the per-VM
+//!     `Vm::stack_record_allocs` / `stack_record_heap_fallbacks`
+//!     counters (`AllocStackTuple`'s stack path shares the
+//!     record arena counter). Fully deterministic.
+//!
+//!  2. **Speedup with lowering enabled** — wall-clock A/B over a tight
+//!     loop, `#[ignore]`d by default (timing is noisy on shared CI).
+//!     Run explicitly for the number; the assertion uses a relaxed
+//!     floor as a regression gate only.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::vm::Vm;
+use lex_bytecode::{compile_program, Op, Program, Value};
+use lex_syntax::parse_source;
+
+/// Six non-escaping intermediate tuples per `handle` call, each built
+/// and destructured via `match` (the surface construct that emits
+/// `MakeTuple` + `GetElem`). `drive` passes scalars and reads the
+/// scalar result, so no tuple escapes across the call boundary.
+const SRC: &str = r#"
+fn handle(a :: Int, b :: Int) -> Int {
+  let s1 := match (a, b)   { (x, y) => x + y }
+  let s2 := match (a, b)   { (x, y) => x * y }
+  let s3 := match (s1, s2) { (x, y) => x + y }
+  let s4 := match (s1, s2) { (x, y) => x - y }
+  let s5 := match (s3, s4) { (x, y) => x * 2 + y }
+  let s6 := match (s4, s3) { (x, y) => x + y * 3 }
+  s1 + s2 + s3 + s4 + s5 + s6
+}
+
+fn drive(n :: Int) -> Int {
+  match n {
+    0 => 0,
+    _ => {
+      let r := handle(n, 7)
+      r + drive(n - 1)
+    },
+  }
+}
+"#;
+
+fn compile_with_env(src: &str, no_stack: bool) -> Arc<Program> {
+    // The `unsafe` is required by Rust 2024's audited env API. This
+    // test is single-threaded: set the flag, compile, unset.
+    if no_stack {
+        unsafe { std::env::set_var("LEX_NO_STACK_RECORDS", "1"); }
+    }
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    lex_types::check_program(&stages).expect("typecheck");
+    let p = Arc::new(compile_program(&stages));
+    if no_stack {
+        unsafe { std::env::remove_var("LEX_NO_STACK_RECORDS"); }
+    }
+    p
+}
+
+fn count_tuple_sites(p: &Program) -> (usize, usize) {
+    let mut make_tuple = 0usize;
+    let mut alloc_stack = 0usize;
+    for f in &p.functions {
+        for op in &f.code {
+            match op {
+                Op::MakeTuple(_) => make_tuple += 1,
+                Op::AllocStackTuple { .. } => alloc_stack += 1,
+                _ => {}
+            }
+        }
+    }
+    (make_tuple, alloc_stack)
+}
+
+/// Bar 1: every non-escaping tuple lowers to `AllocStackTuple` and
+/// runs on the stack path. Exact, counter-driven, no timing noise.
+#[test]
+fn all_non_escaping_tuples_lower_and_run_on_stack() {
+    let p = compile_with_env(SRC, false);
+    let (make_tuple, alloc_stack) = count_tuple_sites(&p);
+    // The 6 `handle` tuples are non-escaping; `drive`'s match is on an
+    // Int (no tuple). All 6 lower; none stay on the heap.
+    assert_eq!(alloc_stack, 6, "expected all 6 tuple sites to lower");
+    assert_eq!(make_tuple, 0, "no heap MakeTuple should remain after lowering");
+
+    // The disabled arm must keep them all on the heap — proves the
+    // A/B baseline the bench/profile harness relies on is real.
+    let disabled = compile_with_env(SRC, true);
+    let (make_tuple_off, alloc_stack_off) = count_tuple_sites(&disabled);
+    assert_eq!(alloc_stack_off, 0, "lowering should be fully suppressed");
+    assert_eq!(make_tuple_off, 6, "all 6 tuples should stay MakeTuple");
+
+    // Runtime: drive(200) calls handle 200 times, 6 stack tuples each.
+    // Each handle frame uses 6×2 = 12 arena slots ≪ the 64-slot
+    // budget, so nothing falls back.
+    let mut vm = Vm::new(&p);
+    vm.set_step_limit(u64::MAX);
+    let r = vm.call("drive", vec![Value::Int(200)]).unwrap();
+    assert!(matches!(r, Value::Int(_)), "expected Int return, got {r:?}");
+
+    println!(
+        "[#464 tuple] stack={}, fallback={}",
+        vm.stack_record_allocs, vm.stack_record_heap_fallbacks
+    );
+    assert_eq!(vm.stack_record_allocs, 200 * 6,
+        "expected 6 stack tuples per handle × 200 calls");
+    assert_eq!(vm.stack_record_heap_fallbacks, 0,
+        "no budget exhaustion expected for this workload");
+
+    // Both arms must compute the same answer.
+    let mut vm_off = Vm::new(&disabled);
+    vm_off.set_step_limit(u64::MAX);
+    let r_off = vm_off.call("drive", vec![Value::Int(200)]).unwrap();
+    assert_eq!(r, r_off, "stack and heap paths must agree");
+}
+
+/// Bar 2: speedup with lowering. Timing-based → `#[ignore]`d; relaxed
+/// floor as a regression gate. Run with `--ignored --nocapture` for
+/// the number (the callgrind harness gives the deterministic count).
+#[test]
+#[ignore = "timing-based; see doc comment"]
+fn tuple_lowering_speedup() {
+    let enabled = compile_with_env(SRC, false);
+    let disabled = compile_with_env(SRC, true);
+
+    for prog in [&enabled, &disabled] {
+        let mut vm = Vm::new(prog);
+        vm.set_step_limit(u64::MAX);
+        let _ = vm.call("drive", vec![Value::Int(50)]).unwrap();
+    }
+
+    let n: i64 = 500;
+    let iters: usize = 200;
+    let time_arm = |prog: &Arc<Program>| -> f64 {
+        let t0 = Instant::now();
+        for _ in 0..iters {
+            let mut vm = Vm::new(prog);
+            vm.set_step_limit(u64::MAX);
+            std::hint::black_box(vm.call("drive", vec![Value::Int(n)]).unwrap());
+        }
+        t0.elapsed().as_secs_f64()
+    };
+
+    let mut on = [time_arm(&enabled), time_arm(&enabled), time_arm(&enabled)];
+    let mut off = [time_arm(&disabled), time_arm(&disabled), time_arm(&disabled)];
+    on.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    off.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let ratio = off[0] / on[0];
+    println!("[#464 tuple] best-of-3: enabled={:.4}s disabled={:.4}s speedup={ratio:.2}×",
+        on[0], off[0]);
+    assert!(ratio >= 1.15,
+        "speedup {ratio:.2}× below the 1.15× regression floor");
+}


### PR DESCRIPTION
## Summary

The tuple codegen slice (#540) shipped validated for correctness but **unmeasured**. This adds the #464 step-3 measurement triad for a tuple-heavy workload, mirroring `response_build`, and reports the deterministic win.

- **`examples/profile_tuple_build.rs`** — callgrind harness. A/B via the `LEX_NO_STACK_RECORDS` escape hatch (it gates the whole escape lowering, tuples included).
- **`tests/tuple_build_acceptance.rs`** — deterministic CI regression gate: all 6 non-escaping tuples lower to `AllocStackTuple` and run on the stack path (`stack_record_allocs == 6×calls`, `fallback == 0`); the disabled arm keeps them all on the heap; both arms agree on the result. Plus an `#[ignore]`d wall-clock A/B (1.15× floor).
- **`benches/tuple_build.rs`** — criterion A/B for humans (registered in `Cargo.toml`).

## Measured

Workload: 6 non-escaping intermediate tuples per call, built and destructured via `match`.

**Callgrind** (`profile_tuple_build 120 3`, deterministic):

| arm | I-refs |
|---|---|
| heap baseline (`LEX_NO_STACK_RECORDS=1`) | 11,678,894 |
| stack-tuple path | 9,635,286 |
| **Δ** | **−17.5% instructions** |

`stack=2160` (= 6 × 120 × 3) confirms every tuple took the stack path; `fallback=0`.

**Wall-clock** best-of-3 (n=500, 200 iters): **1.32× speedup**.

## Test plan
- [x] `cargo test -p lex-bytecode --test tuple_build_acceptance` (deterministic bar) green
- [x] `cargo test ... -- --include-ignored` → 1.32× speedup, passes the 1.15× floor
- [x] callgrind A/B as above
- [x] `cargo bench --bench tuple_build --no-run` compiles clean
- [ ] `cargo test --workspace` — deferred to CI (dev-container disk). This slice is additive only (no `src/` changes).

## Notes
- Builds on the tuple codegen (#540, merged) and its escape-analysis precision fix.
- Branch force-pushed (with lease) to re-base on merged `main` for a clean per-slice diff — prior content was already merged, no work lost.

https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk)_