### PR TITLE
Make Polars (std.df) an optional `df` feature so embedders build without it

### DIFF
--- a/crates/lex-api/Cargo.toml
+++ b/crates/lex-api/Cargo.toml
@@ -20,7 +20,12 @@ lex-syntax = { path = "../lex-syntax", version = "0.9.5" }
 lex-ast = { path = "../lex-ast", version = "0.9.5" }
 lex-types = { path = "../lex-types", version = "0.9.5" }
 lex-bytecode = { path = "../lex-bytecode", version = "0.9.5" }
-lex-runtime = { path = "../lex-runtime", version = "0.9.5" }
+# `default-features = false` drops the `df` (Polars) feature: lex-api
+# and its embedders (lex-hub) never call `std.df`, and polars pulls a
+# heavy dep tree that has conflicted on `chrono`. `std.arrow` is
+# unaffected. Workspace builds that include lex-cli still get `df` via
+# feature unification, so the toolchain is unchanged.
+lex-runtime = { path = "../lex-runtime", version = "0.9.5", default-features = false }
 lex-store = { path = "../lex-store", version = "0.9.5" }
 lex-trace = { path = "../lex-trace", version = "0.9.5" }
 lex-vcs = { path = "../lex-vcs", version = "0.9.5" }

--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -68,12 +68,20 @@ parquet = { version = "58", default-features = false, features = ["arrow", "snap
 # `strings`; add `temporal` explicitly so `strings`'s string ops still
 # compile. Found the hard way during the arrow-55→58 / polars-0.50→0.53
 # coordinated bump.
-polars = { version = "0.53", default-features = false, features = ["lazy", "is_in", "csv", "performant", "strings", "temporal"] }
+polars = { version = "0.53", optional = true, default-features = false, features = ["lazy", "is_in", "csv", "performant", "strings", "temporal"] }
 lex-bytecode = { path = "../lex-bytecode", version = "0.9.5" }
 smol_str = { workspace = true }
 
 [features]
-default = []
+default = ["df"]
+# `df` gates the Polars-backed `std.df` query ops (filter / sort /
+# group_by / join). Polars pulls a heavy dep tree (polars-arrow, …)
+# that embedders like lex-hub don't need and that has conflicted on
+# `chrono`'s `std` feature in the past. On by default for the `lex`
+# toolchain; API/embedder consumers drop it with
+# `default-features = false`. `std.arrow` (arrow-rs) stays available
+# regardless — only the polars-backed query layer is gated.
+df = ["dep:polars"]
 # `quic` brings in quinn / h3 / rcgen / rustls + rustls-pemfile. Off
 # by default to keep `cargo build` slim; enable with `--features quic`
 # to use `net.serve_quic`, `tls.from_pem_files`, or `tls.self_signed`.

--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -1614,11 +1614,19 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             Some(r) => r,
             None => Err(format!("unknown pure builtin: arrow.{op}")),
         },
-        // -- df -- Polars-backed query ops (#427)
+        // -- df -- Polars-backed query ops (#427), gated behind the
+        // `df` feature so embedders that don't need dataframes avoid
+        // the polars dep tree.
+        #[cfg(feature = "df")]
         ("df", op) => match crate::df::dispatch(op, args) {
             Some(r) => r,
             None => Err(format!("unknown pure builtin: df.{op}")),
         },
+        #[cfg(not(feature = "df"))]
+        ("df", op) => Err(format!(
+            "df.{op}: this build was compiled without the `df` feature; \
+             Polars-backed dataframe query ops are unavailable"
+        )),
 
         _ => Err(format!("unknown pure builtin: {kind}.{op}")),
     }

--- a/crates/lex-runtime/src/lib.rs
+++ b/crates/lex-runtime/src/lib.rs
@@ -16,6 +16,7 @@
 pub mod arena;
 pub mod arrow;
 pub mod builtins;
+#[cfg(feature = "df")]
 pub mod df;
 pub mod cli;
 pub mod policy;

--- a/crates/lex-runtime/tests/std_df.rs
+++ b/crates/lex-runtime/tests/std_df.rs
@@ -1,6 +1,10 @@
 //! Integration tests for `std.df` (#427). Each test builds an
 //! `arrow.Table` via `std.arrow`, runs a Polars-backed kernel, and
 //! checks the resulting Table shape / values.
+//!
+//! Gated on the `df` feature (Polars). With `--no-default-features`
+//! the `std.df` ops aren't compiled in, so these tests are skipped.
+#![cfg(feature = "df")]
 
 use lex_ast::canonicalize_program;
 use lex_bytecode::{compile_program, vm::Vm, Value};


### PR DESCRIPTION
## Summary
`polars` (and its `polars-arrow` tree) was an **unconditional** dependency of `lex-runtime`, but it's only used by `std.df` (the `df` module, 31 refs — zero polars usage anywhere else). That tree is heavy and has conflicted on `chrono`'s `std` feature — which is exactly what blocked **lex-hub** from bumping its lex-api pin to pick up the security ceiling (lex-hub#11 / #6).

This makes polars optional, mirroring the existing `quic` feature pattern:

- `polars` is now `optional = true` behind a **`df`** feature, **on by default** (`default = ["df"]`), so the `lex` toolchain is unchanged.
- The `df` module and its dispatch arm are `#[cfg(feature = "df")]`-gated; with the feature off, `df.*` ops return a clean `"compiled without the df feature"` error.
- **`std.arrow` (Apache `arrow-rs`) is unaffected** and stays available regardless — only the polars-backed query layer is gated. (`Value::ArrowTable` lives in lex-bytecode and keeps `arrow-array`/`arrow-schema`, which don't have the chrono conflict.)
- **lex-api** sets `default-features = false` on lex-runtime, so API/embedder consumers (lex-hub) build polars-free. The lex-lang workspace still gets `df` via lex-cli's default-feature dependency (feature unification), so workspace builds/tests are unchanged.

## Why this matters
Unblocks the full fix for the `/v1/run` RCE: once this is released, lex-hub can bump its lex-api pin (no more chrono conflict), wire `State::new_with_tenant_and_ceiling`, and drop the interim 403 — running `/v1/run` under a real server-imposed sandbox instead of disabling it.

## Test plan
- [x] `cargo build -p lex-runtime --no-default-features` → compiles with **no polars** (gating correct)
- [x] `cargo test -p lex-runtime --test std_df` (df on, default) → **16/16 pass** (no regression)
- [x] Out-of-workspace consumer of lex-api (path dep, simulating lex-hub) resolves **0 polars crates**; `arrow-array` remains as expected
- [ ] Final confirmation: lex-hub bumps the pin to a release carrying this and builds polars-free (follow-up)

## Notes
- Fully removing *arrow* from embedders would be a larger change (it's structural in `lex-bytecode`'s `Value::ArrowTable`); out of scope here since arrow-rs doesn't carry the conflict. Happy to do it separately if you want embedders fully dataframe-free.

https://claude.ai/code/session_01KYmz1jwh7vPrJJzbKhmvpY

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYmz1jwh7vPrJJzbKhmvpY)_