### PR TITLE
perf(#464): drop the per-call args Vec in Op::TailCall (−18% on tail-recursive loops)

### DIFF
--- a/crates/lex-bytecode/examples/profile_tailrec.rs
+++ b/crates/lex-bytecode/examples/profile_tailrec.rs
@@ -1,0 +1,56 @@
+//! Callgrind harness for a tail-recursive loop workload (#464
+//! call-overhead). An accumulator countdown that the compiler lowers
+//! to `Op::TailCall` (tail position in a `match` arm, see
+//! compiler.rs:207 + compile_match): the recursive call reuses the
+//! current frame instead of pushing a new one, so deep recursion runs
+//! in constant stack. This is the idiomatic shape for loops in Lex, and
+//! the path that — before #464 — allocated a fresh args Vec per tail
+//! call. Both `drive -> sum_to` and `sum_to -> sum_to` are tail calls,
+//! so the run is dominated by `Op::TailCall`.
+//!
+//!   cargo build --release --example profile_tailrec -p lex-bytecode
+//!   valgrind --tool=callgrind --callgrind-out-file=cg.tail \
+//!     target/release/examples/profile_tailrec 20000 3
+//!
+//! Args: <n> <iters>. Defaults 20000 3.
+
+use std::sync::Arc;
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::vm::Vm;
+use lex_bytecode::{compile_program, Value};
+use lex_syntax::parse_source;
+
+const SRC: &str = r#"
+fn sum_to(n :: Int, acc :: Int) -> Int {
+  match n {
+    0 => acc,
+    _ => sum_to(n - 1, acc + n),
+  }
+}
+
+fn drive(n :: Int) -> Int {
+  sum_to(n, 0)
+}
+"#;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let n: i64 = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(20000);
+    let iters: u64 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(3);
+
+    let prog = parse_source(SRC).expect("parse");
+    let stages = canonicalize_program(&prog);
+    lex_types::check_program(&stages).expect("typecheck");
+    let p = Arc::new(compile_program(&stages));
+
+    let mut acc = 0i64;
+    for _ in 0..iters {
+        let mut vm = Vm::new(&p);
+        vm.set_step_limit(u64::MAX);
+        if let Value::Int(v) = vm.call("drive", vec![Value::Int(n)]).unwrap() {
+            acc = acc.wrapping_add(v);
+        }
+    }
+    std::process::exit((acc & 0x7f) as i32);
+}

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -1944,26 +1944,34 @@ impl<'a> Vm<'a> {
                     })?;
                 }
                 Op::TailCall { fn_id, arity, node_id_idx } => {
-                    let mut args: Vec<Value> = (0..arity).map(|_| Value::Unit).collect();
-                    for i in (0..arity as usize).rev() { args[i] = self.pop()?; }
+                    let arity = arity as usize;
+                    let fid = fn_id as usize;
+                    // Args sit on the value stack at [args_base..]. Read
+                    // them in place for the refinement / trace checks and
+                    // move them into the reused frame's locals at the end
+                    // — no per-call args Vec (#464). Tail calls have no
+                    // memoization, so the consumers are refinement, trace,
+                    // then the locals move. The args live on `self.stack`
+                    // while locals live on `self.locals_storage`, so the
+                    // `truncate(old_locals_start)` below (which releases
+                    // the *old* frame's locals) doesn't touch them.
+                    let args_base = self.stack.len() - arity;
                     let node_id = const_str(&self.program.constants, node_id_idx);
-                    let budget_cost = call_budget_cost(&self.program.functions[fn_id as usize]);
+                    let budget_cost = call_budget_cost(&self.program.functions[fid]);
                     if budget_cost > 0 {
                         self.handler.note_call_budget(budget_cost)
                             .map_err(VmError::Effect)?;
                     }
                     // Refinement runtime check on tail calls too
-                    // (#209 slice 3). Same shape as Op::Call —
-                    // iterate by reference to avoid a per-call Vec
-                    // allocation (#461).
-                    let refinements = &self.program.functions[fn_id as usize].refinements;
+                    // (#209 slice 3). Same shape as Op::Call.
+                    let refinements = &self.program.functions[fid].refinements;
                     for (i, refinement) in refinements.iter().enumerate() {
                         if let Some(r) = refinement {
-                            let arg = args.get(i).cloned().unwrap_or(Value::Unit);
+                            let arg = self.stack[args_base + i].clone();
                             match eval_refinement(&r.predicate, &r.binding, &arg) {
                                 Ok(true) => {}
                                 Ok(false) => return Err(VmError::RefinementFailed {
-                                    fn_name: self.program.functions[fn_id as usize].name.clone(),
+                                    fn_name: self.program.functions[fid].name.clone(),
                                     param_index: i,
                                     binding: r.binding.clone(),
                                     reason: format!(
@@ -1971,7 +1979,7 @@ impl<'a> Vm<'a> {
                                         r.binding),
                                 }),
                                 Err(reason) => return Err(VmError::RefinementFailed {
-                                    fn_name: self.program.functions[fn_id as usize].name.clone(),
+                                    fn_name: self.program.functions[fid].name.clone(),
                                     param_index: i,
                                     binding: r.binding.clone(),
                                     reason,
@@ -1983,18 +1991,20 @@ impl<'a> Vm<'a> {
                     // opens a new one in its place — preserves the caller's
                     // tree depth in the trace.
                     self.tracer.exit_call_tail();
-                    self.tracer.enter_call(&node_id, &self.program.functions[fn_id as usize].name, &args);
-                    let f = &self.program.functions[fn_id as usize];
+                    self.tracer.enter_call(&node_id, &self.program.functions[fid].name, &self.stack[args_base..]);
                     // Reuse the current frame's locals_start position:
                     // truncate to release old locals then extend for the
                     // new function (#389 slice 3, same as Op::Return but
                     // without popping the frame).
                     let old_locals_start = self.frames.last().unwrap().locals_start;
                     self.locals_storage.truncate(old_locals_start);
-                    let new_locals_len = f.locals_count.max(f.arity) as usize;
+                    let new_locals_len = self.program.functions[fid].locals_count
+                        .max(self.program.functions[fid].arity) as usize;
                     self.locals_storage.resize(old_locals_start + new_locals_len, Value::Unit);
-                    for (i, v) in args.into_iter().enumerate() {
-                        self.locals_storage[old_locals_start + i] = v;
+                    // Move the args off the value stack into the callee's
+                    // locals (popping leaves the stack at `args_base`).
+                    for i in (0..arity).rev() {
+                        self.locals_storage[old_locals_start + i] = self.pop()?;
                     }
                     // #464 step 2: a tail-called function gets a fresh
                     // stack-record arena view. Release any records the


### PR DESCRIPTION
## Summary

Follow-up to #549, applying the same reorder to `Op::TailCall`. Instead of allocating a fresh `Vec<Value>` of `arity` slots per tail call, keep the args on the value stack and read them **in place** (`self.stack[args_base + i]`) for the refinement check and tracer, then move them into the reused frame's locals at the end.

`TailCall` has no memoization, so there's no early-exit cleanup — a refinement failure aborts the VM. The args live on `self.stack` while locals live on the separate `self.locals_storage`, so the `truncate(old_locals_start)` that releases the *old* frame's locals never touches the pending args.

## Measured (callgrind, `20000 3`)

| | instructions | |
|---|---|---|
| before (main) | 109,904,175 | |
| after | 89,620,859 | **−18.46%** |

Why so much larger than #549's −1.86%: in this workload each tail call does almost no *other* work (just integer arithmetic), so the args `Vec` malloc/free was a big fraction of the total. The annotation confirms it — `malloc`/`free`/`_int_free` are all **roughly halved**. **Loop-heavy Lex code benefits most, since loops are tail recursion.**

## New benchmark: `profile_tailrec`

The existing record/list benches use *non-tail* recursion (`r + drive(n-1)`) and never execute `Op::TailCall`, so this op was previously unmeasured. The new bench is an accumulator countdown the compiler lowers to `TailCall` (tail position in a `match` arm — confirmed via compiler.rs:207 + `compile_match`):

```lex
fn sum_to(n :: Int, acc :: Int) -> Int {
  match n { 0 => acc, _ => sum_to(n - 1, acc + n) }
}
fn drive(n :: Int) -> Int { sum_to(n, 0) }
```

Both `drive→sum_to` and `sum_to→sum_to` are tail calls, so the run is `TailCall`-dominated. It runs 20000-deep in **constant stack** — no overflow is itself proof the tail-call path is taken (plain calls would blow the stack) — and the result is verified (`sum_to(20000)=200010000`).

## Scope / thread status

Call-overhead args-Vec elimination now covers `Op::Call` (#549) and `Op::TailCall` (this). **`CallClosure` still builds a Vec** — it concatenates `captures ++ args` for `invoke`, a different shape — remaining follow-up.

## Test plan
- [x] full `lex-bytecode` suite green (13 binaries) — factorial recursion, memo, refinements, 45 call tests
- [x] `profile_tailrec` runs 20000-deep without overflow and returns the correct sum (exit code 48 = `(3 × 200010000) & 0x7f`)
- [ ] `cargo test --workspace` — deferred to CI

## Notes
- Continues the call-overhead thread: #543 (closure path), #548 (name clones), #549 (Op::Call args Vec).

https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk)_