### PR TITLE
Add Claude Code plugin for the Lex toolchain + lex-hub

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "lex",
+  "description": "Claude Code plugins for the Lex toolchain and the lex-hub gateway.",
+  "owner": {
+    "name": "alpibrusl",
+    "url": "https://github.com/alpibrusl"
+  },
+  "plugins": [
+    {
+      "name": "lex",
+      "source": "./integrations/claude-plugin",
+      "description": "Lex agent-code loop (check/repair/publish/run), idiom rules, and MCP tools for a hosted lex-hub gateway.",
+      "category": "languages",
+      "keywords": ["lex", "lex-lang", "lex-hub", "typed-effects", "mcp"]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -287,6 +287,20 @@ with semantic exit codes. The auto-generated `.cli/` folder is
 committed in this repo so agents browsing GitHub can read
 `commands.json` without running the binary.
 
+### Claude Code plugin
+
+For [Claude Code](https://code.claude.com) specifically, a ready-made
+plugin lives in [`integrations/claude-plugin/`](integrations/claude-plugin).
+It bundles a skill (the `lex` CLI + idiom rules), slash commands
+(`/lex:lex-check`, `/lex:lex-repair`, `/lex:lex-publish`,
+`/lex:lex-run`), and an MCP server that bridges to a hosted
+[lex-hub](https://github.com/alpibrusl/lex-hub) gateway:
+
+```text
+/plugin marketplace add alpibrusl/lex-lang
+/plugin install lex@lex
+```
+
 ## Toolchain reference
 
 The full table is regenerable via `lex --output json introspect`; the

--- a/crates/lex-bytecode/benches/dispatch.rs
+++ b/crates/lex-bytecode/benches/dispatch.rs
@@ -22,7 +22,8 @@
 
 use std::sync::Arc;
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use std::hint::black_box;
 use lex_ast::canonicalize_program;
 use lex_bytecode::vm::Vm;
 use lex_bytecode::{compile_program, Program, Value};

--- a/crates/lex-bytecode/benches/field_access.rs
+++ b/crates/lex-bytecode/benches/field_access.rs
@@ -30,7 +30,8 @@
 
 use std::sync::Arc;
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use std::hint::black_box;
 use lex_ast::canonicalize_program;
 use lex_bytecode::vm::Vm;
 use lex_bytecode::{compile_program, Program, Value};

--- a/crates/lex-bytecode/benches/response_build.rs
+++ b/crates/lex-bytecode/benches/response_build.rs
@@ -29,7 +29,8 @@
 
 use std::sync::Arc;
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use std::hint::black_box;
 use lex_ast::canonicalize_program;
 use lex_bytecode::vm::Vm;
 use lex_bytecode::{compile_program, Program, Value};

--- a/crates/lex-bytecode/benches/tuple_build.rs
+++ b/crates/lex-bytecode/benches/tuple_build.rs
@@ -17,7 +17,8 @@
 
 use std::sync::Arc;
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use std::hint::black_box;
 use lex_ast::canonicalize_program;
 use lex_bytecode::vm::Vm;
 use lex_bytecode::{compile_program, Program, Value};

--- a/crates/lex-runtime/src/quic.rs
+++ b/crates/lex-runtime/src/quic.rs
@@ -386,6 +386,6 @@ pub(crate) fn self_signed_pem(hostname: &str) -> Result<(Vec<u8>, Vec<u8>), Stri
     let ck = rcgen::generate_simple_self_signed(vec![hostname.to_string()])
         .map_err(|e| format!("rcgen self-signed: {e}"))?;
     let cert_pem = ck.cert.pem().into_bytes();
-    let key_pem = ck.key_pair.serialize_pem().into_bytes();
+    let key_pem = ck.signing_key.serialize_pem().into_bytes();
     Ok((cert_pem, key_pem))
 }

--- a/integrations/claude-plugin/.claude-plugin/plugin.json
+++ b/integrations/claude-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "lex",
+  "displayName": "Lex",
+  "description": "Drive the Lex toolchain (lex CLI) and a hosted lex-hub gateway from Claude Code: the agent-code loop (check → repair → publish → run), the idiom rules, and MCP tools against a remote hub.",
+  "version": "0.1.0",
+  "author": {
+    "name": "alpibrusl",
+    "url": "https://github.com/alpibrusl"
+  },
+  "homepage": "https://github.com/alpibrusl/lex-lang",
+  "repository": "https://github.com/alpibrusl/lex-lang",
+  "license": "EUPL-1.2",
+  "keywords": ["lex", "lex-lang", "lex-hub", "typed-effects", "agent", "mcp"]
+}

--- a/integrations/claude-plugin/.mcp.json
+++ b/integrations/claude-plugin/.mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "lex-hub": {
+      "command": "lex-hub-mcp",
+      "env": {
+        "LEXHUB_URL": "${LEXHUB_URL}",
+        "LEXHUB_TOKEN": "${LEXHUB_TOKEN}",
+        "LEXHUB_JWT_SECRET": "${LEXHUB_JWT_SECRET}",
+        "LEXHUB_TENANT": "${LEXHUB_TENANT}",
+        "LEXHUB_JWT_AUDIENCE": "${LEXHUB_JWT_AUDIENCE}",
+        "LEXHUB_JWT_ISSUER": "${LEXHUB_JWT_ISSUER}"
+      }
+    }
+  }
+}

