### PR TITLE
perf(#464): native list.map/filter/fold ops (−62% on list-heavy workload)

### DIFF
--- a/crates/lex-bytecode/examples/profile_list_build.rs
+++ b/crates/lex-bytecode/examples/profile_list_build.rs
@@ -1,0 +1,62 @@
+//! Callgrind harness for a list-builder workload (#464 native
+//! list ops). Chains `list.map`/`fold` over small lists — the shape
+//! that, with the old inlined loops, re-`LoadLocal`'d (cloned) the
+//! whole input and accumulator lists each iteration (O(n²)). With the
+//! native `Op::ListMap`/`ListFold` ops the VM owns the list and builds
+//! results with one pre-sized allocation.
+//!
+//!   cargo build --release --example profile_list_build -p lex-bytecode
+//!   valgrind --tool=callgrind --callgrind-out-file=cg.list \
+//!     target/release/examples/profile_list_build 120 3
+//!
+//! Args: <n> <iters>. Defaults 400 30.
+
+use std::sync::Arc;
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::vm::Vm;
+use lex_bytecode::{compile_program, Value};
+use lex_syntax::parse_source;
+
+const SRC: &str = r#"
+import "std.list" as list
+
+fn handle(n :: Int) -> Int {
+  let a := [n, n + 1, n + 2, n + 3]
+  let b := list.map(a, fn(x :: Int) -> Int { x + 1 })
+  let c := list.map(b, fn(x :: Int) -> Int { x * 2 })
+  let d := list.map(c, fn(x :: Int) -> Int { x - 1 })
+  list.fold(d, 0, fn(acc :: Int, x :: Int) -> Int { acc + x })
+}
+
+fn drive(n :: Int) -> Int {
+  match n {
+    0 => 0,
+    _ => {
+      let r := handle(n)
+      r + drive(n - 1)
+    },
+  }
+}
+"#;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let n: i64 = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(400);
+    let iters: u64 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(30);
+
+    let prog = parse_source(SRC).expect("parse");
+    let stages = canonicalize_program(&prog);
+    lex_types::check_program(&stages).expect("typecheck");
+    let p = Arc::new(compile_program(&stages));
+
+    let mut acc = 0i64;
+    for _ in 0..iters {
+        let mut vm = Vm::new(&p);
+        vm.set_step_limit(u64::MAX);
+        if let Value::Int(v) = vm.call("drive", vec![Value::Int(n)]).unwrap() {
+            acc = acc.wrapping_add(v);
+        }
+    }
+    std::process::exit((acc & 0x7f) as i32);
+}

--- a/crates/lex-bytecode/src/compiler.rs
+++ b/crates/lex-bytecode/src/compiler.rs
@@ -1473,66 +1473,16 @@ impl<'a> FnCompiler<'a> {
         true
     }
 
