### PR TITLE
perf(#463) slice 2a-iii: materialize-at-boundary helper

### DIFF
--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -1168,6 +1168,113 @@ impl<'a> Vm<'a> {
         self.handler.exit_request_scope(scope_id)
     }
 
+    /// Deep-walk `value` and resolve every `Value::ArenaRecord` /
+    /// `Value::ArenaTuple` handle into its heap-owned equivalent
+    /// (`Value::Record` / `Value::Tuple`), reading field contents
+    /// out of `Vm::arena_slab` along the way. Primitives, closures,
+    /// maps/sets, and the host-managed handles (`Actor` / `Ticker` /
+    /// `ArrowTable`) are returned unchanged.
+    ///
+    /// **The boundary helper** flagged in
+    /// `docs/design/arena-plumbing.md` § "Arena handles MUST be
+    /// readable at serialization". Callers — the response
+    /// serialization path in `lex-runtime`, the trace recorder when
+    /// it records a Call/EffectCall arg, anywhere a value crosses
+    /// out of the VM into host-managed storage — call this
+    /// **while the producing scope is still active**, before
+    /// `exit_request_scope`. After exit the slab is truncated, so a
+    /// handle materialized after-the-fact would read garbage (or
+    /// panic on the bounds check).
+    ///
+    /// `Value::StackRecord` / `Value::StackTuple` would similarly
+    /// need slab resolution, but the #464 escape analysis prevents
+    /// them from reaching boundary-crossing ops in the first place
+    /// (they're frame-local by construction). Reaching here means a
+    /// hand-built or analysis-buggy program; we panic with the same
+    /// loud-not-silent contract the other inspection paths use.
+    ///
+    /// Idempotent on already-materialized values (no arena handles
+    /// in the tree → only the recursive walk's clones, no slab
+    /// lookups). Cost per call is one walk + clone of the tree —
+    /// amortized over the per-node mallocs avoided during request
+    /// handling, the net stays strongly positive.
+    pub fn materialize_arena_handles(&self, value: Value) -> Value {
+        use crate::value::Value as V;
+        match value {
+            // Primitives + opaque handles cross unchanged. Cheap
+            // — clones are essentially free for the Copy-ish ones
+            // and Arc-bumps for the handle types.
+            V::Int(_) | V::Float(_) | V::Bool(_) | V::Str(_) | V::Bytes(_)
+            | V::Unit | V::Closure { .. } | V::F64Array { .. }
+            | V::Map(_) | V::Set(_) | V::Actor(_) | V::Ticker(_)
+            | V::ArrowTable(_) => value,
+
+            // Containers: recurse on each element. Map/Set keys are
+            // MapKey (Str | Int), never Value, so no handles can
+            // hide there.
+            V::List(items) => V::List(
+                items.into_iter().map(|v| self.materialize_arena_handles(v)).collect()),
+            V::Tuple(items) => V::Tuple(
+                items.into_iter().map(|v| self.materialize_arena_handles(v)).collect()),
+            V::Deque(items) => V::Deque(
+                items.into_iter().map(|v| self.materialize_arena_handles(v)).collect()),
+            V::Variant { name, args } => V::Variant {
+                name,
+                args: args.into_iter().map(|v| self.materialize_arena_handles(v)).collect(),
+            },
+            V::Record { shape_id, fields } => {
+                let mut out: IndexMap<SmolStr, Value> = IndexMap::with_capacity(fields.len());
+                for (k, v) in fields.into_iter() {
+                    out.insert(k, self.materialize_arena_handles(v));
+                }
+                V::Record { shape_id, fields: Box::new(out) }
+            }
+
+            // The actual resolution work — read the slab and build a
+            // heap form. Field-name ordering for ArenaRecord matches
+            // the shape's, same as `MakeRecord`'s IndexMap insertion
+            // pattern; that's the contract that makes the polymorphic
+            // GetField IC work, and we reuse it here.
+            V::ArenaRecord { shape_id, slab_start, field_count } => {
+                let start = slab_start as usize;
+                let n = field_count as usize;
+                debug_assert!(start + n <= self.arena_slab.len(),
+                    "ArenaRecord handle out of bounds — likely materialized after exit_request_scope");
+                let shape = &self.program.record_shapes[shape_id as usize];
+                let mut fields: IndexMap<SmolStr, Value> = IndexMap::with_capacity(n);
+                for (i, name_const_idx) in shape.iter().take(n).enumerate() {
+                    let name: SmolStr = match &self.program.constants[*name_const_idx as usize] {
+                        Const::FieldName(s) => s.as_str().into(),
+                        _ => panic!("BUG(#463): ArenaRecord shape entry not a FieldName const"),
+                    };
+                    let v = self.materialize_arena_handles(self.arena_slab[start + i].clone());
+                    fields.insert(name, v);
+                }
+                V::Record { shape_id, fields: Box::new(fields) }
+            }
+            V::ArenaTuple { slab_start, arity } => {
+                let start = slab_start as usize;
+                let n = arity as usize;
+                debug_assert!(start + n <= self.arena_slab.len(),
+                    "ArenaTuple handle out of bounds — likely materialized after exit_request_scope");
+                let items: Vec<Value> = (0..n)
+                    .map(|i| self.materialize_arena_handles(self.arena_slab[start + i].clone()))
+                    .collect();
+                V::Tuple(items)
+            }
+
+            // #464 stack handles are frame-local; the analysis
+            // prevents them from reaching any boundary the
+            // materializer is called at. Reach = bug; panic loud.
+            V::StackRecord { .. } =>
+                panic!("BUG(#464/#463): Value::StackRecord reached materialize_arena_handles \
+                        — escape analysis should keep stack handles inside their frame"),
+            V::StackTuple { .. } =>
+                panic!("BUG(#464/#463): Value::StackTuple reached materialize_arena_handles \
+                        — escape analysis should keep stack handles inside their frame"),
+        }
+    }
+
     pub fn invoke(&mut self, fn_id: u32, args: Vec<Value>) -> Result<Value, VmError> {
         let f = &self.program.functions[fn_id as usize];
         if args.len() != f.arity as usize {

--- a/crates/lex-bytecode/tests/arena_records.rs
+++ b/crates/lex-bytecode/tests/arena_records.rs
@@ -372,3 +372,165 @@ fn arena_record_round_trips_through_local() {
     vm.exit_request_scope(scope);
     assert_eq!(r, Value::Int(9));
 }
+
+// ---------------------------------------------------------------
+// Vm::materialize_arena_handles — the boundary helper (slice 2a-iii)
+// ---------------------------------------------------------------
+
+/// Helper: build a handler that returns its arena record without
+/// destructuring it (so we can hand the raw handle to materialize).
+fn handler_returning_xy_record() -> Arc<Program> {
+    let code = vec![
+        Op::PushConst(2),
+        Op::PushConst(3),
+        Op::AllocArenaRecord { shape_idx: 0, field_count: 2 },
+        Op::Return,
+    ];
+    xy_program("build_xy", 0, code)
+}
+
+#[test]
+fn materialize_passthrough_primitives() {
+    let prog = xy_program("noop", 0, vec![Op::PushConst(2), Op::Return]);
+    let vm = Vm::new(&prog);
+    assert_eq!(vm.materialize_arena_handles(Value::Int(42)), Value::Int(42));
+    assert_eq!(vm.materialize_arena_handles(Value::Bool(true)), Value::Bool(true));
+    assert_eq!(vm.materialize_arena_handles(Value::Unit), Value::Unit);
+}
+
+#[test]
+fn materialize_passthrough_heap_record() {
+    // A Value::Record already in heap form materializes to itself
+    // (idempotency over the no-arena case).
+    let prog = xy_program("noop", 0, vec![Op::PushConst(2), Op::Return]);
+    let vm = Vm::new(&prog);
+    let mut fields: IndexMap<smol_str::SmolStr, Value> = IndexMap::new();
+    fields.insert("x".into(), Value::Int(7));
+    fields.insert("y".into(), Value::Int(9));
+    let v = Value::Record { shape_id: 0, fields: Box::new(fields) };
+    assert_eq!(vm.materialize_arena_handles(v.clone()), v);
+}
+
+#[test]
+fn materialize_arena_record_becomes_heap_record() {
+    let prog = handler_returning_xy_record();
+    let mut vm = Vm::new(&prog);
+
+    let scope = vm.enter_request_scope();
+    let arena_value = vm.invoke(0, vec![]).unwrap();
+    // The handler returned a raw ArenaRecord — confirm the shape
+    // before we materialize so the assertion is meaningful.
+    assert!(matches!(arena_value, Value::ArenaRecord { .. }));
+
+    let heap_value = vm.materialize_arena_handles(arena_value);
+    // Now we can safely exit the scope — the materialized value is
+    // independent of the slab.
+    vm.exit_request_scope(scope);
+
+    match heap_value {
+        Value::Record { shape_id, fields } => {
+            assert_eq!(shape_id, 0);
+            assert_eq!(fields.get("x"), Some(&Value::Int(7)));
+            assert_eq!(fields.get("y"), Some(&Value::Int(9)));
+        }
+        other => panic!("expected materialized Value::Record, got {other:?}"),
+    }
+}
+
+#[test]
+fn materialize_arena_tuple_becomes_heap_tuple() {
+    let prog = tup_program("build_tup", 0, vec![
+        Op::PushConst(0), Op::PushConst(1),
+        Op::AllocArenaTuple { arity: 2 },
+        Op::Return,
+    ]);
+    let mut vm = Vm::new(&prog);
+    let scope = vm.enter_request_scope();
+    let arena_value = vm.invoke(0, vec![]).unwrap();
+    assert!(matches!(arena_value, Value::ArenaTuple { .. }));
+    let heap_value = vm.materialize_arena_handles(arena_value);
+    vm.exit_request_scope(scope);
+    assert_eq!(heap_value, Value::Tuple(vec![Value::Int(11), Value::Int(13)]));
+}
+
+#[test]
+fn materialize_recurses_into_list_elements() {
+    // A heap list containing arena records — confirm the walk
+    // descends into the list. (Hand-constructed because no op
+    // currently builds a list of arena handles, but the helper
+    // must handle it for slice-2b safety.)
+    let prog = handler_returning_xy_record();
+    let mut vm = Vm::new(&prog);
+    let scope = vm.enter_request_scope();
+    let arena_a = vm.invoke(0, vec![]).unwrap();
+    let arena_b = vm.invoke(0, vec![]).unwrap();
+    let list = Value::List([arena_a, arena_b].into_iter().collect());
+    let materialized = vm.materialize_arena_handles(list);
+    vm.exit_request_scope(scope);
+    match materialized {
+        Value::List(items) => {
+            assert_eq!(items.len(), 2);
+            for item in items {
+                assert!(matches!(item, Value::Record { .. }),
+                    "list element should be heap Record, got {item:?}");
+            }
+        }
+        other => panic!("expected Value::List, got {other:?}"),
+    }
+}
+
+#[test]
+fn materialize_recurses_into_record_field_value() {
+    // Heap Record whose field value is an arena handle — confirms
+    // we walk into Record fields (the common case once codegen
+    // mixes arena children inside non-arena parents).
+    let prog = handler_returning_xy_record();
+    let mut vm = Vm::new(&prog);
+    let scope = vm.enter_request_scope();
+    let inner = vm.invoke(0, vec![]).unwrap(); // ArenaRecord
+    let mut fields: IndexMap<smol_str::SmolStr, Value> = IndexMap::new();
+    fields.insert("nested".into(), inner);
+    let outer = Value::Record { shape_id: 0, fields: Box::new(fields) };
+    let materialized = vm.materialize_arena_handles(outer);
+    vm.exit_request_scope(scope);
+    match materialized {
+        Value::Record { fields, .. } => {
+            let nested = fields.get("nested").expect("nested field present");
+            assert!(matches!(nested, Value::Record { .. }),
+                "nested field should be heap Record after materialization, got {nested:?}");
+        }
+        other => panic!("expected Value::Record outer, got {other:?}"),
+    }
+}
+
+#[test]
+fn materialize_to_json_roundtrip_does_not_panic() {
+    // The whole reason this helper exists: an arena value can't be
+    // to_json'd directly (defensive panic), but materialize-then-
+    // to_json works. This pair is exactly the response-serialization
+    // pattern slice 2b will wire up.
+    let prog = handler_returning_xy_record();
+    let mut vm = Vm::new(&prog);
+    let scope = vm.enter_request_scope();
+    let arena_value = vm.invoke(0, vec![]).unwrap();
+    let heap_value = vm.materialize_arena_handles(arena_value);
+    vm.exit_request_scope(scope);
+
+    let json = heap_value.to_json();
+    assert_eq!(json["x"], serde_json::json!(7));
+    assert_eq!(json["y"], serde_json::json!(9));
+}
+
+#[test]
+fn materialize_is_idempotent() {
+    // Materialize twice — second pass walks a tree with no handles,
+    // which must return an equivalent value (clones notwithstanding).
+    let prog = handler_returning_xy_record();
+    let mut vm = Vm::new(&prog);
+    let scope = vm.enter_request_scope();
+    let arena_value = vm.invoke(0, vec![]).unwrap();
+    let once = vm.materialize_arena_handles(arena_value);
+    let twice = vm.materialize_arena_handles(once.clone());
+    vm.exit_request_scope(scope);
+    assert_eq!(once, twice);
+}


### PR DESCRIPTION
## Summary

Slice 2a-iii of #463 — the boundary helper. Adds `Vm::materialize_arena_handles`, which deep-walks a `Value` tree and resolves every `Value::ArenaRecord` / `Value::ArenaTuple` handle into its heap-owned form (`Value::Record` / `Value::Tuple`) by reading from `Vm::arena_slab`.

This is the one place Route A genuinely diverges from #464's `StackRecord` panic-guard shortcut, flagged in the scoping doc as **"arena handles MUST be readable at serialization"** — because the `Response` IS `to_json`'d before the request scope closes.

### Contract

- Caller invokes the helper **while the producing scope is still active** (before `exit_request_scope`). A `debug_assert` bounds check fires loudly if called after exit truncates the slab.
- Primitives, closures, opaque host handles (`Actor` / `Ticker` / `ArrowTable` / `F64Array`), and `Map` / `Set` (whose keys are `MapKey`, never `Value`) pass through unchanged.
- Containers (`List` / `Tuple` / `Deque` / `Record` / `Variant`) recurse on their contents — so a heap `Record` with arena children fully materializes.
- **Idempotent**: a tree with no arena handles round-trips equal.
- `Value::StackRecord` / `StackTuple` still defensively panic — the #464 escape analysis keeps them frame-local, so any reach to the boundary helper is a soundness bug.

### What this unblocks

Slice 2b's codegen lowering. Once `apply_arena_lowering` emits `AllocArenaRecord` / `AllocArenaTuple` at the sites `build_arena_index` marks eligible, the runtime serialization path can `vm.materialize_arena_handles(response)` before `to_json` instead of tripping the `value.rs` panic guard.

### Test plan

- [x] **8 new integration tests** in `tests/arena_records.rs` cover:
  - passthrough on primitives + heap records (idempotency over the no-arena case)
  - conversion of arena handles to heap form (record + tuple)
  - recursion into `List` elements and `Record` field values
  - the `to_json` roundtrip — the canonical slice-2b usage pattern
  - idempotency over two-pass materialization
- [x] `cargo test -p lex-bytecode` — full suite green (52 lib + 18 arena integration including 8 new + everything else).
- [x] `cargo clippy -p lex-bytecode --all-targets -- -D warnings` clean.
- [ ] `--workspace` not runnable in the dev container (same disk-cap constraint as prior slices).

https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk)_