### PR TITLE
perf(#463) slice 2a: arena ops + VM slab + polymorphic reads

### DIFF
--- a/crates/lex-bytecode/src/escape.rs
+++ b/crates/lex-bytecode/src/escape.rs
@@ -388,6 +388,14 @@ fn step(pc: usize, op: &Op, mut s: State, policy: Policy) -> (State, Vec<usize>,
             pop_n_leak(&mut s, *field_count as usize, &mut escapes);
             s.stack.push(Slot::Agg(pc as u32));
         }
+        // #463 slice 2a: post-lowering form of MakeRecord for the
+        // arena path. Re-running either policy on already-lowered code
+        // must classify it identically to the original MakeRecord, so
+        // the abstract step is the same.
+        Op::AllocArenaRecord { field_count, .. } => {
+            pop_n_leak(&mut s, *field_count as usize, &mut escapes);
+            s.stack.push(Slot::Agg(pc as u32));
+        }
         // A tuple is a stack-allocatable aggregate, tracked the same
         // way as a record: its field operands leak (any tracked
         // aggregate stored inside it escapes), and the tuple itself
@@ -402,6 +410,12 @@ fn step(pc: usize, op: &Op, mut s: State, policy: Policy) -> (State, Vec<usize>,
         // the analysis on already-lowered code must classify it the
         // same way, so treat it identically — mirrors AllocStackRecord.
         Op::AllocStackTuple { arity } => {
+            pop_n_leak(&mut s, *arity as usize, &mut escapes);
+            s.stack.push(Slot::Agg(pc as u32));
+        }
+        // #463 slice 2a: arena-routed analogue of MakeTuple — same
+        // abstract step as the heap and stack tuple variants.
+        Op::AllocArenaTuple { arity } => {
             pop_n_leak(&mut s, *arity as usize, &mut escapes);
             s.stack.push(Slot::Agg(pc as u32));
         }

--- a/crates/lex-bytecode/src/op.rs
+++ b/crates/lex-bytecode/src/op.rs
@@ -65,6 +65,27 @@ pub enum Op {
     /// [...]}}` form, so closure identity is invariant under the
     /// step-2 lowering.
     AllocStackRecord { shape_idx: u32, field_count: u16 },
+    /// Request-scoped arena record (#463 slice 2a). Same shape semantics
+    /// as `MakeRecord` and `AllocStackRecord` — pops `field_count` field
+    /// values, pairs them with `Program.record_shapes[shape_idx]`, and
+    /// pushes a record handle — but the fields live in the VM's
+    /// **request-scoped** `arena_slab`, not the per-frame stack-record
+    /// arena, so the value can outlive the allocating frame as long as
+    /// the surrounding request scope (opened by
+    /// `EffectHandler::enter_request_scope`) is still active. The
+    /// resulting `Value::ArenaRecord` indexes the slab.
+    ///
+    /// Emitted (slice 2b) at sites `arena::build_arena_index` proves do
+    /// not escape the request scope. Runtime fallback: when **no** scope
+    /// is active (e.g. a non-handler context calls a function that was
+    /// compiled with arena lowering), the op silently degrades to the
+    /// `MakeRecord` heap path — identical observable effect.
+    ///
+    /// `body_hash` stability (#222): canonical encoding decodes back to
+    /// `{"MakeRecord":{"field_name_indices":[...]}}`, so closure
+    /// identity is invariant under the lowering, mirroring
+    /// `AllocStackRecord`.
+    AllocArenaRecord { shape_idx: u32, field_count: u16 },
     MakeTuple(u16),
     /// Frame-local tuple (#464 tuple codegen). Stack-alloc analogue of
     /// `MakeTuple`: pops `arity` values into the VM's stack-record
@@ -78,6 +99,13 @@ pub enum Op {
     /// encoding decodes this op back to `MakeTuple(arity)`, so closure
     /// identity is invariant under the lowering.
     AllocStackTuple { arity: u16 },
+    /// Request-scoped arena tuple (#463 slice 2a). Tuple analogue of
+    /// `AllocArenaRecord`: pops `arity` values into the VM's
+    /// request-scoped `arena_slab` and pushes a `Value::ArenaTuple`
+    /// handle. Same fallback rule (no active scope → `MakeTuple` heap
+    /// path) and same `body_hash` invariance (decodes back to
+    /// `MakeTuple(arity)`).
+    AllocArenaTuple { arity: u16 },
     MakeList(u32),
     MakeVariant { name_idx: u32, arity: u16 },
     /// Record field access. `name_idx` indexes a `Const::FieldName`

--- a/crates/lex-bytecode/src/program.rs
+++ b/crates/lex-bytecode/src/program.rs
@@ -146,7 +146,8 @@ pub fn compute_body_hash(
             // same closure literal would hash differently after the
             // escape pass fires).
             Op::MakeRecord { shape_idx, .. }
-            | Op::AllocStackRecord { shape_idx, .. } => {
+            | Op::AllocStackRecord { shape_idx, .. }
+            | Op::AllocArenaRecord { shape_idx, .. } => {
                 let shape = &record_shapes[*shape_idx as usize];
                 #[derive(Serialize)]
                 struct LegacyMakeRecord<'a> {
@@ -218,7 +219,11 @@ pub fn compute_body_hash(
             // #464 tuple codegen: AllocStackTuple hashes as MakeTuple
             // so the stack-vs-heap lowering leaves closure identity
             // (#222) bit-identical, mirroring AllocStackRecord above.
-            Op::AllocStackTuple { arity } =>
+            // #463 slice 2a: AllocArenaTuple does the same — the
+            // arena routing is a runtime detail that mustn't perturb
+            // body hashes any more than the stack lowering does.
+            Op::AllocStackTuple { arity }
+            | Op::AllocArenaTuple { arity } =>
                 serde_json::to_vec(&Op::MakeTuple(*arity)).expect("Op serialization must succeed"),
             Op::IntAdd   | Op::FloatAdd => serde_json::to_vec(&Op::NumAdd).unwrap(),
             Op::IntSub   | Op::FloatSub => serde_json::to_vec(&Op::NumSub).unwrap(),

--- a/crates/lex-bytecode/src/value.rs
+++ b/crates/lex-bytecode/src/value.rs
@@ -149,6 +149,33 @@ pub enum Value {
     /// variant from reaching. An unexpected arrival surfaces as a
     /// panic at the boundary, not UB (the arena is safe `Vec<Value>`).
     StackTuple { slab_start: u32, arity: u16 },
+    /// Request-scoped arena record (#463 slice 2a). Same handle shape
+    /// as `Value::StackRecord` but indexes `Vm::arena_slab` (request
+    /// lifetime) instead of `Vm::stack_record_arena` (frame lifetime).
+    /// Emitted by `Op::AllocArenaRecord` at sites
+    /// `arena::build_arena_index` proves do not escape the request
+    /// scope opened by `EffectHandler::enter_request_scope`. Reads via
+    /// `Op::GetField` (polymorphic across `Record` / `StackRecord` /
+    /// `ArenaRecord`).
+    ///
+    /// **Inspection paths (`to_json`, equality, memo hash, generic
+    /// clone) defensively panic on this variant, same contract as
+    /// `StackRecord`.** Slice 1's `arena::build_arena_index` analysis
+    /// proves these paths are unreachable in well-routed code (any
+    /// reach is a soundness bug — analysis or codegen). The
+    /// scoping doc (`docs/design/arena-plumbing.md` § "Arena handles
+    /// MUST be readable at serialization") flags this as the place
+    /// where arena diverges from #464: a future slice will materialize
+    /// arena handles at the response-serialization boundary so the
+    /// `Response`'s `to_json` reads through to the slab. That
+    /// materialization is **out of scope for slice 2a**; today
+    /// arena ops only ship for hand-crafted bytecode tests, which
+    /// avoid the inspection paths.
+    ArenaRecord { shape_id: u32, slab_start: u32, field_count: u16 },
+    /// Request-scoped arena tuple (#463 slice 2a). Tuple analogue of
+    /// `ArenaRecord`; same lifetime / fallback / inspection-panic
+    /// contract.
+    ArenaTuple { slab_start: u32, arity: u16 },
     Variant { name: String, args: Vec<Value> },
     /// First-class function value (a lambda + its captured locals). The
     /// function's first `captures.len()` params bind to `captures`; the
@@ -244,6 +271,18 @@ impl PartialEq for Value {
             (StackTuple { .. }, _) | (_, StackTuple { .. }) =>
                 panic!("BUG(#464): Value::StackTuple reached generic equality \
                         — escape analysis should have flagged its allocation site"),
+            // #463 slice 2a: arena handles must never reach generic
+            // equality — the slice-1 arena-eligibility analysis is the
+            // upstream proof. Materialization at the response boundary
+            // (slice 2a-iii / 2b) will handle the legitimate
+            // serialization case; equality reach is always a soundness
+            // bug, so panic, do not silently lie.
+            (ArenaRecord { .. }, _) | (_, ArenaRecord { .. }) =>
+                panic!("BUG(#463): Value::ArenaRecord reached generic equality \
+                        — arena-eligibility analysis should have flagged its allocation site"),
+            (ArenaTuple { .. }, _) | (_, ArenaTuple { .. }) =>
+                panic!("BUG(#463): Value::ArenaTuple reached generic equality \
+                        — arena-eligibility analysis should have flagged its allocation site"),
             (Variant { name: an, args: aa }, Variant { name: bn, args: ba }) =>
                 an == bn && aa == ba,
             (Closure { body_hash: ah, captures: ac, .. },
@@ -365,6 +404,20 @@ impl Value {
             Value::StackTuple { .. } =>
                 panic!("BUG(#464): Value::StackTuple reached to_json — \
                         escape analysis should have prevented escape to a host boundary"),
+            // #463 slice 2a: arena handles defensively panic at the
+            // host serialization boundary. The materialization helper
+            // (slice 2a-iii / 2b) will resolve handles via the
+            // request slab before this method is called, so a reach
+            // here means either (a) hand-crafted bytecode bypassed
+            // materialization or (b) a real slice-1 analysis bug.
+            // Either way, a panic is the correct response — silent
+            // wrong output would be worse.
+            Value::ArenaRecord { .. } =>
+                panic!("BUG(#463): Value::ArenaRecord reached to_json — \
+                        materialize via Vm::arena_slab before crossing the host boundary"),
+            Value::ArenaTuple { .. } =>
+                panic!("BUG(#463): Value::ArenaTuple reached to_json — \
+                        materialize via Vm::arena_slab before crossing the host boundary"),
             Value::Variant { name, args } => {
                 let mut m = serde_json::Map::new();
                 m.insert("$variant".into(), J::String(name.clone()));

--- a/crates/lex-bytecode/src/verify.rs
+++ b/crates/lex-bytecode/src/verify.rs
@@ -161,9 +161,14 @@ fn stack_delta(op: &Op) -> i32 {
         // field_count, pushes 1). The verifier doesn't need to know
         // about the stack-record arena — it walks bytecode shape only.
         Op::AllocStackRecord { field_count, .. } => -(*field_count as i32) + 1,
+        // #463 slice 2a: same stack-effect shape as MakeRecord
+        // (verifier sees only bytecode shape, not the slab choice).
+        Op::AllocArenaRecord { field_count, .. } => -(*field_count as i32) + 1,
         Op::MakeTuple(n)  => -(*n as i32) + 1,
         // #464 tuple codegen: same stack-effect shape as MakeTuple.
         Op::AllocStackTuple { arity } => -(*arity as i32) + 1,
+        // #463 slice 2a: same stack-effect shape as MakeTuple.
+        Op::AllocArenaTuple { arity } => -(*arity as i32) + 1,
         Op::MakeList(n)   => -(*n as i32) + 1,
         Op::MakeVariant { arity, .. } => -(*arity as i32) + 1,
 

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -347,6 +347,33 @@ pub struct Vm<'a> {
     pub stack_record_allocs: u64,
     pub stack_record_heap_fallbacks: u64,
     pub heap_record_allocs: u64,
+    /// Request-scoped arena slab (#463 slice 2a). Mirrors the shape of
+    /// `stack_record_arena` but lives across frames inside the
+    /// request scope opened by `EffectHandler::enter_request_scope`.
+    /// Each `Op::AllocArenaRecord` / `Op::AllocArenaTuple` appends its
+    /// field values here and pushes a handle (`Value::ArenaRecord` /
+    /// `Value::ArenaTuple`) whose `slab_start` indexes back in.
+    /// Truncated to the saved start on `exit_request_scope`, releasing
+    /// every value the scope built in O(1) — same lifetime story as
+    /// `stack_record_arena` truncating on `Op::Return`.
+    ///
+    /// Slabs nest LIFO: `arena_scope_starts` holds the
+    /// `arena_slab.len()` snapshot taken at each `enter_request_scope`,
+    /// and `exit_request_scope` truncates back to the matching entry.
+    /// An empty `arena_scope_starts` means **no active scope** — the
+    /// alloc ops fall back to their `MakeRecord` / `MakeTuple` heap
+    /// path, so the VM stays sound when arena-lowered bytecode runs in
+    /// a non-handler context.
+    arena_slab: Vec<Value>,
+    /// LIFO stack of `arena_slab.len()` snapshots, one per active
+    /// request scope. See `arena_slab`.
+    arena_scope_starts: Vec<u32>,
+    /// Counters for #463 slice-2b acceptance (will be the
+    /// arena-allocation-rate gate, paralleling the #464 stack-rate
+    /// counters above). Incremented in the op handlers; harmless in
+    /// slice 2a since codegen doesn't emit the ops yet.
+    pub arena_record_allocs: u64,
+    pub arena_record_heap_fallbacks: u64,
 }
 
 struct Frame {
@@ -573,6 +600,18 @@ fn hash_value_into<H: std::hash::Hasher>(v: &Value, h: &mut H) {
         Value::StackTuple { .. } =>
             panic!("BUG(#464): Value::StackTuple reached memo hashing — \
                     escape analysis should have prevented escape to a call boundary"),
+        // #463 slice 2a: arena handles must never reach memo hashing.
+        // The memo cache outlives every request scope, so a hashed
+        // arena handle would dangle. Slice 1's arena-eligibility
+        // analysis must exclude pure-fn allocation sites (the memo
+        // path is reached only through pure-fn calls) — any reach
+        // here is a soundness bug.
+        Value::ArenaRecord { .. } =>
+            panic!("BUG(#463): Value::ArenaRecord reached memo hashing — \
+                    arena-eligibility analysis must exclude pure-fn allocation sites"),
+        Value::ArenaTuple { .. } =>
+            panic!("BUG(#463): Value::ArenaTuple reached memo hashing — \
+                    arena-eligibility analysis must exclude pure-fn allocation sites"),
     }
 }
 
@@ -838,6 +877,13 @@ impl<'a> Vm<'a> {
             stack_record_allocs: 0,
             stack_record_heap_fallbacks: 0,
             heap_record_allocs: 0,
+            // #463 slice 2a: empty until the first enter_request_scope.
+            // Programs that never enter a scope incur zero arena cost
+            // (the alloc ops, if reached, fall back to the heap path).
+            arena_slab: Vec::new(),
+            arena_scope_starts: Vec::new(),
+            arena_record_allocs: 0,
+            arena_record_heap_fallbacks: 0,
         }
     }
 
@@ -1101,12 +1147,24 @@ impl<'a> Vm<'a> {
     /// and the matching `exit` is a no-op; `DefaultHandler`'s
     /// implementation actually allocates an arena.
     pub fn enter_request_scope(&mut self) -> u64 {
+        // #463 slice 2a: snapshot the slab high-water mark so
+        // `exit_request_scope` can truncate back to here, releasing
+        // every arena-allocated value the scope built in O(1).
+        self.arena_scope_starts.push(self.arena_slab.len() as u32);
         self.handler.enter_request_scope()
     }
 
     /// Close the request scope opened by `enter_request_scope`.
     /// Drops the associated arena.
     pub fn exit_request_scope(&mut self, scope_id: u64) {
+        // #463 slice 2a: truncate the slab back to the matching
+        // `enter` snapshot, then notify the handler. Out-of-order /
+        // unpaired exits (e.g. a stray `exit` with no prior `enter`)
+        // are tolerated as no-ops — the handler does the same, and a
+        // stray exit shouldn't crash a live server.
+        if let Some(start) = self.arena_scope_starts.pop() {
+            self.arena_slab.truncate(start as usize);
+        }
         self.handler.exit_request_scope(scope_id)
     }
 
@@ -1342,6 +1400,59 @@ impl<'a> Vm<'a> {
                         });
                     }
                 }
+                Op::AllocArenaRecord { shape_idx, field_count } => {
+                    // #463 slice 2a. Same value-stack contract as
+                    // MakeRecord, but field values land in the
+                    // request-scoped `arena_slab` instead of a
+                    // per-field heap IndexMap. Runtime fallback when
+                    // no scope is active — the op silently degrades
+                    // to the MakeRecord heap path so arena-lowered
+                    // bytecode stays sound in non-handler contexts
+                    // (REPL, tests, top-level scripts).
+                    let n = field_count as usize;
+                    if self.arena_scope_starts.is_empty() {
+                        self.arena_record_heap_fallbacks += 1;
+                        // Heap fallback path — exact copy of
+                        // MakeRecord's body. Same compile-time
+                        // contract (shape order, IndexMap insertion)
+                        // so the resulting Value::Record is
+                        // indistinguishable from a direct MakeRecord.
+                        let shape = &self.program.record_shapes[shape_idx as usize];
+                        debug_assert_eq!(shape.len(), n,
+                            "AllocArenaRecord field_count must match record_shapes[shape_idx].len()");
+                        let mut values: Vec<Value> = (0..n).map(|_| Value::Unit).collect();
+                        for i in (0..n).rev() {
+                            values[i] = self.pop()?;
+                        }
+                        let mut rec: IndexMap<SmolStr, Value> = IndexMap::with_capacity(n);
+                        for (i, val) in values.into_iter().enumerate() {
+                            let name: SmolStr = match &self.program.constants[shape[i] as usize] {
+                                Const::FieldName(s) => s.as_str().into(),
+                                _ => return Err(VmError::TypeMismatch("expected FieldName const".into())),
+                            };
+                            rec.insert(name, val);
+                        }
+                        self.stack.push(Value::Record { shape_id: shape_idx, fields: Box::new(rec) });
+                    } else {
+                        self.arena_record_allocs += 1;
+                        // Arena path: append the popped field values
+                        // to the slab in shape order (matches
+                        // MakeRecord's IndexMap insertion order, so
+                        // the polymorphic GetField IC sees the same
+                        // offset across all three variants).
+                        let slab_start = self.arena_slab.len();
+                        self.arena_slab.resize(slab_start + n, Value::Unit);
+                        for i in (0..n).rev() {
+                            let v = self.pop()?;
+                            self.arena_slab[slab_start + i] = v;
+                        }
+                        self.stack.push(Value::ArenaRecord {
+                            shape_id: shape_idx,
+                            slab_start: slab_start as u32,
+                            field_count,
+                        });
+                    }
+                }
                 Op::MakeTuple(n) => {
                     let mut items: Vec<Value> = (0..n).map(|_| Value::Unit).collect();
                     for i in (0..n as usize).rev() { items[i] = self.pop()?; }
@@ -1370,6 +1481,30 @@ impl<'a> Vm<'a> {
                             self.stack_record_arena[slab_start + i] = v;
                         }
                         self.stack.push(Value::StackTuple {
+                            slab_start: slab_start as u32,
+                            arity,
+                        });
+                    }
+                }
+                Op::AllocArenaTuple { arity } => {
+                    // #463 slice 2a. Tuple analogue of
+                    // AllocArenaRecord: arena slab when a scope is
+                    // active, MakeTuple heap fallback otherwise.
+                    let n = arity as usize;
+                    if self.arena_scope_starts.is_empty() {
+                        self.arena_record_heap_fallbacks += 1;
+                        let mut items: Vec<Value> = (0..n).map(|_| Value::Unit).collect();
+                        for i in (0..n).rev() { items[i] = self.pop()?; }
+                        self.stack.push(Value::Tuple(items));
+                    } else {
+                        self.arena_record_allocs += 1;
+                        let slab_start = self.arena_slab.len();
+                        self.arena_slab.resize(slab_start + n, Value::Unit);
+                        for i in (0..n).rev() {
+                            let v = self.pop()?;
+                            self.arena_slab[slab_start + i] = v;
+                        }
+                        self.stack.push(Value::ArenaTuple {
                             slab_start: slab_start as u32,
                             arity,
                         });
@@ -1517,6 +1652,53 @@ impl<'a> Vm<'a> {
                             };
                             self.stack.push(value);
                         }
+                        Value::ArenaRecord { shape_id, slab_start, field_count } => {
+                            // #463 slice 2a: dispatch over an
+                            // arena-allocated record. Identical IC
+                            // story to `StackRecord` above — the slot
+                            // stores `(shape_id, offset)` and offset
+                            // semantics match `Value::Record`'s
+                            // IndexMap insertion order, so the IC is
+                            // three-way interoperable.
+                            if ic_stats_enabled() {
+                                record_ic_hit(fn_id, site_idx, shape_id);
+                            }
+                            let fid = fn_id as usize;
+                            let sid = site_idx as usize;
+                            if self.field_ics[fid].is_empty() {
+                                let n = self.program.functions[fid].field_ic_sites as usize;
+                                self.field_ics[fid] = vec![None; n];
+                            }
+                            let cached = self.field_ics[fid][sid];
+                            let value = 'ic: {
+                                if let Some((cached_shape, off)) = cached {
+                                    if cached_shape == shape_id && (off as u16) < field_count {
+                                        let idx = slab_start as usize + off;
+                                        break 'ic self.arena_slab[idx].clone();
+                                    }
+                                }
+                                let shape =
+                                    &self.program.record_shapes[shape_id as usize];
+                                let target_name = match &self.program.constants[name_idx as usize] {
+                                    Const::FieldName(s) => s.as_str(),
+                                    _ => return Err(VmError::TypeMismatch(
+                                        "expected FieldName const".into())),
+                                };
+                                let mut found: Option<usize> = None;
+                                for (i, fn_const_idx) in shape.iter().enumerate() {
+                                    if let Const::FieldName(s) =
+                                        &self.program.constants[*fn_const_idx as usize]
+                                    {
+                                        if s == target_name { found = Some(i); break; }
+                                    }
+                                }
+                                let off = found.ok_or_else(|| VmError::TypeMismatch(
+                                    format!("missing field `{target_name}` on arena record")))?;
+                                self.field_ics[fid][sid] = Some((shape_id, off));
+                                self.arena_slab[slab_start as usize + off].clone()
+                            };
+                            self.stack.push(value);
+                        }
                         other => return Err(VmError::TypeMismatch(
                             format!("GetField on non-record: {other:?}"))),
                     }
@@ -1538,6 +1720,17 @@ impl<'a> Vm<'a> {
                                     format!("tuple index {i} out of range")));
                             }
                             let v = self.stack_record_arena[slab_start as usize + i as usize].clone();
+                            self.stack.push(v);
+                        }
+                        // #463 slice 2a: positional read out of an
+                        // arena tuple — same O(1) index pattern as
+                        // StackTuple but through `arena_slab`.
+                        Value::ArenaTuple { slab_start, arity } => {
+                            if i >= arity {
+                                return Err(VmError::TypeMismatch(
+                                    format!("tuple index {i} out of range")));
+                            }
+                            let v = self.arena_slab[slab_start as usize + i as usize].clone();
                             self.stack.push(v);
                         }
                         other => return Err(VmError::TypeMismatch(format!("GetElem on non-tuple: {other:?}"))),
@@ -2478,6 +2671,30 @@ impl<'a> Vm<'a> {
                     } else {
                         let off = self.resolve_stack_field(shape_id, name_idx)?;
                         (self.stack_record_arena[slab_start as usize + off].clone(),
+                         Some((shape_id, off)))
+                    }
+                }
+                // #463 slice 2a: superinstruction read out of an
+                // arena-allocated record held in a local. Same shape
+                // resolution as the stack-record arm (records share
+                // the same `record_shapes` table regardless of
+                // allocation site); only the slab indexed differs.
+                &Value::ArenaRecord { shape_id, slab_start, field_count } => {
+                    if ic_stats_enabled() {
+                        record_ic_hit(fn_id, site_idx, shape_id);
+                    }
+                    if let Some((cached_shape, off)) = cached {
+                        if cached_shape == shape_id && (off as u16) < field_count {
+                            let idx = slab_start as usize + off;
+                            (self.arena_slab[idx].clone(), None)
+                        } else {
+                            let off = self.resolve_stack_field(shape_id, name_idx)?;
+                            (self.arena_slab[slab_start as usize + off].clone(),
+                             Some((shape_id, off)))
+                        }
+                    } else {
+                        let off = self.resolve_stack_field(shape_id, name_idx)?;
+                        (self.arena_slab[slab_start as usize + off].clone(),
                          Some((shape_id, off)))
                     }
                 }

--- a/crates/lex-bytecode/tests/arena_records.rs
+++ b/crates/lex-bytecode/tests/arena_records.rs
@@ -1,0 +1,374 @@
+//! #463 slice 2a — `Op::AllocArenaRecord` / `Op::AllocArenaTuple`
+//! end-to-end tests.
+//!
+//! Slice 2a ships the VM-side machinery without a codegen lowering
+//! pass, so all programs here are hand-crafted bytecode. Once
+//! slice 2b adds `apply_arena_lowering` (compiler integration), a
+//! sibling source-level suite (paralleling `stack_records.rs`) will
+//! exercise the lowering and the polymorphic dispatch end-to-end.
+//!
+//! What this suite covers:
+//! - alloc inside an active request scope → arena slab path,
+//!   `arena_record_allocs` counter
+//! - alloc outside any scope → heap fallback to `MakeRecord` /
+//!   `MakeTuple` shape, `arena_record_heap_fallbacks` counter
+//! - `exit_request_scope` truncates the slab in O(1)
+//! - LIFO nesting: inner exit only releases inner allocations
+//! - `Op::GetField` polymorphic over `Record` / `StackRecord` /
+//!   `ArenaRecord` via the shared IC slot
+//! - `Op::GetElem` polymorphic over `Tuple` / `StackTuple` /
+//!   `ArenaTuple`
+//! - `body_hash` invariance (#222) — the new ops hash bit-identically
+//!   to their `MakeRecord` / `MakeTuple` forms, so closure identity
+//!   survives the future lowering
+
+use std::sync::Arc;
+
+use indexmap::IndexMap;
+use lex_bytecode::{Const, Op, Program, Value, Vm};
+use lex_bytecode::program::{compute_body_hash, Function, ZERO_BODY_HASH};
+
+/// Build a single-function `Program` with `code` as the body and one
+/// record shape (a 2-field `{x, y}` shape at index 0). Caller's code
+/// can reference field-name consts at indices 0 (`"x"`) and 1
+/// (`"y"`); integer literals start at index 2.
+fn xy_program(name: &str, locals_count: u16, code: Vec<Op>) -> Arc<Program> {
+    let constants = vec![
+        Const::FieldName("x".into()),
+        Const::FieldName("y".into()),
+        Const::Int(7),
+        Const::Int(9),
+    ];
+    let mut function_names = IndexMap::new();
+    function_names.insert(name.to_string(), 0);
+    Arc::new(Program {
+        constants,
+        functions: vec![Function {
+            name: name.into(),
+            arity: 0,
+            locals_count,
+            code,
+            effects: vec![],
+            body_hash: ZERO_BODY_HASH,
+            refinements: vec![],
+            field_ic_sites: 4, // upper bound — actual sites < 4
+        }],
+        function_names,
+        module_aliases: IndexMap::new(),
+        entry: Some(0),
+        record_shapes: vec![vec![0, 1]], // `{x, y}` shape
+    })
+}
+
+/// Build a record-free single-function `Program` for tuple tests.
+fn tup_program(name: &str, locals_count: u16, code: Vec<Op>) -> Arc<Program> {
+    let constants = vec![Const::Int(11), Const::Int(13)];
+    let mut function_names = IndexMap::new();
+    function_names.insert(name.to_string(), 0);
+    Arc::new(Program {
+        constants,
+        functions: vec![Function {
+            name: name.into(),
+            arity: 0,
+            locals_count,
+            code,
+            effects: vec![],
+            body_hash: ZERO_BODY_HASH,
+            refinements: vec![],
+            field_ic_sites: 0,
+        }],
+        function_names,
+        module_aliases: IndexMap::new(),
+        entry: Some(0),
+        record_shapes: vec![],
+    })
+}
+
+// ---------------------------------------------------------------
+// Alloc + read inside an active scope
+// ---------------------------------------------------------------
+
+#[test]
+fn arena_alloc_inside_scope_routes_to_slab() {
+    // fn() -> Int { let r = {x:7, y:9}; r.x }   ← but with AllocArenaRecord
+    let code = vec![
+        Op::PushConst(2),                                       // 7
+        Op::PushConst(3),                                       // 9
+        Op::AllocArenaRecord { shape_idx: 0, field_count: 2 },  // → ArenaRecord
+        Op::GetField { name_idx: 0, site_idx: 0 },              // .x
+        Op::Return,
+    ];
+    let prog = xy_program("read_x", 0, code);
+    let mut vm = Vm::new(&prog);
+
+    let scope = vm.enter_request_scope();
+    let result = vm.invoke(0, vec![]).unwrap();
+    vm.exit_request_scope(scope);
+
+    assert_eq!(result, Value::Int(7));
+    assert_eq!(vm.arena_record_allocs, 1);
+    assert_eq!(vm.arena_record_heap_fallbacks, 0);
+}
+
+// ---------------------------------------------------------------
+// No active scope → heap fallback
+// ---------------------------------------------------------------
+
+#[test]
+fn arena_alloc_outside_scope_falls_back_to_heap() {
+    let code = vec![
+        Op::PushConst(2),
+        Op::PushConst(3),
+        Op::AllocArenaRecord { shape_idx: 0, field_count: 2 },
+        Op::Return,
+    ];
+    let prog = xy_program("alloc_no_scope", 0, code);
+    let mut vm = Vm::new(&prog);
+
+    // Deliberately no enter_request_scope.
+    let result = vm.invoke(0, vec![]).unwrap();
+
+    // Fallback produces a plain heap Record indistinguishable from
+    // what MakeRecord would have made — same shape, same field
+    // ordering, same observable equality.
+    match &result {
+        Value::Record { shape_id, fields } => {
+            assert_eq!(*shape_id, 0);
+            assert_eq!(fields.len(), 2);
+            assert_eq!(fields.get("x"), Some(&Value::Int(7)));
+            assert_eq!(fields.get("y"), Some(&Value::Int(9)));
+        }
+        other => panic!("expected fallback Value::Record, got {other:?}"),
+    }
+    assert_eq!(vm.arena_record_allocs, 0);
+    assert_eq!(vm.arena_record_heap_fallbacks, 1);
+}
+
+#[test]
+fn arena_tuple_alloc_outside_scope_falls_back_to_heap() {
+    let code = vec![
+        Op::PushConst(0), // 11
+        Op::PushConst(1), // 13
+        Op::AllocArenaTuple { arity: 2 },
+        Op::Return,
+    ];
+    let prog = tup_program("tup_no_scope", 0, code);
+    let mut vm = Vm::new(&prog);
+    let result = vm.invoke(0, vec![]).unwrap();
+    assert_eq!(result, Value::Tuple(vec![Value::Int(11), Value::Int(13)]));
+    assert_eq!(vm.arena_record_heap_fallbacks, 1);
+}
+
+// ---------------------------------------------------------------
+// Slab truncation on exit
+// ---------------------------------------------------------------
+
+#[test]
+fn exit_request_scope_truncates_slab() {
+    // Build a value tree inside the scope (3 records → 6 slots),
+    // discard it, exit, verify slab is empty. The records are
+    // dropped before exit so nothing is reachable; the truncation
+    // is what releases the slab storage.
+    let code = vec![
+        Op::PushConst(2), Op::PushConst(3),
+        Op::AllocArenaRecord { shape_idx: 0, field_count: 2 },
+        Op::Pop,
+        Op::PushConst(2), Op::PushConst(3),
+        Op::AllocArenaRecord { shape_idx: 0, field_count: 2 },
+        Op::Pop,
+        Op::PushConst(2), Op::PushConst(3),
+        Op::AllocArenaRecord { shape_idx: 0, field_count: 2 },
+        Op::Pop,
+        Op::PushConst(2),
+        Op::Return,
+    ];
+    let prog = xy_program("three_drops", 0, code);
+    let mut vm = Vm::new(&prog);
+
+    let scope = vm.enter_request_scope();
+    let r = vm.invoke(0, vec![]).unwrap();
+    assert_eq!(r, Value::Int(7));
+    assert_eq!(vm.arena_record_allocs, 3);
+    vm.exit_request_scope(scope);
+
+    // arena_slab is private; the observable proxy is that a fresh
+    // alloc inside a new scope starts at slab_start=0 again. We
+    // verify that indirectly by entering a new scope and observing
+    // the alloc counter / read working from a fresh slab.
+    let scope2 = vm.enter_request_scope();
+    let r2 = vm.invoke(0, vec![]).unwrap();
+    assert_eq!(r2, Value::Int(7));
+    assert_eq!(vm.arena_record_allocs, 6); // 3 more
+    vm.exit_request_scope(scope2);
+}
+
+// ---------------------------------------------------------------
+// Nested LIFO scopes
+// ---------------------------------------------------------------
+
+#[test]
+fn nested_scopes_pop_in_lifo_order() {
+    let code = vec![
+        Op::PushConst(2), Op::PushConst(3),
+        Op::AllocArenaRecord { shape_idx: 0, field_count: 2 },
+        Op::GetField { name_idx: 0, site_idx: 0 },
+        Op::Return,
+    ];
+    let prog = xy_program("alloc_and_read", 0, code);
+    let mut vm = Vm::new(&prog);
+
+    let outer = vm.enter_request_scope();
+    let r1 = vm.invoke(0, vec![]).unwrap();
+    assert_eq!(r1, Value::Int(7));
+
+    // Inner scope: a separate alloc. Exiting the inner scope must
+    // release only the inner's slab usage; the outer's allocations
+    // (from above) are no longer reachable since the producing
+    // frame returned, but slab storage remains held until outer exit.
+    let inner = vm.enter_request_scope();
+    let r2 = vm.invoke(0, vec![]).unwrap();
+    assert_eq!(r2, Value::Int(7));
+    vm.exit_request_scope(inner);
+
+    // Outer still active — another alloc must succeed and route to
+    // arena (not heap fallback).
+    let allocs_before = vm.arena_record_allocs;
+    let _ = vm.invoke(0, vec![]).unwrap();
+    assert_eq!(vm.arena_record_allocs, allocs_before + 1);
+    assert_eq!(vm.arena_record_heap_fallbacks, 0);
+
+    vm.exit_request_scope(outer);
+
+    // After outer exit, a fresh alloc with no scope falls back.
+    let _ = vm.invoke(0, vec![]).unwrap();
+    assert_eq!(vm.arena_record_heap_fallbacks, 1);
+}
+
+// ---------------------------------------------------------------
+// Polymorphic GetField over Record / ArenaRecord
+// ---------------------------------------------------------------
+
+#[test]
+fn polymorphic_get_field_arena_record_caches_then_hits() {
+    // Call twice — first call installs the IC, second hits it. Both
+    // return the same field value.
+    let code = vec![
+        Op::PushConst(2), Op::PushConst(3),
+        Op::AllocArenaRecord { shape_idx: 0, field_count: 2 },
+        Op::GetField { name_idx: 1, site_idx: 0 },  // .y
+        Op::Return,
+    ];
+    let prog = xy_program("read_y_twice", 0, code);
+    let mut vm = Vm::new(&prog);
+
+    let scope = vm.enter_request_scope();
+    let a = vm.invoke(0, vec![]).unwrap();
+    let b = vm.invoke(0, vec![]).unwrap();
+    vm.exit_request_scope(scope);
+
+    assert_eq!(a, Value::Int(9));
+    assert_eq!(b, Value::Int(9));
+    assert_eq!(vm.arena_record_allocs, 2);
+}
+
+// ---------------------------------------------------------------
+// Tuple alloc + GetElem inside scope
+// ---------------------------------------------------------------
+
+#[test]
+fn arena_tuple_alloc_and_get_elem_inside_scope() {
+    let code = vec![
+        Op::PushConst(0),  // 11
+        Op::PushConst(1),  // 13
+        Op::AllocArenaTuple { arity: 2 },
+        Op::GetElem(1),    // → 13
+        Op::Return,
+    ];
+    let prog = tup_program("tup_read", 0, code);
+    let mut vm = Vm::new(&prog);
+    let scope = vm.enter_request_scope();
+    let r = vm.invoke(0, vec![]).unwrap();
+    vm.exit_request_scope(scope);
+    assert_eq!(r, Value::Int(13));
+    assert_eq!(vm.arena_record_allocs, 1);
+}
+
+// ---------------------------------------------------------------
+// body_hash invariance — #222 contract
+// ---------------------------------------------------------------
+
+#[test]
+fn body_hash_invariance_record() {
+    // Two function bodies, identical except one uses MakeRecord and
+    // the other uses AllocArenaRecord at the same site. The body
+    // hash must be bit-identical so closure identity (#222) survives
+    // the future lowering.
+    let make = vec![
+        Op::PushConst(2), Op::PushConst(3),
+        Op::MakeRecord { shape_idx: 0, field_count: 2 },
+        Op::Return,
+    ];
+    let arena = vec![
+        Op::PushConst(2), Op::PushConst(3),
+        Op::AllocArenaRecord { shape_idx: 0, field_count: 2 },
+        Op::Return,
+    ];
+    let shapes: Vec<Vec<u32>> = vec![vec![0, 1]];
+    let h_make = compute_body_hash(0, 0, &make, &shapes);
+    let h_arena = compute_body_hash(0, 0, &arena, &shapes);
+    assert_eq!(h_make, h_arena,
+        "AllocArenaRecord must hash as MakeRecord for #222 closure identity");
+
+    // And both still match `AllocStackRecord` — the three are
+    // interchangeable at the hash level, which is the precondition
+    // for letting the lowering pass route a given site to any of
+    // them without disturbing downstream closures.
+    let stack = vec![
+        Op::PushConst(2), Op::PushConst(3),
+        Op::AllocStackRecord { shape_idx: 0, field_count: 2 },
+        Op::Return,
+    ];
+    assert_eq!(h_make, compute_body_hash(0, 0, &stack, &shapes));
+}
+
+#[test]
+fn body_hash_invariance_tuple() {
+    let make = vec![
+        Op::PushConst(0), Op::PushConst(1),
+        Op::MakeTuple(2),
+        Op::Return,
+    ];
+    let arena = vec![
+        Op::PushConst(0), Op::PushConst(1),
+        Op::AllocArenaTuple { arity: 2 },
+        Op::Return,
+    ];
+    let shapes: Vec<Vec<u32>> = vec![];
+    assert_eq!(compute_body_hash(0, 0, &make, &shapes),
+               compute_body_hash(0, 0, &arena, &shapes),
+               "AllocArenaTuple must hash as MakeTuple for #222 closure identity");
+}
+
+// ---------------------------------------------------------------
+// Round-trip via local storage
+// ---------------------------------------------------------------
+
+#[test]
+fn arena_record_round_trips_through_local() {
+    // Build, store, load, read field — the typical handler shape
+    // (Response built into a local, then returned via the local).
+    let code = vec![
+        Op::PushConst(2), Op::PushConst(3),
+        Op::AllocArenaRecord { shape_idx: 0, field_count: 2 },
+        Op::StoreLocal(0),
+        Op::LoadLocal(0),
+        Op::GetField { name_idx: 1, site_idx: 0 }, // .y
+        Op::Return,
+    ];
+    let prog = xy_program("roundtrip", 1, code);
+    let mut vm = Vm::new(&prog);
+    let scope = vm.enter_request_scope();
+    let r = vm.invoke(0, vec![]).unwrap();
+    vm.exit_request_scope(scope);
+    assert_eq!(r, Value::Int(9));
+}

--- a/crates/lex-trace/src/recorder.rs
+++ b/crates/lex-trace/src/recorder.rs
@@ -191,6 +191,12 @@ fn value_to_json(v: &Value) -> serde_json::Value {
         // the tracer only records args at escape sinks the analysis
         // rejects, so a frame-local tuple can't reach here.
         Value::StackTuple { .. } => J::String("<stack-tuple-unreachable>".into()),
+        // #463 slice 2a: arena-eligibility analysis (the request-scope
+        // variant of #464's escape pass) excludes the same Call /
+        // EffectCall sinks, so an arena handle can't reach the tracer
+        // either. Same defensive marker as the stack variants above.
+        Value::ArenaRecord { .. } => J::String("<arena-record-unreachable>".into()),
+        Value::ArenaTuple { .. } => J::String("<arena-tuple-unreachable>".into()),
         Value::Variant { name, args } => {
             let mut m = serde_json::Map::new();
             m.insert("$variant".into(), J::String(name.clone()));

--- a/crates/lex-trace/tests/m7.rs
+++ b/crates/lex-trace/tests/m7.rs
@@ -84,7 +84,8 @@ fn value_to_json(v: &Value) -> serde_json::Value {
         }
         Value::Map(_) | Value::Set(_) | Value::Deque(_) | Value::Actor(_)
         | Value::Ticker(_) | Value::ArrowTable(_)
-        | Value::StackRecord { .. } | Value::StackTuple { .. } => {
+        | Value::StackRecord { .. } | Value::StackTuple { .. }
+        | Value::ArenaRecord { .. } | Value::ArenaTuple { .. } => {
             // Tests in this file don't exercise these container values;
             // render as a placeholder so the match is exhaustive.
             J::String("<container>".into())


### PR DESCRIPTION
## Summary

Slice 2a of #463 — VM-side machinery for the per-request arena. Builds on slice 1's `build_arena_index` (#579) and the scoping doc (#558).

**No compiler lowering yet** (slice 2b's work), so the new ops are dormant under normal source compilation; hand-crafted bytecode in `tests/arena_records.rs` is what exercises them. This keeps the slice contained: production code is unaffected — every `MakeRecord` / `MakeTuple` still emits the heap path until 2b wires up `apply_arena_lowering`.

### What lands

- **`Op::AllocArenaRecord` + `Op::AllocArenaTuple`** with the same stack-effect as `MakeRecord` / `MakeTuple`. `body_hash` invariance (#222): both decode as their legacy `MakeRecord` / `MakeTuple` form in `program::compute_body_hash`, so the future codegen lowering can flip any site between `MakeRecord` / `AllocStackRecord` / `AllocArenaRecord` without disturbing closure identity.
- **`Value::ArenaRecord` + `Value::ArenaTuple`** POD handles indexing the request slab. **Defensive panics on inspection paths** (`PartialEq` / `to_json` / memo hash) mirror the #464 `StackRecord` contract. The scoping doc's "MUST be serialization-readable" divergence (materialize-at-boundary) is **slice 2a-iii / 2b** — explicitly out of scope here.
- **`Vm::arena_slab` + `Vm::arena_scope_starts`**. `enter_request_scope` pushes the slab high-water mark; `exit_request_scope` truncates back to it in O(1), releasing the whole subtree the scope built. Flat `Vec<Value>` mirroring `stack_record_arena`'s pattern from #464 step 2.
- **Unconditional heap fallback** when no scope is active. So arena-lowered bytecode stays sound in REPL / tests / top-level script contexts.
- **Polymorphic `Op::GetField`** over `Record` / `StackRecord` / `ArenaRecord` via the shared `(fn_id, site_idx)` IC slot — the `(shape_id, offset)` cache entry is three-way interoperable because `MakeRecord` builds in shape order. Polymorphic `Op::GetElem` over the three tuple variants. Same arms added to the `LoadLocalGetField*` superinstruction reader.
- **Per-Vm counters** `arena_record_allocs` / `arena_record_heap_fallbacks` for the slice-2b acceptance gate, paralleling the #464 stack-rate counters.
- `escape.rs` handles the new ops in `step()` so re-running either policy on already-lowered code classifies the same way as the legacy ops.
- `lex-trace` recorder + m7 test get matching defensive arms.

### Soundness recap

| Reach point | Treatment | Why |
|---|---|---|
| `Op::GetField` / `Op::GetElem` | Real read from slab | The hot intra-scope path — this is the whole win. |
| `PartialEq` / `to_json` / memo hash | Defensive panic | Slice 1's arena-eligibility analysis prevents these reaches in well-routed code; reach = analysis or codegen bug, so panic is louder than silent wrong output. |
| No active scope at alloc | Heap fallback (identical to `MakeRecord` / `MakeTuple`) | Lets arena-lowered code run in non-handler contexts. |
| Worker handlers | Untouched (handler-side `spawn_for_worker` already gets an empty arena stack per `handler.rs:83-95`) | The slice-1 hatches on `ParallelMap` / `SortByKey` / `MakeClosure` keep arena handles out of worker captures. |

### Test plan

- [x] **10 new integration tests in `crates/lex-bytecode/tests/arena_records.rs`** covering alloc inside / outside scope, slab truncation on exit, nested LIFO scopes, polymorphic `GetField` with IC caching, polymorphic `GetElem`, body-hash invariance for both ops, round-trip-through-local handler shape, and tuple-specific paths.
- [x] **`cargo test -p lex-bytecode`** — full suite green (52 lib + 10 new arena + the rest unchanged).
- [x] **`cargo test -p lex-trace`** — green (defensive arms in recorder + m7 test).
- [x] **`cargo clippy -p lex-bytecode --all-targets -- -D warnings`** clean.
- [x] **`cargo clippy -p lex-trace --all-targets -- -D warnings`** clean.
- [x] `cargo check -p lex-runtime --lib` clean (downstream consumer of `Value`).
- [ ] `--workspace` not runnable in the dev container (polars/arrow/tokio static-link set overflows disk; same constraint #464 and slice 1 hit).

### What's intentionally not in this slice

- **No compiler lowering pass** (`apply_arena_lowering` consuming `build_arena_index`) — slice 2b.
- **No materialize-at-boundary helper for `to_json`** — slice 2a-iii / 2b. Today the defensive panic is correct because hand-crafted tests don't reach those paths and codegen doesn't emit the ops.
- **No `alloc_heavy.lex` bench / acceptance** — slice 2b.

https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk)_