--- a/integrations/claude-plugin/README.md
+++ b/integrations/claude-plugin/README.md
@@ -1,0 +1,87 @@
+# Lex — Claude Code plugin
+
+A [Claude Code](https://code.claude.com) plugin that teaches Claude to drive
+the **Lex** toolchain and, optionally, a hosted **lex-hub** gateway.
+
+It bundles three things:
+
+- **A skill** (`skills/lex/`) — when/how to run the `lex` CLI plus the
+  effect-discipline idiom rules and syntax pitfalls. Auto-loads when you're
+  working with `.lex` files or `lex.toml`.
+- **Slash commands** — one-key wrappers over the agent-code loop:
+  - `/lex:lex-check` — type-check and surface structured errors.
+  - `/lex:lex-repair` — the repair-not-regenerate loop (`lex repair --apply`).
+  - `/lex:lex-publish` — fmt + check + publish to the store.
+  - `/lex:lex-run` — check + run a function under a narrow policy.
+- **An MCP server** (`lex-hub`) — first-class tools (`lex_check`,
+  `lex_publish`, `lex_run`, `lex_patch`, `lex_stage_attestations`,
+  `lex_health`) against a remote lex-hub gateway.
+
+## Install
+
+```text
+/plugin marketplace add alpibrusl/lex-lang
+/plugin install lex@lex
+```
+
+That installs the skill and slash commands immediately. The two integration
+points below are only needed for the workflows that use them.
+
+### Local `lex` CLI (for the skill + slash commands)
+
+The skill and commands shell out to the `lex` binary. Install a release from
+<https://github.com/alpibrusl/lex-lang/releases> (or `cargo build --release`
+in a checkout) and make sure `lex` is on your `PATH`:
+
+```sh
+lex --version
+```
+
+### Remote lex-hub (for the MCP tools)
+
+The `lex-hub` MCP server runs the `lex-hub-mcp` binary, which lives in the
+[lex-hub](https://github.com/alpibrusl/lex-hub) repo. Put it on your `PATH`:
+
+```sh
+cargo install --git https://github.com/alpibrusl/lex-hub lex-hub-mcp
+```
+
+Then set the gateway URL and credentials in your environment (the plugin's
+`.mcp.json` passes these through). Provide **either** a pre-minted token
+**or** a secret + tenant to mint one:
+
+```sh
+export LEXHUB_URL="https://api.example.com"
+
+# Option A — a pre-minted bearer JWT:
+export LEXHUB_TOKEN="eyJhbGciOi..."
+
+# Option B — mint a short-lived HS256 token (sub = tenant):
+export LEXHUB_JWT_SECRET="your-secret"
+export LEXHUB_TENANT="my-tenant"
+```
+
+If `LEXHUB_URL` and credentials aren't set, the MCP server won't start — the
+skill and slash commands (local CLI) still work without it.
+
+## Layout
+
+```
+integrations/claude-plugin/
+├── .claude-plugin/plugin.json   # manifest
+├── .mcp.json                    # lex-hub MCP server (runs lex-hub-mcp)
+├── commands/                    # /lex:lex-check, lex-repair, lex-publish, lex-run
+├── skills/lex/SKILL.md          # the lex CLI skill + idiom rules
+└── README.md
+```
+
+The marketplace manifest is at the repo root: `.claude-plugin/marketplace.json`.
+
+## Why this split
+
+The local `lex` CLI is already agent-discoverable (it implements the ACLI
+contract: `lex introspect` / `lex skill` / `lex agent-guidelines`), so the
+skill + commands are thin orchestration over a self-describing tool. The
+hosted gateway isn't MCP-native — it speaks JWT'd HTTP/JSON — so the
+`lex-hub-mcp` bridge (shipped in the lex-hub repo) turns it into first-class
+MCP tools.

--- a/integrations/claude-plugin/commands/lex-check.md
+++ b/integrations/claude-plugin/commands/lex-check.md
@@ -1,0 +1,20 @@
+---
+description: Type-check Lex source and, on failure, surface the structured errors (rule_tag + suggested_transform) ready for a repair step.
+argument-hint: "[file-or-dir]"
+allowed-tools: Bash(lex:*), Read
+---
+
+Type-check the Lex target: `$ARGUMENTS` (default to the project `src/` if no
+argument is given).
+
+1. Run `lex check --strict $ARGUMENTS`.
+2. If it passes, report `ok` plus any required-effects hint and stop.
+3. If it fails, re-run with `lex --output json check $ARGUMENTS` and, for each
+   error, report:
+   - `file:line:col`
+   - the `rule_tag` and `rule_explanation`
+   - the `suggested_transform` verbatim, if present
+4. Do **not** fix anything by broadening an effect signature. If there is a
+   `suggested_transform`, recommend `/lex:lex-repair` to apply it. If the fix
+   is a body change, propose the narrowed body but wait for confirmation
+   before editing.

--- a/integrations/claude-plugin/commands/lex-publish.md
+++ b/integrations/claude-plugin/commands/lex-publish.md
@@ -1,0 +1,24 @@
+---
+description: Format, type-check, then publish Lex functions as typed Operations into the content-addressed store, reporting each fn's SigId / StageId / status.
+argument-hint: "[file] [--activate]"
+allowed-tools: Bash(lex:*), Read
+---
+
+Publish Lex source into the store. Target: `$ARGUMENTS`.
+
+Gate before publishing so you don't churn SigIds or store a broken stage:
+
+1. `lex fmt --check $1` — if it isn't canonical, run `lex fmt $1` (do **not**
+   hand-format) and continue.
+2. `lex check --strict $1` — must pass. If it fails, stop and hand off to
+   `/lex:lex-repair`; do not publish a failing stage.
+3. Publish:
+   ```bash
+   lex publish $ARGUMENTS        # add --activate to make the stages the head
+   ```
+   Report each function's `{name, sig_id, stage_id, status}`.
+4. Confirm with `lex blame <fn> --with-evidence` that the expected
+   TypeCheck / Examples attestations landed.
+
+If you only want to preview, append `--dry-run` (exit code 9 + a
+planned-actions envelope) and report the plan without writing.

