### PR TITLE
perf(#463): slab-direct accessors — Vm::get_record_field / get_tuple_elem / value_to_json

### DIFF
--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -1284,6 +1284,157 @@ impl<'a> Vm<'a> {
         }
     }
 
+    /// Read a named field out of a record without materializing its
+    /// parent. Works uniformly on `Value::Record` (heap) and
+    /// `Value::ArenaRecord` (slab handle), so a runtime layer can
+    /// consume the response record structurally — straight out of
+    /// the arena slab — instead of paying for a tree-wide
+    /// `materialize_arena_handles` walk just to read three top-level
+    /// fields.
+    ///
+    /// Returns `None` if the value isn't a record or the field
+    /// doesn't exist. The returned `Value` is a clone of the slot
+    /// contents (records' field values can themselves be records,
+    /// variants, etc.; cloning at the boundary is unavoidable
+    /// without lifetime trickery on the public API).
+    ///
+    /// Performance: on the heap path it's a `IndexMap::get` + clone.
+    /// On the arena path it's a linear walk of the shape's
+    /// field-name vec (`field_count` long, typically ≤ 10) +
+    /// an O(1) slab index + clone. The polymorphic-IC equivalent
+    /// inside the VM is faster, but this API is for **host**
+    /// consumers, not hot-loop dispatch.
+    ///
+    /// `Value::StackRecord` is deliberately not handled — those
+    /// handles are frame-local by construction (#464 escape pass)
+    /// and shouldn't reach host boundaries; reaching them here is
+    /// a soundness bug surfaced as a panic, matching the existing
+    /// inspection-path contract.
+    pub fn get_record_field(&self, value: &Value, name: &str) -> Option<Value> {
+        match value {
+            Value::Record { fields, .. } => fields.get(name).cloned(),
+            Value::ArenaRecord { shape_id, slab_start, field_count } => {
+                let shape = self.program.record_shapes.get(*shape_id as usize)?;
+                let n = (*field_count as usize).min(shape.len());
+                for (i, &name_const_idx) in shape.iter().take(n).enumerate() {
+                    if let Const::FieldName(s) = &self.program.constants[name_const_idx as usize] {
+                        if s == name {
+                            return Some(self.arena_slab[*slab_start as usize + i].clone());
+                        }
+                    }
+                }
+                None
+            }
+            Value::StackRecord { .. } =>
+                panic!("BUG(#464): Value::StackRecord reached Vm::get_record_field \
+                        — frame-local handles should never reach the host boundary"),
+            _ => None,
+        }
+    }
+
+    /// Positional read out of a tuple without materializing its
+    /// parent. Works uniformly on `Value::Tuple` and
+    /// `Value::ArenaTuple`. See `get_record_field` for the lifetime
+    /// rationale.
+    pub fn get_tuple_elem(&self, value: &Value, idx: u16) -> Option<Value> {
+        match value {
+            Value::Tuple(items) => items.get(idx as usize).cloned(),
+            Value::ArenaTuple { slab_start, arity } => {
+                if idx >= *arity { return None; }
+                Some(self.arena_slab[*slab_start as usize + idx as usize].clone())
+            }
+            Value::StackTuple { .. } =>
+                panic!("BUG(#464): Value::StackTuple reached Vm::get_tuple_elem \
+                        — frame-local handles should never reach the host boundary"),
+            _ => None,
+        }
+    }
+
+    /// Arena-aware `to_json` — produces a `serde_json::Value` from
+    /// a `Value` whose tree may contain `ArenaRecord` / `ArenaTuple`
+    /// handles, reading them straight out of `Vm::arena_slab`
+    /// instead of materializing into a heap `Value::Record` mirror
+    /// first.
+    ///
+    /// Equivalent output to `value.to_json()` on a fully-materialized
+    /// tree (idempotent in that sense). Use this when serializing a
+    /// handler return value to JSON for the response — saves the
+    /// per-node IndexMap allocations the materialize-then-to_json
+    /// pattern pays.
+    pub fn value_to_json(&self, value: &Value) -> serde_json::Value {
+        use serde_json::Value as J;
+        match value {
+            // Primitives + opaque host handles: delegate to the
+            // existing `Value::to_json` — its output is identical
+            // and it handles the host-handle types we don't model
+            // (Actor / Ticker / ArrowTable / F64Array / Map / Set /
+            // Closure / Bytes encoding) in one place.
+            Value::Int(_) | Value::Float(_) | Value::Bool(_) | Value::Str(_)
+            | Value::Bytes(_) | Value::Unit | Value::Closure { .. }
+            | Value::F64Array { .. } | Value::Map(_) | Value::Set(_)
+            | Value::Actor(_) | Value::Ticker(_) | Value::ArrowTable(_)
+                => value.to_json(),
+
+            Value::List(items) => J::Array(items.iter().map(|v| self.value_to_json(v)).collect()),
+            Value::Tuple(items) => J::Array(items.iter().map(|v| self.value_to_json(v)).collect()),
+            Value::Deque(items) => J::Array(items.iter().map(|v| self.value_to_json(v)).collect()),
+            Value::Variant { name, args } => {
+                let mut m = serde_json::Map::new();
+                m.insert("$variant".into(), J::String(name.clone()));
+                m.insert("args".into(),
+                    J::Array(args.iter().map(|v| self.value_to_json(v)).collect()));
+                J::Object(m)
+            }
+            Value::Record { fields, .. } => {
+                let mut m = serde_json::Map::new();
+                for (k, v) in fields.iter() {
+                    m.insert(k.to_string(), self.value_to_json(v));
+                }
+                J::Object(m)
+            }
+
+            // Slab-direct: read the cells in shape order, emit a
+            // JSON object using the shape's field names. The cost
+            // delta vs the `Value::to_json` materialize-then-walk
+            // path is the saved `Box<IndexMap>` allocation +
+            // insertion + drop.
+            Value::ArenaRecord { shape_id, slab_start, field_count } => {
+                let shape = match self.program.record_shapes.get(*shape_id as usize) {
+                    Some(s) => s,
+                    None => return J::Null,
+                };
+                let n = (*field_count as usize).min(shape.len());
+                let mut m = serde_json::Map::with_capacity(n);
+                for (i, &name_const_idx) in shape.iter().take(n).enumerate() {
+                    let name = match &self.program.constants[name_const_idx as usize] {
+                        Const::FieldName(s) => s.to_string(),
+                        _ => continue,
+                    };
+                    let cell = &self.arena_slab[*slab_start as usize + i];
+                    m.insert(name, self.value_to_json(cell));
+                }
+                J::Object(m)
+            }
+            Value::ArenaTuple { slab_start, arity } => {
+                let start = *slab_start as usize;
+                let n = *arity as usize;
+                let items: Vec<serde_json::Value> = (0..n)
+                    .map(|i| self.value_to_json(&self.arena_slab[start + i]))
+                    .collect();
+                J::Array(items)
+            }
+
+            // Stack handles must not reach the host — same defensive
+            // panic as the other inspection paths.
+            Value::StackRecord { .. } =>
+                panic!("BUG(#464): Value::StackRecord reached Vm::value_to_json \
+                        — frame-local handles should never reach the host boundary"),
+            Value::StackTuple { .. } =>
+                panic!("BUG(#464): Value::StackTuple reached Vm::value_to_json \
+                        — frame-local handles should never reach the host boundary"),
+        }
+    }
+
     pub fn invoke(&mut self, fn_id: u32, args: Vec<Value>) -> Result<Value, VmError> {
         let f = &self.program.functions[fn_id as usize];
         if args.len() != f.arity as usize {

--- a/crates/lex-bytecode/tests/arena_records.rs
+++ b/crates/lex-bytecode/tests/arena_records.rs
@@ -534,3 +534,161 @@ fn materialize_is_idempotent() {
     vm.exit_request_scope(scope);
     assert_eq!(once, twice);
 }
+
+// ---------------------------------------------------------------
+// Slab-direct accessors (slice 2c-i)
+// ---------------------------------------------------------------
+// Vm::get_record_field / get_tuple_elem / value_to_json — read
+// arena handles straight out of the slab without going through
+// materialize_arena_handles. Host runtimes use these to consume a
+// response record structurally without paying for a tree walk.
+
+#[test]
+fn get_record_field_reads_arena_record() {
+    let prog = handler_returning_xy_record();
+    let mut vm = Vm::new(&prog);
+    let scope = vm.enter_request_scope();
+    let arena_value = vm.invoke(0, vec![]).unwrap();
+    assert!(matches!(arena_value, Value::ArenaRecord { .. }),
+        "test precondition: arena handle, got {arena_value:?}");
+
+    // Slab-direct read — no materialize between alloc and read.
+    let x = vm.get_record_field(&arena_value, "x");
+    let y = vm.get_record_field(&arena_value, "y");
+    let missing = vm.get_record_field(&arena_value, "z");
+    assert_eq!(x, Some(Value::Int(7)));
+    assert_eq!(y, Some(Value::Int(9)));
+    assert_eq!(missing, None);
+
+    vm.exit_request_scope(scope);
+}
+
+#[test]
+fn get_record_field_reads_heap_record_uniformly() {
+    // Same API works on heap Record — uniform interface for the
+    // host that doesn't have to know which variant it has.
+    let prog = xy_program("noop", 0, vec![Op::PushConst(2), Op::Return]);
+    let vm = Vm::new(&prog);
+    let mut fields: IndexMap<smol_str::SmolStr, Value> = IndexMap::new();
+    fields.insert("x".into(), Value::Int(7));
+    fields.insert("y".into(), Value::Int(9));
+    let heap = Value::Record { shape_id: 0, fields: Box::new(fields) };
+    assert_eq!(vm.get_record_field(&heap, "x"), Some(Value::Int(7)));
+    assert_eq!(vm.get_record_field(&heap, "missing"), None);
+}
+
+#[test]
+fn get_record_field_returns_none_on_non_record() {
+    let prog = xy_program("noop", 0, vec![Op::PushConst(2), Op::Return]);
+    let vm = Vm::new(&prog);
+    assert_eq!(vm.get_record_field(&Value::Int(42), "x"), None);
+    assert_eq!(vm.get_record_field(&Value::Unit, "x"), None);
+}
+
+#[test]
+fn get_tuple_elem_reads_arena_tuple() {
+    let prog = tup_program("build_tup", 0, vec![
+        Op::PushConst(0), Op::PushConst(1),
+        Op::AllocArenaTuple { arity: 2 },
+        Op::Return,
+    ]);
+    let mut vm = Vm::new(&prog);
+    let scope = vm.enter_request_scope();
+    let arena_tup = vm.invoke(0, vec![]).unwrap();
+    assert!(matches!(arena_tup, Value::ArenaTuple { .. }));
+
+    assert_eq!(vm.get_tuple_elem(&arena_tup, 0), Some(Value::Int(11)));
+    assert_eq!(vm.get_tuple_elem(&arena_tup, 1), Some(Value::Int(13)));
+    assert_eq!(vm.get_tuple_elem(&arena_tup, 2), None);
+
+    vm.exit_request_scope(scope);
+}
+
+#[test]
+fn get_tuple_elem_reads_heap_tuple_uniformly() {
+    let prog = tup_program("noop", 0, vec![Op::PushConst(0), Op::Return]);
+    let vm = Vm::new(&prog);
+    let heap = Value::Tuple(vec![Value::Int(11), Value::Int(13)]);
+    assert_eq!(vm.get_tuple_elem(&heap, 0), Some(Value::Int(11)));
+    assert_eq!(vm.get_tuple_elem(&heap, 5), None);
+}
+
+#[test]
+fn value_to_json_matches_materialize_then_to_json_for_arena_record() {
+    let prog = handler_returning_xy_record();
+    let mut vm = Vm::new(&prog);
+    let scope = vm.enter_request_scope();
+    let arena_value = vm.invoke(0, vec![]).unwrap();
+
+    // The slab-direct path equals materialize-then-to_json byte for
+    // byte — this is the slab-direct serializer's correctness gate.
+    let direct = vm.value_to_json(&arena_value);
+    let materialized = vm.materialize_arena_handles(arena_value).to_json();
+    vm.exit_request_scope(scope);
+
+    assert_eq!(direct, materialized);
+    assert_eq!(direct["x"], serde_json::json!(7));
+    assert_eq!(direct["y"], serde_json::json!(9));
+}
+
+#[test]
+fn value_to_json_recurses_through_nested_arena_records() {
+    // Two-level nested arena record (the deep-leaf shape). The
+    // slab-direct path must reach into the slab at every level, not
+    // just the top.
+    let constants = vec![
+        Const::FieldName("inner".into()),
+        Const::FieldName("status".into()),
+        Const::FieldName("a".into()),
+        Const::Int(200),
+        Const::Int(42),
+    ];
+    let mut function_names = IndexMap::new();
+    function_names.insert("nested".to_string(), 0);
+    // Inner: { a: 42 } (shape 0)
+    // Outer: { inner: <inner>, status: 200 } (shape 1)
+    let prog = Arc::new(Program {
+        constants,
+        functions: vec![Function {
+            name: "nested".into(),
+            arity: 0,
+            locals_count: 0,
+            code: vec![
+                Op::PushConst(4),                                       // 42
+                Op::AllocArenaRecord { shape_idx: 0, field_count: 1 },  // inner: { a: 42 }
+                Op::PushConst(3),                                       // 200
+                Op::AllocArenaRecord { shape_idx: 1, field_count: 2 },  // outer: { inner, status }
+                Op::Return,
+            ],
+            effects: vec![],
+            body_hash: ZERO_BODY_HASH,
+            refinements: vec![],
+            field_ic_sites: 4,
+        }],
+        function_names,
+        module_aliases: IndexMap::new(),
+        entry: Some(0),
+        record_shapes: vec![vec![2], vec![0, 1]], // inner shape, outer shape
+    });
+    let mut vm = Vm::new(&prog);
+    let scope = vm.enter_request_scope();
+    let arena_value = vm.invoke(0, vec![]).unwrap();
+    let direct = vm.value_to_json(&arena_value);
+    vm.exit_request_scope(scope);
+
+    assert_eq!(direct["status"], serde_json::json!(200));
+    assert_eq!(direct["inner"]["a"], serde_json::json!(42));
+}
+
+#[test]
+fn value_to_json_passes_primitives_through() {
+    // The host can call value_to_json on any value — primitives
+    // delegate to the existing Value::to_json so the output stays
+    // identical.
+    let prog = xy_program("noop", 0, vec![Op::PushConst(2), Op::Return]);
+    let vm = Vm::new(&prog);
+    assert_eq!(vm.value_to_json(&Value::Int(42)), serde_json::json!(42));
+    assert_eq!(vm.value_to_json(&Value::Bool(true)), serde_json::json!(true));
+    assert_eq!(vm.value_to_json(&Value::Unit), serde_json::Value::Null);
+    assert_eq!(vm.value_to_json(&Value::Str("hi".into())), serde_json::json!("hi"));
+}

--- a/docs/design/arena-plumbing.md
+++ b/docs/design/arena-plumbing.md
@@ -429,3 +429,71 @@ across 3 × 1000 calls × 3 levels per call.
   that emits JSON bytes directly out of `arena_slab` without
   rebuilding a `Value::Record` mirror would shed it on the
   HTTP-serving path.
+
+## Status update (2026-06-05) — slab-direct accessors landed
+
+Bytecode-side foundations for the slab-direct serializer:
+
+- **`Vm::get_record_field(&self, value: &Value, name: &str) ->
+  Option<Value>`** — uniform field access over `Value::Record` (heap)
+  and `Value::ArenaRecord` (slab handle). On the arena path it walks
+  the shape's field-name vec and reads from `arena_slab` directly,
+  with no `IndexMap` allocation.
+- **`Vm::get_tuple_elem(&self, value: &Value, idx: u16) ->
+  Option<Value>`** — same for `Value::Tuple` / `Value::ArenaTuple`.
+- **`Vm::value_to_json(&self, value: &Value) -> serde_json::Value`** —
+  arena-aware analogue of `Value::to_json`. Recurses through
+  `ArenaRecord` / `ArenaTuple` reading cells out of `arena_slab`,
+  delegates to `Value::to_json` for primitives + opaque host handles
+  to keep output identical. Saves the per-record `Box<IndexMap>`
+  alloc + insert + drop that the materialize-then-`to_json` path
+  pays.
+
+`Value::StackRecord` / `Value::StackTuple` defensively panic on
+these methods, mirroring the existing inspection-path contract —
+frame-local handles by construction shouldn't reach the host.
+
+### Unit-test coverage
+
+`crates/lex-bytecode/tests/arena_records.rs` gains 8 tests:
+- `get_record_field` on arena + heap variants + non-record fallthrough.
+- `get_tuple_elem` on arena + heap variants.
+- `value_to_json` byte-identical with `materialize_arena_handles` +
+  `to_json` (the **correctness gate** the wire-up will rely on).
+- `value_to_json` recurses correctly through 2-deep nested arena
+  records.
+- `value_to_json` passes primitives through to `Value::to_json`.
+
+### What's still open: `lex-runtime` wire-up
+
+The accessor API is ready; the wire-up into `net.serve_fn`'s response
+pipeline is a separate slice because of a real **runtime
+architecture obstacle**:
+
+`build_hyper_response` and the `unpack_response` it calls live
+**outside** the `tokio::task::spawn_blocking` closure where `vm`
+lives (`handler.rs:2329` / `:2493` / `:2754`). By the time the
+hyper-response is built, the vm has been dropped. So a vm-aware
+`unpack_response` requires either:
+
+1. Moving the `unpack_response` call **inside** the spawn_blocking
+   closure (closure returns the unpacked tuple instead of the raw
+   `Value`), so `vm` is still alive — natural fit but rearranges
+   three call sites' control flow.
+2. Returning the `Vm` *alongside* the `Value` and arranging
+   lifetimes through the response pipeline — more invasive,
+   touches lifetimes across `async` boundaries.
+
+Option 1 is the recommended next slice. The lifetime change is
+local to the three spawn_blocking sites; `unpack_response` becomes
+`fn unpack_response(vm: &mut Vm, v: &Value) -> (u16,
+ResponseBodyOut, Vec<...>)` and merges with the lazy-iter draining
+of `materialize_response_body`; `build_hyper_response` then takes
+the unpacked tuple (no `Vm` needed). The materialize call disappears
+on the common `BodyStr` path; only the `BodyStream` / `BodyBytes`
+case still needs the iter materialization step.
+
+When that wire-up lands, the win on a real `/plaintext`-style HTTP
+benchmark — one fewer `IndexMap` allocation per request, scaled by
+request rate — becomes measurable. Estimated saving: small per
+request but cumulative on a hot path.


### PR DESCRIPTION
## Summary

Bytecode-side foundations for the slab-direct serializer. Adds three public `Vm` methods that read arena handles **directly out of `arena_slab`** without going through `materialize_arena_handles` first — saving the per-record `Box<IndexMap>` alloc + insert + drop the materialize path pays.

## What lands

- **`Vm::get_record_field(&self, value: &Value, name: &str) -> Option<Value>`** — uniform field access over `Value::Record` (heap) and `Value::ArenaRecord` (slab handle). On the arena path it walks the shape's field-name vec and reads from `arena_slab` directly; no `IndexMap` allocation.
- **`Vm::get_tuple_elem(&self, value: &Value, idx: u16) -> Option<Value>`** — same for `Value::Tuple` / `Value::ArenaTuple`.
- **`Vm::value_to_json(&self, value: &Value) -> serde_json::Value`** — arena-aware analogue of `Value::to_json`. Recurses through `ArenaRecord` / `ArenaTuple` reading cells out of `arena_slab`, delegates to `Value::to_json` for primitives + opaque host handles so output is **byte-identical** with the materialize-then-`to_json` path.

`Value::StackRecord` / `StackTuple` defensively panic on these methods, mirroring the existing inspection-path contract — frame-local handles by construction shouldn't reach the host.

## What's NOT in this slice — the runtime wire-up

The accessor API is ready, but plumbing it into `net.serve_fn`'s response pipeline runs into a real **runtime architecture obstacle**: `build_hyper_response` and the `unpack_response` it calls live **outside** the `tokio::task::spawn_blocking` closure where `vm` is moved (`handler.rs:2329 / :2493 / :2754`). By the time the hyper-response is built, `vm` has been dropped. So vm-aware `unpack_response` needs the spawn_blocking closure to return the *unpacked tuple* instead of the raw `Value` — a contained but separate runtime refactor.

`arena-plumbing.md`'s new "Status update (2026-06-05)" section spells out the recommended approach: closure returns `(u16, ResponseBodyOut, Vec<...>)` instead of `Value`; `unpack_response` becomes vm-aware and merges with the lazy-iter draining; `build_hyper_response` takes the unpacked tuple. Common `BodyStr` path then skips materialize entirely.

## Test plan

- [x] **8 new unit tests** in `arena_records.rs` (26 total in that file now):
  - `get_record_field` on arena variants, heap variants, and non-record fallthrough.
  - `get_tuple_elem` on arena and heap variants.
  - **`value_to_json` byte-identical with `materialize_arena_handles` + `to_json`** — the correctness gate the wire-up will rely on.
  - `value_to_json` recurses correctly through 2-deep nested arena records.
  - `value_to_json` passes primitives through to `Value::to_json`.
- [x] `cargo test -p lex-bytecode` full suite green.
- [x] `cargo clippy -p lex-bytecode --all-targets -- -D warnings` clean.

https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk)_