### PR TITLE
perf(#463) slice 1: request-scope arena-eligibility analysis

### DIFF
--- a/crates/lex-bytecode/src/arena.rs
+++ b/crates/lex-bytecode/src/arena.rs
@@ -1,0 +1,365 @@
+//! Request-scope arena-eligibility analysis (#463 slice 1).
+//!
+//! Per-allocation-site classification: is this `MakeRecord` /
+//! `MakeTuple` value safe to route through the active per-request
+//! arena (`EffectHandler::enter_request_scope`), instead of the
+//! global allocator?
+//!
+//! ## Relationship to `escape::analyze_function` (#464)
+//!
+//! Same lattice, same worklist, same step rules — with **one bit of
+//! policy flipped**: `Op::Return` is not an escape op here, because
+//! the returned value goes to the caller's stack and the caller is
+//! in the same request scope as us. Everything else (`Call`,
+//! `CallClosure`, `TailCall`, `EffectCall`, `MakeClosure` captures,
+//! aggregate-as-field, worker-pool ops, `Dup`, …) stays a hatch under
+//! the slice-1 intra-procedural conservative policy. The shared
+//! machinery is `escape::analyze_function_with_policy(_,
+//! Policy::RequestScope)`; this module wraps it and inverts the
+//! per-site `escapes` bool into `arena_eligible`.
+//!
+//! ## Slice scope
+//!
+//! Analysis only. No opcode lowering, no runtime behavior change, no
+//! bytecode-format change. Slice 2 (`AllocArenaRecord` /
+//! `AllocArenaList` / handle variants on `Value`) consults
+//! `build_arena_index` at codegen time.
+//!
+//! ## Soundness contract
+//!
+//! Inherits #464's contract verbatim (`docs/design/escape-analysis.md`
+//! § "Soundness contract"):
+//!
+//! - **Over-approximation** (`arena_eligible = false` when the value
+//!   actually stays in-scope) costs a heap allocation — the
+//!   status-quo baseline. Acceptable.
+//! - **Under-approximation** (`arena_eligible = true` when the value
+//!   actually escapes the request) would let an arena handle outlive
+//!   its slab and is UB. Slice 2 must pair this analysis with an
+//!   unconditional runtime fallback (same shape as #464's
+//!   `AllocStackRecord` heap fallback), so a missed hatch costs
+//!   correctness only if the analysis is wrong *and* the fallback is
+//!   omitted — never both.
+//!
+//! ## Out of scope for slice 1
+//!
+//! - Inter-procedural escape (the scoping doc defers this until
+//!   inlining lands with #465 phase 1; any `Call` is a hatch here).
+//! - Worker-handler lifetime split (`spawn_for_worker` clone-handlers
+//!   get a fresh empty arena stack — values handed to workers must
+//!   never become arena handles). Already covered by the conservative
+//!   hatches on `Call`/`ParallelMap`/`SortByKey`; slice 2 must keep
+//!   that invariant when routing.
+
+use std::collections::HashMap;
+
+use crate::escape::{analyze_function_with_policy, Policy, SiteKind};
+use crate::program::Function;
+
+/// Per-function arena-eligibility report. Mirrors `EscapeReport`'s
+/// shape with the per-site bool inverted (`arena_eligible =
+/// !escapes_under_request_scope`) and renamed to reflect what
+/// downstream codegen will use it for.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArenaReport {
+    pub fn_name: String,
+    pub sites: Vec<ArenaSite>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ArenaSite {
+    pub pc: u32,
+    pub kind: SiteKind,
+    pub shape_idx: u32,
+    pub field_count: u16,
+    /// `true` if the value never leaves the request scope on any
+    /// reachable path — safe to allocate from the active request
+    /// arena. `false` means a hatch (`Call`, `EffectCall`,
+    /// `MakeClosure` capture, worker-pool op, …) is reachable — keep
+    /// on the heap.
+    pub arena_eligible: bool,
+}
+
+/// Analyze one function. Cheap on functions with no aggregate sites
+/// (early-exits in the underlying pass).
+pub fn analyze_function(func: &Function) -> ArenaReport {
+    let r = analyze_function_with_policy(func, Policy::RequestScope);
+    let sites = r
+        .sites
+        .into_iter()
+        .map(|s| ArenaSite {
+            pc: s.pc,
+            kind: s.kind,
+            shape_idx: s.shape_idx,
+            field_count: s.field_count,
+            arena_eligible: !s.escapes,
+        })
+        .collect();
+    ArenaReport { fn_name: r.fn_name, sites }
+}
+
+/// Analyze every function. Functions with no aggregate sites are
+/// omitted from the result, matching `escape::analyze_program`.
+pub fn analyze_program(functions: &[Function]) -> Vec<ArenaReport> {
+    functions
+        .iter()
+        .filter_map(|f| {
+            let r = analyze_function(f);
+            (!r.sites.is_empty()).then_some(r)
+        })
+        .collect()
+}
+
+/// Convenience map keyed by `(fn_name, pc)` for direct lookup during
+/// the slice-2 codegen pass. Mirrors `escape::build_escape_index`
+/// exactly so the codegen swap is structural.
+pub fn build_arena_index(functions: &[Function]) -> HashMap<(String, u32), bool> {
+    let mut idx = HashMap::new();
+    for report in analyze_program(functions) {
+        for site in report.sites {
+            idx.insert((report.fn_name.clone(), site.pc), site.arena_eligible);
+        }
+    }
+    idx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::op::Op;
+    use crate::program::{Function, ZERO_BODY_HASH};
+
+    fn func(name: &str, locals_count: u16, arity: u16, code: Vec<Op>) -> Function {
+        Function {
+            name: name.into(),
+            arity,
+            locals_count,
+            code,
+            effects: vec![],
+            body_hash: ZERO_BODY_HASH,
+            refinements: vec![],
+            field_ic_sites: 0,
+        }
+    }
+
+    fn assert_eligible(report: &ArenaReport, expected: &[(u32, bool)]) {
+        let got: Vec<(u32, bool)> = report
+            .sites
+            .iter()
+            .map(|s| (s.pc, s.arena_eligible))
+            .collect();
+        assert_eq!(
+            got, expected,
+            "arena eligibility for `{}` differs from expected",
+            report.fn_name
+        );
+    }
+
+    // ---- The slice's reason for existing: Return is not a hatch ----
+
+    /// A record built and returned (e.g. the `Response` the handler
+    /// hands up to `net.serve_fn`) is arena-eligible. Under #464's
+    /// frame-scope policy this identical shape escapes — the
+    /// divergence is the whole point.
+    #[test]
+    fn record_returned_is_arena_eligible() {
+        let f = func("handler", 0, 0, vec![
+            Op::PushConst(0),
+            Op::PushConst(1),
+            Op::MakeRecord { shape_idx: 0, field_count: 2 },
+            Op::Return,
+        ]);
+        let r = analyze_function(&f);
+        assert_eligible(&r, &[(2, true)]);
+    }
+
+    /// Tuple returned: same divergence as record. Confirms the
+    /// policy bit applies uniformly across aggregate kinds.
+    #[test]
+    fn tuple_returned_is_arena_eligible() {
+        let f = func("handler_t", 0, 0, vec![
+            Op::PushConst(0),
+            Op::PushConst(1),
+            Op::MakeTuple(2),
+            Op::Return,
+        ]);
+        let r = analyze_function(&f);
+        assert_eligible(&r, &[(2, true)]);
+    }
+
+    /// Round-trip through a local, then returned. The local read
+    /// keeps the slot tracked, and the Return doesn't escape under
+    /// request scope. End-to-end arena-eligible.
+    #[test]
+    fn record_round_tripped_and_returned_is_arena_eligible() {
+        let f = func("handler_rt", 1, 0, vec![
+            Op::PushConst(0),
+            Op::PushConst(1),
+            Op::MakeRecord { shape_idx: 0, field_count: 2 },
+            Op::StoreLocal(0),
+            Op::LoadLocal(0),
+            Op::Return,
+        ]);
+        let r = analyze_function(&f);
+        assert_eligible(&r, &[(2, true)]);
+    }
+
+    // ---- All other hatches still apply (parity with #464) ----
+
+    /// Slice 1's intra-procedural conservatism: any `Call` into a
+    /// non-inlined helper is a hatch. Args may leak via the callee's
+    /// own escape paths (`spawn`, channel send, module-level store).
+    #[test]
+    fn record_passed_to_call_is_not_arena_eligible() {
+        let f = func("caller", 0, 0, vec![
+            Op::PushConst(0),
+            Op::MakeRecord { shape_idx: 0, field_count: 1 },
+            Op::Call { fn_id: 1, arity: 1, node_id_idx: 0 },
+            Op::Return,
+        ]);
+        let r = analyze_function(&f);
+        assert_eligible(&r, &[(1, false)]);
+    }
+
+    /// Closure capture is a hatch — closures may outlive the request
+    /// (stored in module-level state, returned to the runtime, …).
+    #[test]
+    fn record_captured_in_closure_is_not_arena_eligible() {
+        let f = func("capturer", 0, 0, vec![
+            Op::PushConst(0),
+            Op::MakeRecord { shape_idx: 0, field_count: 1 },
+            Op::MakeClosure { fn_id: 1, capture_count: 1 },
+            Op::Return,
+        ]);
+        let r = analyze_function(&f);
+        assert_eligible(&r, &[(1, false)]);
+    }
+
+    /// EffectCall is a hatch — effect handlers can spawn workers,
+    /// send on channels, persist to disk: any path that outlives the
+    /// request.
+    #[test]
+    fn record_passed_to_effect_is_not_arena_eligible() {
+        let f = func("effecting", 0, 0, vec![
+            Op::PushConst(0),
+            Op::MakeRecord { shape_idx: 0, field_count: 1 },
+            Op::EffectCall { kind_idx: 0, op_idx: 0, arity: 1, node_id_idx: 0 },
+            Op::Return,
+        ]);
+        let r = analyze_function(&f);
+        assert_eligible(&r, &[(1, false)]);
+    }
+
+    // ---- Site bookkeeping ----
+
+    #[test]
+    fn record_dropped_is_arena_eligible() {
+        let f = func("drop", 0, 0, vec![
+            Op::PushConst(0),
+            Op::MakeRecord { shape_idx: 0, field_count: 1 },
+            Op::Pop,
+            Op::PushConst(0),
+            Op::Return,
+        ]);
+        let r = analyze_function(&f);
+        assert_eligible(&r, &[(1, true)]);
+    }
+
+    /// Inner record stored as a field of outer; outer returned.
+    /// Inner escapes (consumed by the outer aggregate's heap
+    /// constructor — slice-1 doesn't yet model "outer is also
+    /// arena → inner can live with it"; that's a slice-2 codegen
+    /// question). Outer is arena-eligible — its only consumer is
+    /// `Return`, which doesn't escape under request scope.
+    #[test]
+    fn outer_returned_aggregate_is_arena_eligible_inner_field_is_not() {
+        let f = func("nest", 0, 0, vec![
+            Op::PushConst(0),
+            Op::MakeRecord { shape_idx: 0, field_count: 1 }, // inner @ pc=1
+            Op::PushConst(1),
+            Op::MakeRecord { shape_idx: 1, field_count: 2 }, // outer @ pc=3
+            Op::Return,
+        ]);
+        let r = analyze_function(&f);
+        assert_eligible(&r, &[(1, false), (3, true)]);
+    }
+
+    /// Two sites in one function, independently classified: one
+    /// returned (arena), one passed to a call (heap).
+    #[test]
+    fn two_sites_classified_independently() {
+        let f = func("mixed", 1, 0, vec![
+            Op::PushConst(0),
+            Op::MakeRecord { shape_idx: 0, field_count: 1 }, // pc=1: kept, returned
+            Op::StoreLocal(0),
+            Op::PushConst(0),
+            Op::MakeRecord { shape_idx: 0, field_count: 1 }, // pc=4: passed to call
+            Op::Call { fn_id: 1, arity: 1, node_id_idx: 0 },
+            Op::Pop,
+            Op::LoadLocal(0),
+            Op::Return,
+        ]);
+        let r = analyze_function(&f);
+        assert_eligible(&r, &[(1, true), (4, false)]);
+    }
+
+    #[test]
+    fn build_arena_index_keys_by_fn_and_pc() {
+        let f = func("idx_test", 0, 0, vec![
+            Op::PushConst(0),
+            Op::MakeRecord { shape_idx: 0, field_count: 1 },
+            Op::Return,
+        ]);
+        let idx = build_arena_index(&[f]);
+        assert_eq!(idx.get(&("idx_test".into(), 1)), Some(&true));
+    }
+
+    #[test]
+    fn analyze_program_skips_functions_with_no_sites() {
+        let f1 = func("noaggs", 0, 0, vec![Op::PushConst(0), Op::Return]);
+        let f2 = func("hasagg", 0, 0, vec![
+            Op::PushConst(0),
+            Op::MakeRecord { shape_idx: 0, field_count: 1 },
+            Op::Return,
+        ]);
+        let reports = analyze_program(&[f1, f2]);
+        assert_eq!(reports.len(), 1);
+        assert_eq!(reports[0].fn_name, "hasagg");
+    }
+
+    // ---- Parity sanity vs #464 ----
+
+    /// Where the two analyses *should* agree (a Call hatch is a hatch
+    /// regardless of policy), they do.
+    #[test]
+    fn parity_with_frame_escape_on_shared_hatch() {
+        use crate::escape::analyze_function as analyze_frame;
+        let f = func("parity_hatch", 0, 0, vec![
+            Op::PushConst(0),
+            Op::MakeRecord { shape_idx: 0, field_count: 1 },
+            Op::Call { fn_id: 1, arity: 1, node_id_idx: 0 },
+            Op::Return,
+        ]);
+        let arena = analyze_function(&f);
+        let frame = analyze_frame(&f);
+        assert!(!arena.sites[0].arena_eligible);
+        assert!(frame.sites[0].escapes);
+    }
+
+    /// Where the two *should* diverge (a plain Return), they do —
+    /// this test is the documented intentional difference and would
+    /// fire if the policy bit ever got dropped in a refactor.
+    #[test]
+    fn diverges_from_frame_escape_on_return() {
+        use crate::escape::analyze_function as analyze_frame;
+        let f = func("parity_return", 0, 0, vec![
+            Op::PushConst(0),
+            Op::MakeRecord { shape_idx: 0, field_count: 1 },
+            Op::Return,
+        ]);
+        let arena = analyze_function(&f);
+        let frame = analyze_frame(&f);
+        assert!(arena.sites[0].arena_eligible);
+        assert!(frame.sites[0].escapes);
+    }
+}

--- a/crates/lex-bytecode/src/escape.rs
+++ b/crates/lex-bytecode/src/escape.rs
@@ -62,6 +62,26 @@ use std::collections::{HashMap, HashSet};
 use crate::op::Op;
 use crate::program::Function;
 
+/// Scope policy for the escape analysis. Only `Op::Return` consults
+/// it — every other escape rule is identical across policies.
+///
+/// - `FrameScope` (default for #464 stack-record lowering): `Return`
+///   leaks its operand, because the returned value crosses the
+///   current function's frame into the caller.
+/// - `RequestScope` (for #463 arena routing): `Return` does NOT leak
+///   its operand — the value goes to the caller's stack and the
+///   caller is in the same request scope opened by
+///   `EffectHandler::enter_request_scope`. What the caller does with
+///   the returned value is an inter-procedural question, deliberately
+///   left to the caller's own conservative `Call` arm (which marks
+///   its args as escaping in the intra-procedural first cut). See
+///   `docs/design/arena-plumbing.md`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Policy {
+    FrameScope,
+    RequestScope,
+}
+
 /// Abstract value at a stack or local slot during the analysis.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Slot {
