### PR TITLE
docs(#463): measure arena slice 2b-i — −36% on alloc_heavy, 0% on response_build

### DIFF
--- a/crates/lex-bytecode/examples/profile_alloc_heavy.rs
+++ b/crates/lex-bytecode/examples/profile_alloc_heavy.rs
@@ -1,0 +1,65 @@
+use std::sync::Arc;
+use lex_ast::canonicalize_program;
+use lex_bytecode::vm::Vm;
+use lex_bytecode::{compile_program, Op, Value};
+use lex_syntax::parse_source;
+
+const SRC: &str = r#"
+type Response = { status :: Int, total :: Int, count :: Int }
+
+fn handle(i :: Int) -> Response {
+  { status: 200, total: i * 2, count: i + 1 }
+}
+
+fn drive(n :: Int) -> Int {
+  match n {
+    0 => 0,
+    _ => {
+      let r := handle(n)
+      r.total + drive(n - 1)
+    },
+  }
+}
+"#;
+
+fn main() {
+    let n: i64 = std::env::args().nth(1).and_then(|s| s.parse().ok()).unwrap_or(120);
+    let iters: u64 = std::env::args().nth(2).and_then(|s| s.parse().ok()).unwrap_or(3);
+    let arena_scope = std::env::var_os("LEX_PROFILE_ARENA").is_some();
+
+    let prog = parse_source(SRC).expect("parse");
+    let stages = canonicalize_program(&prog);
+    lex_types::check_program(&stages).expect("typecheck");
+    let p = Arc::new(compile_program(&stages));
+
+    let h = &p.functions[p.function_names["handle"] as usize];
+    let arena = h.code.iter().filter(|o| matches!(o, Op::AllocArenaRecord { .. })).count();
+    let stack = h.code.iter().filter(|o| matches!(o, Op::AllocStackRecord { .. })).count();
+    let heap = h.code.iter().filter(|o| matches!(o, Op::MakeRecord { .. })).count();
+    eprintln!("[diag] handle() record sites: arena={arena}, stack={stack}, heap={heap}");
+
+    let mut acc = 0i64;
+    let mut tot_arena = 0u64;
+    let mut tot_heap = 0u64;
+    for _ in 0..iters {
+        let mut vm = Vm::new(&p);
+        vm.set_step_limit(u64::MAX);
+        let r = if arena_scope {
+            let scope = vm.enter_request_scope();
+            let r = vm.call("drive", vec![Value::Int(n)]);
+            let r = r.map(|v| vm.materialize_arena_handles(v));
+            vm.exit_request_scope(scope);
+            r
+        } else {
+            vm.call("drive", vec![Value::Int(n)])
+        };
+        if let Value::Int(v) = r.unwrap() {
+            acc = acc.wrapping_add(v);
+        }
+        tot_arena += vm.arena_record_allocs;
+        tot_heap += vm.heap_record_allocs;
+    }
+    eprintln!("[diag] arena_scope_mode={arena_scope}");
+    eprintln!("[diag] counters: arena={tot_arena}, heap={tot_heap}");
+    std::process::exit((acc & 0x7f) as i32);
+}

--- a/crates/lex-bytecode/examples/profile_response_build.rs
+++ b/crates/lex-bytecode/examples/profile_response_build.rs
@@ -49,25 +49,67 @@ fn main() {
     let args: Vec<String> = std::env::args().collect();
     let n: i64 = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(400);
     let iters: u64 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(30);
+    // #463 slice 2b-i measurement: when set, wrap each iter's
+    // `vm.call("drive")` in an enter/exit_request_scope pair and
+    // materialize the result — mirrors the `net.serve_fn` flow so
+    // arena-lowered ops actually fire. Without the flag, the call
+    // runs outside any scope, the alloc ops fall back to MakeRecord,
+    // and the profile captures the pre-arena baseline shape.
+    let arena_scope = std::env::var_os("LEX_PROFILE_ARENA").is_some();
 
     let prog = parse_source(SRC).expect("parse");
     let stages = canonicalize_program(&prog);
     lex_types::check_program(&stages).expect("typecheck");
     let p = Arc::new(compile_program(&stages));
 
+    // Diagnostic: how many AllocArenaRecord / AllocStackRecord /
+    // MakeRecord sites in `handle()`? Lets the measurement reader
+    // verify whether the arena lowering pass actually fired before
+    // attributing the I-refs to it.
+    {
+        use lex_bytecode::Op;
+        let h = &p.functions[p.function_names["handle"] as usize];
+        let arena = h.code.iter().filter(|o| matches!(o, Op::AllocArenaRecord { .. })).count();
+        let stack = h.code.iter().filter(|o| matches!(o, Op::AllocStackRecord { .. })).count();
+        let heap = h.code.iter().filter(|o| matches!(o, Op::MakeRecord { .. })).count();
+        eprintln!("[diag] handle() record sites: arena={arena}, stack={stack}, heap={heap}");
+    }
+
     let mut acc = 0i64;
+    let mut tot_arena = 0u64;
+    let mut tot_arena_fb = 0u64;
+    let mut tot_stack = 0u64;
+    let mut tot_heap = 0u64;
     let (mut hits, mut misses, mut skips) = (0u64, 0u64, 0u64);
     for _ in 0..iters {
         let mut vm = Vm::new(&p);
         vm.set_step_limit(u64::MAX);
-        if let Value::Int(v) = vm.call("drive", vec![Value::Int(n)]).unwrap() {
+        let r = if arena_scope {
+            let scope = vm.enter_request_scope();
+            let r = vm.call("drive", vec![Value::Int(n)]);
+            // Materialize before exit so the result is heap-owned
+            // and the slab can drop safely — matches the runtime's
+            // `materialize_response_body` discipline.
+            let r = r.map(|v| vm.materialize_arena_handles(v));
+            vm.exit_request_scope(scope);
+            r
+        } else {
+            vm.call("drive", vec![Value::Int(n)])
+        };
+        if let Value::Int(v) = r.unwrap() {
             acc = acc.wrapping_add(v);
         }
         hits += vm.pure_memo_hits;
         misses += vm.pure_memo_misses;
         skips += vm.pure_memo_skips;
+        tot_arena += vm.arena_record_allocs;
+        tot_arena_fb += vm.arena_record_heap_fallbacks;
+        tot_stack += vm.stack_record_allocs;
+        tot_heap += vm.heap_record_allocs;
     }
     eprintln!("pure_memo: hits={hits} misses={misses} skips={skips}");
+    eprintln!("[diag] arena_scope_mode={arena_scope}");
+    eprintln!("[diag] runtime counters: arena_allocs={tot_arena}, arena_fallbacks={tot_arena_fb}, stack_allocs={tot_stack}, heap_allocs={tot_heap}");
     // Keep the result observable so the optimizer can't elide the loop.
     std::process::exit((acc & 0x7f) as i32);
 }

--- a/docs/design/arena-plumbing.md
+++ b/docs/design/arena-plumbing.md
@@ -204,3 +204,109 @@ handles** and the **worker-thread hatch** in from the start — those
 are the two places Route A genuinely diverges from #464. Repurpose or
 retire the byte-bump `arena.rs`; it backs the toolchain-blocked Route
 B, not the path we can ship.
+
+## Status update (2026-06-02) — slice 2b-i landed; measured
+
+All four planned slices are now on `main` (#579 analysis, #588 ops +
+slab, #589 boundary helper, #590 codegen lowering + runtime
+wire-up). Callgrind measurement on the two workloads we care about:
+
+### `alloc_heavy` (simple single-record-return handler)
+
+`examples/profile_alloc_heavy.rs` — `drive(1000)` × 5 iters. The
+handler is `fn handle(i) -> Response { {status: 200, total: i*2,
+count: i+1} }`. Single allocation site per call, no `match` in the
+return position, so the slice-1 analysis classifies it as arena-
+eligible and `apply_arena_lowering` rewrites it to
+`AllocArenaRecord`.
+
+| | I-refs | Δ |
+|---|---|---|
+| arena off (LEX_NO_ARENA_RECORDS=1 or no scope) | 40,078,370 | — |
+| arena on (scope wraps `vm.call("drive")`) | 25,656,712 | **−36.0%** |
+
+Where the savings land:
+
+|  | off | on | Δ |
+|---|---|---|---|
+| `_int_malloc` | 2.92M (7.28%) | 0.82M (3.19%) | **−71.9%** |
+| `_int_free` | 2.05M (5.10%) | 0.71M (2.75%) | **−65.5%** |
+| `malloc` | 1.43M (3.58%) | 0.49M (1.92%) | **−65.7%** |
+| `free` | 0.89M (2.22%) | 0.30M (1.18%) | **−65.9%** |
+| `IndexMap::insert_full` | 1.58M (3.93%) | 0 | **gone** |
+| `Vec::resize` | 0.71M (1.77%) | 1.18M (4.58%) | slab growth |
+| `Vm::run_to` | 13.57M | 12.08M | −11.0% |
+
+The per-record `Box<IndexMap>` malloc/free pair vanishes — replaced
+by bulk slab writes (`Vec::resize`) and bulk truncation on
+`exit_request_scope`. This is the alloc-churn lever the #461 profile
+identified at ~15% of total I-refs on a record-heavy workload.
+
+### `response_build` (the original `#461`-profile workload)
+
+`examples/profile_response_build.rs`. The handler returns a
+`Response` built inside a two-arm `match`:
+
+```lex
+match v6.s > 0 {
+  true  => { status: 200, total: v6.s + v6.t + v6.u },
+  false => { status: 400, total: 0 },
+}
+```
+
+| | I-refs |
+|---|---|
+| arena off | 11,005,530 |
+| arena on  | 11,009,096 |
+
+**Indistinguishable (Δ < 0.1%).** The arena pass **fires zero times**
+on this workload — `[diag] handle() record sites: arena=0, stack=6,
+heap=2`. The 6 intermediates (v1..v6) hit the cheaper #464 stack
+tier; the two `match`-arm `MakeRecord` sites are flagged as escaping
+by slice-1's lattice because the join point merges `Slot::Rec(p)`
+and `Slot::Rec(q)` to `Slot::Other` (both sites then recorded as
+escapes).
+
+This is the **"if/else merge" conservative case** already explicitly
+documented in `escape-analysis.md` § "Status quo lattice precision"
+(carries over verbatim under the request-scope policy):
+
+> "Records produced in alternate `if/else` branches and merged
+> before `Return` — both escape at the join. (Conservative; a
+> per-path refinement could recover this but is out of scope.)"
+
+So the analysis is doing exactly what its spec says, and the
+workload's shape (which is representative — handlers commonly
+return one of several response shapes via match) is precisely the
+case it conservatively rejects.
+
+### What this means for next work
+
+The honest read across both measurements:
+
+1. **The arena machinery works** and delivers a clean ~36% I-ref
+   reduction on the workload shape it covers.
+2. **The slice-1 analysis is the next lever.** A per-path refinement
+   that tracks `Slot::Rec(pc)` separately along each branch (instead
+   of merging to `Other` at joins) would let `response_build`'s
+   two-arm `match` classify both branches as arena-eligible, since
+   neither leaks under the request-scope policy. This is a pure
+   analysis change — the codegen and runtime already handle two
+   independent `AllocArenaRecord` sites in a function (slice 2b-i
+   tests cover the per-site classification).
+3. **The "deep-leaf" widening** (children whose only hatch is the
+   outer's `MakeRecord`) is a sibling case, also pure analysis.
+   Both would land via a single slice that adds two precision
+   refinements to `arena::analyze_function_with_policy`.
+
+Neither refinement requires any change to the runtime, codegen, or
+serialization paths landed in slices 2a–2b. The work is contained.
+
+Out of immediate scope: the materialize-at-boundary step (slice 2a-iii)
+does pay a non-trivial walk + alloc, and shows up as ~9% of the on-
+arm in `drop_in_place` and ~4.6% in `Vec::resize`. A future
+**slab-direct serializer** (walk arena handles → JSON bytes without
+ever materializing into `Value::Record`) would recover that cost on
+the HTTP-serving path. Not on the critical path until the analysis
+refinements above land and the response-build shape sees the arena
+fire.


### PR DESCRIPTION
## Summary

Closes the measurement loop on the arena work that landed across #579 / #588 / #589 / #590. Records callgrind I-refs for both arms (arena enabled vs disabled) on two representative workloads, plus the harness updates that produced the numbers. **Docs + perf-infrastructure only — no behavior change.**

## Headline numbers

### `alloc_heavy` (single-record-return handler — arena fires here)

| | I-refs | Δ |
|---|---|---|
| arena off | 40,078,370 | — |
| arena on  | 25,656,712 | **−36.0%** |

Where the savings land:

|  | off | on | Δ |
|---|---|---|---|
| `_int_malloc` | 7.28% | 3.19% | **−71.9%** |
| `_int_free` | 5.10% | 2.75% | **−65.5%** |
| `malloc` | 3.58% | 1.92% | **−65.7%** |
| `free` | 2.22% | 1.18% | **−65.9%** |
| `IndexMap::insert_full` | 3.93% | 0 | **gone** |
| `Vec::resize` | 1.77% | 4.58% | slab growth |
| `Vm::run_to` | 13.57M | 12.08M | −11.0% |

This is the alloc-churn lever the #461 profile identified at ~15% of I-refs on a record-heavy workload. The per-record `Box<IndexMap>` malloc/free pair is gone — replaced by bulk slab writes and bulk truncation on `exit_request_scope`.

### `response_build` (the original #461-profile workload — arena does NOT fire)

| | I-refs |
|---|---|
| arena off | 11,005,530 |
| arena on  | 11,009,096 |

**Indistinguishable (Δ < 0.1%).** Diagnostic: `[diag] handle() record sites: arena=0, stack=6, heap=2`. The 6 intermediates take the cheaper #464 stack tier; the two `match`-arm `MakeRecord` sites are flagged as escaping because slice-1's lattice merges them to `Slot::Other` at the return join — explicitly documented in `escape-analysis.md` § "Status quo lattice precision" as the if/else-merge conservative case.

## What this means for next work

1. **The arena machinery works** and delivers a clean ~36% on the shape it covers.
2. **The slice-1 analysis is the next lever.** A per-path refinement (track `Slot::Rec(pc)` separately along each branch instead of merging to `Other` at joins) would let `response_build`'s match-return classify both branches as arena-eligible. Pure analysis change — no codegen/runtime work; the slice 2b-i compiler pass and runtime already handle per-site classification.
3. **Deep-leaf widening** (sibling case — children whose only hatch is the outer's `MakeRecord`) and **per-path refinement** could land in a single slice that adds two precision refinements to `arena::analyze_function_with_policy`.

Out of immediate scope: a future **slab-direct serializer** would also recover the ~9% in `drop_in_place` + ~4.6% in `Vec::resize` that the materialize-at-boundary helper currently pays. Not on the critical path until the analysis refinements above land and `response_build`-shape handlers see the arena fire.

## What's in the diff

- **`crates/lex-bytecode/examples/profile_alloc_heavy.rs`** (new) — single-record-return harness, structured so arena lowering fires. `LEX_PROFILE_ARENA` flag mirrors `net.serve_fn`'s enter/exit/materialize cycle. Diagnostic counters.
- **`crates/lex-bytecode/examples/profile_response_build.rs`** — same `LEX_PROFILE_ARENA` flag + diagnostic counters. Default off keeps existing baselines comparable.
- **`docs/design/arena-plumbing.md`** — new "Status update (2026-06-02)" section with the tables above and the analysis-refinement next-step.

## Test plan

- [x] `cargo test -p lex-bytecode --lib` — 52 passing.
- [x] `cargo clippy -p lex-bytecode --all-targets -- -D warnings` clean (covers both example binaries).
- [x] `cargo build --release --example profile_alloc_heavy -p lex-bytecode` clean.
- [x] `cargo build --release --example profile_response_build -p lex-bytecode` clean.
- [x] Both profile binaries run successfully under callgrind; diagnostic counters confirm `arena_record_allocs` increments only with `LEX_PROFILE_ARENA=1`.

https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk)_