### PR TITLE
feat(lex-cli): lex docs <path> emits structured API-docs JSON (#564)

### DIFF
--- a/crates/lex-ast/src/canon_print.rs
+++ b/crates/lex-ast/src/canon_print.rs
@@ -16,6 +16,15 @@ pub fn print_stages(stages: &[Stage]) -> String {
     p.out
 }
 
+/// Render a single `examples {}` case as canonical `name(args...) => expected`.
+/// Exposed so tooling (e.g. `lex docs --output json`) can surface examples as
+/// human-readable strings without re-implementing the expression printer.
+pub fn print_example(fn_name: &str, ex: &Example) -> String {
+    let mut p = Printer::new();
+    p.example_call(fn_name, ex);
+    p.out
+}
+
 struct Printer { out: String, indent: usize }
 
 impl Printer {
@@ -65,16 +74,7 @@ impl Printer {
             for (i, ex) in fd.examples.iter().enumerate() {
                 self.nl();
                 self.pad();
-                // Render as `name(args...) => expected`. Since canonical
-                // form doesn't carry the call expression, we synthesize
-                // a Call(Var name, args) for the printer.
-                write!(self.out, "{}(", fd.name).unwrap();
-                for (j, a) in ex.args.iter().enumerate() {
-                    if j > 0 { write!(self.out, ", ").unwrap(); }
-                    self.expr(a);
-                }
-                write!(self.out, ") => ").unwrap();
-                self.expr(&ex.expected);
+                self.example_call(&fd.name, ex);
                 if i + 1 < fd.examples.len() { write!(self.out, ",").unwrap(); }
             }
             self.indent -= 1;
@@ -85,6 +85,19 @@ impl Printer {
         write!(self.out, " ").unwrap();
         self.expr_as_block(&fd.body);
         self.nl();
+    }
+
+    /// Render one example case as `name(args...) => expected`. Canonical
+    /// form doesn't carry the call expression, so we synthesize the call
+    /// from the fn name and the case's argument list.
+    fn example_call(&mut self, fn_name: &str, ex: &Example) {
+        write!(self.out, "{}(", fn_name).unwrap();
+        for (j, a) in ex.args.iter().enumerate() {
+            if j > 0 { write!(self.out, ", ").unwrap(); }
+            self.expr(a);
+        }
+        write!(self.out, ") => ").unwrap();
+        self.expr(&ex.expected);
     }
 
     fn effects(&mut self, effects: &[Effect]) {

--- a/crates/lex-ast/src/lib.rs
+++ b/crates/lex-ast/src/lib.rs
@@ -14,7 +14,7 @@ pub mod transforms;
 
 pub use canonical::*;
 pub use canonicalize::{canonicalize_program, canonicalize_item};
-pub use canon_print::print_stages;
+pub use canon_print::{print_example, print_stages};
 pub use ids::{collect_ids, expr_ids, NodeId, NodeRef};
 pub use patch::{apply_patch, Patch, PatchError};
 pub use transforms::{

--- a/crates/lex-cli/src/docs.rs
+++ b/crates/lex-cli/src/docs.rs
@@ -12,9 +12,11 @@
 //! on-disk state; no new persistence.
 
 use crate::acli;
+use crate::fmt::collect_lex_files;
 use ::acli::OutputFormat;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use lex_store::{Store, DEFAULT_BRANCH};
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 /// Schema version of the emitted JSON. Bump when fields are
@@ -24,7 +26,8 @@ const LEX_DOCS_VERSION: u32 = 1;
 
 pub fn cmd_docs(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let sub = args.first().ok_or_else(|| anyhow!(
-        "usage: lex docs --for-agent [--branch B] [--limit-recent N] [--store DIR]\n\
+        "usage: lex docs <path>...        # API docs for source files/dirs\n\
+         usage: lex docs --for-agent [--branch B] [--limit-recent N] [--store DIR]\n\
          usage: lex docs --rules"))?;
     if sub == "--rules" {
         // #306 slice 2: enumerate every type-error rule with its
@@ -48,12 +51,15 @@ pub fn cmd_docs(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         });
         return Ok(());
     }
-    if sub != "--for-agent" {
-        // Future subcommands (`lex docs serve`, `lex docs sig X`, …)
-        // can land here. For 0.5.0's slice, only `--for-agent`.
+    if sub.starts_with("--") && sub != "--for-agent" {
         anyhow::bail!(
-            "unknown `lex docs` subcommand `{sub}`. only `--for-agent` and `--rules` are supported today"
+            "unknown `lex docs` flag `{sub}`. supported: `lex docs <path>...`, `--for-agent`, `--rules`"
         );
+    }
+    if sub != "--for-agent" {
+        // No recognized flag → treat every arg as a source file/dir and
+        // emit API docs (#564).
+        return cmd_docs_source(fmt, args);
     }
     let mut branch: Option<String> = None;
     let mut limit_recent: usize = 50;
@@ -426,6 +432,188 @@ fn render_text(env: &DocsEnvelope) {
         println!("Attention queue: {} item(s)", env.attention.len());
         for a in &env.attention {
             println!("  {} {} — {}", a.sig_id, a.stage_id, a.reason);
+        }
+    }
+}
+
+// --- #564: `lex docs <path>` — API docs from source ----------------
+
+/// Schema version of the `lex docs <path>` API-docs JSON. Bump on a
+/// breaking reshape; adding optional fields is schema-additive.
+const LEX_API_DOCS_VERSION: u32 = 1;
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct ApiDocs {
+    pub lex_docs_version: u32,
+    /// Package name from the nearest `lex.toml`, if one is found.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub package: Option<String>,
+    /// Package version from the nearest `lex.toml` (empty when absent).
+    pub version: String,
+    pub modules: Vec<ModuleDoc>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct ModuleDoc {
+    /// Path to the source file, as supplied on the command line.
+    pub file: String,
+    /// Module-level doc: the `#` comment block at the top of the file
+    /// (before the first item). The parser attributes top-of-file
+    /// comments to the module rather than to the first declaration.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub doc: Option<String>,
+    pub functions: Vec<FnDoc>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct FnDoc {
+    pub name: String,
+    /// Stable SigId (canonical-AST hash). Absent only if the stage
+    /// can't produce one (e.g. malformed signature).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sig_id: Option<String>,
+    /// Human-readable `(params) -> ret [effects]` render.
+    pub signature: String,
+    pub effects: Vec<String>,
+    /// `examples {}` cases rendered as `name(args) => expected`.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub examples: Vec<String>,
+    /// Doc comment (the `#` lines immediately preceding the fn), with
+    /// the leading `#` stripped and lines joined by newlines.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub doc: Option<String>,
+}
+
+fn cmd_docs_source(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    let paths: Vec<PathBuf> = args.iter().map(PathBuf::from).collect();
+    let files = collect_lex_files(&paths)?;
+    if files.is_empty() {
+        anyhow::bail!("no .lex files found under {:?}", args);
+    }
+
+    let (package, version) = package_meta(&paths);
+
+    let mut modules = Vec::with_capacity(files.len());
+    for file in &files {
+        let src = std::fs::read_to_string(file)
+            .with_context(|| format!("reading {}", file.display()))?;
+        let prog = lex_syntax::parse_source(&src)
+            .map_err(|e| anyhow!("parse error in {}: {e:?}", file.display()))?;
+
+        // Doc comments live on the syntax tree (the canonicalizer strips
+        // them so they never enter the SigId). Map fn name → doc here,
+        // then look them up while walking the canonical stages.
+        let mut docs_by_name: BTreeMap<String, String> = BTreeMap::new();
+        for item in &prog.items {
+            if let lex_syntax::Item::FnDecl(fd) = item {
+                if let Some(doc) = clean_doc(&fd.leading_comments) {
+                    docs_by_name.insert(fd.name.clone(), doc);
+                }
+            }
+        }
+
+        let stages = lex_ast::canonicalize_program(&prog);
+        let mut functions = Vec::new();
+        for stage in &stages {
+            let lex_ast::Stage::FnDecl(fd) = stage else { continue };
+            let examples = fd.examples.iter()
+                .map(|ex| lex_ast::print_example(&fd.name, ex))
+                .collect();
+            functions.push(FnDoc {
+                name: fd.name.clone(),
+                sig_id: lex_ast::sig_id(stage),
+                signature: render_signature(fd),
+                effects: effect_strings(fd),
+                examples,
+                doc: docs_by_name.get(&fd.name).cloned(),
+            });
+        }
+
+        modules.push(ModuleDoc {
+            file: file.display().to_string(),
+            doc: clean_doc(&prog.leading_comments),
+            functions,
+        });
+    }
+
+    let docs = ApiDocs {
+        lex_docs_version: LEX_API_DOCS_VERSION,
+        package,
+        version,
+        modules,
+    };
+    let data = serde_json::to_value(&docs)?;
+    acli::emit_or_text("docs", data, fmt, || render_api_text(&docs));
+    Ok(())
+}
+
+/// Resolve `(package_name, package_version)` from the nearest `lex.toml`
+/// above the first supplied path. Missing manifest or `[package]` table
+/// yields `(None, "")` — docs generation doesn't require a manifest.
+fn package_meta(paths: &[PathBuf]) -> (Option<String>, String) {
+    let start = paths.first().cloned().unwrap_or_else(|| PathBuf::from("."));
+    let Some((toml_path, _)) = lex_syntax::find_manifest(&start) else {
+        return (None, String::new());
+    };
+    match lex_syntax::Manifest::load(&toml_path) {
+        Ok(m) => match m.package {
+            Some(p) => (Some(p.name), p.version),
+            None => (None, String::new()),
+        },
+        Err(_) => (None, String::new()),
+    }
+}
+
+/// Strip the leading `#` (and one optional space) from each comment line
+/// and join them. Returns `None` when there are no comment lines.
+fn clean_doc(lines: &[String]) -> Option<String> {
+    if lines.is_empty() {
+        return None;
+    }
+    let cleaned: Vec<String> = lines.iter()
+        .map(|l| {
+            let s = l.trim_start().trim_start_matches('#');
+            s.strip_prefix(' ').unwrap_or(s).to_string()
+        })
+        .collect();
+    Some(cleaned.join("\n"))
+}
+
+/// Render a canonical fn's effect row as a list of strings, mirroring the
+/// parameterized-effect rendering used by the `--for-agent` envelope.
+fn effect_strings(fd: &lex_ast::FnDecl) -> Vec<String> {
+    fd.effects.iter()
+        .map(|e| match &e.arg {
+            Some(lex_ast::EffectArg::Int { value }) => format!("{}({})", e.name, value),
+            Some(lex_ast::EffectArg::Str { value }) => format!("{}({:?})", e.name, value),
+            Some(lex_ast::EffectArg::Ident { value }) => format!("{}({})", e.name, value),
+            None => e.name.clone(),
+        })
+        .collect()
+}
+
+fn render_api_text(docs: &ApiDocs) {
+    let pkg = docs.package.as_deref().unwrap_or("(no package)");
+    println!("API docs for {pkg} {} (schema v{})", docs.version, docs.lex_docs_version);
+    for m in &docs.modules {
+        println!();
+        println!("{} ({} fn):", m.file, m.functions.len());
+        if let Some(doc) = &m.doc {
+            for line in doc.lines() {
+                println!("  # {line}");
+            }
+        }
+        for f in &m.functions {
+            let sid = f.sig_id.as_deref().map(|s| &s[..12.min(s.len())]).unwrap_or("-");
+            println!("  {}{}  [{}]", f.name, f.signature, sid);
+            if let Some(doc) = &f.doc {
+                for line in doc.lines() {
+                    println!("    {line}");
+                }
+            }
+            for ex in &f.examples {
+                println!("    e.g. {ex}");
+            }
         }
     }
 }

--- a/crates/lex-cli/src/fmt.rs
+++ b/crates/lex-cli/src/fmt.rs
@@ -104,7 +104,7 @@ fn fmt_file(path: &Path) -> Result<Option<String>> {
 }
 
 /// Expand a list of file/directory paths to a sorted list of .lex files.
-fn collect_lex_files(paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
+pub(crate) fn collect_lex_files(paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
     let mut files: Vec<PathBuf> = Vec::new();
     for path in paths {
         if path.is_dir() {

--- a/crates/lex-cli/tests/docs_api.rs
+++ b/crates/lex-cli/tests/docs_api.rs
@@ -1,0 +1,125 @@
+//! `lex docs <path>` — structured API docs from source (#564). Emits
+//! per-module / per-function JSON (name, sig_id, signature, effects,
+//! examples, doc) consumable by a static site renderer or a doc-gen
+//! agent.
+
+use std::process::{Command, Stdio};
+
+fn lex_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_lex")
+}
+
+fn run(args: &[&str]) -> (i32, String) {
+    let out = Command::new(lex_bin())
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("spawn lex");
+    (out.status.code().unwrap_or(-1), String::from_utf8_lossy(&out.stdout).to_string())
+}
+
+/// Build a temp package: `lex.toml` + `src/math.lex`. Returns the dir.
+fn seed_pkg() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("lex.toml"),
+        "[package]\nname = \"demo-pkg\"\nversion = \"0.3.1\"\n",
+    )
+    .unwrap();
+    std::fs::create_dir(dir.path().join("src")).unwrap();
+    // First fn carries an `examples {}` block and a per-fn doc comment;
+    // the file opens with a module-level comment; the second fn is
+    // effectful so we can assert the effect row is surfaced.
+    std::fs::write(
+        dir.path().join("src/math.lex"),
+        "# Arithmetic helpers.\n\
+         import \"std.io\" as io\n\n\
+         # Add two integers.\n\
+         # Pure and total.\n\
+         fn add(x :: Int, y :: Int) -> Int\n\
+         \x20\x20examples { add(2, 3) => 5, add(0, 0) => 0 }\n\
+         { x + y }\n\n\
+         fn shout(s :: Str) -> [io] Nil {\n\
+         \x20\x20io.print(s)\n\
+         }\n",
+    )
+    .unwrap();
+    dir
+}
+
+#[test]
+fn api_docs_json_has_package_modules_and_functions() {
+    let dir = seed_pkg();
+    let src = dir.path().join("src");
+    let (code, stdout) = run(&["--output", "json", "docs", src.to_str().unwrap()]);
+    assert_eq!(code, 0, "docs should succeed: {stdout}");
+
+    let env: serde_json::Value = serde_json::from_str(&stdout).expect("envelope parses");
+    let data = &env["data"];
+    assert_eq!(data["lex_docs_version"], 1);
+    assert_eq!(data["package"], "demo-pkg");
+    assert_eq!(data["version"], "0.3.1");
+
+    let modules = data["modules"].as_array().expect("modules array");
+    assert_eq!(modules.len(), 1, "one .lex file → one module: {data}");
+    let m = &modules[0];
+    assert!(m["file"].as_str().unwrap().ends_with("math.lex"));
+    // Module-level comment (top of file) surfaces as the module doc.
+    assert_eq!(m["doc"], "Arithmetic helpers.");
+
+    let fns = m["functions"].as_array().expect("functions array");
+    let add = fns.iter().find(|f| f["name"] == "add").expect("add present");
+    assert!(add["sig_id"].as_str().is_some_and(|s| s.len() == 64), "sig_id is a hash: {add}");
+    assert_eq!(add["signature"], "(x :: Int, y :: Int) -> Int");
+    assert!(add["effects"].as_array().unwrap().is_empty(), "add is pure");
+    let examples: Vec<&str> = add["examples"].as_array().unwrap().iter().map(|e| e.as_str().unwrap()).collect();
+    assert_eq!(examples, vec!["add(2, 3) => 5", "add(0, 0) => 0"]);
+    assert_eq!(add["doc"], "Add two integers.\nPure and total.");
+
+    let shout = fns.iter().find(|f| f["name"] == "shout").expect("shout present");
+    assert_eq!(shout["effects"].as_array().unwrap(), &vec![serde_json::json!("io")]);
+}
+
+#[test]
+fn api_docs_sig_id_matches_workspace_sig_id() {
+    // The sig_id emitted by `lex docs` must equal the one the rest of
+    // the toolchain computes for the same source, so docs can be keyed
+    // by SigId across renames/reformats.
+    let dir = seed_pkg();
+    let src = dir.path().join("src/math.lex");
+    let (code, stdout) = run(&["--output", "json", "docs", src.to_str().unwrap()]);
+    assert_eq!(code, 0, "{stdout}");
+    let env: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let add = env["data"]["modules"][0]["functions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|f| f["name"] == "add")
+        .unwrap()
+        .clone();
+
+    let source = std::fs::read_to_string(&src).unwrap();
+    let prog = lex_syntax::parse_source(&source).unwrap();
+    let stages = lex_ast::canonicalize_program(&prog);
+    let stage = stages
+        .iter()
+        .find(|s| matches!(s, lex_ast::Stage::FnDecl(fd) if fd.name == "add"))
+        .unwrap();
+    assert_eq!(add["sig_id"].as_str().unwrap(), lex_ast::sig_id(stage).unwrap());
+}
+
+#[test]
+fn api_docs_text_mode_succeeds() {
+    let dir = seed_pkg();
+    let (code, stdout) = run(&["docs", dir.path().join("src").to_str().unwrap()]);
+    assert_eq!(code, 0, "text docs should succeed: {stdout}");
+    assert!(stdout.contains("demo-pkg 0.3.1"), "text render names the package: {stdout}");
+    assert!(stdout.contains("add"), "text render lists fns: {stdout}");
+}
+
+#[test]
+fn unknown_docs_flag_is_rejected() {
+    let (code, _stdout) = run(&["docs", "--bogus"]);
+    assert_ne!(code, 0, "unknown --flag should be rejected, not treated as a path");
+}


### PR DESCRIPTION
## Summary

Implements #564: a source-directory mode for `lex docs`. `lex docs --output json <path>` now walks the `.lex` files under a path, parses them, and emits a machine-readable doc tree — the input both a static site renderer and a doc-gen agent need.

```json
{
  "lex_docs_version": 1,
  "package": "demo-pkg",
  "version": "0.3.1",
  "modules": [
    {
      "file": "src/math.lex",
      "doc": "Arithmetic helpers.",
      "functions": [
        {
          "name": "add",
          "sig_id": "233718e1…",
          "signature": "(x :: Int, y :: Int) -> Int",
          "effects": [],
          "examples": ["add(2, 3) => 5", "add(0, 0) => 0"],
          "doc": "Add two integers.\nPure and total."
        }
      ]
    }
  ]
}
```

### What changed
- **New `lex docs <path>` mode** (`crates/lex-cli/src/docs.rs`), dispatched when the first arg is a path rather than `--for-agent`/`--rules`. Unknown `--flags` are still rejected (no silent fallthrough). Package name + version come from the nearest `lex.toml` via `lex_syntax::find_manifest`; a missing manifest is non-fatal.
- **Per-function entries**: `name`, `sig_id` (the canonical-AST SigId — same value the rest of the toolchain computes, so docs survive renames/reformats), `signature`, `effects`, `examples`, `doc`.
- **Module-level docs**: top-of-file comments are attributed by the parser to `Program.leading_comments` (not the first fn), so they surface as `module.doc` rather than being mis-attached to the first function.
- **`lex_ast::print_example`** exposed (refactored out of the canonical printer's existing inline example rendering — single source of truth, byte-identical output) so examples render as `name(args) => expected`.
- `collect_lex_files` is now `pub(crate)` and reused from the `fmt` module.

### Scope note
Issue #564 lists three deliverables; this PR does **#1 (the JSON schema + command)** and the module-doc surfacing. The reusable GitHub Actions workflow / `doc_agent.lex` (deliverables 2–3) overlap with #567 and will land there, built on this output.

## Test plan
- [x] New `crates/lex-cli/tests/docs_api.rs` (4 tests): JSON shape (package/version/modules/functions), `sig_id` equals the toolchain's `lex_ast::sig_id` for the same source, text-mode success, unknown-flag rejection.
- [x] `cargo test -p lex-ast -p lex-cli` — full suites green (formatter/canonical-printer round-trips unaffected by the `print_example` refactor).
- [x] `cargo clippy -p lex-ast -p lex-cli --all-targets -- -D warnings` clean.
- [x] Manual smoke test on a sample package (JSON + text output) confirms doc comments, examples, and effect rows render correctly.

Part of the 561–567 series (follows #565, merged as #568). #567 builds directly on this.

https://claude.ai/code/session_016KYLi6YbTmbWvyoARZ6GhY

---
_Generated by [Claude Code](https://claude.ai/code/session_016KYLi6YbTmbWvyoARZ6GhY)_