### PR TITLE
perf(#463): per-path precision in escape lattice (response_build −10.7%)

### DIFF
--- a/crates/lex-bytecode/src/escape.rs
+++ b/crates/lex-bytecode/src/escape.rs
@@ -83,9 +83,17 @@ pub enum Policy {
 }
 
 /// Abstract value at a stack or local slot during the analysis.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+///
+/// Per-path refinement (#463 follow-up — precision pass): a slot can
+/// hold a **set** of allocation sites, not just one, because two
+/// branches of an `if`/`match` can each push a distinct `MakeRecord`
+/// / `MakeTuple` value onto the stack and the join point's "either-
+/// or" semantics must be modeled without losing tracking. The
+/// 3-variant shape keeps the singleton case zero-alloc — `Slot::Agg`
+/// is plain 8 bytes inline — and only branch-merges allocate.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Slot {
-    /// Holds the stack-allocatable aggregate (a record from
+    /// Holds a single tracked aggregate (a record from
     /// `Op::MakeRecord` or a tuple from `Op::MakeTuple`) allocated at
     /// this pc. As long as every consumer reads this slot via a field
     /// / element read (`GetField` / `GetElem`), `Pop`, or a
@@ -94,6 +102,14 @@ pub enum Slot {
     /// aggregate kinds — only the codegen opcode differs — so the
     /// analysis tracks them with one variant keyed on the alloc pc.
     Agg(u32),
+    /// Holds one of N tracked aggregates, depending on which branch
+    /// reached this program point. Produced at join points where
+    /// distinct `Agg(p)` and `Agg(q)` flow together; the set remains
+    /// tracked across the merge so the eventual consumer (e.g.
+    /// `Return` under `Policy::RequestScope`) decides whether any
+    /// site leaks. Invariant: vec is sorted, dedup'd, length ≥ 2 —
+    /// `Slot::from_sites` normalizes single-element / empty inputs.
+    AggSet(Vec<u32>),
     /// Anything else — primitives, already-escaped aggregates,
     /// values produced by ops we don't model precisely. Treated
     /// as not-a-tracked-aggregate for escape purposes.
@@ -101,15 +117,48 @@ pub enum Slot {
 }
 
 impl Slot {
-    /// Pointwise merge for join points. Same site survives;
-    /// anything else collapses to `Other`. Callers responsible for
-    /// recording any `Rec(_)` that was merged-away into the
-    /// escape set — we lose track of those sites past this merge.
-    fn merge(self, other: Slot) -> Slot {
-        match (self, other) {
-            (Slot::Agg(a), Slot::Agg(b)) if a == b => Slot::Agg(a),
-            _ => Slot::Other,
+    /// View this slot as a slice of tracked sites. Empty for
+    /// `Other`, singleton for `Agg`, the inner vec for `AggSet`.
+    /// Lets callers iterate sites uniformly across the three
+    /// variants — used by every consumer that needs to leak all
+    /// sites a slot might hold.
+    fn sites(&self) -> &[u32] {
+        match self {
+            Slot::Agg(p) => std::slice::from_ref(p),
+            Slot::AggSet(v) => v.as_slice(),
+            Slot::Other => &[],
         }
+    }
+
+    /// Construct a slot from an arbitrary list of site pcs.
+    /// Normalizes: sorts + dedups + collapses empty → `Other`,
+    /// singleton → `Agg`. Used by `merge` and any other code that
+    /// produces a set-like slot.
+    fn from_sites(mut sites: Vec<u32>) -> Slot {
+        sites.sort_unstable();
+        sites.dedup();
+        match sites.len() {
+            0 => Slot::Other,
+            1 => Slot::Agg(sites[0]),
+            _ => Slot::AggSet(sites),
+        }
+    }
+
+    /// Pointwise merge for join points. Unions the site sets — both
+    /// sides stay tracked across the join, contra the pre-refinement
+    /// behavior of collapsing to `Other` (which also flagged both
+    /// sides as escaping). Under `Policy::RequestScope` this is the
+    /// whole point: a `match`-arm return like `match cond { true =>
+    /// {x:1}, false => {x:2} }` now produces an `AggSet([p, q])` at
+    /// the merge, which `Op::Return` passes through without leaking
+    /// (request-scope) instead of being forced into `Other` (escape).
+    fn merge(self, other: Slot) -> Slot {
+        if self == other { return self; }
+        let mut combined: Vec<u32> = Vec::with_capacity(
+            self.sites().len() + other.sites().len());
+        combined.extend_from_slice(self.sites());
+        combined.extend_from_slice(other.sites());
+        Slot::from_sites(combined)
     }
 }
 
@@ -133,43 +182,37 @@ impl State {
         }
     }
 
-    /// Merge `other` into `self`. Returns `(merged_state, escaped_sites)`
-    /// — the sites that we lost track of during the merge. Callers
-    /// union the escapes into the function-level set.
+    /// Merge `other` into `self`. Returns `(merged_state, escaped_sites)`.
+    ///
+    /// Per-path refinement: the merge itself **does not record any
+    /// escapes**. `Slot::merge` keeps both sides' sites tracked
+    /// across the join (`AggSet([p, q])` instead of `Other`), so the
+    /// downstream consumer ops decide whether any leak. The pre-
+    /// refinement collapse-to-Other behavior was the conservative
+    /// case the doc had labeled future work; this is that work.
+    ///
+    /// The one remaining escape source here is the dropped-tail case
+    /// for mismatched stack depths. That's a verifier-level bug
+    /// (#347 already checks shape-consistent merges), not the join-
+    /// point trap — those sites really are unreachable from the
+    /// merged state, so flagging them as escaped stays conservative-
+    /// correct.
     fn merge_with(&self, other: &State) -> (State, HashSet<u32>) {
         let mut escaped = HashSet::new();
-        // Mismatched stack depths are a verifier-level bug (#347
-        // already checks this); for the escape analysis we just
-        // truncate to the shorter and proceed — any sites on the
-        // extra slots count as escapes since they're no longer
-        // reachable from the join state.
         let stack_len = self.stack.len().min(other.stack.len());
         let mut stack = Vec::with_capacity(stack_len);
         for i in 0..stack_len {
-            let merged = self.stack[i].merge(other.stack[i]);
-            // If a Rec was merged-away (either path had Rec, the
-            // result is Other), the corresponding site escapes.
-            if merged == Slot::Other {
-                if let Slot::Agg(p) = self.stack[i]  { escaped.insert(p); }
-                if let Slot::Agg(p) = other.stack[i] { escaped.insert(p); }
-            }
-            stack.push(merged);
+            stack.push(self.stack[i].clone().merge(other.stack[i].clone()));
         }
-        // The dropped tail of the longer stack also leaks any Rec.
         for tail in self.stack.iter().skip(stack_len).chain(other.stack.iter().skip(stack_len)) {
-            if let Slot::Agg(p) = tail { escaped.insert(*p); }
+            for &p in tail.sites() { escaped.insert(p); }
         }
         let local_len = self.locals.len().max(other.locals.len());
         let mut locals = Vec::with_capacity(local_len);
         for i in 0..local_len {
-            let a = self.locals.get(i).copied().unwrap_or(Slot::Other);
-            let b = other.locals.get(i).copied().unwrap_or(Slot::Other);
-            let merged = a.merge(b);
-            if merged == Slot::Other {
-                if let Slot::Agg(p) = a { escaped.insert(p); }
-                if let Slot::Agg(p) = b { escaped.insert(p); }
-            }
-            locals.push(merged);
+            let a = self.locals.get(i).cloned().unwrap_or(Slot::Other);
+            let b = other.locals.get(i).cloned().unwrap_or(Slot::Other);
+            locals.push(a.merge(b));
         }
         (State { stack, locals }, escaped)
     }
@@ -321,13 +364,17 @@ pub fn analyze_function_with_policy(func: &Function, policy: Policy) -> EscapeRe
 fn step(pc: usize, op: &Op, mut s: State, policy: Policy) -> (State, Vec<usize>, HashSet<u32>) {
     let mut escapes: HashSet<u32> = HashSet::new();
 
-    // Helper closures for the common pop-n / push patterns.
-    let leak = |slot: Slot, into: &mut HashSet<u32>| {
-        if let Slot::Agg(p) = slot { into.insert(p); }
+    // Helper closures for the common pop-n / push patterns. `leak`
+    // iterates `slot.sites()` so multi-site slots (`AggSet`) leak
+    // every member — same conservative escape behavior as before for
+    // ops that genuinely escape, but now correctly handles the
+    // post-merge sets that the per-path lattice produces.
+    let leak = |slot: &Slot, into: &mut HashSet<u32>| {
+        for &p in slot.sites() { into.insert(p); }
     };
     let pop_n_leak = |state: &mut State, n: usize, esc: &mut HashSet<u32>| {
         for _ in 0..n {
-            if let Some(top) = state.stack.pop() { leak(top, esc); }
+            if let Some(top) = state.stack.pop() { leak(&top, esc); }
         }
     };
     let pop_n_drop = |state: &mut State, n: usize| {
@@ -341,14 +388,14 @@ fn step(pc: usize, op: &Op, mut s: State, policy: Policy) -> (State, Vec<usize>,
             // Aliasing breaks our linear-flow tracking. Anything
             // duplicated escapes — both copies become Other.
             if let Some(top) = s.stack.pop() {
-                leak(top, &mut escapes);
+                leak(&top, &mut escapes);
                 s.stack.push(Slot::Other);
                 s.stack.push(Slot::Other);
             }
         }
 
         Op::LoadLocal(i) => {
-            let slot = s.locals.get(*i as usize).copied().unwrap_or(Slot::Other);
+            let slot = s.locals.get(*i as usize).cloned().unwrap_or(Slot::Other);
             s.stack.push(slot);
         }
         Op::StoreLocal(i) => {
@@ -452,7 +499,7 @@ fn step(pc: usize, op: &Op, mut s: State, policy: Policy) -> (State, Vec<usize>,
         }
         Op::ListAppend => {
             // pop [list, value]; value is now inside the list → escape
-            if let Some(value) = s.stack.pop() { leak(value, &mut escapes); }
+            if let Some(value) = s.stack.pop() { leak(&value, &mut escapes); }
             s.stack.pop(); // list itself
             s.stack.push(Slot::Other);
         }
@@ -473,7 +520,7 @@ fn step(pc: usize, op: &Op, mut s: State, policy: Policy) -> (State, Vec<usize>,
             // returned value crosses our frame and leaks; under
             // RequestScope it stays inside the request and does not.
             if matches!(policy, Policy::FrameScope) {
-                if let Some(top) = top { leak(top, &mut escapes); }
+                if let Some(top) = top { leak(&top, &mut escapes); }
             }
             return (s, vec![], escapes);
         }
@@ -750,7 +797,10 @@ mod tests {
     #[test]
     fn record_in_one_branch_returned_escapes_after_merge() {
         // if cond { rec1 } else { rec2 } — Return after merge.
-        // Conservative analysis: at the merge both sites escape.
+        // Under FrameScope, Return leaks every site in the merged
+        // `AggSet`, so both still escape. The precision refinement
+        // (sibling `merged_branch_records_kept_tracked_*` tests
+        // below) only changes the answer under RequestScope.
         let f = func("brancher", 0, 1, vec![
             Op::LoadLocal(0),                          // pc=0
             Op::JumpIfNot(4),                          // pc=1; offset 4 → pc=6
@@ -763,6 +813,52 @@ mod tests {
         ]);
         let r = analyze_function(&f);
         // Both record sites escape — Return sees a merged stack.
+        assert_escapes(&r, &[(3, true), (6, true)]);
+    }
+
+    /// Per-path precision refinement: under `RequestScope`, two
+    /// records produced in alternate `if`/`else` branches and merged
+    /// before `Return` stay tracked across the join (`AggSet([p,q])`)
+    /// and `Return` leaves them alone, so neither escapes. This is
+    /// the win that makes the `response_build`-shape `match`-arm
+    /// handlers arena-eligible.
+    #[test]
+    fn merged_branch_records_kept_tracked_under_request_scope() {
+        let f = func("brancher_req", 0, 1, vec![
+            Op::LoadLocal(0),
+            Op::JumpIfNot(4),
+            Op::PushConst(0),
+            Op::MakeRecord { shape_idx: 0, field_count: 1 }, // pc=3
+            Op::Jump(2),
+            Op::PushConst(1),
+            Op::MakeRecord { shape_idx: 0, field_count: 1 }, // pc=6
+            Op::Return,
+        ]);
+        let r = analyze_function_with_policy(&f, Policy::RequestScope);
+        // Neither site escapes — both stay in the merged AggSet
+        // through Return, which doesn't leak under RequestScope.
+        assert_escapes(&r, &[(3, false), (6, false)]);
+    }
+
+    /// Sibling guard: under `RequestScope`, if the merged set is
+    /// then passed to a `Call` (a hatch under both policies), every
+    /// site in the set still escapes. Confirms the leak helper
+    /// iterates `sites()` correctly across the multi-site variant.
+    #[test]
+    fn merged_branch_records_all_escape_at_call_under_request_scope() {
+        let f = func("brancher_then_call", 0, 1, vec![
+            Op::LoadLocal(0),
+            Op::JumpIfNot(4),
+            Op::PushConst(0),
+            Op::MakeRecord { shape_idx: 0, field_count: 1 }, // pc=3
+            Op::Jump(2),
+            Op::PushConst(1),
+            Op::MakeRecord { shape_idx: 0, field_count: 1 }, // pc=6
+            Op::Call { fn_id: 1, arity: 1, node_id_idx: 0 }, // pc=7
+            Op::Return,
+        ]);
+        let r = analyze_function_with_policy(&f, Policy::RequestScope);
+        // The Call consumes the merged AggSet → both sites leak.
         assert_escapes(&r, &[(3, true), (6, true)]);
     }
 

--- a/crates/lex-bytecode/tests/arena_codegen.rs
+++ b/crates/lex-bytecode/tests/arena_codegen.rs
@@ -253,3 +253,65 @@ fn body_hash_unchanged_by_arena_lowering() {
     assert_eq!(on_fn.body_hash, off_fn.body_hash,
         "arena lowering must not perturb body_hash (closure identity #222)");
 }
+
+// ---------------------------------------------------------------
+// Per-path precision refinement (escape.rs `merge` keeps sets)
+// ---------------------------------------------------------------
+
+/// The win the precision pass delivers: a handler whose `match` arms
+/// each build their own response record now arena-lowers **both**
+/// records, where pre-refinement the join-point merge would have
+/// flagged both as escaping and they'd have stayed on the heap.
+/// This is the `response_build`-shape case `arena-plumbing.md`'s
+/// "Status update" measurement called out.
+#[test]
+fn match_arm_records_both_lower_to_arena_under_precision() {
+    let src = r#"
+        fn handler(cond :: Bool) -> { status :: Int, total :: Int } {
+          match cond {
+            true  => { status: 200, total: 42 },
+            false => { status: 400, total: 0 },
+          }
+        }
+    "#;
+    let p = compile(src);
+    let code = fn_code(&p, "handler");
+
+    // Both match-arm MakeRecord sites should land on the arena tier.
+    // Pre-precision they merged to Slot::Other at the return join
+    // and both were flagged escaping, so they stayed on heap.
+    let arena_sites = count(code, |op| matches!(op, Op::AllocArenaRecord { .. }));
+    let heap_sites = count(code, |op| matches!(op, Op::MakeRecord { .. }));
+    assert_eq!(arena_sites, 2,
+        "expected both match arms to lower to AllocArenaRecord, got code: {code:?}");
+    assert_eq!(heap_sites, 0,
+        "no heap MakeRecord should remain after the precision refinement");
+
+    // And the runtime path still works: each call alloc-routes
+    // through the arena, materializes correctly at the boundary.
+    let mut vm = Vm::new(&p);
+    let scope = vm.enter_request_scope();
+    let r_true = vm.invoke(p.function_names["handler"], vec![Value::Bool(true)]).unwrap();
+    let r_true = vm.materialize_arena_handles(r_true);
+    let r_false = vm.invoke(p.function_names["handler"], vec![Value::Bool(false)]).unwrap();
+    let r_false = vm.materialize_arena_handles(r_false);
+    vm.exit_request_scope(scope);
+
+    match r_true {
+        Value::Record { fields, .. } => {
+            assert_eq!(fields.get("status"), Some(&Value::Int(200)));
+            assert_eq!(fields.get("total"), Some(&Value::Int(42)));
+        }
+        other => panic!("expected materialized true-arm Record, got {other:?}"),
+    }
+    match r_false {
+        Value::Record { fields, .. } => {
+            assert_eq!(fields.get("status"), Some(&Value::Int(400)));
+            assert_eq!(fields.get("total"), Some(&Value::Int(0)));
+        }
+        other => panic!("expected materialized false-arm Record, got {other:?}"),
+    }
+    // Two calls, one arena alloc each, no fallbacks.
+    assert_eq!(vm.arena_record_allocs, 2);
+    assert_eq!(vm.arena_record_heap_fallbacks, 0);
+}

--- a/crates/lex-bytecode/tests/response_build_acceptance.rs
+++ b/crates/lex-bytecode/tests/response_build_acceptance.rs
@@ -92,62 +92,92 @@ fn compile_with_env(src: &str, no_stack_records: bool) -> Arc<Program> {
     }
 }
 
-fn count_record_sites(p: &Program) -> (usize, usize) {
+fn count_record_sites(p: &Program) -> (usize, usize, usize) {
     let mut make_record = 0usize;
     let mut alloc_stack = 0usize;
+    let mut alloc_arena = 0usize;
     for f in &p.functions {
         for op in &f.code {
             match op {
                 Op::MakeRecord { .. } => make_record += 1,
                 Op::AllocStackRecord { .. } => alloc_stack += 1,
+                Op::AllocArenaRecord { .. } => alloc_arena += 1,
                 _ => {}
             }
         }
     }
-    (make_record, alloc_stack)
+    (make_record, alloc_stack, alloc_arena)
 }
 
 /// Acceptance bar 1: ≥60% of record allocations land on the stack
 /// path. Exact, counter-driven; no timing noise.
+///
+/// History note: pre per-path-refinement (#463 follow-up) the `match
+/// v6.s > 0 { true => {Response}, false => {Response} }` shape kept
+/// the two match-arm records on the heap because the lattice merged
+/// them to `Slot::Other` at the return join and flagged both as
+/// escaping. The refinement keeps both tracked as `AggSet([p,q])`
+/// across the merge; under the request-scope policy they're now
+/// arena-eligible, and `apply_arena_lowering` rewrites them to
+/// `AllocArenaRecord`. So this workload's record allocations split
+/// across **three** tiers now (stack / arena / heap), not just two,
+/// and the assertions below cover the three-tier reality.
 #[test]
 fn at_least_60_percent_of_records_on_stack() {
     let p = compile_with_env(SRC, false);
-    let (make_record_sites, alloc_stack_sites) = count_record_sites(&p);
-    assert!(alloc_stack_sites > 0, "expected lowering to fire");
-    assert!(make_record_sites > 0, "expected at least one escaping record (the Response)");
+    let (make_record_sites, alloc_stack_sites, alloc_arena_sites) = count_record_sites(&p);
+    assert!(alloc_stack_sites > 0, "expected stack lowering to fire");
+    // Per-path refinement: the two match-arm records used to remain
+    // `MakeRecord` (heap) here — now they land on arena.
+    assert!(alloc_arena_sites > 0,
+        "expected arena lowering to fire on match-arm Response sites");
+    assert_eq!(make_record_sites, 0,
+        "no heap-tier records expected in this workload");
 
     let mut vm = Vm::new(&p);
     vm.set_step_limit(u64::MAX);
-    let r = vm.call("drive", vec![Value::Int(200)]).unwrap();
-    assert!(matches!(r, Value::Int(_)), "expected Int return, got {r:?}");
+    // Materialize through a request scope so the arena ops route
+    // through the slab — mirrors `net.serve_fn`. Without the scope
+    // the alloc ops fall back to heap and the counters below would
+    // miscount.
+    let scope = vm.enter_request_scope();
+    let r = vm.invoke(p.function_names["drive"], vec![Value::Int(200)]).unwrap();
+    let _ = vm.materialize_arena_handles(r);
+    vm.exit_request_scope(scope);
 
     let stack = vm.stack_record_allocs;
+    let arena = vm.arena_record_allocs;
     let heap = vm.heap_record_allocs;
     let fallback = vm.stack_record_heap_fallbacks;
-    let total = stack + heap + fallback;
+    let total = stack + arena + heap + fallback;
     assert!(total > 0);
     let rate = stack as f64 / total as f64;
     println!(
-        "[#464 step 3] record alloc breakdown: stack={stack}, heap={heap}, \
-         fallback={fallback}, total={total}, stack_rate={:.2}%",
+        "[#464 step 3 / #463 precision] record alloc breakdown: \
+         stack={stack}, arena={arena}, heap={heap}, fallback={fallback}, \
+         total={total}, stack_rate={:.2}%",
         rate * 100.0
     );
     assert!(rate >= 0.60,
         "stack-allocation rate {:.2}% is below the 60% acceptance bar",
         rate * 100.0);
 
-    // Exact numbers (the test acts as a regression gate for the
-    // lowering pass and the analysis):
-    //   Per `handle()` call: 6 stack records (v1..v6) + 1 heap
-    //   record (Response). drive(200) calls handle 200 times.
-    //   stack    = 200 * 6 = 1200
-    //   heap     = 200 * 1 = 200
-    //   fallback = 0 (each frame uses 21 slots ≪ 64-slot budget)
-    //   total = 1400, rate = 1200/1400 ≈ 85.7%.
+    // Exact numbers (regression gate for both the #464 stack lowering
+    // and the #463 per-path arena refinement). Per `handle()` call:
+    //   - 6 stack records (v1..v6, frame-local — #464)
+    //   - 1 arena record (the chosen match-arm Response — #463
+    //     precision; pre-refinement this was 1 heap MakeRecord).
+    // drive(200) calls handle 200 times.
+    //   stack    = 200 × 6 = 1200
+    //   arena    = 200 × 1 = 200
+    //   heap     = 0
+    //   fallback = 0
+    //   total = 1400, stack_rate = 1200/1400 ≈ 85.7% — unchanged.
     assert_eq!(fallback, 0,
         "no budget exhaustion expected for this workload");
     assert_eq!(stack, 200 * 6, "expected 6 stack records per handle × 200");
-    assert_eq!(heap, 200, "expected 1 heap record (Response) per handle × 200");
+    assert_eq!(arena, 200, "expected 1 arena Response per handle × 200");
+    assert_eq!(heap, 0, "no heap records expected after the precision refinement");
 }
 
 /// Acceptance bar 2: ≥1.5× speedup with lowering. Timing-based, so

--- a/docs/design/arena-plumbing.md
+++ b/docs/design/arena-plumbing.md
@@ -310,3 +310,60 @@ ever materializing into `Value::Record`) would recover that cost on
 the HTTP-serving path. Not on the critical path until the analysis
 refinements above land and the response-build shape sees the arena
 fire.
+
+## Status update (2026-06-03) — per-path precision refinement landed
+
+The "next lever" from the 2026-06-02 measurement above (track
+`Slot::Rec(pc)` separately along each branch instead of merging to
+`Slot::Other` at joins) is now on `main`. `escape::Slot` gained a
+3-variant `Agg(pc) | AggSet(Vec<u32>) | Other` shape; `Slot::merge`
+unions site sets across joins; `State::merge_with` no longer records
+escapes at the merge itself; the leak helper in `step()` iterates
+`Slot::sites()` so multi-site slots leak every member at genuine
+escape ops (`Call` / `EffectCall` / `MakeClosure` / etc.).
+
+Soundness: under `Policy::FrameScope` (the #464 default), `Op::Return`
+still leaks every site in the merged set, so the frame-escape result
+is bit-identical to pre-refinement. Under `Policy::RequestScope`
+(#463), `Op::Return` is the only consumer whose answer changes — the
+merge set passes through it without leaking, and only request-leaking
+hatches downstream cause an escape.
+
+### `response_build` re-measured (same harness as 2026-06-02)
+
+`examples/profile_response_build.rs`, `drive(120)` × 3 iters,
+callgrind I-refs.
+
+| | I-refs | Δ vs OFF |
+|---|---|---|
+| arena off (LEX_NO_ARENA_RECORDS=1 / no scope) | 11,228,628 | — |
+| arena on  (precision pass + scope) | **10,023,352** | **−10.7%** |
+
+Where the savings land:
+
+| | off | on | Δ abs |
+|---|---|---|---|
+| `_int_malloc` | 4.92% | 3.43% | **−37.7%** |
+| `_int_free` | 3.37% | 2.50% | **−33.8%** |
+| `malloc` | 2.50% | 1.90% | **−32.1%** |
+| `free` | 1.47% | 1.08% | **−34.2%** |
+| `IndexMap::insert_full` | 1.00% | 0.38% | **−66.5%** |
+| `Vm::run_to` | 37.05% | 40.73% | (relative — abs ~unchanged) |
+
+Diagnostic shows `[diag] handle() record sites: arena=2, stack=6,
+heap=0` (was `arena=0, stack=6, heap=2` before the refinement). Both
+`match`-arm `Response` records now land on the arena tier; runtime
+counters confirm `arena_allocs=360, arena_fallbacks=0` across the
+3 × 120 calls.
+
+### What's still open
+
+- **Deep-leaf widening** — `MakeRecord` still pessimistically leaks
+  every field operand at the build site, so a record stored as a
+  field of another record continues to escape. Sibling to the join
+  precision; would be a second refinement to the lattice that
+  threads parent-eligibility through nested aggregates.
+- **Slab-direct serializer** — the materialize-at-boundary cost
+  (`drop_in_place` + `Vec::resize` in the materialize walk) is still
+  paid. A walker that emits JSON bytes directly out of `arena_slab`
+  would shed it on the HTTP-serving path.

--- a/docs/design/escape-analysis.md
+++ b/docs/design/escape-analysis.md
@@ -162,8 +162,13 @@ The implementation pinned by `escape::tests`:
   `MakeList`. ✓
 - Records duplicated via `Dup`. ✓
 - Records produced in alternate `if/else` branches and merged
-  before `Return` — both escape at the join. (Conservative; a
-  per-path refinement could recover this but is out of scope.)
+  before `Return` — under `Policy::FrameScope` both escape at the
+  `Return` (`Return` leaks every site in the merged set, same
+  result as the pre-refinement collapse-to-Other). Under
+  `Policy::RequestScope` neither escapes — the join's `AggSet([p,q])`
+  passes through `Return` without leaking. This was previously
+  listed as future work; the precision refinement landed via #463
+  follow-up (see `arena-plumbing.md` § "Status update (2026-06-03)").
 
 ## API surface
 


### PR DESCRIPTION
## Summary

The "next lever" from the 2026-06-02 arena measurement (PR #591) — per-path precision in the escape lattice so branch-merged aggregates don't collapse to `Slot::Other` at joins. Closes the gap that kept `response_build`'s `match`-arm `Response` records on the heap.

## The refinement

`escape::Slot` grows from 2 variants to 3:

```rust
pub enum Slot {
    Agg(u32),           // singleton, common case, 8 bytes inline
    AggSet(Vec<u32>),   // branch-merged set, ≥2 sites, sorted+dedup'd
    Other,              // primitives + untracked
}
```

- **`Slot::merge`** unions the site sets across joins.
- **`State::merge_with`** no longer records escapes at the merge itself (only the dropped-tail-of-mismatched-stack case stays — those sites really are unreachable past the merge).
- **`step()`**'s `leak` helper iterates `Slot::sites()` so multi-site slots leak every member at genuine escape ops (`Call`/`EffectCall`/`MakeClosure`/…).

## Soundness

- **Under `Policy::FrameScope`** (#464): `Op::Return` still leaks every site in the merged set, so the frame-escape result is **bit-identical** to pre-refinement. The existing `record_in_one_branch_returned_escapes_after_merge` test continues to assert `(3, true) / (6, true)` and still passes — same answer, via the new lattice.
- **Under `Policy::RequestScope`** (#463): `Op::Return` is the only consumer whose answer changes — the merge set passes through without leaking, so only downstream request-leaking hatches cause an escape.

## Measurement — `response_build` (the canonical #461 workload)

`examples/profile_response_build.rs`, `drive(120) × 3 iters`, callgrind:

| | I-refs | Δ |
|---|---|---|
| arena off | 11,228,628 | — |
| arena on (precision pass) | **10,023,352** | **−10.7%** |

| | off | on | Δ abs |
|---|---|---|---|
| `_int_malloc` | 4.92% | 3.43% | **−37.7%** |
| `_int_free` | 3.37% | 2.50% | **−33.8%** |
| `malloc` | 2.50% | 1.90% | **−32.1%** |
| `free` | 1.47% | 1.08% | **−34.2%** |
| `IndexMap::insert_full` | 1.00% | 0.38% | **−66.5%** |

Diagnostic confirms: `[diag] handle() record sites: arena=2, stack=6, heap=0` (was `arena=0, stack=6, heap=2`). Runtime counters: 360 arena allocs / 0 fallbacks across the 3×120 calls.

Combined with the #588/#590 `alloc_heavy` measurement (−36.0%), the arena now delivers on both representative shapes.

## Test plan

- [x] **2 new escape unit tests** pin the new per-policy behavior (`merged_branch_records_kept_tracked_under_request_scope` and `merged_branch_records_all_escape_at_call_under_request_scope` — the latter is the soundness guard that multi-site `AggSet`s still leak all members at a hatch).
- [x] **1 new `arena_codegen` source-level test** (`match_arm_records_both_lower_to_arena_under_precision`) proves the source-level win + runtime path: `match cond { ... }` returning two distinct records → both lower to `AllocArenaRecord`, route through the slab, materialize correctly.
- [x] **`response_build_acceptance`** updated to the three-tier reality: `response_build` now has 6 stack + 1 arena per `handle()` call (was 6 stack + 1 heap). Stack rate 85.7% unchanged.
- [x] `cargo test -p lex-bytecode` full suite green (54 lib + 10 arena_codegen + everything else).
- [x] `cargo clippy -p lex-bytecode --all-targets -- -D warnings` clean.

## Docs

- `arena-plumbing.md` gains a "Status update (2026-06-03)" section with the measurement above and the remaining work (deep-leaf widening, slab-direct serializer).
- `escape-analysis.md` updates the if/else-merge entry from "future work" to the refined per-policy behavior.

## What's still open (not in this slice)

- **Deep-leaf widening** — `MakeRecord` still pessimistically leaks every field operand at the build site, so a record stored as a field of another record continues to escape. Sibling refinement to today's join precision.
- **Slab-direct serializer** — the materialize-at-boundary cost (`drop_in_place` + `Vec::resize` in the materialize walk) is still paid; a walker that emits JSON bytes directly out of `arena_slab` would shed it on the HTTP-serving path.

https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk)_