--- a/integrations/claude-plugin/commands/lex-repair.md
+++ b/integrations/claude-plugin/commands/lex-repair.md
@@ -1,0 +1,28 @@
+---
+description: Run the repair-not-regenerate loop — turn a lex check failure into a typed lex repair --apply, landing a RepairAttempt attestation instead of rewriting the body.
+argument-hint: "[file] [op_id?]"
+allowed-tools: Bash(lex:*), Read
+---
+
+Repair the failing Lex op rather than regenerating it. Target: `$ARGUMENTS`.
+
+Follow the rule from `lex agent-guidelines` §4:
+
+1. Get the structured error: `lex --output json check $1`. Read the
+   `rule_tag` and `suggested_transform` from the first error.
+2. Identify the failing `op_id` (use the second argument if provided, else
+   find it via `lex blame <fn> --with-evidence` or the publish output).
+3. Apply the suggested transform **verbatim**:
+   ```bash
+   lex --output json repair <op_id> \
+     --apply --transform '<suggested_transform>' --store .lex-store
+   ```
+   Expect `{"outcome":"passed","applied_op_id":"op_..."}`. The attempt lands
+   as a `RepairAttempt` attestation linked to the originating hint.
+4. Re-run `lex check --strict $1` to confirm.
+5. If repair fails, inspect the new error and try **once** more. After **two**
+   failed repair attempts, stop and report that the body's design — not its
+   syntax — is wrong; recommend an intentional regeneration that keeps the
+   signature (and thus the SigId + attestations) stable.
+
+Never broaden an effect signature to make the error disappear.

