### PR TITLE
Release 0.9.6

### DIFF
--- a/.cli/README.md
+++ b/.cli/README.md
@@ -1,6 +1,6 @@
 # lex
 
-Version: 0.9.5
+Version: 0.9.6
 ACLI version: 0.1.0
 
 ## Commands

--- a/.cli/commands.json
+++ b/.cli/commands.json
@@ -1,6 +1,6 @@
 {
   "name": "lex",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "acli_version": "0.1.0",
   "commands": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,67 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+## [0.9.6] — 2026-05-25
+
+### Added
+
+- **#564: `lex docs <path> --output json` — structured API-docs JSON.**
+  Walks the `.lex` files under a path and emits a machine-readable doc
+  tree: package + version (from the nearest `lex.toml`), per-module
+  docs, and per-function `name` / `sig_id` / `signature` / `effects` /
+  `examples` / `doc`. The `sig_id` is the canonical-AST SigId, so docs
+  survive renames and reformats.
+- **#567: `docs` CI workflow.** Generates the API-docs JSON as a build
+  artifact (`lex docs --output json examples`), validates it (`ok:
+  true`, ≥1 module), and uploads it. Path-filtered + `workflow_dispatch`.
+- **#533/#534: `std.redis` — thin Redis client.** Key/value + pub/sub;
+  every op carries `[net]`. Pairs with `lex-queue` for pooling and
+  work-queue retry.
+- **#496/#501: `net.serve_quic` — HTTP/3 over QUIC + `std.tls`.** Behind
+  the opt-in `quic` cargo feature so the default dep graph stays lean.
+- **#497/#499: `net.serve_with(opts)` — first-class `ServeOpts` record**
+  for HTTP server configuration.
+- **#500/#504: `iter.collect`** — alias for `iter.to_list`.
+- **#503/#505: `http.send` supports PUT / PATCH / DELETE / HEAD.**
+- **#513: package endpoints — `POST /v1/pkg/publish` + index.**
+
+### Changed
+
+- **#565/#568: effect-row invariance is now its own
+  `effect-row-mismatch` error.** Record-field closures (e.g.
+  `Skill.handle`, `Tool.execute`) unify effect rows by equality, not
+  subtyping — a concrete row must match exactly. The checker reports
+  this with a dedicated `rule_tag` + `rule_explanation` instead of a
+  generic unification failure, and points at narrowing the body.
+- **#555: `std.df` (Polars) gated behind an optional `df` feature.**
+  Keeps the default build and `target/` footprint down.
+- **#519/#547: coordinated dependency bumps** — arrow 55→58, polars
+  0.50→0.53, redis 0.27→1.2.
+
+### Fixed
+
+- **#514: Ollama local-model integration** — unicode escapes, `io.argv`,
+  fs-write path.
+- **#477/#506: `net` — drain lazy iter bodies before `unpack_response`.**
+- **#536: `std.redis` — open handler effect row for
+  `subscribe`/`psubscribe`.**
+
+### Security
+
+- **#554: server-imposed policy ceiling for `/v1/run`.** Caps the
+  effects a submitted program may request, closing an RCE enabler
+  (lex-hub#6).
+
+### Performance
+
+- Major interpreter-throughput work (**#461 / #462 / #464 / #229**):
+  bytecode superinstructions (`LoadLocal`+`GetField`+arith fusion,
+  match-arm fusion), escape-analysis stack allocation of non-escaping
+  tuples and records, native `list.map`/`filter`/`fold` ops (kills the
+  O(n²) clone), adaptive memoization (stop hashing cold pure functions;
+  fast structural hash in place of SHA-256), inline-cache shape
+  interning keyed on `shape_id`, and dispatch-loop code-slice caching.
+
 ### Removed
 
 - **Dropped the empty `core-syntax` and `lex-stdlib` placeholder

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.9.5"
+version = "0.9.6"
 edition = "2021"
 license = "EUPL-1.2"
 repository = "https://github.com/alpibrusl/lex-lang"

--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ tools, and orchestrators.
 
 | Module | Surface | Effect kind |
 |---|---|---|
-| **`std.http`** | Rich client with builders + decoders; `get` / `post` / `send`; per-host scopes | `[net]` (per-host scoped) |
+| **`std.http`** | Rich client with builders + decoders; `get` / `post` / `send` (GET/POST/PUT/PATCH/DELETE/HEAD); per-host scopes | `[net]` (per-host scoped) |
+| **`std.redis`** | Thin Redis client — key/value + pub/sub; connection pooling and work-queue retry via [lex-queue](https://github.com/alpibrusl/lex-queue) | `[net]` |
 | **`std.sql`** | Embedded SQLite **or** Postgres (`postgres://...`) under one API; per-connection locking | `[sql, fs_write]` |
 | **`std.kv`** | Persistent key-value store via sled | `[kv, fs_write]` |
 | **`std.crypto`** | SHA-256/512, BLAKE2b, HMAC, AES-GCM / ChaCha20-Poly1305 AEAD, PBKDF2 / HKDF / Argon2id KDFs, base64 / base64url / hex, constant-time `eq` | pure (KDFs / hashes) ; `[random]` for CSPRNG |
@@ -178,6 +179,28 @@ fn pg_users(conn :: Str) -> [sql, fs_write] Result[List[{ id :: Int, name :: Str
   }
 }
 ```
+
+## Ecosystem packages
+
+Lex is the toolchain; the agent-facing capabilities ship as separate
+pure-Lex packages. Add one to your project's `lex.toml`
+`[dependencies]` and `lex pkg install` fetches it. All live under the
+[alpibrusl](https://github.com/alpibrusl) org.
+
+| Package | What it is |
+|---|---|
+| [**lex-agent**](https://github.com/alpibrusl/lex-agent) | Pure-Lex implementation of the Google **Agent2Agent (A2A)** protocol — AgentCard, JSON-RPC 2.0 envelope, task lifecycle, SSE streaming |
+| [**lex-llm**](https://github.com/alpibrusl/lex-llm) | LLM-agent runtime — provider abstraction (Anthropic / OpenAI / Google / Ollama), multi-step tool-call loop, schema-validated structured output |
+| [**lex-spec**](https://github.com/alpibrusl/lex-spec) | Capability-precondition + spec DSL — three-valued evaluator, randomized property check, SMT-LIB export, "evaluate at both ends" gating |
+| [**lex-trail**](https://github.com/alpibrusl/lex-trail) | Content-addressed event log for A2A / LLM audit — tamper-evident attestation chains and task replay |
+| [**lex-schema**](https://github.com/alpibrusl/lex-schema) | JSON Schema 2020-12 model types + constraint validation, shared by lex-agent and lex-llm |
+| [**lex-web**](https://github.com/alpibrusl/lex-web) | HTTP router / framework — request-id correlation, gzip, structured access logs; A2A agents mount onto it |
+| [**lex-queue**](https://github.com/alpibrusl/lex-queue) | Redis-backed work queue + pub/sub fan-out, built on `std.redis` |
+| [**lex-code**](https://github.com/alpibrusl/lex-code) | A Lex-native coding assistant (build / plan / spec / test / review agents), written entirely in the packages above |
+
+The toolchain itself is this repo,
+[**lex-lang**](https://github.com/alpibrusl/lex-lang); the CLI-discovery
+contract it implements is [**acli**](https://github.com/alpibrusl/acli).
 
 ## Quickstart
 
@@ -507,7 +530,8 @@ context.
 | `std.conc` actor model | **Production-ready** | #381; synchronous mailbox, mutex-serialised |
 | `std.sql` (SQLite + Postgres) | **Production-ready** | `:memory:`, file, or `postgres://...` URI |
 | `std.crypto` (AEAD, KDFs, hashes, MAC, encodings) | **Production-ready** | AES-GCM, ChaCha20-Poly1305, Argon2id, PBKDF2, HKDF |
-| `std.http` rich client | **Production-ready** | per-host scopes; builders + decoders |
+| `std.http` rich client | **Production-ready** | per-host scopes; builders + decoders; GET/POST/PUT/PATCH/DELETE/HEAD |
+| `std.redis` (key/value + pub/sub) | **Production-ready** | #533; all ops `[net]`; pooling / work-queues via lex-queue |
 | `lex-lsp` (LSP — VS Code) | **Production-ready** | diagnostics, hover, QuickFix, RepairHint surface |
 | `lex-tea` web browser | **Production-ready** (read-only) | branches / fns / stage info |
 | Conformance harness + property tests | **Production-ready** | JSON descriptors at `conformance/` |
@@ -574,8 +598,8 @@ Linux (x86_64 / aarch64), macOS (x86_64 / aarch64), and Windows
 LICENSE / CHANGELOG. SHA-256 sums are uploaded alongside each tarball.
 
 ```bash
-tar -xzf lex-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz
-mv lex-vX.Y.Z-x86_64-unknown-linux-gnu/lex /usr/local/bin/
+tar -xzf lex-v0.9.6-x86_64-unknown-linux-gnu.tar.gz
+mv lex-v0.9.6-x86_64-unknown-linux-gnu/lex /usr/local/bin/
 lex version
 ```
 
@@ -586,16 +610,16 @@ containerd):
 
 ```bash
 # Run the agent VCS server (default; serves on :4040, stores at /data)
-docker run -p 4040:4040 -v lex-store:/data ghcr.io/alpibrusl/lex:v0.9.3
+docker run -p 4040:4040 -v lex-store:/data ghcr.io/alpibrusl/lex:v0.9.6
 
 # One-shot CLI invocation (subcommand args override the default CMD)
-docker run --rm ghcr.io/alpibrusl/lex:v0.9.3 --version
+docker run --rm ghcr.io/alpibrusl/lex:v0.9.6 --version
 docker run --rm -v "$(pwd):/work" -w /work \
-  ghcr.io/alpibrusl/lex:v0.9.3 check src/main.lex
+  ghcr.io/alpibrusl/lex:v0.9.6 check src/main.lex
 
 # Use as a base image for a downstream Lex project
 # (Dockerfile in your repo)
-FROM ghcr.io/alpibrusl/lex:v0.9.3
+FROM ghcr.io/alpibrusl/lex:v0.9.6
 COPY src /app/src
 WORKDIR /app
 CMD ["run", "src/main.lex", "main"]
@@ -606,7 +630,7 @@ this repo ships — same base, same uid 1000 `lex` user, same `/data`
 volume, same `lex serve` default — so the Docker Compose stack at
 [`docs/deploy.md`](docs/deploy.md) can switch between
 `build: .` (fast iteration, cargo-chef cached) and
-`image: ghcr.io/alpibrusl/lex:v0.9.3` (fast deploy, ~30s pull vs
+`image: ghcr.io/alpibrusl/lex:v0.9.6` (fast deploy, ~30s pull vs
 ~3 min build) without other changes.
 
 ## Building from source

--- a/crates/lex-api/Cargo.toml
+++ b/crates/lex-api/Cargo.toml
@@ -16,19 +16,19 @@ serde_json.workspace = true
 anyhow.workspace = true
 indexmap.workspace = true
 tiny_http = "0.12"
-lex-syntax = { path = "../lex-syntax", version = "0.9.5" }
-lex-ast = { path = "../lex-ast", version = "0.9.5" }
-lex-types = { path = "../lex-types", version = "0.9.5" }
-lex-bytecode = { path = "../lex-bytecode", version = "0.9.5" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.6" }
+lex-ast = { path = "../lex-ast", version = "0.9.6" }
+lex-types = { path = "../lex-types", version = "0.9.6" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.9.6" }
 # `default-features = false` drops the `df` (Polars) feature: lex-api
 # and its embedders (lex-hub) never call `std.df`, and polars pulls a
 # heavy dep tree that has conflicted on `chrono`. `std.arrow` is
 # unaffected. Workspace builds that include lex-cli still get `df` via
 # feature unification, so the toolchain is unchanged.
-lex-runtime = { path = "../lex-runtime", version = "0.9.5", default-features = false }
-lex-store = { path = "../lex-store", version = "0.9.5" }
-lex-trace = { path = "../lex-trace", version = "0.9.5" }
-lex-vcs = { path = "../lex-vcs", version = "0.9.5" }
+lex-runtime = { path = "../lex-runtime", version = "0.9.6", default-features = false }
+lex-store = { path = "../lex-store", version = "0.9.6" }
+lex-trace = { path = "../lex-trace", version = "0.9.6" }
+lex-vcs = { path = "../lex-vcs", version = "0.9.6" }
 
 flate2 = "1"
 tar = "0.4"

--- a/crates/lex-ast/Cargo.toml
+++ b/crates/lex-ast/Cargo.toml
@@ -16,4 +16,4 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-syntax = { path = "../lex-syntax", version = "0.9.5" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.6" }

--- a/crates/lex-bytecode/Cargo.toml
+++ b/crates/lex-bytecode/Cargo.toml
@@ -19,11 +19,11 @@ indexmap.workspace = true
 sha2.workspace = true
 arrow-array = "58"
 arrow-schema = "58"
-lex-ast = { path = "../lex-ast", version = "0.9.5" }
-lex-types = { path = "../lex-types", version = "0.9.5" }
+lex-ast = { path = "../lex-ast", version = "0.9.6" }
+lex-types = { path = "../lex-types", version = "0.9.6" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.9.5" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.6" }
 criterion = { version = "0.8", default-features = false, features = ["cargo_bench_support"] }
 
 [[bench]]

--- a/crates/lex-lsp/Cargo.toml
+++ b/crates/lex-lsp/Cargo.toml
@@ -25,12 +25,12 @@ serde_json.workspace = true
 # are rust-analyzer-team-maintained.
 lsp-server = "0.7"
 lsp-types = "0.97"
-lex-syntax = { path = "../lex-syntax", version = "0.9.5" }
-lex-ast = { path = "../lex-ast", version = "0.9.5" }
-lex-types = { path = "../lex-types", version = "0.9.5" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.6" }
+lex-ast = { path = "../lex-ast", version = "0.9.6" }
+lex-types = { path = "../lex-types", version = "0.9.6" }
 # Phase 4 of #304: surface RepairHint attestations from the store.
-lex-vcs = { path = "../lex-vcs", version = "0.9.5" }
-lex-store = { path = "../lex-store", version = "0.9.5" }
+lex-vcs = { path = "../lex-vcs", version = "0.9.6" }
+lex-store = { path = "../lex-store", version = "0.9.6" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -69,7 +69,7 @@ parquet = { version = "58", default-features = false, features = ["arrow", "snap
 # compile. Found the hard way during the arrow-55→58 / polars-0.50→0.53
 # coordinated bump.
 polars = { version = "0.53", optional = true, default-features = false, features = ["lazy", "is_in", "csv", "performant", "strings", "temporal"] }
-lex-bytecode = { path = "../lex-bytecode", version = "0.9.5" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.9.6" }
 smol_str = { workspace = true }
 
 [features]
@@ -88,7 +88,7 @@ df = ["dep:polars"]
 quic = ["dep:quinn", "dep:h3", "dep:h3-quinn", "dep:rustls", "dep:rustls-pemfile", "dep:rcgen"]
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.9.5" }
-lex-ast = { path = "../lex-ast", version = "0.9.5" }
-lex-types = { path = "../lex-types", version = "0.9.5" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.6" }
+lex-ast = { path = "../lex-ast", version = "0.9.6" }
+lex-types = { path = "../lex-types", version = "0.9.6" }
 tempfile = "3"

--- a/crates/lex-search/Cargo.toml
+++ b/crates/lex-search/Cargo.toml
@@ -17,10 +17,10 @@ thiserror.workspace = true
 sha2.workspace = true
 hex.workspace = true
 ureq = { version = "3.3", default-features = false, features = ["rustls", "platform-verifier", "json"] }
-lex-ast = { path = "../lex-ast", version = "0.9.5" }
-lex-store = { path = "../lex-store", version = "0.9.5" }
+lex-ast = { path = "../lex-ast", version = "0.9.6" }
+lex-store = { path = "../lex-store", version = "0.9.6" }
 
 [dev-dependencies]
 tempfile = "3"
 tiny_http = "0.12"
-lex-syntax = { path = "../lex-syntax", version = "0.9.5" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.6" }

--- a/crates/lex-store/Cargo.toml
+++ b/crates/lex-store/Cargo.toml
@@ -21,11 +21,11 @@ hex.workspace = true
 # transitive dep via tempfile; promoting to direct so the lock
 # call sites compile.
 fs2 = "0.4"
-lex-ast = { path = "../lex-ast", version = "0.9.5" }
-lex-trace = { path = "../lex-trace", version = "0.9.5" }
-lex-types = { path = "../lex-types", version = "0.9.5" }
-lex-vcs = { path = "../lex-vcs", version = "0.9.5" }
+lex-ast = { path = "../lex-ast", version = "0.9.6" }
+lex-trace = { path = "../lex-trace", version = "0.9.6" }
+lex-types = { path = "../lex-types", version = "0.9.6" }
+lex-vcs = { path = "../lex-vcs", version = "0.9.6" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.9.5" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.6" }
 tempfile = "3"

--- a/crates/lex-trace/Cargo.toml
+++ b/crates/lex-trace/Cargo.toml
@@ -16,9 +16,9 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-bytecode = { path = "../lex-bytecode", version = "0.9.5" }
-lex-ast = { path = "../lex-ast", version = "0.9.5" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.9.6" }
+lex-ast = { path = "../lex-ast", version = "0.9.6" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.9.5" }
-lex-runtime = { path = "../lex-runtime", version = "0.9.5" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.6" }
+lex-runtime = { path = "../lex-runtime", version = "0.9.6" }

--- a/crates/lex-types/Cargo.toml
+++ b/crates/lex-types/Cargo.toml
@@ -15,7 +15,7 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-ast = { path = "../lex-ast", version = "0.9.5" }
+lex-ast = { path = "../lex-ast", version = "0.9.6" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.9.5" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.6" }

--- a/crates/lex-vcs/Cargo.toml
+++ b/crates/lex-vcs/Cargo.toml
@@ -11,8 +11,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-lex-ast = { path = "../lex-ast", version = "0.9.5" }
-lex-types = { path = "../lex-types", version = "0.9.5" }
+lex-ast = { path = "../lex-ast", version = "0.9.6" }
+lex-types = { path = "../lex-types", version = "0.9.6" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
@@ -24,4 +24,4 @@ hex.workspace = true
 
 [dev-dependencies]
 tempfile = "3"
-lex-syntax = { path = "../lex-syntax", version = "0.9.5" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.6" }

--- a/crates/spec-checker/Cargo.toml
+++ b/crates/spec-checker/Cargo.toml
@@ -16,11 +16,11 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-syntax = { path = "../lex-syntax", version = "0.9.5" }
-lex-ast = { path = "../lex-ast", version = "0.9.5" }
-lex-types = { path = "../lex-types", version = "0.9.5" }
-lex-bytecode = { path = "../lex-bytecode", version = "0.9.5" }
-lex-runtime = { path = "../lex-runtime", version = "0.9.5" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.6" }
+lex-ast = { path = "../lex-ast", version = "0.9.6" }
+lex-types = { path = "../lex-types", version = "0.9.6" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.9.6" }
+lex-runtime = { path = "../lex-runtime", version = "0.9.6" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.9.5" }
+lex-syntax = { path = "../lex-syntax", version = "0.9.6" }


### PR DESCRIPTION
## Summary

Cuts **0.9.6**. Bumps the workspace version `0.9.5 → 0.9.6` (and the inter-crate dependency pins) and adds the CHANGELOG entry for the **69 commits** merged since `v0.9.5` (2026-05-17).

Headlines:
- `lex docs <path> --output json` — structured API-docs JSON (#564) + the docs CI workflow (#567)
- `std.redis` thin Redis client (#533); `net.serve_quic` HTTP/3 (#496); `net.serve_with` (#497); `iter.collect` (#500); `http.send` PUT/PATCH/DELETE/HEAD (#503)
- **Effect-row invariance** surfaced as its own `effect-row-mismatch` error (#565)
- **Security:** server-imposed policy ceiling for `/v1/run` (#554)
- Large interpreter performance pass (#461/#462/#464/#229)

Once merged, pushing the `v0.9.6` tag triggers the release workflow to build + publish the cross-platform binaries. This unblocks downstream repos (e.g. lex-agent, whose `src/client.lex` already uses `http.stream_lines` that doesn't exist in 0.9.5).

## Test plan

- [ ] `cargo test --workspace` / clippy green on CI
- [ ] `lex --version` reports `0.9.6`
- [ ] After merge: tag `v0.9.6` → release workflow publishes binaries

https://claude.ai/code/session_01YEEq364jnTBau9BudzDNBm

---
_Generated by [Claude Code](https://claude.ai/code/session_01YEEq364jnTBau9BudzDNBm)_