-    /// `list.map(xs, f)` — inline loop applying `f` to each element.
-    /// Stack contract: pushes the resulting List.
+    /// `list.map(xs, f)` — native map op (#464). Pushes `xs` then `f`
+    /// and emits a single `Op::ListMap`. The previous inlined loop
+    /// re-`LoadLocal`'d (cloned) the whole input and accumulator lists
+    /// each iteration — O(n²); the native op owns the list and builds
+    /// the result with one pre-sized allocation.
     fn emit_list_map(&mut self, args: &[a::CExpr]) {
-        // Compile xs and f, store both as locals.
-        self.compile_expr(&args[0], false);
-        let xs = self.alloc_local("__lm_xs");
-        self.emit(Op::StoreLocal(xs));
-        self.compile_expr(&args[1], false);
-        let f = self.alloc_local("__lm_f");
-        self.emit(Op::StoreLocal(f));
-
-        // out := []
-        self.emit(Op::MakeList(0));
-        let out = self.alloc_local("__lm_out");
-        self.emit(Op::StoreLocal(out));
-
-        // i := 0
-        let zero = self.pool.int(0);
-        self.emit(Op::PushConst(zero));
-        let i = self.alloc_local("__lm_i");
-        self.emit(Op::StoreLocal(i));
-
-        // loop_top: while i < len(xs) { ... }
-        let loop_top = self.code.len();
-        self.emit(Op::LoadLocal(i));
-        self.emit(Op::LoadLocal(xs));
-        self.emit(Op::GetListLen);
-        self.emit(Op::IntLt);
-        let j_exit = self.code.len();
-        self.emit(Op::JumpIfNot(0));
-
-        // body: out := out ++ [f(xs[i])]
+        self.compile_expr(&args[0], false); // xs
+        self.compile_expr(&args[1], false); // f
         let nid = self.pool.node_id("n_list_map");
-        self.emit(Op::LoadLocal(out));
-        self.emit(Op::LoadLocal(f));
-        self.emit(Op::LoadLocal(xs));
-        self.emit(Op::LoadLocal(i));
-        self.emit(Op::GetListElemDyn);
-        self.emit(Op::CallClosure { arity: 1, node_id_idx: nid });
-        self.emit(Op::ListAppend);
-        self.emit(Op::StoreLocal(out));
-
-        // i := i + 1
-        self.emit(Op::LoadLocal(i));
-        let one = self.pool.int(1);
-        self.emit(Op::PushConst(one));
-        self.emit(Op::IntAdd);
-        self.emit(Op::StoreLocal(i));
-
-        // jump back
-        let jump_back = self.code.len();
-        let back = (loop_top as i32) - (jump_back as i32 + 1);
-        self.emit(Op::Jump(back));
-
-        // exit: patch j_exit, push out
-        let exit_target = self.code.len() as i32;
-        if let Op::JumpIfNot(off) = &mut self.code[j_exit] {
-            *off = exit_target - (j_exit as i32 + 1);
-        }
-        self.emit(Op::LoadLocal(out));
+        self.emit(Op::ListMap { node_id_idx: nid });
     }
 
     /// `list.par_map(xs, f)` (#305 slice 1). Pushes `xs` and `f`,
@@ -1561,127 +1511,23 @@ impl<'a> FnCompiler<'a> {
         self.emit(Op::SortByKey { node_id_idx: nid });
     }
 
-    /// `list.filter(xs, pred)` — keep elements where pred returns true.
+    /// `list.filter(xs, pred)` — native filter op (#464). Same
+    /// rationale as `emit_list_map`.
     fn emit_list_filter(&mut self, args: &[a::CExpr]) {
-        self.compile_expr(&args[0], false);
-        let xs = self.alloc_local("__lf_xs");
-        self.emit(Op::StoreLocal(xs));
-        self.compile_expr(&args[1], false);
-        let f = self.alloc_local("__lf_f");
-        self.emit(Op::StoreLocal(f));
-
-        self.emit(Op::MakeList(0));
-        let out = self.alloc_local("__lf_out");
-        self.emit(Op::StoreLocal(out));
-
-        let zero = self.pool.int(0);
-        self.emit(Op::PushConst(zero));
-        let i = self.alloc_local("__lf_i");
-        self.emit(Op::StoreLocal(i));
-
-        let loop_top = self.code.len();
-        self.emit(Op::LoadLocal(i));
-        self.emit(Op::LoadLocal(xs));
-        self.emit(Op::GetListLen);
-        self.emit(Op::IntLt);
-        let j_exit = self.code.len();
-        self.emit(Op::JumpIfNot(0));
-
-        // x := xs[i]
-        self.emit(Op::LoadLocal(xs));
-        self.emit(Op::LoadLocal(i));
-        self.emit(Op::GetListElemDyn);
-        let x = self.alloc_local("__lf_x");
-        self.emit(Op::StoreLocal(x));
-
-        // if pred(x) { out := out ++ [x] }
+        self.compile_expr(&args[0], false); // xs
+        self.compile_expr(&args[1], false); // pred
         let nid = self.pool.node_id("n_list_filter");
-        self.emit(Op::LoadLocal(f));
-        self.emit(Op::LoadLocal(x));
-        self.emit(Op::CallClosure { arity: 1, node_id_idx: nid });
-        let j_skip = self.code.len();
-        self.emit(Op::JumpIfNot(0));
-
-        self.emit(Op::LoadLocal(out));
-        self.emit(Op::LoadLocal(x));
-        self.emit(Op::ListAppend);
-        self.emit(Op::StoreLocal(out));
-
-        let skip_target = self.code.len() as i32;
-        if let Op::JumpIfNot(off) = &mut self.code[j_skip] {
-            *off = skip_target - (j_skip as i32 + 1);
-        }
-
-        // i := i + 1
-        self.emit(Op::LoadLocal(i));
-        let one = self.pool.int(1);
-        self.emit(Op::PushConst(one));
-        self.emit(Op::IntAdd);
-        self.emit(Op::StoreLocal(i));
-
-        let jump_back = self.code.len();
-        let back = (loop_top as i32) - (jump_back as i32 + 1);
-        self.emit(Op::Jump(back));
-
-        let exit_target = self.code.len() as i32;
-        if let Op::JumpIfNot(off) = &mut self.code[j_exit] {
-            *off = exit_target - (j_exit as i32 + 1);
-        }
-        self.emit(Op::LoadLocal(out));
+        self.emit(Op::ListFilter { node_id_idx: nid });
     }
 