--- a/integrations/claude-plugin/commands/lex-run.md
+++ b/integrations/claude-plugin/commands/lex-run.md
@@ -1,0 +1,26 @@
+---
+description: Type-check then execute one Lex function under an explicit, narrow capability policy (args parsed as JSON).
+argument-hint: "[file] [fn] [json-args...]"
+allowed-tools: Bash(lex:*), Read
+---
+
+Run a Lex function. Invocation: `$ARGUMENTS` (file, then fn name, then any
+JSON-encoded positional args).
+
+1. Always type-check first: `lex check $1`. If it reports required effects,
+   note them — you'll need matching grants.
+2. Run under the **narrowest** policy that satisfies the declared effects.
+   Pure functions need no grants:
+   ```bash
+   lex run $ARGUMENTS
+   ```
+   Effectful functions need explicit, scoped grants — never a blanket grant:
+   ```bash
+   lex run --allow-effects net --allow-net-host api.example.com $1 $2 <args>
+   lex run --allow-fs-read /etc/myapp/ $1 $2 <args>
+   ```
+3. Report the output. If the run returns HTTP `503` with `Retry-After: 0`
+   (budget exceeded), do **not** retry as-is — report it and recommend
+   raising the cap or refactoring to spend less.
+4. To capture a trace for later inspection, add `--trace`, then read it with
+   `lex trace <id>`.

