### PR TITLE
docs(#463): measure the slab-direct wire-up — −59.2% on the response boundary

### DIFF
--- a/crates/lex-bytecode/examples/profile_unpack_response.rs
+++ b/crates/lex-bytecode/examples/profile_unpack_response.rs
@@ -1,0 +1,106 @@
+//! #463 slab-direct wire-up measurement.
+//!
+//! Compares the **per-request boundary cost** of two response-reading
+//! patterns on a typical `Response { status, body, total }` handler:
+//!
+//! - **Old path** (pre-#595): `vm.materialize_arena_handles(r)` walks
+//!   the tree allocating a heap `Box<IndexMap>` mirror, then the
+//!   runtime reads three fields via `IndexMap::get`.
+//! - **New path** (post-#595): `vm.get_record_field(r, name)` reads
+//!   straight out of `arena_slab` — no materialize walk, no `IndexMap`
+//!   alloc.
+//!
+//! Both arms invoke an arena-eligible handler inside an active scope
+//! so the response is a `Value::ArenaRecord` (the case the wire-up
+//! actually affects). The arena-off baseline isn't interesting here:
+//! when arena is off the response is already a heap `Value::Record`
+//! and both arms degenerate to the same `IndexMap::get` lookups.
+//!
+//! Run under callgrind:
+//!   cargo build --release --example profile_unpack_response -p lex-bytecode
+//!   valgrind --tool=callgrind --callgrind-out-file=cg.materialize.out \
+//!     target/release/examples/profile_unpack_response 10000
+//!   LEX_PROFILE_SLAB_DIRECT=1 valgrind --tool=callgrind \
+//!     --callgrind-out-file=cg.slab.out \
+//!     target/release/examples/profile_unpack_response 10000
+//!
+//! Arg: <iters>. Default 10000.
+
+use std::sync::Arc;
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::vm::Vm;
+use lex_bytecode::{compile_program, Value};
+use lex_syntax::parse_source;
+
+const SRC: &str = r#"
+type Response = { status :: Int, body :: Str, total :: Int }
+
+fn handler() -> Response {
+  { status: 200, body: "hello", total: 42 }
+}
+"#;
+
+fn main() {
+    let iters: u64 = std::env::args().nth(1).and_then(|s| s.parse().ok()).unwrap_or(10_000);
+    let slab_direct = std::env::var_os("LEX_PROFILE_SLAB_DIRECT").is_some();
+
+    let prog = parse_source(SRC).expect("parse");
+    let stages = canonicalize_program(&prog);
+    lex_types::check_program(&stages).expect("typecheck");
+    let p = Arc::new(compile_program(&stages));
+    let handler_id = p.function_names["handler"];
+
+    let mut vm = Vm::new(&p);
+    vm.set_step_limit(u64::MAX);
+    let mut acc = 0i64;
+
+    for _ in 0..iters {
+        let scope = vm.enter_request_scope();
+        let resp = vm.invoke(handler_id, vec![]).unwrap();
+        debug_assert!(matches!(resp, Value::ArenaRecord { .. }),
+            "expected arena handle under active scope");
+
+        if slab_direct {
+            // New path: read each field directly from the slab. No
+            // materialize walk, no IndexMap allocation.
+            let status = vm.get_record_field(&resp, "status")
+                .and_then(|v| if let Value::Int(n) = v { Some(n) } else { None })
+                .unwrap_or(0);
+            let body_len = match vm.get_record_field(&resp, "body") {
+                Some(Value::Str(s)) => s.len() as i64,
+                _ => 0,
+            };
+            let total = vm.get_record_field(&resp, "total")
+                .and_then(|v| if let Value::Int(n) = v { Some(n) } else { None })
+                .unwrap_or(0);
+            acc = acc.wrapping_add(status).wrapping_add(body_len).wrapping_add(total);
+        } else {
+            // Old path: materialize the full tree first, then read
+            // fields via IndexMap::get. This is exactly what
+            // `materialize_response_body` + `unpack_response`
+            // (pre-#595) did at the response boundary.
+            let materialized = vm.materialize_arena_handles(resp);
+            if let Value::Record { fields, .. } = &materialized {
+                let status = fields.get("status")
+                    .and_then(|v| if let Value::Int(n) = v { Some(*n) } else { None })
+                    .unwrap_or(0);
+                let body_len = match fields.get("body") {
+                    Some(Value::Str(s)) => s.len() as i64,
+                    _ => 0,
+                };
+                let total = fields.get("total")
+                    .and_then(|v| if let Value::Int(n) = v { Some(*n) } else { None })
+                    .unwrap_or(0);
+                acc = acc.wrapping_add(status).wrapping_add(body_len).wrapping_add(total);
+            }
+        }
+
+        vm.exit_request_scope(scope);
+    }
+
+    eprintln!("[diag] slab_direct={slab_direct}, iters={iters}, acc={acc}");
+    eprintln!("[diag] arena_allocs={}, arena_fallbacks={}",
+        vm.arena_record_allocs, vm.arena_record_heap_fallbacks);
+    std::process::exit((acc & 0x7f) as i32);
+}

--- a/docs/design/arena-plumbing.md
+++ b/docs/design/arena-plumbing.md
@@ -585,3 +585,70 @@ elsewhere:
 - **Real-workload measurement** — re-profile a representative
   `bench/floor.lex /plaintext` and `/json` run on `main` to confirm
   the wire-up's per-request saving shows up.
+
+## Status update (2026-06-07) — wire-up measured
+
+`examples/profile_unpack_response.rs` (new) compares the
+**per-request boundary cost** of the pre-wire-up and post-wire-up
+patterns on a typical `Response { status, body, total }` handler.
+Both arms hold an active request scope so the response is a
+`Value::ArenaRecord` (the case the wire-up actually changes — the
+arena-off baseline degenerates to a heap `Value::Record` and both
+arms collapse to `IndexMap::get` lookups).
+
+10,000-iteration callgrind run:
+
+| | I-refs | Δ |
+|---|---|---|
+| materialize path (pre-#595) | 46,453,233 | — |
+| slab-direct (post-#595) | **18,931,066** | **−59.2%** |
+
+Where the savings land:
+
+| | materialize | slab-direct | Δ abs |
+|---|---|---|---|
+| `materialize_arena_handles` | 3,460,000 (7.45%) | 0 | **−100%** |
+| `IndexMap::insert_full` | 3,133,707 (6.75%) | 13,707 (0.07%) | **−99.6%** |
+| `_int_malloc` (combined w/ malloc) | 1,370,441 (2.95%) | 20,483 (0.11%) | **−98.5%** |
+| `_int_free` (combined w/ free) | 1,648,466 (3.55%) | 28,520 (0.15%) | **−98.3%** |
+| NEW: `Vm::get_record_field` | — | 2,940,000 (15.53%) | (replaces the above) |
+| `Vm::run_to` | 6,270,000 (13.50%) | 6,270,000 (33.12%) | unchanged abs |
+
+**Per-request saving: ~2,752 I-refs.** The materialize walk and its
+`Box<IndexMap>` allocation + insertion + drop are fully replaced by
+three `Vm::get_record_field` reads that walk the shape's
+field-name vec (typically ≤ 10 entries) and index the slab. The
+total I-ref budget for the response boundary drops from ~4.6K per
+request to ~1.9K per request.
+
+For a `/plaintext`-style workload at 1M requests/sec, the wire-up
+sheds ~2.75 billion I-refs/sec from the response-boundary path
+alone. Caveat: this is a *boundary-isolated* harness — real HTTP
+serving adds hyper / TLS / accept-loop costs that aren't measured
+here. The headline ratio is upper-bound on what's recoverable from
+the materialize step specifically.
+
+### Final headline summary
+
+| Lever | Workload | Win |
+|---|---|---|
+| Arena lowering (slice 2b-i) | `alloc_heavy` (flat return) | −36.0% |
+| Per-path precision | `response_build` (match-arm) | −10.7% |
+| Deep-leaf containment | `deep_tree` (3-deep nested) | −55.0% |
+| Slab-direct wire-up | `unpack_response` boundary | **−59.2%** |
+
+### What's still on the JIT-prereq board
+
+The arena work is at a natural stopping point — the analysis is
+intra-procedurally precise, the runtime path skips materialize, and
+all measured workloads see clean wins. The two remaining levers
+both need decisions outside this work:
+
+- **Threaded dispatch (#461 slice C)** — still the largest single
+  remaining lever per the original 2026-05-21 profile (`Vm::run_to`
+  at ~48% of I-refs there; ~33% on the slab-direct path above).
+  Still blocked on the pinned stable toolchain.
+- **Inter-procedural escape** — would let the analysis recover
+  helper-shape patterns (`format_response(r: Response) -> Str`)
+  that today are flagged at the `Call` hatch. Out of scope until
+  inlining lands (#465 phase 1).


### PR DESCRIPTION
## Summary

Closes the measurement loop on PR #595 (slab-direct wire-up). A new focused harness (`examples/profile_unpack_response.rs`) compares the per-request **boundary cost** of the pre-wire-up materialize-then-read pattern vs the post-wire-up slab-direct `Vm::get_record_field` pattern on a typical `Response { status, body, total }` handler.

## Headline — wire-up isolated to its actual change

Both arms invoke an arena-eligible handler **inside an active scope** so the response is a `Value::ArenaRecord` (the case the wire-up changes). Callgrind, 10,000 iterations:

| | I-refs | Δ |
|---|---|---|
| materialize path (pre-#595) | 46,453,233 | — |
| slab-direct (post-#595) | **18,931,066** | **−59.2%** |

| | materialize | slab-direct | Δ abs |
|---|---|---|---|
| `materialize_arena_handles` | 7.45% | **0** | −100% |
| `IndexMap::insert_full` | 6.75% | 0.07% (noise) | −99.6% |
| `_int_malloc` combined | 2.95% | 0.11% | −98.5% |
| `_int_free` combined | 3.55% | 0.15% | −98.3% |
| NEW: `Vm::get_record_field` | — | 15.53% | replaces the above |

**Per-request saving: ~2,752 I-refs.** Response-boundary budget drops from ~4.6K → ~1.9K per request.

For a `/plaintext`-style workload at 1M requests/sec, that's ~2.75 billion I-refs/sec saved on the materialize path alone. Caveat: boundary-isolated — real HTTP serving adds hyper / TLS / accept-loop costs not measured here. The ratio is upper-bound on what's recoverable from the materialize step specifically.

## Final headline across the arena arc

| Lever | Workload | Win |
|---|---|---|
| Arena lowering (#590) | `alloc_heavy` (flat return) | −36.0% |
| Per-path precision (#592) | `response_build` (match-arm) | −10.7% |
| Deep-leaf containment (#593) | `deep_tree` (3-deep nested) | −55.0% |
| Slab-direct wire-up (#595, **measured here**) | `unpack_response` boundary | **−59.2%** |

## Test plan

- [x] `cargo build --release --example profile_unpack_response -p lex-bytecode` clean.
- [x] `cargo clippy -p lex-bytecode --example profile_unpack_response -- -D warnings` clean.
- [x] Both arms produce identical accumulator output (correctness check — same Lex program, same `Vm` semantics, just different read paths).
- [x] Diagnostic counters confirm 10,000 arena allocs / 0 fallbacks on both arms.

## What's still open

The arena work is at a natural stopping point — analysis is intra-procedurally precise, runtime skips materialize, all measured workloads see clean wins. Remaining JIT-prereq levers need decisions outside this arc:

- **Threaded dispatch (#461 slice C)** — still the largest single remaining lever per the original 2026-05-21 profile (`Vm::run_to` at ~48% there, ~33% on the slab-direct path above). Still blocked on the pinned stable toolchain.
- **Inter-procedural escape** — would recover helper-shape patterns like `format_response(r: Response) -> Str` that today are flagged at the `Call` hatch. Out of scope until inlining lands (#465 phase 1).

https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk)_