-    /// `list.fold(xs, init, f)` — left fold with two-arg combiner.
+    /// `list.fold(xs, init, f)` — native left-fold op (#464). Same
+    /// rationale as `emit_list_map`. Stack: `[xs, init, f]`.
     fn emit_list_fold(&mut self, args: &[a::CExpr]) {
-        // args: xs, init, f
-        self.compile_expr(&args[0], false);
-        let xs = self.alloc_local("__lo_xs");
-        self.emit(Op::StoreLocal(xs));
-        self.compile_expr(&args[1], false);
-        let acc = self.alloc_local("__lo_acc");
-        self.emit(Op::StoreLocal(acc));
-        self.compile_expr(&args[2], false);
-        let f = self.alloc_local("__lo_f");
-        self.emit(Op::StoreLocal(f));
-
-        let zero = self.pool.int(0);
-        self.emit(Op::PushConst(zero));
-        let i = self.alloc_local("__lo_i");
-        self.emit(Op::StoreLocal(i));
-
-        let loop_top = self.code.len();
-        self.emit(Op::LoadLocal(i));
-        self.emit(Op::LoadLocal(xs));
-        self.emit(Op::GetListLen);
-        self.emit(Op::IntLt);
-        let j_exit = self.code.len();
-        self.emit(Op::JumpIfNot(0));
-
-        // acc := f(acc, xs[i])
+        self.compile_expr(&args[0], false); // xs
+        self.compile_expr(&args[1], false); // init
+        self.compile_expr(&args[2], false); // f
         let nid = self.pool.node_id("n_list_fold");
-        self.emit(Op::LoadLocal(f));
-        self.emit(Op::LoadLocal(acc));
-        self.emit(Op::LoadLocal(xs));
-        self.emit(Op::LoadLocal(i));
-        self.emit(Op::GetListElemDyn);
-        self.emit(Op::CallClosure { arity: 2, node_id_idx: nid });
-        self.emit(Op::StoreLocal(acc));
-
-        // i := i + 1
-        self.emit(Op::LoadLocal(i));
-        let one = self.pool.int(1);
-        self.emit(Op::PushConst(one));
-        self.emit(Op::IntAdd);
-        self.emit(Op::StoreLocal(i));
-
-        let jump_back = self.code.len();
-        let back = (loop_top as i32) - (jump_back as i32 + 1);
-        self.emit(Op::Jump(back));
-
-        let exit_target = self.code.len() as i32;
-        if let Op::JumpIfNot(off) = &mut self.code[j_exit] {
-            *off = exit_target - (j_exit as i32 + 1);
-        }
-        self.emit(Op::LoadLocal(acc));
+        self.emit(Op::ListFold { node_id_idx: nid });
     }
 
     // ── Iter[T] operations (#364) ─────────────────────────────────────────

