### PR TITLE
Manifesto demo: effects are machine-verifiable constraints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,19 @@ jobs:
       # binary is enough.
       - run: cargo test -p lex-runtime --features quic --test net_serve_quic
       - run: cargo clippy --workspace --all-targets -- -D warnings
+      # Manifesto demo: effects are machine-verifiable constraints. The
+      # honest effect row type-checks; a [net] call under an [io]
+      # signature is rejected. lex-cli is already compiled by the
+      # `cargo test` step above, so this `cargo run` is incremental.
+      - name: Manifesto effects demo
+        run: |
+          set -e
+          LEX="cargo run -q -p lex-cli --"
+          echo "== honest effect rows must type-check =="
+          $LEX check examples/manifesto_effects/honest.lex
+          echo "== mislabeled effect row ([io] hiding [net]) must be REJECTED =="
+          if $LEX check examples/manifesto_effects/dishonest.lex >/dev/null 2>&1; then
+            echo "::error::dishonest.lex type-checked but must be rejected"
+            exit 1
+          fi
+          echo "VALIDATED: the type system refused the mislabeled effect."

--- a/examples/manifesto_effects/dishonest.lex
+++ b/examples/manifesto_effects/dishonest.lex
@@ -1,0 +1,27 @@
+# lex-lang — manifesto demo: the type system refuses a mislabeled effect
+#
+# This is the DISHONEST twin of honest.lex. The body makes the exact
+# same network call, but the signature LIES: it claims `[io]` (local
+# I/O only), hiding the fact that it reaches the network.
+#
+# The checker REJECTS it. You cannot mislabel what a function may do —
+# the `[net]` effect reached in the body is not in the declared row, so
+# `lex check` fails with an effect-not-declared error. This is the
+# enforcement behind "the type system tells the caller": a `[net]`-free
+# signature is a *guarantee*, not a comment.
+#
+#   lex check examples/manifesto_effects/dishonest.lex   # → FAILS (by design)
+#
+# run.sh asserts this failure. A passing `lex check` here would mean the
+# manifesto's central claim had regressed.
+
+import "std.http" as http
+
+# Claims [io], but the body touches the network. Rejected.
+fn fetch(url :: Str) -> [io] Bool {
+  match http.get(url) {
+    Ok(_) => true,
+    Err(_) => false,
+  }
+}
+

--- a/examples/manifesto_effects/honest.lex
+++ b/examples/manifesto_effects/honest.lex
@@ -1,0 +1,41 @@
+# lex-lang — manifesto demo: effects are machine-verifiable constraints
+#
+# Manifesto §IV:
+#   "An agent that generates a function with a [net] effect row does not
+#    need to read the function body to know it touches the network. The
+#    type system tells it. The type system tells the caller. Trust
+#    without comprehension."
+#
+# This file is the HONEST half: every effect row tells the truth, so it
+# type-checks. A caller reads the signatures alone and knows exactly
+# what each function may touch — without reading a single body.
+#
+#   lex check examples/manifesto_effects/honest.lex      # → passes
+#
+# Its dishonest twin (dishonest.lex) makes the same network call under a
+# lying signature and is REJECTED by the checker. See run.sh.
+
+import "std.http" as http
+
+# The signature says [net]. That declaration alone is the contract: any
+# caller — human or agent — knows this function may reach the network,
+# without inspecting the body.
+fn fetch(url :: Str) -> [net] Bool {
+  match http.get(url) {
+    Ok(_) => true,
+    Err(_) => false,
+  }
+}
+
+# The signature declares no effects. That alone certifies purity: this
+# function cannot touch the network, the disk, or the clock — the
+# checker forbids it. The `examples {}` block runs at `lex check` time.
+fn double(n :: Int) -> Int
+  examples {
+    double(21) => 42,
+    double(0) => 0
+  }
+{
+  n * 2
+}
+

--- a/examples/manifesto_effects/run.sh
+++ b/examples/manifesto_effects/run.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Manifesto demo (lex-lang): effects are machine-verifiable constraints.
+#
+# Validates §IV's claim "the type system tells the caller" by asserting:
+#   1. honest.lex type-checks      — truthful effect rows are accepted.
+#   2. dishonest.lex is REJECTED   — a [net] call under an [io] signature
+#                                    cannot compile.
+# Exit 0 only if BOTH hold, so running this script *is* the proof.
+#
+#   bash examples/manifesto_effects/run.sh
+#   LEX=/path/to/lex bash examples/manifesto_effects/run.sh   # custom binary
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LEX="${LEX:-lex}"
+fail=0
+
+echo "==> honest.lex must type-check (effect rows tell the truth)"
+if "$LEX" check "$HERE/honest.lex" >/dev/null 2>&1; then
+  echo "    OK: honest.lex type-checks"
+else
+  echo "    FAIL: honest.lex should type-check but did not:"
+  "$LEX" check "$HERE/honest.lex" 2>&1 | head -8
+  fail=1
+fi
+
+echo "==> dishonest.lex must be REJECTED (claims [io], body touches [net])"
+if "$LEX" check "$HERE/dishonest.lex" >/dev/null 2>&1; then
+  echo "    FAIL: dishonest.lex type-checked but should have been rejected"
+  fail=1
+else
+  echo "    OK: the checker refused the mislabeled effect row. Reason:"
+  reason="$("$LEX" --output json check "$HERE/dishonest.lex" 2>&1)"
+  echo "$reason" | head -20 || true
+  if ! grep -qi '"effect": *"net"\|effect-not-declared' <<<"$reason"; then
+    echo "    FAIL: rejection was not the expected effect-not-declared(net) error"
+    fail=1
+  fi
+fi
+
+if [ "$fail" -eq 0 ]; then
+  echo "VALIDATED: effects are machine-verifiable — the type IS the contract."
+else
+  echo "FAILED: see errors above."
+fi
+exit "$fail"


### PR DESCRIPTION
## Summary

A self-validating demo for the manifesto's §IV claim that **"the type system tells the caller"** — a `[net]` effect row certifies that a function may touch the network *without anyone reading its body*.

- `examples/manifesto_effects/honest.lex` — truthful effect rows; type-checks.
- `examples/manifesto_effects/dishonest.lex` — the same `http.get` call under a lying `[io]` signature; **rejected** with `effect-not-declared`.
- `examples/manifesto_effects/run.sh` — asserts the honest file is accepted and the dishonest one is rejected (exit 0 only if both hold).
- `.github/workflows/ci.yml` — a *Manifesto effects demo* step runs the same assertion in CI, reusing the `lex-cli` already compiled by `cargo test`.

This is one of six demos (one per repo) validating the "On Agents as First-Class Citizens" manifesto; the common thread is **trust by verification, not comprehension** — each demo asserts its prediction so that running it *is* the proof.

## Test plan

- [x] `lex check examples/manifesto_effects/honest.lex` passes
- [x] `lex check examples/manifesto_effects/dishonest.lex` is rejected with `effect-not-declared` (effect `net`)
- [x] `bash examples/manifesto_effects/run.sh` prints `VALIDATED`
- [x] Validated against both lex-lang HEAD and the released v0.9.5 binary

https://claude.ai/code/session_01YEEq364jnTBau9BudzDNBm

---
_Generated by [Claude Code](https://claude.ai/code/session_01YEEq364jnTBau9BudzDNBm)_