--- a/integrations/claude-plugin/skills/lex/SKILL.md
+++ b/integrations/claude-plugin/skills/lex/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: lex
+description: Write, type-check, repair, publish, and run Lex (lex-lang) code via the `lex` CLI. Use whenever working with `.lex` files, the Lex typed-effect language, the content-addressed AST / attestation store, or a lex-hub gateway. Covers the agent-code loop (check → repair → publish → run), the effect-discipline idiom rules, and the syntax pitfalls (`::`, `:=`, `->`).
+paths:
+  - "**/*.lex"
+  - "**/lex.toml"
+---
+
+# Working with Lex
+
+Lex is a typed-effect language with a content-addressed AST and an
+attestation graph, purpose-built for code an LLM (you) authors. Every
+function declares its **effects** (`[io]`, `[net]`, `[fs_write("/tmp/x")]`,
+…); the type checker rejects any body that reaches outside its declaration
+*before a byte runs*. Source is a projection of the canonical AST — what
+persists is the signature, the effects, and the attestation chain.
+
+You drive Lex through the **`lex` CLI**, which is self-describing (it
+implements the ACLI discovery contract). For a **remote/hosted** store, use
+the `lex-hub` MCP tools instead (see the bottom of this file).
+
+## First: confirm the toolchain and read the contract
+
+```bash
+lex --version                       # confirm `lex` is installed
+lex agent-guidelines                # AUTHORITATIVE idiom rules — read in full
+lex --output json introspect        # full command tree as JSON
+lex skill                           # CLI surface + semantic exit codes
+```
+
+`lex agent-guidelines` is the source of truth for project conventions. If
+`lex` is not installed, install a release from
+<https://github.com/alpibrusl/lex-lang/releases> (or `cargo build --release`
+in a checkout) before continuing. Pin the version the project's `lex.toml` /
+CI declares.
+
+## The loop
+
+Every change goes through the same steps. **Do not claim a task done until
+they're all green.**
+
+```bash
+lex check --strict <file>           # type-check (+ extra lints)
+lex fmt --check <file>              # canonical formatting
+lex test                            # runs tests/test_*.lex
+lex ci                              # umbrella: check + fmt + test + pkg install
+```
+
+To run a single function (args are JSON):
+
+```bash
+lex check <file>                                   # always check first
+lex run <file> <fn> '"arg"' 42                     # pure fn
+lex run --allow-effects io <file> echo '"hi"'      # grant effects explicitly
+```
+
+## The ten rules that matter most
+
+These distill `lex agent-guidelines`; read the full doc for the rest.
+
+1. **Narrow effects, always (MUST).** Declare the *narrowest* effect set,
+   with path/host scopes: `[fs_write("/var/log/app.log")]`, not
+   `[fs_write]`, never `[io, fs_read, fs_write, net]`. Wide annotations
+   typecheck but defeat the entire point of the sandbox.
+
+2. **Never broaden effects to satisfy the checker (MUST).** When `lex check`
+   says "effect `fs_write` not declared at line X", the fix is almost never
+   "add `fs_write` to the signature" — it's "remove/narrow the code that
+   reached for it." If a fn should be pure and isn't, **the body is wrong**.
+
+3. **Repair, don't regenerate (MUST → SHOULD).** On a check failure, get the
+   structured error with `lex --output json check`, then apply its
+   `suggested_transform` via `lex repair --apply` rather than rewriting the
+   body. Only regenerate after **two** failed repair attempts. See
+   `/lex:lex-repair`.
+
+4. **`examples {}` on every pure fn (SHOULD).** They fold into the canonical
+   AST (part of the SigId) and run at `lex check` time — free regression
+   tests:
+   ```lex
+   fn add(x :: Int, y :: Int) -> Int
+     examples { add(2, 3) => 5, add(-1, 1) => 0 }
+   { x + y }
+   ```
+
+5. **`Result[T, E]` / `Option[T]`, no exceptions, no null (MUST).** Match or
+   pipe through `result.map` / `result.and_then` / `result.map_err`.
+
+6. **Exhaustive matches (AVOID stray `_ =>`).** List every variant; reserve
+   `_ =>` for genuine catch-alls. A silent `_` swallows variants added later.
+
+7. **Use the stdlib (MUST).** `std.crypto` not hand-rolled crypto, `std.sql`
+   with parameterised queries not string-concat, `std.conc` actors not OS
+   threads, `std.http` with per-host scopes not raw sockets, `std.regex` not
+   manual scanners. Check the stdlib index before reaching for raw bytes.
+
+8. **Don't churn the SigId (AVOID).** Cosmetic edits cost real money — they
+   invalidate attestations. Don't rename params/locals, reorder top-level
+   fns, or hand-reformat. Run `lex fmt` (it's canonical) and leave it.
+
+9. **Respect the budget gate (MUST).** HTTP `503` + `Retry-After: 0` from a
+   run means "don't retry as-is; raise the cap or refactor to spend less."
+   Auto-retrying makes the cap meaningless.
+
+10. **Query before you redo work.** `lex blame <fn> --with-evidence` shows
+    the TypeCheck / Spec / Examples / SandboxRun / RepairAttempt chain that
+    already covers a fn. Don't re-attest what the substrate has.
+
+## Syntax pitfalls (coming from Rust / TS / Python)
+
+| Lex | Meaning | Common mistake |
+|---|---|---|
+| `x :: Int` | type annotation | `x: Int` (Lex wants `::`) |
+| `let x := e` | let binding | `let x = e` (Lex wants `:=`) |
+| `-> T` | return type | `: T` (missing the arrow) |
+| `[net]` before `->`'s type | effect row | putting effects after the type |
+
+`Str + Str` concatenates. Type aliases can't be recursive — use a flat
+representation + recursion in functions.
+
+## Structured errors
+
+`lex --output json check` emits one JSON error per line:
+
+```json
+{
+  "kind": "type_error",
+  "rule_tag": "EFFECT_NOT_DECLARED",
+  "position": {"file": "src/handler.lex", "line": 14, "col": 22},
+  "rule_explanation": "effect `fs_write` reached here is not declared.",
+  "suggested_transform": { "kind": "narrow_path", "param": "path", "value": "/tmp/handler-output/" }
+}
+```
+
+The `rule_tag` + `suggested_transform` are exactly what `lex repair --apply`
+consumes. Exit code is `0` on success, `1` on type errors, `9` on a
+`--dry-run` plan.
+
+## Pre-"done" checklist
+
+- [ ] Every signature declares the **narrowest** effect set (+ path/host scopes).
+- [ ] Every pure fn has an `examples {}` block (or a one-line "why not").
+- [ ] No `_ =>` arms outside genuine catch-alls.
+- [ ] Stdlib used over roll-your-own.
+- [ ] Any `lex check` failure was handled with `lex repair --apply`, not a regen.
+- [ ] No SigId churn from cosmetic edits.
+- [ ] `lex ci` is green.
+
+## Remote: the lex-hub MCP tools
+
+When the work targets a **hosted** lex-hub gateway rather than a local
+store, this plugin also provides MCP tools (server `lex-hub`):
+
+| Tool | Use |
+|---|---|
+| `lex_health` | Confirm the gateway is reachable. |
+| `lex_check` | Type-check source for the tenant (same structured errors). |
+| `lex_publish` | Publish functions into the tenant's store. |
+| `lex_run` | Type-check + run a function (gateway clamps effects to pure + time/rand). |
+| `lex_patch` | Apply a typed transform to a stage (the repair path). |
+| `lex_stage_attestations` | Walk a stage's attestation chain. |
+
+These need the `lex-hub-mcp` binary on `PATH` and `LEXHUB_URL` + credentials
+set — see the plugin README. The same idiom rules above apply; the only
+difference is the store lives behind JWT auth on a server.
+
+## Where to read more
+
+- `lex agent-guidelines` — the authoritative rule list.
+- `docs/AGENT.md` (in lex-lang) — error envelope schema, every `rule_tag`,
+  the full stdlib surface, known sharp edges.
+- `README.md` — the agent-code loop overview + CLI reference table.


### PR DESCRIPTION
## What

A ready-to-install [Claude Code](https://code.claude.com) plugin so Claude Code can drive the Lex toolchain and, optionally, a hosted **lex-hub** gateway. Lives under `integrations/claude-plugin/`, with a repo-root marketplace manifest.

```text
/plugin marketplace add alpibrusl/lex-lang
/plugin install lex@lex
```

## Contents

- **Skill** — `skills/lex/SKILL.md`: when/how to run the `lex` CLI, the effect-discipline idiom rules (distilled from `docs/AGENT_GUIDELINES.md`), the agent-code loop, structured-error handling, and the `::` / `:=` / `->` syntax pitfalls. Auto-loads for `**/*.lex` and `lex.toml`.
- **Slash commands** — `/lex:lex-check`, `/lex:lex-repair`, `/lex:lex-publish`, `/lex:lex-run`, each wrapping a common loop and enforcing the "repair-not-regenerate / never broaden effects" discipline.
- **MCP server** — `.mcp.json` wires the `lex-hub` server, which runs the `lex-hub-mcp` binary (shipped in the companion lex-hub PR) to expose `lex_check` / `lex_publish` / `lex_run` / `lex_patch` / `lex_stage_attestations` / `lex_health` against a hosted gateway.

## Why this split

The local `lex` CLI is already agent-discoverable via ACLI (`lex introspect` / `lex skill` / `lex agent-guidelines`), so the skill + commands are thin orchestration over a self-describing tool. The hosted gateway speaks JWT'd HTTP/JSON (not MCP), so the bridge is the companion `lex-hub-mcp` server in [alpibrusl/lex-hub](https://github.com/alpibrusl/lex-hub).

## Notes / validation

- All manifests validated as JSON; plugin/marketplace/skill/command file layout follows current Claude Code plugin conventions.
- The MCP tools require the `lex-hub-mcp` binary on `PATH` (`cargo install --git https://github.com/alpibrusl/lex-hub lex-hub-mcp`) plus `LEXHUB_URL` + credentials; the skill and slash commands work without it.

Companion PR: `lex-hub-mcp` server in alpibrusl/lex-hub.

https://claude.ai/code/session_015VD79C5uZxw8W1JpqcGLcj

---
_Generated by [Claude Code](https://claude.ai/code/session_015VD79C5uZxw8W1JpqcGLcj)_