--- a/crates/lex-bytecode/src/escape.rs
+++ b/crates/lex-bytecode/src/escape.rs
@@ -445,9 +445,15 @@ fn step(pc: usize, op: &Op, mut s: State) -> (State, Vec<usize>, HashSet<u32>) {
             pop_n_leak(&mut s, *arity as usize + 1, &mut escapes);
             s.stack.push(Slot::Other);
         }
-        Op::SortByKey { .. } | Op::ParallelMap { .. } => {
+        Op::SortByKey { .. } | Op::ParallelMap { .. }
+        | Op::ListMap { .. } | Op::ListFilter { .. } => {
             // pop [xs, f]; both escape
             pop_n_leak(&mut s, 2, &mut escapes);
+            s.stack.push(Slot::Other);
+        }
+        Op::ListFold { .. } => {
+            // pop [xs, init, f]; all escape into the native op
+            pop_n_leak(&mut s, 3, &mut escapes);
             s.stack.push(Slot::Other);
         }
         Op::EffectCall { arity, .. } => {

--- a/crates/lex-bytecode/src/op.rs
+++ b/crates/lex-bytecode/src/op.rs
@@ -132,6 +132,23 @@ pub enum Op {
     /// runtime with `VmError::Effect`. The per-thread effect handler
     /// split is queued as slice 2.
     ParallelMap { node_id_idx: u32 },
+    /// Map a list (#464 list-builder fast path). Stack: `[xs, f]` (xs
+    /// underneath). Pops the closure `f` and list `xs`, applies `f` to
+    /// each element, pushes the result list. Native opcode (mirrors
+    /// `SortByKey`/`ParallelMap`) rather than an inlined bytecode loop:
+    /// the loop form re-`LoadLocal`'d (cloned) the whole input and
+    /// accumulator lists each iteration — O(n²) — whereas the VM here
+    /// owns `xs` and builds the output with one pre-sized allocation.
+    ListMap { node_id_idx: u32 },
+    /// Filter a list (#464). Stack: `[xs, pred]`. Pops `pred` and `xs`,
+    /// keeps the elements for which `pred(x)` is true. Native, same
+    /// rationale as `ListMap`.
+    ListFilter { node_id_idx: u32 },
+    /// Left-fold a list (#464). Stack: `[xs, init, f]` (xs deepest).
+    /// Pops `f`, `init`, `xs`; threads `acc = f(acc, x)` from `init`
+    /// over the elements; pushes the final `acc`. Native, same
+    /// rationale as `ListMap`.
+    ListFold { node_id_idx: u32 },
     /// EFFECT_CALL `<effect_kind_const_idx>` `<op_name_const_idx>` `<arity>`.
     /// Pops `arity` args, dispatches to a host effect handler, pushes result.
     /// `node_id_idx` points to a `Const::NodeId` for trace keying.

--- a/crates/lex-bytecode/src/verify.rs
+++ b/crates/lex-bytecode/src/verify.rs
@@ -205,6 +205,11 @@ fn stack_delta(op: &Op) -> i32 {
         // Higher-order ops: pop list + fn, push result list
         Op::SortByKey { .. }  => -1,
         Op::ParallelMap { .. }=> -1,
+        // #464 native list builders. map/filter pop [xs, f] push 1;
+        // fold pops [xs, init, f] push 1.
+        Op::ListMap { .. }    => -1,
+        Op::ListFilter { .. } => -1,
+        Op::ListFold { .. }   => -2,
 
         // Terminators
         Op::Return  => -1,  // pop return value

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -1726,6 +1726,73 @@ impl<'a> Vm<'a> {
                     let results = par_map_run(self.program, f, items.into_iter().collect(), worker_handlers)?;
                     self.stack.push(Value::List(results.into()));
                 }
+                Op::ListMap { node_id_idx: _ } => {
+                    // #464: native map. Owns `xs` (no per-iteration
+                    // clone of the input or accumulator that the old
+                    // inlined `LoadLocal`-based loop incurred) and
+                    // builds the output with one pre-sized allocation.
+                    let f = self.pop()?;
+                    let xs = self.pop()?;
+                    let items = match xs {
+                        Value::List(v) => v,
+                        other => return Err(VmError::TypeMismatch(
+                            format!("ListMap requires a List, got: {other:?}"))),
+                    };
+                    if !matches!(f, Value::Closure { .. }) {
+                        return Err(VmError::TypeMismatch(
+                            format!("ListMap requires a closure, got: {f:?}")));
+                    }
+                    let mut out: VecDeque<Value> = VecDeque::with_capacity(items.len());
+                    for item in items {
+                        out.push_back(self.invoke_closure_value(f.clone(), vec![item])?);
+                    }
+                    self.stack.push(Value::List(out));
+                }
+                Op::ListFilter { node_id_idx: _ } => {
+                    // #464: native filter. Pred is applied to a clone
+                    // of each element; the original element is kept on
+                    // a true result.
+                    let f = self.pop()?;
+                    let xs = self.pop()?;
+                    let items = match xs {
+                        Value::List(v) => v,
+                        other => return Err(VmError::TypeMismatch(
+                            format!("ListFilter requires a List, got: {other:?}"))),
+                    };
+                    if !matches!(f, Value::Closure { .. }) {
+                        return Err(VmError::TypeMismatch(
+                            format!("ListFilter requires a closure, got: {f:?}")));
+                    }
+                    let mut out: VecDeque<Value> = VecDeque::new();
+                    for item in items {
+                        let keep = self.invoke_closure_value(f.clone(), vec![item.clone()])?;
+                        if keep.as_bool() {
+                            out.push_back(item);
+                        }
+                    }
+                    self.stack.push(Value::List(out));
+                }
+                Op::ListFold { node_id_idx: _ } => {
+                    // #464: native left-fold. `acc` is threaded by
+                    // value; each element is moved into the combiner.
+                    let f = self.pop()?;
+                    let init = self.pop()?;
+                    let xs = self.pop()?;
+                    let items = match xs {
+                        Value::List(v) => v,
+                        other => return Err(VmError::TypeMismatch(
+                            format!("ListFold requires a List, got: {other:?}"))),
+                    };
+                    if !matches!(f, Value::Closure { .. }) {
+                        return Err(VmError::TypeMismatch(
+                            format!("ListFold requires a closure, got: {f:?}")));
+                    }
+                    let mut acc = init;
+                    for item in items {
+                        acc = self.invoke_closure_value(f.clone(), vec![acc, item])?;
+                    }
+                    self.stack.push(acc);
+                }
                 Op::Call { fn_id, arity, node_id_idx } => {
                     let mut args: Vec<Value> = (0..arity).map(|_| Value::Unit).collect();
                     for i in (0..arity as usize).rev() { args[i] = self.pop()?; }

--- a/crates/lex-bytecode/tests/list_ops.rs
+++ b/crates/lex-bytecode/tests/list_ops.rs
@@ -1,0 +1,153 @@
+//! #464 — native `list.map` / `list.filter` / `list.fold` opcodes.
+//!
+//! These used to compile to inlined bytecode loops that re-`LoadLocal`'d
+//! (cloned) the whole input and accumulator lists every iteration —
+//! O(n²). They now lower to single native VM opcodes (`Op::ListMap` /
+//! `ListFilter` / `ListFold`), mirroring `SortByKey` / `ParallelMap`.
+//! These tests pin the observable semantics (the runtime-level tests
+//! in lex-runtime exercise the same ops end-to-end in CI).
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, Op, Program, Value, Vm};
+use lex_syntax::parse_source;
+
+fn compile(src: &str) -> Program {
+    let p = parse_source(src).unwrap();
+    let stages = canonicalize_program(&p);
+    lex_types::check_program(&stages).expect("typecheck");
+    compile_program(&stages)
+}
+
+fn run(src: &str, func: &str) -> Value {
+    let p = compile(src);
+    let mut vm = Vm::new(&p);
+    vm.set_step_limit(u64::MAX);
+    vm.call(func, vec![]).unwrap()
+}
+
+fn ints(v: &Value) -> Vec<i64> {
+    match v {
+        Value::List(items) => items.iter().map(|x| match x {
+            Value::Int(n) => *n,
+            other => panic!("expected Int element, got {other:?}"),
+        }).collect(),
+        other => panic!("expected List, got {other:?}"),
+    }
+}
+
+fn op_count<F: Fn(&Op) -> bool>(p: &Program, name: &str, pred: F) -> usize {
+    let idx = p.function_names[name];
+    p.functions[idx as usize].code.iter().filter(|o| pred(o)).count()
+}
+
+#[test]
+fn map_doubles_and_preserves_order() {
+    let src = r#"
+        import "std.list" as list
+        fn m() -> List[Int] {
+          list.map([1, 2, 3, 4], fn(x :: Int) -> Int { x * 2 })
+        }
+    "#;
+    let p = compile(src);
+    // Lowered to a single native op, with no leftover inlined-loop ops.
+    assert_eq!(op_count(&p, "m", |o| matches!(o, Op::ListMap { .. })), 1);
+    assert_eq!(op_count(&p, "m", |o| matches!(o, Op::ListAppend)), 0,
+        "no inlined ListAppend loop should remain");
+    let mut vm = Vm::new(&p);
+    vm.set_step_limit(u64::MAX);
+    assert_eq!(ints(&vm.call("m", vec![]).unwrap()), vec![2, 4, 6, 8]);
+}
+
+#[test]
+fn map_over_empty_list() {
+    let src = r#"
+        import "std.list" as list
+        fn m(xs :: List[Int]) -> List[Int] {
+          list.map(xs, fn(x :: Int) -> Int { x + 1 })
+        }
+    "#;
+    let p = compile(src);
+    let mut vm = Vm::new(&p);
+    vm.set_step_limit(u64::MAX);
+    let r = vm.call("m", vec![Value::List(Default::default())]).unwrap();
+    assert_eq!(ints(&r), Vec::<i64>::new());
+}
+
+#[test]
+fn filter_keeps_matching_in_order() {
+    let src = r#"
+        import "std.list" as list
+        fn f() -> List[Int] {
+          list.filter([1, 2, 3, 4, 5], fn(x :: Int) -> Bool { x > 2 })
+        }
+    "#;
+    let p = compile(src);
+    assert_eq!(op_count(&p, "f", |o| matches!(o, Op::ListFilter { .. })), 1);
+    assert_eq!(ints(&run(src, "f")), vec![3, 4, 5]);
+}
+
+#[test]
+fn filter_can_drop_everything() {
+    let src = r#"
+        import "std.list" as list
+        fn f() -> List[Int] {
+          list.filter([1, 2, 3], fn(x :: Int) -> Bool { x > 100 })
+        }
+    "#;
+    assert_eq!(ints(&run(src, "f")), Vec::<i64>::new());
+}
+
+#[test]
+fn fold_sums() {
+    let src = r#"
+        import "std.list" as list
+        fn s() -> Int {
+          list.fold([1, 2, 3, 4], 0, fn(acc :: Int, x :: Int) -> Int { acc + x })
+        }
+    "#;
+    let p = compile(src);
+    assert_eq!(op_count(&p, "s", |o| matches!(o, Op::ListFold { .. })), 1);
+    assert_eq!(run(src, "s"), Value::Int(10));
+}
+
+#[test]
+fn fold_is_left_associative() {
+    // ((((0*10+1)*10+2)*10+3) = 123 — a non-commutative combiner pins
+    // the left-to-right order.
+    let src = r#"
+        import "std.list" as list
+        fn s() -> Int {
+          list.fold([1, 2, 3], 0, fn(acc :: Int, x :: Int) -> Int { acc * 10 + x })
+        }
+    "#;
+    assert_eq!(run(src, "s"), Value::Int(123));
+}
+
+#[test]
+fn fold_over_empty_returns_init() {
+    let src = r#"
+        import "std.list" as list
+        fn s(xs :: List[Int]) -> Int {
+          list.fold(xs, 42, fn(acc :: Int, x :: Int) -> Int { acc + x })
+        }
+    "#;
+    let p = compile(src);
+    let mut vm = Vm::new(&p);
+    vm.set_step_limit(u64::MAX);
+    let r = vm.call("s", vec![Value::List(Default::default())]).unwrap();
+    assert_eq!(r, Value::Int(42));
+}
+
+#[test]
+fn nested_map_then_fold() {
+    let src = r#"
+        import "std.list" as list
+        fn pipeline() -> Int {
+          let doubled := list.map([1, 2, 3, 4], fn(x :: Int) -> Int { x * 2 })
+          let big := list.filter(doubled, fn(x :: Int) -> Bool { x > 3 })
+          list.fold(big, 0, fn(acc :: Int, x :: Int) -> Int { acc + x })
+        }
+    "#;
+    // doubled = [2,4,6,8]; big = [4,6,8]; sum = 18.
+    assert_eq!(run(src, "pipeline"), Value::Int(18));
+}


### PR DESCRIPTION
## Summary

The reprofile (after records + tuples were stack-allocated) found list-heavy code dominated by an **O(n²) clone**, not allocation. The inlined `list.map`/`filter`/`fold` loops did `out := out ++ [x]`, and each `LoadLocal` of the input (`xs`) and accumulator (`out`) **cloned the whole `VecDeque` every iteration** (`vm.rs` `LoadLocal` clones). `ListAppend` itself was fine (in-place `push_back`); the clone was upstream.

Fix: replace the inlined bytecode loops with single **native VM opcodes** — `Op::ListMap` / `ListFilter` / `ListFold` — mirroring the existing `Op::SortByKey` / `ParallelMap`. The VM owns the popped list, iterates **by value** (no per-iteration list clone), and builds the output with one pre-sized allocation via `invoke_closure_value` per element. O(n).

## Measured

callgrind, `profile_list_build 120 3` (chain of `map`/`map`/`map`/`fold` over 4-element lists), before/after **verified reproducibly via a worktree at the parent commit**:

| | I-refs |
|---|---|
| before (inlined loops) | 39,740,803 |
| after (native ops) | 15,156,147 |
| **Δ** | **−62% instructions** |

The win is both the eliminated O(n²) `VecDeque` clones *and* removing the ~15-op-per-element bytecode-loop dispatch through `run_to`.

## body_hash / closure identity

This is **uniform** primary codegen — every `list.map` site now emits `ListMap` — so closure identity (#222) is preserved with no special-case (and `body_hash` is in-process-only per INVARIANTS.md). No conditional-codegen ambiguity like the escape-lowering/peephole passes that *do* need hash special-cases.

## Tests
- [x] `crates/lex-bytecode/tests/list_ops.rs` (8): map order + empty, filter keep / drop-all, fold sum / left-associativity / empty→init, a nested `map→filter→fold` pipeline; asserts the native op is emitted with **no leftover inlined `ListAppend` loop** (structural regression gate).
- [x] full `lex-bytecode` suite green (39 unit + 8 list_ops + 9 stack_records + 7 stack_tuples + rest); `lex-trace` green.
- [ ] `cargo test --workspace` — deferred to CI (dev-container disk). The runtime-level `std.list` tests in lex-runtime exercise these ops end-to-end there.

## Notes
- Builds on #539/#540/#541 (merged). Branch force-pushed (with lease), re-based on merged `main` for a clean per-slice diff.

https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk)_