### PR TITLE
ci(#567): generate lex docs API JSON as a build artifact

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,78 @@
+name: docs
+
+# Generate machine-readable API docs (`lex docs --output json`, #564) for
+# this repo's example Lex sources and publish them as a build artifact.
+#
+# This is the non-deploying half of #567: it produces the JSON that a
+# static-site renderer or a doc-gen agent consumes. Wiring the artifact to
+# a published site (GitHub Pages vs. the existing Caddy-served `docs/`) is a
+# separate deployment decision and is intentionally left out here.
+#
+# Requires a `lex` that supports `lex docs --output json <path>` (#564). The
+# job builds `lex` from this checkout, so the docs always track the current
+# toolchain. Merge order matters: this can only run green once #564 is on
+# `main`.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'examples/**.lex'
+      - 'crates/lex-cli/src/docs.rs'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+    inputs:
+      source-path:
+        description: 'Directory of .lex sources to document'
+        default: 'examples'
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  api-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      # The lex-cli dep graph (lex-runtime → arrow-rs/Polars) inflates
+      # target/; reclaim runner space the same way ci.yml does so the
+      # debug build doesn't exhaust the disk.
+      - uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # Debug build: doc generation is parse-only, so the release
+      # optimizer buys nothing here. Build just the `lex` bin.
+      - name: Build lex
+        run: cargo build --bin lex
+      - name: Generate API docs JSON
+        env:
+          SRC: ${{ github.event.inputs.source-path || 'examples' }}
+        run: |
+          mkdir -p site
+          ./target/debug/lex --output json docs "$SRC" > site/api-docs.json
+          # Human-readable render to the job log for a quick eyeball.
+          ./target/debug/lex docs "$SRC"
+      - name: Validate output
+        run: |
+          python3 - <<'PY'
+          import json
+          d = json.load(open("site/api-docs.json"))
+          assert d["ok"], "lex docs reported failure"
+          mods = d["data"]["modules"]
+          fns = sum(len(m["functions"]) for m in mods)
+          print(f"documented {len(mods)} module(s), {fns} function(s)")
+          assert mods, "no modules documented"
+          PY
+      - uses: actions/upload-artifact@v7
+        with:
+          name: api-docs
+          path: site/api-docs.json
+          if-no-files-found: error


### PR DESCRIPTION
## Summary

Implements the **non-deploying half of #567**: a `docs` GitHub Actions workflow that generates the machine-readable API-docs JSON (`lex docs --output json`, #564) for this repo's example Lex sources and uploads it as a build artifact.

- Builds `lex` from the checkout (debug — doc generation is parse-only, so the release optimizer buys nothing) and runs `lex docs --output json examples`.
- Validates the JSON (`ok: true`, at least one module) and prints a human-readable render to the job log.
- Uploads `site/api-docs.json` as the `api-docs` artifact.
- Triggers on `push` to `main` (path-filtered to example/docs changes) and `workflow_dispatch` (with a `source-path` input).
- Reuses the repo's existing CI conventions (`free-disk-space`, `rust-cache`) since the lex-cli dep graph (arrow/Polars) inflates `target/`.

Verified locally: `lex docs --output json examples` documents **21 modules / 75 functions**; the YAML parses and the embedded generate+validate steps run clean.

## Scope / deferred decisions
Issue #567 also asks to **publish** the docs to GitHub Pages. I deliberately left deployment out because:
- This repo already ships a docs landing page (`docs/index.html`) that appears to be served via the in-repo `Caddyfile`/`docker-compose`, **not** GitHub Pages — so a Pages deploy is a deployment-model decision, not a mechanical addition, and may need repo Pages settings.
- The artifact is the reusable, low-risk piece; wiring it to a publish target can follow once Pages-vs-Caddy is settled.

## Dependency / merge order
This workflow calls `lex docs --output json <path>`, added in **#564 (PR #569)**. It can only run green once #564 is on `main`, so **merge #564 first**. Until then the build step passes but the docs step would fail — hence the path filter keeps it from running on unrelated pushes.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — workflow is valid YAML.
- [x] Dry-ran the generate + validate steps locally against `examples/` (21 modules, 75 functions, `ok: true`).
- [ ] CI run on `main` after #564 merges (will confirm the build + docs step end-to-end on a runner).

Part of the 561–567 series. Builds on #564.

https://claude.ai/code/session_016KYLi6YbTmbWvyoARZ6GhY

---
_Generated by [Claude Code](https://claude.ai/code/session_016KYLi6YbTmbWvyoARZ6GhY)_