### PR TITLE
feat(lex-types): surface effect-row invariance as its own error (#565)

### DIFF
--- a/crates/lex-types/src/checker.rs
+++ b/crates/lex-types/src/checker.rs
@@ -641,7 +641,11 @@ impl Checker {
                 for (x, y) in pa.clone().into_iter().zip(pb.clone()) {
                     self.unify_coerce_inner(x, y)?;
                 }
-                self.u.unify_effects(ea, eb).map_err(|_| UnifyError::Mismatch { a: a.clone(), b: b.clone() })?;
+                // Propagate the EffectMismatch verbatim (rather than
+                // collapsing it into a whole-type Mismatch) so the
+                // invariant-effect-row case surfaces as its own
+                // rule_tag with the narrow-the-body fix (#565).
+                self.u.unify_effects(ea, eb)?;
                 self.unify_coerce_inner((**ra).clone(), (**rb).clone())
             }
             _ => self.u.unify(&a, &b),
@@ -1390,16 +1394,17 @@ fn mismatch_err(node_id: &str, e: UnifyError, u: &Unifier, context: Vec<String>)
         },
         UnifyError::Infinite { .. } => TypeError::InfiniteType { at_node: node_id.into() },
         UnifyError::EffectMismatch { a, b } => {
-            // Render effect mismatches as a type-mismatch in compact
-            // form, e.g. `[net]` vs `[]`. Avoids inventing a new
-            // TypeError variant + wire format right now.
+            // Render the two rows in compact form, e.g. `[net]` vs `[]`.
+            // Effect rows are invariant, so this is its own rule_tag
+            // (#565) rather than a generic type-mismatch — the
+            // explanation steers the fix toward narrowing the body.
             let render = |e: &EffectSet| -> String {
                 let mut parts: Vec<String> = e.concrete.iter()
                     .map(crate::types::EffectKind::pretty).collect();
                 if let Some(v) = e.var { parts.push(format!("?e{}", v)); }
                 if parts.is_empty() { "[]".into() } else { format!("[{}]", parts.join(", ")) }
             };
-            TypeError::TypeMismatch {
+            TypeError::EffectRowMismatch {
                 at_node: node_id.into(),
                 expected: render(&b),
                 got: render(&a),

--- a/crates/lex-types/src/error.rs
+++ b/crates/lex-types/src/error.rs
@@ -12,6 +12,22 @@ pub enum TypeError {
         got: String,
         context: Vec<String>,
     },
+    /// Two function types failed to unify specifically because their
+    /// effect rows differ (#565). Effect rows unify by *equality*, not
+    /// subtyping — a concrete row must match exactly, not merely be a
+    /// superset or subset. This most often surfaces on record-field
+    /// closures (e.g. `Skill.handle`, `Tool.execute`) whose declared
+    /// row is fixed by the record type. Split out from `TypeMismatch`
+    /// so the `rule_tag` names the invariance and the suggested fix
+    /// steers toward narrowing the body rather than broadening the row.
+    EffectRowMismatch {
+        at_node: String,
+        /// Pretty-printed expected effect row, e.g. `[io, net]`.
+        expected: String,
+        /// Pretty-printed actual effect row found.
+        got: String,
+        context: Vec<String>,
+    },
     UnknownIdentifier {
         at_node: String,
         name: String,
@@ -101,6 +117,7 @@ impl TypeError {
     pub fn node(&self) -> &str {
         match self {
             TypeError::TypeMismatch { at_node, .. }
+            | TypeError::EffectRowMismatch { at_node, .. }
             | TypeError::UnknownIdentifier { at_node, .. }
             | TypeError::ArityMismatch { at_node, .. }
             | TypeError::NonExhaustiveMatch { at_node, .. }
@@ -124,6 +141,11 @@ impl std::fmt::Display for TypeError {
         match self {
             TypeError::TypeMismatch { at_node, expected, got, context } => {
                 write!(f, "type mismatch at {at_node}: expected {expected}, got {got}")?;
+                if !context.is_empty() { write!(f, " ({})", context.join(" / "))?; }
+                Ok(())
+            }
+            TypeError::EffectRowMismatch { at_node, expected, got, context } => {
+                write!(f, "effect-row mismatch at {at_node}: declared row is invariant — expected {expected}, got {got}; narrow the body, don't broaden the row")?;
                 if !context.is_empty() { write!(f, " ({})", context.join(" / "))?; }
                 Ok(())
             }

--- a/crates/lex-types/src/rules.rs
+++ b/crates/lex-types/src/rules.rs
@@ -28,6 +28,7 @@ impl TypeError {
     pub fn rule_tag(&self) -> &'static str {
         match self {
             TypeError::TypeMismatch { .. } => "type-mismatch",
+            TypeError::EffectRowMismatch { .. } => "effect-row-mismatch",
             TypeError::UnknownIdentifier { .. } => "unknown-identifier",
             TypeError::ArityMismatch { .. } => "arity-mismatch",
             TypeError::NonExhaustiveMatch { .. } => "non-exhaustive-match",
@@ -59,6 +60,7 @@ fn explanation_for_tag(tag: &str) -> &'static str {
 (return type, let-binding annotation, function argument, operator operand, etc.). Fix by changing \
 the expression to produce the expected type, or by adjusting the declared/inferred expected type \
 to match.",
+        "effect-row-mismatch" => EFFECT_ROW_MISMATCH,
         "unknown-identifier" => "A name referenced in scope is not declared. Either the binding is missing, \
 the name is misspelled, or an `import` is missing. Check for typos first; then verify the relevant \
 `let`, parameter, or top-level `fn` is in scope.",
@@ -106,6 +108,7 @@ update the example to match the new behavior, or fix the body to produce the dec
 pub fn all_rules() -> &'static [RuleInfo] {
     &[
         RuleInfo { tag: "type-mismatch", explanation: TYPE_MISMATCH },
+        RuleInfo { tag: "effect-row-mismatch", explanation: EFFECT_ROW_MISMATCH },
         RuleInfo { tag: "unknown-identifier", explanation: UNKNOWN_IDENT },
         RuleInfo { tag: "arity-mismatch", explanation: ARITY_MISMATCH },
         RuleInfo { tag: "non-exhaustive-match", explanation: NON_EXHAUSTIVE },
@@ -173,6 +176,15 @@ otherwise add one explicit arm per missing variant so the audit trail records th
 the effect to the signature via `ChangeEffectSig` (preferred — the effect is genuinely needed) or \
 remove the call that produces it via `ModifyBody` (preferred when the effect was unintentional).",
         ),
+        "effect-row-mismatch" => (
+            "ModifyBody",
+            "Narrow the closure body to use only the effects in the declared row; do NOT broaden the row.",
+            "Effect rows are invariant: the declared row must match exactly, so the intuitive repair \
+(adding the missing effect to the declared row) is wrong when that row is fixed by a record field or \
+other annotation — e.g. `Skill.handle`, `Tool.execute`. Use `ModifyBody` to remove or replace the \
+calls whose effects fall outside the declared row. Reach for `ChangeEffectSig` only when you own the \
+annotation and the extra effect is genuinely required.",
+        ),
         "arity-mismatch" => (
             "ModifyBody",
             "Match the call site's argument count to the function's declared arity.",
@@ -219,6 +231,11 @@ const TYPE_MISMATCH: &str = "An expression's inferred type doesn't match what th
 (return type, let-binding annotation, function argument, operator operand, etc.). Fix by changing \
 the expression to produce the expected type, or by adjusting the declared/inferred expected type \
 to match.";
+const EFFECT_ROW_MISMATCH: &str = "Two function types failed to unify because their effect rows differ. \
+Effect rows unify by equality, not subtyping: a concrete row must match exactly — a superset or subset \
+is rejected. This most often surfaces on record-field closures (e.g. `Skill.handle`, `Tool.execute`), \
+whose declared effect row is fixed by the record type. Fix by narrowing the function body so it uses \
+only the effects in the declared row — do NOT broaden the declared row to match the body.";
 const UNKNOWN_IDENT: &str = "A name referenced in scope is not declared. Either the binding is missing, \
 the name is misspelled, or an `import` is missing. Check for typos first; then verify the relevant \
 `let`, parameter, or top-level `fn` is in scope.";
@@ -291,6 +308,12 @@ mod tests {
                 at_node: "n_0".into(),
                 expected: "Int".into(),
                 got: "Str".into(),
+                context: vec![],
+            },
+            TypeError::EffectRowMismatch {
+                at_node: "n_0".into(),
+                expected: "[io]".into(),
+                got: "[net]".into(),
                 context: vec![],
             },
             TypeError::UnknownIdentifier { at_node: "n_0".into(), name: "x".into() },

--- a/crates/lex-types/tests/check.rs
+++ b/crates/lex-types/tests/check.rs
@@ -72,6 +72,29 @@ fn bad() -> Str {
 }
 
 #[test]
+fn effect_row_mismatch_is_its_own_variant() {
+    // A closure whose concrete effect row differs from the declared
+    // row of the callback parameter must surface as the dedicated
+    // EffectRowMismatch (#565), not a generic TypeMismatch. Effect
+    // rows are invariant: [io] is neither a superset nor subset of
+    // the expected [net], so unification rejects it.
+    let src = "\
+fn apply(f :: (Int) -> [net] Int) -> [net] Int { f(1) }
+fn bad() -> [net] Int { apply(fn (x :: Int) -> [io] Int { x }) }
+";
+    let errs = check(src).unwrap_err();
+    assert!(
+        errs.iter().any(|e| matches!(e, TypeError::EffectRowMismatch { .. })),
+        "expected EffectRowMismatch, got {errs:#?}"
+    );
+    let tagged = errs
+        .iter()
+        .find(|e| matches!(e, TypeError::EffectRowMismatch { .. }))
+        .unwrap();
+    assert_eq!(tagged.rule_tag(), "effect-row-mismatch");
+}
+
+#[test]
 fn detects_unknown_field() {
     let src = "fn bad() -> Int { let r := { x: 1 }\n r.y }\n";
     let errs = check(src).unwrap_err();

--- a/docs/AGENT_GUIDELINES.md
+++ b/docs/AGENT_GUIDELINES.md
@@ -101,6 +101,33 @@ effects in their inferred row, and `lex check` propagates them. If the
 checker complains, the fix is to narrow the *body*, not to widen the
 outer signature.
 
+### 1.6 Record-field closures have invariant effect rows (MUST)
+
+When a function type appears as a record field (e.g. `Skill.handle`,
+`Tool.execute`), its declared effect row is **invariant** — the closure
+you supply must match it *exactly*, not merely be a superset or subset.
+Effect rows unify by equality, not subtyping, so the polymorphism that
+makes `list.map` accept any effectful closure does **not** apply when
+the row is pinned by a record type.
+
+```lex
+# Skill.handle is declared as:
+#   handle :: (Message) -> [io, time, crypto, random, sql,
+#                           fs_read, fs_write, net, concurrent] HandlerOutcome
+#
+# AVOID — adding `env` (or dropping `crypto`) makes the row a superset/
+# subset, which is rejected even though it "looks" safe.
+# GOOD — the closure declares the row verbatim and the body uses only
+# those effects.
+```
+
+The checker surfaces this as `rule_tag: "effect-row-mismatch"` with a
+`rule_explanation` that names the invariance. The fix is the same as
+§1.2: **narrow the body** so it uses only the declared effects. Do
+**not** broaden the declared row to match the body — for a record-field
+closure you usually can't (the row is fixed by the record type), and
+where you can, broadening defeats the audit value of the annotation.
+
 ---
 
 ## 2. Authoring style


### PR DESCRIPTION
## Summary

Implements #565 (the first of the 561–567 batch). Effect rows on function types unify by **equality**, not subtyping, so a record-field closure (`Skill.handle`, `Tool.execute`) whose declared row is fixed by the record type must match exactly. Agents hitting this previously got a generic `type_mismatch` and reflexively broadened the row — the wrong fix — instead of narrowing the body.

This change makes the invariance legible at the point of failure, and documents it.

### Part 1 — error message (issue requirement #1)
- New `TypeError::EffectRowMismatch` variant → `kind: "effect_row_mismatch"`, with its own `rule_tag: "effect-row-mismatch"` and a `rule_explanation` that names the invariance ("rows unify by equality, not subtyping; narrow the body, don't broaden the row").
- A `suggested_transform` keyed to the new tag steers repair toward `ModifyBody` rather than `ChangeEffectSig` (the anti-pattern).
- The checker now propagates the unifier's `EffectMismatch` through function-type coercion (`unify_coerce_inner`) instead of collapsing it into a whole-type `Mismatch`, so the new tag actually fires at call sites and return positions.

### Part 2 — AGENT_GUIDELINES (issue requirement #2)
- New §1.6 under Effect discipline documenting that record-field closures have invariant effect rows, with the same narrow-the-body guidance.

### Out of scope
- Issue requirement #3 (investigating whether covariant effect rows on record-field closures would be sound) is a type-system design question explicitly flagged as longer-term; not attempted here.

## Test plan
- [x] `cargo test -p lex-types` — new `effect_row_mismatch_is_its_own_variant` regression test passes; catalog round-trip + existing checks green.
- [x] `cargo test -p lex-cli -p lex-lsp -p lex-store` — 30 suites green (rule-tag catalog, MCP, LSP type-mismatch surfacing all unaffected).
- [x] `cargo test -p lex-runtime` effect-polymorphism + agent-effect suites green (open-row HOF inference unchanged).
- [x] `cargo clippy -p lex-types --all-targets -- -D warnings` clean.

Note: the repo is not `rustfmt`-clean against stable rustfmt 1.8.0 and CI has no `cargo fmt --check` gate, so this PR matches surrounding style by hand rather than reformatting.

## Notes
This is a wire-format addition: effect-row mismatches now serialize as `kind: effect_row_mismatch` instead of `type_mismatch`. No existing test, conformance fixture, or consumer pinned effect mismatches to `type_mismatch` (verified), so nothing downstream breaks.

Part of the 561–567 series; remaining issues to follow as separate PRs.

https://claude.ai/code/session_016KYLi6YbTmbWvyoARZ6GhY

---
_Generated by [Claude Code](https://claude.ai/code/session_016KYLi6YbTmbWvyoARZ6GhY)_