@@ -210,9 +230,17 @@ pub fn analyze_program(functions: &[Function]) -> Vec<EscapeReport> {
         .collect()
 }
 
-/// Analyze one function. Cheap to call even when there are no
-/// record sites (early-exits after the first pass over `code`).
+/// Analyze one function under the default `Policy::FrameScope`.
+/// See `analyze_function_with_policy` for the policy-parameterized
+/// form used by #463 arena routing.
 pub fn analyze_function(func: &Function) -> EscapeReport {
+    analyze_function_with_policy(func, Policy::FrameScope)
+}
+
+/// Analyze one function under the given scope policy. Cheap to call
+/// even when there are no aggregate sites (early-exits after the
+/// first pass over `code`).
+pub fn analyze_function_with_policy(func: &Function, policy: Policy) -> EscapeReport {
     // Inventory the MakeRecord sites first. If there are none,
     // skip the whole fixpoint — the function can't benefit from
     // stack allocation anyway.
@@ -263,7 +291,7 @@ pub fn analyze_function(func: &Function) -> EscapeReport {
         in_state[pc] = Some(merged.clone());
 
         // Step the op, get the out-state + any successors.
-        let (out, succs, leaked) = step(pc, &func.code[pc], merged);
+        let (out, succs, leaked) = step(pc, &func.code[pc], merged, policy);
         escaped.extend(leaked);
         for s in succs {
             if s < n {
@@ -290,7 +318,7 @@ pub fn analyze_function(func: &Function) -> EscapeReport {
 /// returned state, except for control-flow ops where successors
 /// share the *same* state), and any sites that escaped during the
 /// step.
-fn step(pc: usize, op: &Op, mut s: State) -> (State, Vec<usize>, HashSet<u32>) {
+fn step(pc: usize, op: &Op, mut s: State, policy: Policy) -> (State, Vec<usize>, HashSet<u32>) {
     let mut escapes: HashSet<u32> = HashSet::new();
 
     // Helper closures for the common pop-n / push patterns.
@@ -426,7 +454,13 @@ fn step(pc: usize, op: &Op, mut s: State) -> (State, Vec<usize>, HashSet<u32>) {
             return (s, vec![pc + 1, target], escapes);
         }
         Op::Return => {
-            if let Some(top) = s.stack.pop() { leak(top, &mut escapes); }
+            let top = s.stack.pop();
+            // The only policy-sensitive arm: under FrameScope the
+            // returned value crosses our frame and leaks; under
+            // RequestScope it stays inside the request and does not.
+            if matches!(policy, Policy::FrameScope) {
+                if let Some(top) = top { leak(top, &mut escapes); }
+            }
             return (s, vec![], escapes);
         }
         Op::Panic(_) => {

--- a/crates/lex-bytecode/src/lib.rs
+++ b/crates/lex-bytecode/src/lib.rs
@@ -10,6 +10,7 @@ pub mod parser_runtime;
 pub mod vm;
 pub mod verify;
 pub mod escape;
+pub mod arena;
 
 pub use compiler::compile_program;
 pub use op::{Const, Op};
@@ -17,4 +18,7 @@ pub use program::{Function, Program};
 pub use value::{MapKey, Value};
 pub use vm::{Vm, VmError, MAX_CALL_DEPTH};
 pub use verify::{verify_program, StackError};
-pub use escape::{analyze_program as analyze_escapes, EscapeReport, EscapeSite, SiteKind};
+pub use escape::{analyze_program as analyze_escapes, EscapeReport, EscapeSite, Policy, SiteKind};
+pub use arena::{
+    analyze_program as analyze_arena, build_arena_index, ArenaReport, ArenaSite,
+};


### PR DESCRIPTION
## Summary

First slice of #463 (per-request arena), per the plan in `docs/design/arena-plumbing.md` that merged in #558.

**Analysis only** — no opcode lowering, no runtime behavior change, no bytecode-format change. Adds the `build_arena_index` API that the slice-2 codegen will consult to decide which `MakeRecord` / `MakeTuple` sites can be routed into the active request arena.

### Implementation

- **`escape.rs`**: extract a `Policy` parameter (`FrameScope` for #464, `RequestScope` for #463). The only step rule that depends on policy is `Op::Return`: under `RequestScope` the returned value stays inside the request scope and does not leak. Every other escape op (`Call`, `EffectCall`, `MakeClosure` captures, worker-pool ops, aggregate-as-field, `Dup`, …) is shared verbatim. `analyze_function` keeps its existing signature — it's now a one-line wrapper around `analyze_function_with_policy(_, FrameScope)`, so all #464 callers see identical behavior.
- **`arena.rs`** (new): `ArenaReport` / `ArenaSite` mirror `EscapeReport` / `EscapeSite` with the per-site bool flipped to `arena_eligible`. `build_arena_index` returns the same `HashMap<(String, u32), bool>` shape as `build_escape_index` so slice 2's codegen swap is structural.

### Soundness

Inherits #464's contract verbatim (see the doc comment at the top of `arena.rs`):
- Over-approximation (heap a value that could've been arena) = status quo, fine.
- Under-approximation (arena a value that escapes the request) = UB. Slice 2 must pair this analysis with an unconditional runtime fallback (same shape as `AllocStackRecord`'s heap fallback).

Intra-procedural and conservative on purpose: any `Call` is a hatch, matching the scoping doc's slice-1 framing.

### Test plan

- [x] 13 new tests in `arena::tests` cover the divergence-from-#464 cases (returned record/tuple → arena-eligible) and parity on shared hatches (Call/EffectCall/MakeClosure capture → not eligible).
- [x] Two explicit parity-sanity tests guard against the `Policy` bit getting dropped in a future refactor: one asserts agreement on a shared hatch, the other asserts the *intended* divergence on plain Return.
- [x] `cargo test -p lex-bytecode --lib` → 52 passed (24 escape + 13 arena + the rest), 0 failed.
- [x] `cargo test -p lex-bytecode --tests` → all integration suites green (`stack_records` etc., unchanged).
- [x] `cargo clippy -p lex-bytecode --all-targets -- -D warnings` clean.
- [ ] `--workspace` not runnable in the dev container (polars/arrow/tokio static-link set overflows disk; same constraint as #464). The change is analysis-only and confined to `lex-bytecode`, so the gates above cover the affected surface.

https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk)_