### PR TITLE
perf(#464): drop the per-call args Vec in Op::CallClosure (−23% on closure calls)

### DIFF
--- a/crates/lex-bytecode/examples/profile_closure_call.rs
+++ b/crates/lex-bytecode/examples/profile_closure_call.rs
@@ -1,0 +1,58 @@
+//! Callgrind harness for a closure-call workload (#464 call-overhead).
+//! A function-typed parameter `f` is invoked directly — `f(n)` where
+//! `f` is a local — which the compiler lowers to `Op::CallClosure`
+//! (compiler.rs:1088), the path that allocates a per-call args Vec and
+//! concatenates `captures ++ args`. The closure `g` captures `base`, so
+//! the captures slice is non-empty and the captures-into-locals path is
+//! exercised too. `list.map`/`fold` use the native invoke_closure_* fast
+//! path instead, so a directly-called function-typed param is the way to
+//! drive Op::CallClosure.
+//!
+//!   cargo build --release --example profile_closure_call -p lex-bytecode
+//!   valgrind --tool=callgrind --callgrind-out-file=cg.cc \
+//!     target/release/examples/profile_closure_call 20000 3
+//!
+//! Args: <n> <iters>. Defaults 20000 3.
+
+use std::sync::Arc;
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::vm::Vm;
+use lex_bytecode::{compile_program, Value};
+use lex_syntax::parse_source;
+
+const SRC: &str = r#"
+fn sum_apply(f :: (Int) -> Int, n :: Int, acc :: Int) -> Int {
+  match n {
+    0 => acc,
+    _ => sum_apply(f, n - 1, acc + f(n) + f(n + 1)),
+  }
+}
+
+fn drive(n :: Int) -> Int {
+  let base := n + 7
+  let g := fn(x :: Int) -> Int { x * 2 + base }
+  sum_apply(g, n, 0)
+}
+"#;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let n: i64 = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(20000);
+    let iters: u64 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(3);
+
+    let prog = parse_source(SRC).expect("parse");
+    let stages = canonicalize_program(&prog);
+    lex_types::check_program(&stages).expect("typecheck");
+    let p = Arc::new(compile_program(&stages));
+
+    let mut acc = 0i64;
+    for _ in 0..iters {
+        let mut vm = Vm::new(&p);
+        vm.set_step_limit(u64::MAX);
+        if let Value::Int(v) = vm.call("drive", vec![Value::Int(n)]).unwrap() {
+            acc = acc.wrapping_add(v);
+        }
+    }
+    std::process::exit((acc & 0x7f) as i32);
+}

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -1652,29 +1652,45 @@ impl<'a> Vm<'a> {
                     self.stack.push(Value::Closure { fn_id, body_hash, captures });
                 }
                 Op::CallClosure { arity, node_id_idx } => {
-                    let mut args: Vec<Value> = (0..arity).map(|_| Value::Unit).collect();
-                    for i in (0..arity as usize).rev() { args[i] = self.pop()?; }
-                    let closure = self.pop()?;
+                    let arity = arity as usize;
+                    // Args sit on the value stack at [args_base..]; the
+                    // closure sits just below them at args_base - 1. Take
+                    // the closure out (leaving a Unit placeholder), then
+                    // write its captures and pop the args directly into
+                    // the callee's locals — no per-call args Vec and no
+                    // `captures.extend(args)` realloc (#464). The combined
+                    // [captures, args] view the tracer wants is exactly
+                    // the contiguous locals slice we just filled.
+                    let args_base = self.stack.len() - arity;
+                    let closure = std::mem::replace(&mut self.stack[args_base - 1], Value::Unit);
                     let (fn_id, captures) = match closure {
                         Value::Closure { fn_id, captures, .. } => (fn_id, captures),
                         other => return Err(VmError::TypeMismatch(format!("CallClosure on non-closure: {other:?}"))),
                     };
+                    let fid = fn_id as usize;
                     let node_id = const_str(&self.program.constants, node_id_idx);
-                    let budget_cost = call_budget_cost(&self.program.functions[fn_id as usize]);
+                    let budget_cost = call_budget_cost(&self.program.functions[fid]);
                     if budget_cost > 0 {
                         self.handler.note_call_budget(budget_cost)
                             .map_err(VmError::Effect)?;
                     }
-                    let mut combined = captures;
-                    combined.extend(args);
-                    self.tracer.enter_call(&node_id, &self.program.functions[fn_id as usize].name, &combined);
-                    let f = &self.program.functions[fn_id as usize];
+                    let cap_n = captures.len();
                     let locals_start = self.locals_storage.len();
-                    let locals_len = f.locals_count.max(f.arity) as usize;
+                    let locals_len = self.program.functions[fid].locals_count
+                        .max(self.program.functions[fid].arity) as usize;
                     self.locals_storage.resize(locals_start + locals_len, Value::Unit);
-                    for (i, v) in combined.into_iter().enumerate() {
+                    for (i, v) in captures.into_iter().enumerate() {
                         self.locals_storage[locals_start + i] = v;
                     }
+                    // Move the args off the value stack into the locals
+                    // following the captures (popping leaves the args off
+                    // the stack; the closure's Unit placeholder is then
+                    // the top, so truncate it away).
+                    for i in (0..arity).rev() {
+                        self.locals_storage[locals_start + cap_n + i] = self.pop()?;
+                    }
+                    self.stack.truncate(args_base - 1);
+                    self.tracer.enter_call(&node_id, &self.program.functions[fid].name, &self.locals_storage[locals_start..locals_start + cap_n + arity]);
                     self.push_frame(Frame {
                         fn_id, pc: 0, locals_start, locals_len,
                         stack_base: self.stack.len(),


### PR DESCRIPTION
## Summary

The last of the call-overhead args-`Vec` eliminations (after `Op::Call` #549, `Op::TailCall` #550). `CallClosure` was the **worst offender**: it allocated a per-call args `Vec` *and* concatenated `captures ++ args` via `combined.extend(args)`, which reallocated the captures `Vec` to make room.

The closure sits just below the args on the value stack, so take it out with `mem::replace` (leaving a `Unit` placeholder), then write its captures and pop the args **directly into the callee's locals** — the `[captures, args]` layout the frame needs is built in place, and the contiguous locals slice doubles as the combined-args view for the tracer. Drop the placeholder (now the stack top) afterwards. No args `Vec`, no `extend` realloc.

## Measured (callgrind, `20000 3`)

| | instructions | |
|---|---|---|
| before (main) | 482,543,936 | |
| after | 371,066,424 | **−23.10%** |

The annotation tells the story — both allocation costs vanish:
- `_int_realloc` (the `captures.extend(args)`): **8.8M → gone entirely**
- `_int_malloc` (the args Vec): drops out of the top
- `_int_free` 32.2M → 19.5M, `malloc` 21.5M → 16.1M

Result is **identical** before/after (exit codes 64 / 16). This is the biggest win of the thread because `CallClosure` paid *two* per-call allocations, not one.

## New benchmark: `profile_closure_call`

The existing benches never execute `CallClosure` — `list.map`/`fold` use the native `invoke_closure_*` fast path. A function-typed parameter invoked directly (`f(n)` where `f` is a local) is what lowers to `Op::CallClosure` (compiler.rs:1088). The closure captures `base`, so the captures-into-locals path is non-empty:

```lex
fn sum_apply(f :: (Int) -> Int, n :: Int, acc :: Int) -> Int {
  match n { 0 => acc, _ => sum_apply(f, n - 1, acc + f(n) + f(n + 1)) }
}
fn drive(n :: Int) -> Int {
  let base := n + 7
  let g := fn(x :: Int) -> Int { x * 2 + base }
  sum_apply(g, n, 0)
}
```

## Thread complete

Call-overhead args-`Vec` elimination now covers all three call ops:

| op | PR | win |
|---|---|---|
| `Op::Call` | #549 | −1.86% record / −1.04% list |
| `Op::TailCall` | #550 | −18% tail-recursive loops |
| `Op::CallClosure` | this | −23% closure calls |

(plus #543 closure-invoke path, #548 lazy name clones.)

## Test plan
- [x] full `lex-bytecode` suite green (13 binaries) — incl. `closures_in_records`, `closure_canonicality`
- [x] `profile_closure_call` returns identical results before/after the change
- [ ] `cargo test --workspace` — deferred to CI

https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk)_