### PR TITLE
Hardening: document/​detect the empty-scope allow-any footgun (#552) and escape lex-tea page title (#553)

### DIFF
--- a/crates/lex-api/src/web.rs
+++ b/crates/lex-api/src/web.rs
@@ -79,6 +79,11 @@ fn html_response(status: u16, body: String) -> Response<Cursor<Vec<u8>>> {
 /// highlighted (one of "/", "/web/branches", "/web/trust",
 /// "/web/attention"); for detail pages pass `""`.
 fn page(title: &str, current: &str, body: &str) -> String {
+    // `title` is interpolated into the <title> element below; it can
+    // carry store-derived text (fn names, branch names), so escape it.
+    // `body` is already-rendered HTML built by the callers (each
+    // escapes its own dynamic fields), so it is intentionally raw.
+    let title = esc(title);
     let nav_link = |href: &str, label: &str| -> String {
         let class = if current == href { "current" } else { "" };
         format!(r#"<a href="{href}" class="{class}">{label}</a>"#)
@@ -873,5 +878,26 @@ fn result_short(r: &AttestationResult) -> (&'static str, &'static str) {
         AttestationResult::Passed => ("passed", "ok"),
         AttestationResult::Failed { .. } => ("failed", "fail"),
         AttestationResult::Inconclusive { .. } => ("inconclusive", "inc"),
+    }
+}
+
+#[cfg(test)]
+mod xss_tests {
+    use super::*;
+
+    #[test]
+    fn page_escapes_title() {
+        // A store-derived title (fn/branch name) must not be able to
+        // break out of the <title> element.
+        let html = page("</title><script>alert(1)</script>", "/", "<p>body</p>");
+        assert!(!html.contains("<script>"), "title must not inject a raw <script>");
+        assert!(html.contains("&lt;script&gt;"), "title angle brackets must be escaped");
+        // The caller-built body is intentionally raw HTML and untouched.
+        assert!(html.contains("<p>body</p>"));
+    }
+
+    #[test]
+    fn esc_covers_html_metacharacters() {
+        assert_eq!(esc(r#"<a href="x">&y"#), "&lt;a href=&quot;x&quot;&gt;&amp;y");
     }
 }

--- a/crates/lex-runtime/src/policy.rs
+++ b/crates/lex-runtime/src/policy.rs
@@ -13,11 +13,27 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
-/// Policy a program is run under. Empty allowlist = pure-only execution.
+/// Policy a program is run under. Empty `allow_effects` = pure-only
+/// execution.
+///
+/// **Wildcard scopes (read before embedding):** the scope lists
+/// (`allow_fs_read`, `allow_fs_write`, `allow_net_host`, `allow_proc`)
+/// follow an **empty = allow ANY** convention, *not* empty = deny.
+/// Granting a scoped effect in `allow_effects` while leaving its scope
+/// list empty therefore opens the *unrestricted* form (any path / host
+/// / binary). That's intentional for trusted local use (`lex run`),
+/// but it's a footgun for embedders that build a `Policy` from
+/// untrusted input. Such embedders should populate the scope list for
+/// every kind they grant, or call [`Policy::wildcard_scoped_grants`]
+/// to detect the wide-open ones and refuse them. (#552)
 #[derive(Debug, Clone, Default)]
 pub struct Policy {
     pub allow_effects: BTreeSet<String>,
+    /// Path scope for the `[fs_read]` effect. **Empty = any path**
+    /// (wildcard), not deny — see the type-level note above (#552).
     pub allow_fs_read: Vec<PathBuf>,
+    /// Path scope for the `[fs_write]` effect. **Empty = any path**
+    /// (wildcard), not deny — see the type-level note above (#552).
     pub allow_fs_write: Vec<PathBuf>,
     /// Per-host scope on the [net] effect. Empty = any host (when
     /// [net] is in `allow_effects`); non-empty = only requests to
@@ -39,6 +55,33 @@ pub struct Policy {
 
 impl Policy {
     pub fn pure() -> Self { Self::default() }
+
+    /// Report the granted *scoped* effects whose scope list is empty —
+    /// i.e. the ones the runtime treats as unrestricted ("any"):
+    /// `proc` (any binary), `net` (any host), `fs_read` / `fs_write`
+    /// (any path). Returns an empty vec when no granted kind is left
+    /// wide open.
+    ///
+    /// Intended for embedders that expose execution to untrusted
+    /// callers: build the effective `Policy`, then refuse to run (or
+    /// loudly log) if this returns non-empty. Pure / `time` / `rand`
+    /// grants never appear here — they have no scope. (#552)
+    pub fn wildcard_scoped_grants(&self) -> Vec<&'static str> {
+        let mut open = Vec::new();
+        if self.allow_effects.contains("proc") && self.allow_proc.is_empty() {
+            open.push("proc");
+        }
+        if self.allow_effects.contains("net") && self.allow_net_host.is_empty() {
+            open.push("net");
+        }
+        if self.allow_effects.contains("fs_read") && self.allow_fs_read.is_empty() {
+            open.push("fs_read");
+        }
+        if self.allow_effects.contains("fs_write") && self.allow_fs_write.is_empty() {
+            open.push("fs_write");
+        }
+        open
+    }
 
     pub fn permissive() -> Self {
         let mut s = BTreeSet::new();
@@ -250,4 +293,48 @@ fn parse_grant(s: &str) -> (&str, Option<&str>) {
         return (name, Some(arg));
     }
     (s, None)
+}
+
+#[cfg(test)]
+mod wildcard_tests {
+    use super::*;
+
+    fn effects(kinds: &[&str]) -> BTreeSet<String> {
+        kinds.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn flags_scoped_grants_left_open() {
+        let p = Policy {
+            allow_effects: effects(&["proc", "fs_read", "time"]),
+            ..Policy::default()
+        };
+        let open = p.wildcard_scoped_grants();
+        assert!(open.contains(&"proc"), "empty allow_proc + [proc] is wide open");
+        assert!(open.contains(&"fs_read"), "empty allow_fs_read + [fs_read] is wide open");
+        // `time` has no scope and `net` wasn't granted.
+        assert!(!open.contains(&"time"));
+        assert!(!open.contains(&"net"));
+    }
+
+    #[test]
+    fn populated_scope_is_not_flagged() {
+        let p = Policy {
+            allow_effects: effects(&["fs_read", "net"]),
+            allow_fs_read: vec![PathBuf::from("/srv/data")],
+            allow_net_host: vec!["api.example.com".into()],
+            ..Policy::default()
+        };
+        assert!(p.wildcard_scoped_grants().is_empty());
+    }
+
+    #[test]
+    fn pure_and_unscoped_effects_are_clean() {
+        assert!(Policy::pure().wildcard_scoped_grants().is_empty());
+        let p = Policy {
+            allow_effects: effects(&["time", "rand", "panic"]),
+            ..Policy::default()
+        };
+        assert!(p.wildcard_scoped_grants().is_empty());
+    }
 }


### PR DESCRIPTION
The two remaining lex-lang-side items from the security audit.

## #552 — "empty scope = allow-any" footgun
The runtime scope lists (`allow_fs_read`/`allow_fs_write`/`allow_net_host`/`allow_proc`) treat **empty as "allow any", not deny**. That's intended for trusted local `lex run`, but it's a trap for embedders building a `Policy` from untrusted input.

Changing the default would **break the documented CLI contract** (`--allow-effects fs_read` is meant to grant the kind, optionally narrowed by `--allow-fs-read`), and a struct flag would churn ~20 `Policy {}` construction sites for a benefit the main embedder doesn't need (lex-hub goes through the #554 ceiling). So this is a **non-breaking, behavior-preserving** fix:
- Prominent wildcard warning on the `Policy` type and on the previously-undocumented `allow_fs_read`/`allow_fs_write` fields.
- New **`Policy::wildcard_scoped_grants()`** — returns the granted scoped effects left wide open, so an embedder can detect and refuse them at startup.

## #553 — web.rs XSS sweep
Audited every dynamic interpolation in `web.rs`. The activity/trust/attention tables, error pages, branch/stage detail, and triage forms **already** route store-derived data (tool, model, detail, stage_id, sig_id, branch/fn names, merge src/dst) through `esc()`. The **one gap** was `page()`'s `<title>`, which interpolates store-derived text (fn/branch names) unescaped — fixed. `body` stays raw HTML by design (callers escape their own fields).

## Test plan
- [x] `cargo test -p lex-runtime --lib wildcard` → 3/3 (detects open proc/fs grants; populated scopes & pure/time/rand are clean)
- [x] `cargo test -p lex-api --lib xss` → 2/2 (`page()` escapes a `</title><script>` title; `esc` covers `& < > "`)
- [x] `cargo clippy -p lex-api --lib` clean; lex-runtime lib builds clean (tests use struct-update syntax to avoid `field_reassign_with_default`)

Closes #552, #553.

https://claude.ai/code/session_01KYmz1jwh7vPrJJzbKhmvpY

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYmz1jwh7vPrJJzbKhmvpY)_