### PR TITLE
perf(#463): deep-leaf widening (containment-tracking) — deep_tree −55%

### DIFF
--- a/crates/lex-bytecode/examples/profile_deep_tree.rs
+++ b/crates/lex-bytecode/examples/profile_deep_tree.rs
@@ -1,0 +1,85 @@
+//! #463 deep-leaf measurement harness.
+//!
+//! Profile target for the containment-tracking refinement: a
+//! handler that returns a 3-deep nested record so every level
+//! becomes arena-eligible only under deep-leaf widening. Pre-
+//! refinement the inner two levels leaked at the outer's
+//! `MakeRecord` build sites; post-refinement the whole tree is
+//! a single arena slab allocation.
+//!
+//! Run under callgrind:
+//!   cargo build --release --example profile_deep_tree -p lex-bytecode
+//!   valgrind --tool=callgrind --callgrind-out-file=cg.off.out \
+//!     target/release/examples/profile_deep_tree 1000 5
+//!   LEX_PROFILE_ARENA=1 valgrind --tool=callgrind \
+//!     --callgrind-out-file=cg.on.out \
+//!     target/release/examples/profile_deep_tree 1000 5
+
+use std::sync::Arc;
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::vm::Vm;
+use lex_bytecode::{compile_program, Op, Value};
+use lex_syntax::parse_source;
+
+const SRC: &str = r#"
+type Inner  = { a :: Int, b :: Int }
+type Middle = { inner :: Inner, c :: Int }
+type Outer  = { middle :: Middle, status :: Int }
+
+fn handle(i :: Int) -> Outer {
+  { middle: { inner: { a: i, b: i + 1 }, c: i * 2 }, status: 200 }
+}
+
+fn drive(n :: Int) -> Int {
+  match n {
+    0 => 0,
+    _ => {
+      let r := handle(n)
+      r.status + drive(n - 1)
+    },
+  }
+}
+"#;
+
+fn main() {
+    let n: i64 = std::env::args().nth(1).and_then(|s| s.parse().ok()).unwrap_or(1000);
+    let iters: u64 = std::env::args().nth(2).and_then(|s| s.parse().ok()).unwrap_or(5);
+    let arena_scope = std::env::var_os("LEX_PROFILE_ARENA").is_some();
+
+    let prog = parse_source(SRC).expect("parse");
+    let stages = canonicalize_program(&prog);
+    lex_types::check_program(&stages).expect("typecheck");
+    let p = Arc::new(compile_program(&stages));
+
+    let h = &p.functions[p.function_names["handle"] as usize];
+    let arena = h.code.iter().filter(|o| matches!(o, Op::AllocArenaRecord { .. })).count();
+    let stack = h.code.iter().filter(|o| matches!(o, Op::AllocStackRecord { .. })).count();
+    let heap = h.code.iter().filter(|o| matches!(o, Op::MakeRecord { .. })).count();
+    eprintln!("[diag] handle() record sites: arena={arena}, stack={stack}, heap={heap}");
+
+    let mut acc = 0i64;
+    let mut tot_arena = 0u64;
+    let mut tot_arena_fb = 0u64;
+    for _ in 0..iters {
+        let mut vm = Vm::new(&p);
+        vm.set_step_limit(u64::MAX);
+        let r = if arena_scope {
+            let scope = vm.enter_request_scope();
+            let r = vm.call("drive", vec![Value::Int(n)]);
+            let r = r.map(|v| vm.materialize_arena_handles(v));
+            vm.exit_request_scope(scope);
+            r
+        } else {
+            vm.call("drive", vec![Value::Int(n)])
+        };
+        if let Value::Int(v) = r.unwrap() {
+            acc = acc.wrapping_add(v);
+        }
+        tot_arena += vm.arena_record_allocs;
+        tot_arena_fb += vm.arena_record_heap_fallbacks;
+    }
+    eprintln!("[diag] arena_scope_mode={arena_scope}");
+    eprintln!("[diag] counters: arena={tot_arena}, arena_fallbacks={tot_arena_fb}");
+    std::process::exit((acc & 0x7f) as i32);
+}

--- a/crates/lex-bytecode/src/arena.rs
+++ b/crates/lex-bytecode/src/arena.rs
@@ -266,13 +266,15 @@ mod tests {
     }
 
     /// Inner record stored as a field of outer; outer returned.
-    /// Inner escapes (consumed by the outer aggregate's heap
-    /// constructor — slice-1 doesn't yet model "outer is also
-    /// arena → inner can live with it"; that's a slice-2 codegen
-    /// question). Outer is arena-eligible — its only consumer is
-    /// `Return`, which doesn't escape under request scope.
+    /// **Deep-leaf widening** (#463 follow-up): the analysis now
+    /// tracks `inner` as contained in `outer` rather than leaking
+    /// it at the build site. Under `Policy::RequestScope` `Return`
+    /// doesn't escape `outer`, and the transitive expansion never
+    /// touches `inner` — so **both** sites are arena-eligible. The
+    /// pre-refinement answer was `[(1, false), (3, true)]`; the
+    /// recovery is the deep-tree response shape's whole point.
     #[test]
-    fn outer_returned_aggregate_is_arena_eligible_inner_field_is_not() {
+    fn outer_returned_aggregate_makes_inner_field_arena_eligible_too() {
         let f = func("nest", 0, 0, vec![
             Op::PushConst(0),
             Op::MakeRecord { shape_idx: 0, field_count: 1 }, // inner @ pc=1
@@ -281,7 +283,7 @@ mod tests {
             Op::Return,
         ]);
         let r = analyze_function(&f);
-        assert_eligible(&r, &[(1, false), (3, true)]);
+        assert_eligible(&r, &[(1, true), (3, true)]);
     }
 
     /// Two sites in one function, independently classified: one

--- a/crates/lex-bytecode/src/escape.rs
+++ b/crates/lex-bytecode/src/escape.rs
@@ -312,6 +312,14 @@ pub fn analyze_function_with_policy(func: &Function, policy: Policy) -> EscapeRe
     // Per-pc in-states, computed by the fixpoint. None = unvisited.
     let mut in_state: Vec<Option<State>> = vec![None; n];
     let mut escaped: HashSet<u32> = HashSet::new();
+    // Containment map for deep-leaf widening: at each tracked-
+    // aggregate build site (MakeRecord / MakeTuple / AllocStack* /
+    // AllocArena*), the set of child sites whose values were popped
+    // as fields/elements. Used to transitively escape children when
+    // a parent escapes, instead of pessimistically leaking children
+    // at the build site. Accumulates monotonically across worklist
+    // iterations — sites can only be added.
+    let mut containment: HashMap<u32, HashSet<u32>> = HashMap::new();
 
     let mut worklist: Vec<(usize, State)> = vec![(0, State::entry(locals_count, arity))];
 
@@ -334,11 +342,28 @@ pub fn analyze_function_with_policy(func: &Function, policy: Policy) -> EscapeRe
         in_state[pc] = Some(merged.clone());
 
         // Step the op, get the out-state + any successors.
-        let (out, succs, leaked) = step(pc, &func.code[pc], merged, policy);
+        let (out, succs, leaked) = step(pc, &func.code[pc], merged, policy, &mut containment);
         escaped.extend(leaked);
         for s in succs {
             if s < n {
                 worklist.push((s, out.clone()));
+            }
+        }
+    }
+
+    // Deep-leaf widening: every escaped parent transitively escapes
+    // all sites the containment map records as living inside it. Run
+    // to fixpoint over the accumulated containment so chains
+    // (`a` in `b` in `c`, c escapes → b, a) propagate correctly.
+    let mut changed = true;
+    while changed {
+        changed = false;
+        let snapshot: Vec<u32> = escaped.iter().copied().collect();
+        for p in snapshot {
+            if let Some(contained) = containment.get(&p) {
+                for &c in contained {
+                    if escaped.insert(c) { changed = true; }
+                }
             }
         }
     }
@@ -361,8 +386,37 @@ pub fn analyze_function_with_policy(func: &Function, policy: Policy) -> EscapeRe
 /// returned state, except for control-flow ops where successors
 /// share the *same* state), and any sites that escaped during the
 /// step.
-fn step(pc: usize, op: &Op, mut s: State, policy: Policy) -> (State, Vec<usize>, HashSet<u32>) {
+fn step(
+    pc: usize,
+    op: &Op,
+    mut s: State,
+    policy: Policy,
+    containment: &mut HashMap<u32, HashSet<u32>>,
+) -> (State, Vec<usize>, HashSet<u32>) {
     let mut escapes: HashSet<u32> = HashSet::new();
+
+    // Deep-leaf widening helper: pop `n` slots, but instead of
+    // leaking their sites immediately (as `pop_n_leak` does for
+    // genuine escape ops), record them as contained in the parent
+    // pc. The parent's later fate determines whether the children
+    // escape — transitive expansion at fixpoint exit propagates.
+    let pop_n_contain = |state: &mut State,
+                         n: usize,
+                         parent: u32,
+                         containment: &mut HashMap<u32, HashSet<u32>>| {
+        let entry = containment.entry(parent).or_default();
+        for _ in 0..n {
+            if let Some(top) = state.stack.pop() {
+                for &child in top.sites() {
+                    // Skip self-reference defensively (a parent
+                    // shouldn't appear in its own field operands;
+                    // if it ever does, a self-loop in containment
+                    // would still be sound but pointless).
+                    if child != parent { entry.insert(child); }
+                }
+            }
+        }
+    };
 
     // Helper closures for the common pop-n / push patterns. `leak`
     // iterates `slot.sites()` so multi-site slots (`AggSet`) leak
@@ -420,50 +474,43 @@ fn step(pc: usize, op: &Op, mut s: State, policy: Policy) -> (State, Vec<usize>,
             }
         }
 
-        // Allocation site.
+        // Allocation site. Deep-leaf widening (#463 follow-up):
+        // record child sites as **contained in** this parent
+        // instead of leaking them at the build site. The parent's
+        // eventual fate (escape via Call/etc., or stay local)
+        // decides what happens to the children — caught at the
+        // post-fixpoint transitive-expansion pass.
         Op::MakeRecord { field_count, .. } => {
-            // Field values get stored in the new heap record; if
-            // any of them is itself a tracked Rec, it escapes (now
-            // referenced from inside the parent).
-            pop_n_leak(&mut s, *field_count as usize, &mut escapes);
+            pop_n_contain(&mut s, *field_count as usize, pc as u32, containment);
             s.stack.push(Slot::Agg(pc as u32));
         }
-        // #464 step 2: post-lowering form of MakeRecord (escape
-        // proved). Re-running the analysis on already-lowered code
-        // must produce the same shape, so treat it identically.
+        // #464 step 2: post-lowering form of MakeRecord. Same deep-
+        // leaf containment story so re-running the analysis on
+        // already-lowered code produces the same shape.
         Op::AllocStackRecord { field_count, .. } => {
-            pop_n_leak(&mut s, *field_count as usize, &mut escapes);
+            pop_n_contain(&mut s, *field_count as usize, pc as u32, containment);
             s.stack.push(Slot::Agg(pc as u32));
         }
         // #463 slice 2a: post-lowering form of MakeRecord for the
-        // arena path. Re-running either policy on already-lowered code
-        // must classify it identically to the original MakeRecord, so
-        // the abstract step is the same.
+        // arena path. Same containment treatment.
         Op::AllocArenaRecord { field_count, .. } => {
-            pop_n_leak(&mut s, *field_count as usize, &mut escapes);
+            pop_n_contain(&mut s, *field_count as usize, pc as u32, containment);
             s.stack.push(Slot::Agg(pc as u32));
         }
-        // A tuple is a stack-allocatable aggregate, tracked the same
-        // way as a record: its field operands leak (any tracked
-        // aggregate stored inside it escapes), and the tuple itself
-        // becomes a tracked candidate keyed on this pc. `GetElem`
-        // reads an element without escaping the tuple, exactly as
-        // `GetField` does for records.
+        // Tuple build sites: identical deep-leaf treatment to
+        // records. `GetElem` reads an element without escaping the
+        // tuple, exactly as `GetField` does for records.
         Op::MakeTuple(n) => {
-            pop_n_leak(&mut s, *n as usize, &mut escapes);
+            pop_n_contain(&mut s, *n as usize, pc as u32, containment);
             s.stack.push(Slot::Agg(pc as u32));
         }
-        // Post-lowering form of MakeTuple (escape proved). Re-running
-        // the analysis on already-lowered code must classify it the
-        // same way, so treat it identically — mirrors AllocStackRecord.
+        // Post-lowering form of MakeTuple — same containment.
         Op::AllocStackTuple { arity } => {
-            pop_n_leak(&mut s, *arity as usize, &mut escapes);
+            pop_n_contain(&mut s, *arity as usize, pc as u32, containment);
             s.stack.push(Slot::Agg(pc as u32));
         }
-        // #463 slice 2a: arena-routed analogue of MakeTuple — same
-        // abstract step as the heap and stack tuple variants.
         Op::AllocArenaTuple { arity } => {
-            pop_n_leak(&mut s, *arity as usize, &mut escapes);
+            pop_n_contain(&mut s, *arity as usize, pc as u32, containment);
             s.stack.push(Slot::Agg(pc as u32));
         }
         // Lists and variants remain escape sinks for any tracked
@@ -862,6 +909,81 @@ mod tests {
         assert_escapes(&r, &[(3, true), (6, true)]);
     }
 
+    // ---- Deep-leaf widening (containment-tracking) ----
+
+    /// Inner record returned inside outer record — both arena-
+    /// eligible under request-scope. Pre-deep-leaf, `inner` was
+    /// leaked at the outer's `MakeRecord`; the transitive
+    /// expansion now leaves it alone because the outer doesn't
+    /// escape under `Policy::RequestScope`.
+    #[test]
+    fn deep_leaf_nested_records_both_arena_eligible() {
+        let f = func("nested_ret", 0, 0, vec![
+            Op::PushConst(0),
+            Op::MakeRecord { shape_idx: 0, field_count: 1 }, // inner @ pc=1
+            Op::PushConst(1),
+            Op::MakeRecord { shape_idx: 1, field_count: 2 }, // outer @ pc=3, holds inner
+            Op::Return,
+        ]);
+        let r = analyze_function_with_policy(&f, Policy::RequestScope);
+        assert_escapes(&r, &[(1, false), (3, false)]);
+    }
+
+    /// 3-deep nesting: inner → middle → outer → Return. Under
+    /// `RequestScope` all three are arena-eligible — transitive
+    /// expansion in `analyze_function_with_policy` chains through
+    /// the containment map.
+    #[test]
+    fn deep_leaf_three_deep_chain_all_arena_eligible() {
+        let f = func("three_deep", 0, 0, vec![
+            Op::PushConst(0),
+            Op::MakeRecord { shape_idx: 0, field_count: 1 }, // inner @ pc=1
+            Op::MakeRecord { shape_idx: 0, field_count: 1 }, // middle @ pc=2
+            Op::MakeRecord { shape_idx: 0, field_count: 1 }, // outer @ pc=3
+            Op::Return,
+        ]);
+        let r = analyze_function_with_policy(&f, Policy::RequestScope);
+        assert_escapes(&r, &[(1, false), (2, false), (3, false)]);
+    }
+
+    /// Soundness guard: when the outer reaches a real hatch
+    /// (`Call`), all contained children escape transitively. Same
+    /// chain shape as above but with the outer leaving via Call.
+    #[test]
+    fn deep_leaf_chain_all_escape_when_root_passed_to_call() {
+        let f = func("three_deep_call", 0, 0, vec![
+            Op::PushConst(0),
+            Op::MakeRecord { shape_idx: 0, field_count: 1 }, // inner @ pc=1
+            Op::MakeRecord { shape_idx: 0, field_count: 1 }, // middle @ pc=2
+            Op::MakeRecord { shape_idx: 0, field_count: 1 }, // outer @ pc=3
+            Op::Call { fn_id: 1, arity: 1, node_id_idx: 0 }, // pc=4
+            Op::Return,
+        ]);
+        let r = analyze_function_with_policy(&f, Policy::RequestScope);
+        // outer escapes via Call → middle escapes via containment →
+        // inner escapes via containment. All three flagged.
+        assert_escapes(&r, &[(1, true), (2, true), (3, true)]);
+    }
+
+    /// Mixed: outer dropped, inner contained. Under FrameScope the
+    /// outer is dropped and never returned, so the transitive
+    /// expansion leaves inner alone too — even under FrameScope
+    /// this is a precision win over the pre-refinement behavior
+    /// that leaked inner at the outer's build site.
+    #[test]
+    fn deep_leaf_outer_popped_inner_stays_local_under_frame_scope() {
+        let f = func("nested_pop", 0, 0, vec![
+            Op::PushConst(0),
+            Op::MakeRecord { shape_idx: 0, field_count: 1 }, // inner @ pc=1
+            Op::MakeRecord { shape_idx: 0, field_count: 1 }, // outer @ pc=2
+            Op::Pop,
+            Op::PushConst(0),
+            Op::Return,
+        ]);
+        let r = analyze_function(&f); // FrameScope
+        assert_escapes(&r, &[(1, false), (2, false)]);
+    }
+
     #[test]
     fn two_sites_classified_independently() {
         // One record returned, one popped — they should classify
@@ -1034,9 +1156,16 @@ mod tests {
     }
 
     #[test]
-    fn record_stored_into_tuple_escapes_tuple_stays_local() {
-        // Build a record, wrap it in a tuple, drop the tuple. The
-        // record escapes into the tuple; the tuple itself is local.
+    fn record_stored_into_tuple_dropped_outer_neither_escapes() {
+        // Build a record, wrap it in a tuple, drop the tuple.
+        // Pre-deep-leaf this asserted `[(1, true), (2, false)]` —
+        // the record was leaked at the tuple's build site because
+        // we conservatively assumed any captured value escaped.
+        // With containment-tracking, the record's fate is bound to
+        // the tuple's: the tuple is dropped (no escape), so via
+        // transitive expansion the record doesn't escape either.
+        // The win is real — both can live in the frame's stack-
+        // record arena now.
         let f = func("rec_in_tup", 0, 0, vec![
             Op::PushConst(0),
             Op::MakeRecord { shape_idx: 0, field_count: 1 }, // rec @ pc=1
@@ -1046,7 +1175,7 @@ mod tests {
             Op::Return,
         ]);
         let r = analyze_function(&f);
-        assert_escapes(&r, &[(1, true), (2, false)]);
+        assert_escapes(&r, &[(1, false), (2, false)]);
     }
 
     #[test]

--- a/crates/lex-bytecode/tests/arena_codegen.rs
+++ b/crates/lex-bytecode/tests/arena_codegen.rs
@@ -315,3 +315,58 @@ fn match_arm_records_both_lower_to_arena_under_precision() {
     assert_eq!(vm.arena_record_allocs, 2);
     assert_eq!(vm.arena_record_heap_fallbacks, 0);
 }
+
+// ---------------------------------------------------------------
+// Deep-leaf widening (containment-tracking)
+// ---------------------------------------------------------------
+
+/// A handler returning a nested record (inner record stored as a
+/// field of the outer) should now lower **both** to arena. Pre-deep-
+/// leaf the inner was leaked at the outer's build site and stayed
+/// heap; with containment-tracking neither escapes since the outer
+/// is only consumed by `Return`.
+#[test]
+fn deep_leaf_nested_handler_lowers_both_to_arena() {
+    let src = r#"
+        fn build_inner() -> { x :: Int, y :: Int } {
+          { x: 1, y: 2 }
+        }
+        fn handler() -> { status :: Int, body :: { x :: Int, y :: Int } } {
+          { status: 200, body: { x: 7, y: 9 } }
+        }
+    "#;
+    let p = compile(src);
+    let handler_code = fn_code(&p, "handler");
+
+    // Both MakeRecord sites in `handler` should lower to arena.
+    let arena = count(handler_code, |op| matches!(op, Op::AllocArenaRecord { .. }));
+    let heap = count(handler_code, |op| matches!(op, Op::MakeRecord { .. }));
+    assert_eq!(arena, 2,
+        "expected both nested records to lower to arena: {handler_code:?}");
+    assert_eq!(heap, 0,
+        "no heap records should remain after the deep-leaf refinement");
+
+    // End-to-end runtime: the response value materializes correctly,
+    // the nested body shows up as a heap Record after materialize.
+    let mut vm = Vm::new(&p);
+    let scope = vm.enter_request_scope();
+    let r = vm.invoke(p.function_names["handler"], vec![]).unwrap();
+    let r = vm.materialize_arena_handles(r);
+    vm.exit_request_scope(scope);
+    match r {
+        Value::Record { fields, .. } => {
+            assert_eq!(fields.get("status"), Some(&Value::Int(200)));
+            match fields.get("body") {
+                Some(Value::Record { fields: inner, .. }) => {
+                    assert_eq!(inner.get("x"), Some(&Value::Int(7)));
+                    assert_eq!(inner.get("y"), Some(&Value::Int(9)));
+                }
+                other => panic!("expected nested body Record, got {other:?}"),
+            }
+        }
+        other => panic!("expected outer Record, got {other:?}"),
+    }
+    // 2 arena allocs (inner + outer) per call, 0 fallbacks.
+    assert_eq!(vm.arena_record_allocs, 2);
+    assert_eq!(vm.arena_record_heap_fallbacks, 0);
+}

--- a/docs/design/arena-plumbing.md
+++ b/docs/design/arena-plumbing.md
@@ -367,3 +367,65 @@ counters confirm `arena_allocs=360, arena_fallbacks=0` across the
   (`drop_in_place` + `Vec::resize` in the materialize walk) is still
   paid. A walker that emits JSON bytes directly out of `arena_slab`
   would shed it on the HTTP-serving path.
+
+## Status update (2026-06-04) — deep-leaf widening landed
+
+The sibling refinement from the 2026-06-03 status. The slice-1
+analysis used to leak every field operand at each tracked aggregate's
+build site (`MakeRecord` / `MakeTuple` / `AllocStack*` /
+`AllocArena*`), so a record stored as a field of another record
+escaped immediately — even when the outer itself stayed local.
+
+The fix is a **containment-tracking** refinement: at each build site,
+the analysis records the popped children as *contained in* the
+parent pc rather than escaping them. After the fixpoint, an
+expansion pass transitively escapes the children of every escaped
+parent. Net effect:
+
+- **Outer escapes → all children escape transitively** (sound — same
+  result as before).
+- **Outer stays local → children stay local** (precision win — the
+  pre-refinement analysis pessimistically over-flagged).
+
+### Deep-tree workload — the new measurement
+
+`examples/profile_deep_tree.rs` — a 3-deep nested record per call,
+`drive(1000) × 3 iters`. All three levels arena-eligible only under
+deep-leaf widening; pre-refinement only the outer was eligible (and
+even then was leaked by the slice-1 lattice for `match`-shape
+returns, fixed by the 2026-06-03 precision pass).
+
+| | I-refs | Δ vs OFF |
+|---|---|---|
+| arena off | 40,939,025 | — |
+| arena on  | **18,404,779** | **−55.0%** |
+
+| | off | on | Δ abs |
+|---|---|---|---|
+| `_int_malloc` | 10.67% | 2.98% | **−87.5%** |
+| `_int_free` | 7.01% | 2.47% | **−84.2%** |
+| `malloc` | 4.93% | 1.74% | **−84.2%** |
+| `IndexMap::insert_full` | 4.62% | gone | **−100%** |
+
+Diagnostic: `[diag] handle() record sites: arena=3, stack=0,
+heap=0`; runtime counters confirm 9000 arena allocs / 0 fallbacks
+across 3 × 1000 calls × 3 levels per call.
+
+### Headline summary across the arena work
+
+| Workload | Shape | Arena win |
+|---|---|---|
+| `alloc_heavy`     | flat return record | **−36.0%** |
+| `response_build`  | match-arm return    | **−10.7%** |
+| `deep_tree`       | 3-deep nested      | **−55.0%** |
+
+### What's still open
+
+- **Slab-direct serializer** — the materialize-at-boundary cost
+  (`drop_in_place` + `Vec::resize` in the materialize walk) is still
+  paid. The deep-tree numbers above already pay it (the relative
+  share of `drop_in_place` actually grew, from 3.42% to 9.73%, even
+  though absolute went down — total I-refs shrank faster). A walker
+  that emits JSON bytes directly out of `arena_slab` without
+  rebuilding a `Value::Record` mirror would shed it on the
+  HTTP-serving path.

--- a/docs/design/escape-analysis.md
+++ b/docs/design/escape-analysis.md
@@ -156,8 +156,15 @@ The implementation pinned by `escape::tests`:
 - Fresh record round-tripped through one local → does NOT escape. ✓
 - Two MakeRecord sites in the same function classified
   independently. ✓
-- Records nested inside another record (the inner site escapes
-  via capture by the outer aggregate). ✓
+- Records nested inside another record — pre-refinement, the inner
+  site escaped at the outer's build site. With containment-tracking
+  (#463 follow-up, see `arena-plumbing.md` § "Status update
+  (2026-06-04)"), the inner is recorded as contained in the parent
+  and escapes only if the parent itself escapes (transitive expansion
+  at fixpoint exit). Under `Policy::FrameScope` the existing test
+  `record_stored_into_outer_record_escapes` still flags both because
+  the outer is `Return`'d; under `Policy::RequestScope` both stay
+  arena-eligible.
 - Records passed to `Call` / `EffectCall` / `MakeClosure` /
   `MakeList`. ✓
 - Records duplicated via `Dup`. ✓


### PR DESCRIPTION
## Summary

Sibling refinement to the 2026-06-03 per-path precision pass (#592). The slice-1 analysis used to leak every field operand at each tracked aggregate's build site (`MakeRecord` / `MakeTuple` / `AllocStack*` / `AllocArena*`), so a record stored as a field of another record escaped immediately — even when the outer itself stayed local. That was the **"deep-leaf trap"** explicitly documented in `arena-plumbing.md`.

## The refinement

Containment-tracking: at each build-site pc, the analysis records the popped children as **contained in** the parent pc rather than escaping them at the build site. After the worklist fixpoint, a transitive-expansion pass propagates — every site in `containment[escaped_parent]` is added to `escaped`, run to fixpoint so chains (a in b in c, c escapes → b, a) terminate.

- **Outer escapes** (via `Call` / `EffectCall` / `MakeClosure` / etc.) → all children escape transitively (sound — same result as before).
- **Outer stays local** (popped, returned-under-RequestScope, etc.) → children stay local too (precision win — pre-refinement over-flagged).

Same correctness contract: over-approximation only. The genuine escape ops still `pop_n_leak`.

## Deep-tree measurement — the new headline

`examples/profile_deep_tree.rs` (new), 3-deep nested record per call, `drive(1000) × 3 iters`:

| | I-refs | Δ |
|---|---|---|
| arena off | 40,939,025 | — |
| arena on  | **18,404,779** | **−55.0%** |

| | off | on | Δ abs |
|---|---|---|---|
| `_int_malloc` | 10.67% | 2.98% | **−87.5%** |
| `_int_free` | 7.01% | 2.47% | **−84.2%** |
| `malloc` | 4.93% | 1.74% | **−84.2%** |
| `IndexMap::insert_full` | 4.62% | gone | **−100%** |

Diagnostic confirms `arena=3 sites in handle()` (all three nesting levels); runtime counters: 9000 arena allocs / 0 fallbacks.

## Headline summary across the arena work

| Workload | Shape | Win |
|---|---|---|
| `alloc_heavy` (#590) | flat single-record return | **−36.0%** |
| `response_build` (#592) | match-arm return | **−10.7%** |
| `deep_tree` (this PR) | 3-deep nested | **−55.0%** |

## Test plan

- [x] **4 new escape unit tests** pin the new behavior: nested case, 3-deep chain, soundness guard when root passes to Call, frame-scope precision win on popped outer.
- [x] **1 new arena_codegen source-level test** (`deep_leaf_nested_handler_lowers_both_to_arena`) proves codegen + runtime round-trip on a nested handler — both levels lower to `AllocArenaRecord`, 2 arena allocs per call, materialize roundtrips correctly.
- [x] **Two existing tests** updated to the new precision answer (with comments documenting the change):
  - `record_stored_into_tuple_escapes_tuple_stays_local` → renamed `record_stored_into_tuple_dropped_outer_neither_escapes` ([1, true] → [1, false] under FrameScope when outer is popped).
  - `outer_returned_aggregate_is_arena_eligible_inner_field_is_not` → renamed `outer_returned_aggregate_makes_inner_field_arena_eligible_too` ([1, false], [3, true] → [1, true], [3, true]).
- [x] `cargo test -p lex-bytecode` full suite green (58 lib + 11 arena_codegen + everything else).
- [x] `cargo clippy -p lex-bytecode --all-targets -- -D warnings` clean.
- [x] `cargo build --release --example profile_deep_tree -p lex-bytecode` clean.
- [x] Re-measured `response_build` post-refinement: 11.22M → 10.02M (same −10.7% as #592 — no regression, also no gain since `response_build` has no nested records).

## What's still open

- **Slab-direct serializer** — the materialize-at-boundary cost is still paid. The deep-tree numbers above already pay it (the *relative* share of `drop_in_place` actually grew from 3.42% to 9.73% because total I-refs shrank faster). A walker that emits JSON bytes directly out of `arena_slab` would shed it on the HTTP-serving path. Now the single biggest remaining arena-side lever.

https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk)_