### PR TITLE
feat(#465): MVP JIT — bytecode → Cranelift → native, feature-gated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "arcstr"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,6 +614,9 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "bytemuck"
@@ -1011,6 +1020,174 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "cranelift-assembler-x64"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c80cf55a351448317210f26c434be761bcb25e7b36116ec92f89540b73e2833"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07937ca8617b340162fe3a4716be885b5847e9b56d6c7a89abbe4d42340fdc91"
+dependencies = [
+ "cranelift-srcgen",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88217b08180882436d54c0133274885c590698ae854e352bede1cda041230800"
+dependencies = [
+ "cranelift-entity",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5c3cf7ba29fa56e56040848e34835d4e45988b2760ef212413409af95ffd8c1"
+dependencies = [
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe1aac2efd4cba2047845fce38a68519935a30e20c8a6294ba7e2f448fe722d"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli",
+ "hashbrown 0.17.1",
+ "libm",
+ "log",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0909eaf9d6f18f5bf802d50608cb4368ac340fbd03cc44f2888d1cfcc3faa64e"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+ "cranelift-codegen-shared",
+ "cranelift-srcgen",
+ "heck",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c95a8da8be283f49cda7d0ef228c94f10d791e517b27b0c7e282dadd2e79ce45"
+
+[[package]]
+name = "cranelift-control"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5b19c81145146da1f7afda2e7f52111842fe6793512e740ad5cf3f5639e6212"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a55309b47e6633ab05821304206cb1e92952e845b1224985562bb7ac1e92323"
+dependencies = [
+ "cranelift-bitset",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "064d2d3533d9608f1cf44c8899cf2f7f33feb70300b0fb83e687b0d9e7b91147"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac4e0bc095b2dab2212d1e99d7a74b62afc1485db023f1c0cb34a68758f7bd1"
+
+[[package]]
+name = "cranelift-jit"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b48c2a0720c7d62aadd508c662b9bf666b614a47a888589e553e0511620635e"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-module",
+ "cranelift-native",
+ "libc",
+ "log",
+ "memmap2 0.2.3",
+ "region",
+ "target-lexicon",
+ "wasmtime-internal-jit-icache-coherence",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "cranelift-module"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28f05d9efce7a4e8c2ceec49c76d26e53f1ee8cb13de822b6ca5118d48f50976"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "cranelift-control",
+]
+
+[[package]]
+name = "cranelift-native"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a40053f5cb925451dd1d57393d14ad3145c8e0786701c27b5415ebb9a3ba4f"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ceab9a53f7d362c89841fbaa8e63e44d47c40e91dc96ee6f777fca5d6b323b"
 
 [[package]]
 name = "crc32fast"
@@ -1643,6 +1820,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
+dependencies = [
+ "fnv",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1739,6 +1928,9 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -2313,6 +2505,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "lex-jit"
+version = "0.9.7"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-frontend",
+ "cranelift-jit",
+ "cranelift-module",
+ "cranelift-native",
+ "indexmap",
+ "lex-bytecode",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "lex-lsp"
 version = "0.9.7"
 dependencies = [
@@ -2694,6 +2900,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2718,6 +2933,15 @@ name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "memmap2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723e3ebdcdc5c023db1df315364573789f8857c11b631a2fdfad7c00f5c046b4"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memmap2"
@@ -3388,7 +3612,7 @@ dependencies = [
  "home",
  "itoa",
  "memchr",
- "memmap2",
+ "memmap2 0.9.10",
  "num-traits",
  "object_store",
  "percent-encoding",
@@ -3443,7 +3667,7 @@ version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c394e4cd90186043d4051ce118e90794afbe81ac5eb9a51e358a56728e8ebde3"
 dependencies = [
- "memmap2",
+ "memmap2 0.9.10",
  "polars-arrow",
  "polars-core",
  "polars-error",
@@ -3541,7 +3765,7 @@ dependencies = [
  "either",
  "futures",
  "hashbrown 0.16.1",
- "memmap2",
+ "memmap2 0.9.10",
  "num-traits",
  "percent-encoding",
  "polars-arrow",
@@ -3630,7 +3854,7 @@ dependencies = [
  "crossbeam-utils",
  "futures",
  "memchr",
- "memmap2",
+ "memmap2 0.9.10",
  "num-traits",
  "parking_lot 0.12.5",
  "percent-encoding",
@@ -3697,7 +3921,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "indexmap",
  "libc",
- "memmap2",
+ "memmap2 0.9.10",
  "num-derive",
  "num-traits",
  "polars-error",
@@ -4092,6 +4316,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "regalloc2"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.17.1",
+ "log",
+ "rustc-hash",
+ "smallvec",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4119,6 +4357,18 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "region"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6b6ebd13bc009aef9cd476c1310d49ac354d36e240cf1bd753290f3dc7199a7"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "mach2",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "reqwest"
@@ -4902,6 +5152,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5617,6 +5873,28 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "wasmtime-internal-core"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bdae4b55b15a23d774b15f6e7cd90ae0d0aa17c47c12b4db098b3dd11ba9d58"
+dependencies = [
+ "hashbrown 0.17.1",
+ "libm",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a312ba8bb77955dcd44294a223e7f124c3071ff966583d385d3f6a4639c62e3"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasmtime-internal-core",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/lex-ast",
     "crates/lex-types",
     "crates/lex-bytecode",
+    "crates/lex-jit",
     "crates/lex-store",
     "crates/lex-search",
     "crates/lex-vcs",

--- a/crates/lex-jit/Cargo.toml
+++ b/crates/lex-jit/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "lex-jit"
+description = "Cranelift-backed JIT for a subset of Lex bytecode (#465 phase-1 MVP)."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+# JIT is opt-in. The default build does not pull cranelift so stable
+# CI / release artifacts are unaffected until the JIT graduates from
+# proof-of-concept to a tier in the VM.
+[features]
+default = []
+cranelift = [
+    "dep:cranelift-codegen",
+    "dep:cranelift-frontend",
+    "dep:cranelift-jit",
+    "dep:cranelift-module",
+    "dep:cranelift-native",
+]
+
+[dependencies]
+lex-bytecode = { path = "../lex-bytecode", version = "0.9.7" }
+thiserror.workspace = true
+
+cranelift-codegen = { version = "0.132", optional = true }
+cranelift-frontend = { version = "0.132", optional = true }
+cranelift-jit = { version = "0.132", optional = true }
+cranelift-module = { version = "0.132", optional = true }
+cranelift-native = { version = "0.132", optional = true }
+
+[dev-dependencies]
+lex-bytecode = { path = "../lex-bytecode", version = "0.9.7" }
+indexmap.workspace = true

--- a/crates/lex-jit/src/lib.rs
+++ b/crates/lex-jit/src/lib.rs
@@ -71,9 +71,12 @@ pub enum JitError {
     HeightMismatch { pc: usize, existing: u32, seen: u32 },
     #[error("function has no Return on a reachable path")]
     NoReturn,
+    /// Boxed because `cranelift_module::ModuleError` is ~136 bytes,
+    /// which would make every `Result<_, JitError>` carry a fat
+    /// payload across the JIT boundary (clippy::result_large_err).
     #[cfg(feature = "cranelift")]
     #[error("cranelift module error: {0}")]
-    Module(#[from] cranelift_module::ModuleError),
+    Module(#[from] Box<cranelift_module::ModuleError>),
     /// Catch-all for backend errors and feature-gating messages.
     #[error("backend error: {0}")]
     Backend(String),
@@ -147,6 +150,13 @@ mod stub {
     }
     pub struct JittedFn;
     impl JittedFn {
+        /// Mirror of the cranelift-feature `JittedFn::call` surface.
+        ///
+        /// # Safety
+        ///
+        /// Unconstructible without the `cranelift` feature — the
+        /// surface exists only so callers can name the type. Any
+        /// invocation panics via `unreachable!`.
         pub unsafe fn call(&self, _args: &[i64]) -> i64 {
             unreachable!("no JittedFn can be constructed without the `cranelift` feature")
         }

--- a/crates/lex-jit/src/lib.rs
+++ b/crates/lex-jit/src/lib.rs
@@ -1,0 +1,159 @@
+//! Cranelift-backed JIT for a subset of Lex bytecode.
+//!
+//! This is the #465 phase-1 MVP — a proof-of-concept that the
+//! bytecode → CLIF → native-code path actually works end-to-end on
+//! the simplest function shapes. It is **not** wired into the VM
+//! dispatcher; the only entry point is [`JitContext::compile`],
+//! which takes a `&Function` plus its constant pool and returns a
+//! callable [`JittedFn`]. Tests compare the JITed result to the
+//! interpreter on the same inputs.
+//!
+//! ## What is supported
+//!
+//! The op set covers integer arithmetic, boolean logic, locals,
+//! straight-line control flow, and structured forward / backward
+//! jumps — enough for tail-recursion-free numeric kernels:
+//!
+//! - `PushConst(i)` where `consts[i]` is `Int` or `Bool`
+//! - `Pop`
+//! - `LoadLocal(i)`, `StoreLocal(i)`
+//! - `IntAdd`, `IntSub`, `IntMul`, `IntDiv`, `IntMod`, `IntNeg`
+//! - `IntEq`, `IntLt`, `IntLe`
+//! - `BoolAnd`, `BoolOr`, `BoolNot`
+//! - `Jump(off)`, `JumpIf(off)`, `JumpIfNot(off)`
+//! - `Return`
+//!
+//! Anything else makes the function ineligible — callers must check
+//! [`is_jit_eligible`] before calling [`JitContext::compile`].
+//!
+//! ## Value representation
+//!
+//! Every Lex value at the JIT boundary is an `i64`. `Int` flows
+//! through unchanged; `Bool` is encoded as `0` / `1`. This is the
+//! whole point of the MVP — proving that on a constrained op set
+//! we can drop the boxed `Value` enum and run on unboxed registers.
+//! Extending the JIT to closures / records will require either
+//! NaN-boxing (`#465` phase 2) or a deopt path back into the
+//! interpreter for non-int values.
+//!
+//! ## Calling convention
+//!
+//! The JITed function takes `arity` `i64` arguments in declaration
+//! order and returns one `i64`. Callers route through
+//! [`JittedFn::call`], which dispatches via a fixed table of
+//! `extern "C"` trampolines up to arity 6 — enough for the MVP
+//! shape `fn arith(a, b, c, ...) -> Int`. Higher arities return an
+//! error at compile time.
+//!
+//! Without the `cranelift` cargo feature this crate compiles to an
+//! empty surface so that adding it to the workspace doesn't slow
+//! down stable builds or pull cranelift into release artifacts.
+
+#![cfg_attr(not(feature = "cranelift"), allow(dead_code))]
+
+use lex_bytecode::op::{Const, Op};
+use lex_bytecode::program::Function;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum JitError {
+    #[error("op {0:?} is not supported by the MVP JIT")]
+    UnsupportedOp(Op),
+    #[error("PushConst references an unsupported constant kind at index {0}")]
+    UnsupportedConst(u32),
+    #[error("function arity {0} exceeds the MVP trampoline table (max 6)")]
+    ArityTooLarge(u16),
+    #[error("jump offset out of range at pc {pc}: target {target}, code length {len}")]
+    JumpOutOfRange { pc: usize, target: isize, len: usize },
+    #[error("malformed bytecode: stack underflow at pc {0}")]
+    StackUnderflow(usize),
+    #[error("malformed bytecode: stack height mismatch at block entry pc {pc} ({existing} vs {seen})")]
+    HeightMismatch { pc: usize, existing: u32, seen: u32 },
+    #[error("function has no Return on a reachable path")]
+    NoReturn,
+    #[cfg(feature = "cranelift")]
+    #[error("cranelift module error: {0}")]
+    Module(#[from] cranelift_module::ModuleError),
+    /// Catch-all for backend errors and feature-gating messages.
+    #[error("backend error: {0}")]
+    Backend(String),
+}
+
+/// Cheap structural check: does every op in this function belong
+/// to the MVP-supported set? Callers should run this *before*
+/// instantiating a [`JitContext`] — `compile` will return
+/// [`JitError::UnsupportedOp`] for the first offender, but the
+/// predicate lets you do the gate without building a module.
+pub fn is_jit_eligible(f: &Function, consts: &[Const]) -> bool {
+    if f.arity > 6 {
+        return false;
+    }
+    for op in &f.code {
+        if !op_supported(op, consts) {
+            return false;
+        }
+    }
+    true
+}
+
+pub(crate) fn op_supported(op: &Op, consts: &[Const]) -> bool {
+    match op {
+        Op::PushConst(i) => matches!(
+            consts.get(*i as usize),
+            Some(Const::Int(_)) | Some(Const::Bool(_))
+        ),
+        Op::Pop
+        | Op::LoadLocal(_)
+        | Op::StoreLocal(_)
+        | Op::IntAdd
+        | Op::IntSub
+        | Op::IntMul
+        | Op::IntDiv
+        | Op::IntMod
+        | Op::IntNeg
+        | Op::IntEq
+        | Op::IntLt
+        | Op::IntLe
+        | Op::BoolAnd
+        | Op::BoolOr
+        | Op::BoolNot
+        | Op::Jump(_)
+        | Op::JumpIf(_)
+        | Op::JumpIfNot(_)
+        | Op::Return => true,
+        _ => false,
+    }
+}
+
+#[cfg(feature = "cranelift")]
+mod lower;
+
+#[cfg(feature = "cranelift")]
+pub use lower::{JitContext, JittedFn};
+
+#[cfg(not(feature = "cranelift"))]
+mod stub {
+    use super::*;
+    /// Stub when the `cranelift` feature is off — exposed so callers
+    /// can still depend on `lex-jit` without the optional backend.
+    pub struct JitContext;
+    impl JitContext {
+        pub fn new() -> Result<Self, JitError> {
+            Err(JitError::Backend("lex-jit built without `cranelift` feature".into()))
+        }
+        pub fn compile(&mut self, _f: &Function, _consts: &[Const]) -> Result<JittedFn, JitError> {
+            unreachable!("JitContext::new errors first")
+        }
+    }
+    pub struct JittedFn;
+    impl JittedFn {
+        pub unsafe fn call(&self, _args: &[i64]) -> i64 {
+            unreachable!("no JittedFn can be constructed without the `cranelift` feature")
+        }
+        pub fn arity(&self) -> u16 { 0 }
+    }
+}
+
+#[cfg(not(feature = "cranelift"))]
+pub use stub::{JitContext, JittedFn};
+

--- a/crates/lex-jit/src/lower.rs
+++ b/crates/lex-jit/src/lower.rs
@@ -1,0 +1,559 @@
+//! Bytecode → Cranelift IR lowering for the MVP op subset.
+//!
+//! Two passes:
+//! 1. [`scan_blocks`] walks the op stream to find basic-block
+//!    entries (pc 0, every jump target, every pc following a
+//!    jump) and computes the abstract-interpretation stack height
+//!    at each entry.
+//! 2. [`Lowering::run`] walks ops sequentially, emitting CLIF
+//!    into the current `Block`. Block-entry stack values are
+//!    threaded through CLIF `block_params`; jumps pass the
+//!    current SSA stack as block-call args.
+//!
+//! Locals are CLIF `Variable`s (one per slot). Cranelift's SSA
+//! frontend handles φ-nodes for us via `use_var`/`def_var`, so
+//! we don't need to surface locals through block params even
+//! across joins.
+
+use std::collections::BTreeMap;
+
+use cranelift_codegen::ir::condcodes::IntCC;
+use cranelift_codegen::ir::{
+    types, AbiParam, Block, BlockArg, InstBuilder, Value as ClifValue,
+};
+use cranelift_codegen::isa::CallConv;
+use cranelift_codegen::settings::{self, Configurable};
+use cranelift_codegen::Context;
+use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext, Variable};
+use cranelift_jit::{JITBuilder, JITModule};
+use cranelift_module::{Linkage, Module};
+
+use lex_bytecode::op::{Const, Op};
+use lex_bytecode::program::Function;
+
+use crate::{is_jit_eligible, JitError};
+
+/// Holds the cranelift module so that JITed code stays mapped for
+/// the lifetime of the context. Drop the context and any
+/// [`JittedFn`] handed out becomes a dangling pointer — the borrow
+/// checker enforces this through the `&JitContext` borrow.
+pub struct JitContext {
+    module: JITModule,
+    ctx: Context,
+    fbctx: FunctionBuilderContext,
+    next_id: u64,
+}
+
+impl JitContext {
+    pub fn new() -> Result<Self, JitError> {
+        let mut flags = settings::builder();
+        // opt_level=none keeps compile times bounded for the MVP;
+        // baseline JIT (#465 phase 1) tunes this once we measure.
+        flags.set("opt_level", "none")
+            .map_err(|e| JitError::Backend(format!("flag opt_level: {e}")))?;
+        flags.set("is_pic", "false")
+            .map_err(|e| JitError::Backend(format!("flag is_pic: {e}")))?;
+        let isa_builder = cranelift_native::builder()
+            .map_err(|e| JitError::Backend(format!("native isa: {e}")))?;
+        let isa = isa_builder
+            .finish(settings::Flags::new(flags))
+            .map_err(|e| JitError::Backend(format!("isa finish: {e}")))?;
+        let jit_builder = JITBuilder::with_isa(isa, cranelift_module::default_libcall_names());
+        let module = JITModule::new(jit_builder);
+        let ctx = module.make_context();
+        Ok(Self {
+            module,
+            ctx,
+            fbctx: FunctionBuilderContext::new(),
+            next_id: 0,
+        })
+    }
+
+    /// Compile `f` against `consts`. Returns a callable
+    /// [`JittedFn`] bound to the lifetime of `self`.
+    pub fn compile(&mut self, f: &Function, consts: &[Const]) -> Result<JittedFn<'_>, JitError> {
+        if !is_jit_eligible(f, consts) {
+            // Surface the first offender for callers that didn't
+            // pre-check, matching the doc-comment on JitContext::compile.
+            if f.arity > 6 {
+                return Err(JitError::ArityTooLarge(f.arity));
+            }
+            for op in &f.code {
+                if !crate::op_supported(op, consts) {
+                    if let Op::PushConst(i) = op {
+                        return Err(JitError::UnsupportedConst(*i));
+                    }
+                    return Err(JitError::UnsupportedOp(*op));
+                }
+            }
+            unreachable!("is_jit_eligible disagrees with op_supported");
+        }
+
+        // Reset and rebuild the function. `make_context` is only
+        // run once at construction; subsequent compiles reuse the
+        // Context after `clear` + signature setup.
+        self.ctx.func.clear();
+        self.ctx.func.signature.call_conv = CallConv::SystemV;
+        for _ in 0..f.arity {
+            self.ctx.func.signature.params.push(AbiParam::new(types::I64));
+        }
+        self.ctx.func.signature.returns.push(AbiParam::new(types::I64));
+
+        Lowering::run(&mut self.ctx, &mut self.fbctx, f, consts)?;
+
+        let name = format!("__lex_jit_{}", self.next_id);
+        self.next_id += 1;
+        let id = self
+            .module
+            .declare_function(&name, Linkage::Export, &self.ctx.func.signature)?;
+        self.module.define_function(id, &mut self.ctx)?;
+        self.module.clear_context(&mut self.ctx);
+        self.module.finalize_definitions()?;
+
+        let code_ptr = self.module.get_finalized_function(id);
+        Ok(JittedFn {
+            code_ptr,
+            arity: f.arity,
+            _phantom: std::marker::PhantomData,
+        })
+    }
+}
+
+/// Handle to a JITed function. The code lives in the parent
+/// [`JitContext`]'s `JITModule`; `'ctx` ties the lifetime so calling
+/// after the context drops won't compile.
+pub struct JittedFn<'ctx> {
+    code_ptr: *const u8,
+    arity: u16,
+    _phantom: std::marker::PhantomData<&'ctx JitContext>,
+}
+
+impl<'ctx> JittedFn<'ctx> {
+    pub fn arity(&self) -> u16 {
+        self.arity
+    }
+
+    /// Invoke the JITed function. The caller must pass exactly
+    /// `self.arity()` arguments, all encoded as `i64` (Bool → 0/1,
+    /// Int → as-is). Returns the function's i64 result.
+    ///
+    /// # Safety
+    ///
+    /// - `args.len()` must equal `self.arity()` — otherwise we
+    ///   transmute to the wrong fn signature and undefined behavior
+    ///   follows.
+    /// - The parent [`JitContext`] must still be alive (enforced
+    ///   by the `'ctx` lifetime borrow at construction).
+    pub unsafe fn call(&self, args: &[i64]) -> i64 {
+        assert_eq!(args.len(), self.arity as usize, "JittedFn arity mismatch");
+        let p = self.code_ptr;
+        match self.arity {
+            0 => {
+                let f: extern "C" fn() -> i64 = std::mem::transmute(p);
+                f()
+            }
+            1 => {
+                let f: extern "C" fn(i64) -> i64 = std::mem::transmute(p);
+                f(args[0])
+            }
+            2 => {
+                let f: extern "C" fn(i64, i64) -> i64 = std::mem::transmute(p);
+                f(args[0], args[1])
+            }
+            3 => {
+                let f: extern "C" fn(i64, i64, i64) -> i64 = std::mem::transmute(p);
+                f(args[0], args[1], args[2])
+            }
+            4 => {
+                let f: extern "C" fn(i64, i64, i64, i64) -> i64 = std::mem::transmute(p);
+                f(args[0], args[1], args[2], args[3])
+            }
+            5 => {
+                let f: extern "C" fn(i64, i64, i64, i64, i64) -> i64 = std::mem::transmute(p);
+                f(args[0], args[1], args[2], args[3], args[4])
+            }
+            6 => {
+                let f: extern "C" fn(i64, i64, i64, i64, i64, i64) -> i64 =
+                    std::mem::transmute(p);
+                f(args[0], args[1], args[2], args[3], args[4], args[5])
+            }
+            n => unreachable!("arity {n} should have been rejected at compile time"),
+        }
+    }
+}
+
+// SAFETY: code_ptr points into the JITModule's executable mmap,
+// which is `Send + Sync` for read-execute access.
+unsafe impl<'ctx> Send for JittedFn<'ctx> {}
+unsafe impl<'ctx> Sync for JittedFn<'ctx> {}
+
+// ---------------------------------------------------------------------------
+// Block-discovery pre-pass
+// ---------------------------------------------------------------------------
+
+/// Stack-height effect of an op on the value stack. `(pops, pushes)`.
+/// Only meaningful for ops in the MVP subset.
+fn op_height_delta(op: &Op) -> (u32, u32) {
+    match op {
+        Op::PushConst(_) | Op::LoadLocal(_) => (0, 1),
+        Op::Pop | Op::StoreLocal(_) => (1, 0),
+        Op::IntAdd | Op::IntSub | Op::IntMul | Op::IntDiv | Op::IntMod
+        | Op::IntEq | Op::IntLt | Op::IntLe
+        | Op::BoolAnd | Op::BoolOr => (2, 1),
+        Op::IntNeg | Op::BoolNot => (1, 1),
+        Op::Jump(_) => (0, 0),
+        Op::JumpIf(_) | Op::JumpIfNot(_) => (1, 0),
+        Op::Return => (1, 0),
+        _ => (0, 0),
+    }
+}
+
+fn is_terminator(op: &Op) -> bool {
+    matches!(op, Op::Jump(_) | Op::Return)
+}
+
+/// Resolve a relative jump offset against the dispatch semantics
+/// in `lex-bytecode`'s VM loop: `pc` is bumped to `pc + 1` *before*
+/// the op runs, then `Jump(off)` does `pc = pc + off`. So the
+/// branch target is `(pc_of_jump + 1) + off`.
+fn jump_target(pc: usize, off: i32, code_len: usize) -> Result<usize, JitError> {
+    let next = pc as isize + 1;
+    let t = next + off as isize;
+    if t < 0 || t as usize > code_len {
+        return Err(JitError::JumpOutOfRange {
+            pc,
+            target: t,
+            len: code_len,
+        });
+    }
+    Ok(t as usize)
+}
+
+/// Scan the op stream to find block entries and the stack height
+/// at each. Returns a map from entry-pc to entry-height.
+///
+/// Uses a worklist: seed with pc 0 (height 0), then for each block,
+/// simulate forward op-by-op tracking height, recording every branch
+/// target and post-jump pc as a new block entry. Heights at re-visits
+/// are checked against the existing record.
+fn scan_blocks(f: &Function) -> Result<BTreeMap<usize, u32>, JitError> {
+    let code = &f.code;
+    let mut entries: BTreeMap<usize, u32> = BTreeMap::new();
+    let mut worklist: Vec<(usize, u32)> = vec![(0, 0)];
+
+    while let Some((mut pc, mut height)) = worklist.pop() {
+        // Re-visit check.
+        if let Some(&existing) = entries.get(&pc) {
+            if existing != height {
+                return Err(JitError::HeightMismatch { pc, existing, seen: height });
+            }
+            continue;
+        }
+        entries.insert(pc, height);
+
+        while pc < code.len() {
+            let op = &code[pc];
+            let (pops, pushes) = op_height_delta(op);
+            if (height as i64) - (pops as i64) < 0 {
+                return Err(JitError::StackUnderflow(pc));
+            }
+            let after_height = height - pops + pushes;
+
+            match op {
+                Op::Return => break,
+                Op::Jump(off) => {
+                    let t = jump_target(pc, *off, code.len())?;
+                    worklist.push((t, after_height));
+                    break;
+                }
+                Op::JumpIf(off) | Op::JumpIfNot(off) => {
+                    let t = jump_target(pc, *off, code.len())?;
+                    worklist.push((t, after_height));
+                    let ft = pc + 1;
+                    worklist.push((ft, after_height));
+                    break;
+                }
+                _ => {
+                    height = after_height;
+                    pc += 1;
+                }
+            }
+        }
+    }
+
+    Ok(entries)
+}
+
+// ---------------------------------------------------------------------------
+// Main lowering walk
+// ---------------------------------------------------------------------------
+
+struct Lowering<'a> {
+    builder: FunctionBuilder<'a>,
+    blocks: BTreeMap<usize, (Block, u32)>,
+    consts: &'a [Const],
+    code: &'a [Op],
+    stack: Vec<ClifValue>,
+    /// Cranelift `Variable` handles, indexed by Lex local slot. The
+    /// Lex compiler uses dense slot numbers `0..locals_count`, so a
+    /// `Vec` indexed by slot suffices.
+    locals: Vec<Variable>,
+    /// Set true after a terminator; resets when we switch into the
+    /// next block at its entry pc.
+    terminated: bool,
+}
+
+fn values_to_block_args(vs: &[ClifValue]) -> Vec<BlockArg> {
+    vs.iter().map(|v| BlockArg::from(*v)).collect()
+}
+
+impl<'a> Lowering<'a> {
+    fn run(
+        ctx: &mut Context,
+        fbctx: &mut FunctionBuilderContext,
+        f: &Function,
+        consts: &[Const],
+    ) -> Result<(), JitError> {
+        let entries = scan_blocks(f)?;
+
+        let mut builder = FunctionBuilder::new(&mut ctx.func, fbctx);
+
+        // Pre-create all blocks; remember the height each enters at
+        // so we can build the right number of block params.
+        let mut blocks: BTreeMap<usize, (Block, u32)> = BTreeMap::new();
+        for (&pc, &h) in &entries {
+            let b = builder.create_block();
+            for _ in 0..h {
+                builder.append_block_param(b, types::I64);
+            }
+            blocks.insert(pc, (b, h));
+        }
+
+        // Entry block: the cranelift function entry has the user's
+        // arguments as block params, but our entry block (pc=0) has
+        // *value-stack* params (none, since height-at-entry is 0).
+        // So we synthesize a separate cranelift-entry block that
+        // grabs the function args, copies them into locals, then
+        // jumps into the pc=0 block.
+        let cf_entry = builder.create_block();
+        builder.append_block_params_for_function_params(cf_entry);
+        builder.switch_to_block(cf_entry);
+        builder.seal_block(cf_entry);
+
+        // Declare a Variable per local slot. SSA φ-nodes for locals
+        // across joins are handled by cranelift's frontend.
+        let arg_values: Vec<ClifValue> = builder.block_params(cf_entry).to_vec();
+        let mut locals: Vec<Variable> = Vec::with_capacity(f.locals_count as usize);
+        for i in 0..f.locals_count {
+            let var = builder.declare_var(types::I64);
+            if (i as u16) < f.arity {
+                builder.def_var(var, arg_values[i as usize]);
+            } else {
+                let zero = builder.ins().iconst(types::I64, 0);
+                builder.def_var(var, zero);
+            }
+            locals.push(var);
+        }
+        let (pc0_block, pc0_height) = blocks[&0];
+        debug_assert_eq!(pc0_height, 0, "pc 0 entry height must be 0");
+        builder.ins().jump(pc0_block, &[]);
+
+        let mut state = Lowering {
+            builder,
+            blocks,
+            consts,
+            code: &f.code,
+            stack: Vec::new(),
+            locals,
+            terminated: true, // forces enter-block at pc 0
+        };
+
+        state.walk()?;
+
+        state.builder.seal_all_blocks();
+        state.builder.finalize();
+
+        Ok(())
+    }
+
+    fn walk(&mut self) -> Result<(), JitError> {
+        let n = self.code.len();
+        let mut pc = 0;
+        while pc < n {
+            if let Some(&(block, height)) = self.blocks.get(&pc) {
+                if !self.terminated {
+                    // Falling through into a new block. Pass the
+                    // current SSA stack as block-call args. The
+                    // current stack height must match the target
+                    // block's declared entry height — guaranteed by
+                    // the abstract interp in scan_blocks.
+                    debug_assert_eq!(self.stack.len() as u32, height);
+                    let args = values_to_block_args(&self.stack);
+                    self.builder.ins().jump(block, args.iter());
+                }
+                self.builder.switch_to_block(block);
+                self.stack = self
+                    .builder
+                    .block_params(block)
+                    .iter()
+                    .copied()
+                    .collect();
+                self.terminated = false;
+            } else if self.terminated {
+                // Unreachable code between blocks. Skip until the
+                // next block entry. (Could happen if the compiler
+                // emits dead ops past a Jump.)
+                pc += 1;
+                continue;
+            }
+
+            let op = self.code[pc];
+            self.emit_op(pc, op)?;
+
+            if is_terminator(&op) || matches!(op, Op::JumpIf(_) | Op::JumpIfNot(_)) {
+                // JumpIf/Not don't terminate the block in the
+                // strict CFG sense (there is a fallthrough), but
+                // emit_op took care of branching, so move on.
+                pc += 1;
+                continue;
+            }
+            pc += 1;
+        }
+        if !self.terminated {
+            return Err(JitError::NoReturn);
+        }
+        Ok(())
+    }
+
+    fn pop(&mut self, pc: usize) -> Result<ClifValue, JitError> {
+        self.stack.pop().ok_or(JitError::StackUnderflow(pc))
+    }
+
+    fn emit_op(&mut self, pc: usize, op: Op) -> Result<(), JitError> {
+        match op {
+            Op::PushConst(i) => {
+                let c = self
+                    .consts
+                    .get(i as usize)
+                    .ok_or(JitError::UnsupportedConst(i))?;
+                let v = match c {
+                    Const::Int(n) => self.builder.ins().iconst(types::I64, *n),
+                    Const::Bool(b) => self.builder.ins().iconst(types::I64, if *b { 1 } else { 0 }),
+                    _ => return Err(JitError::UnsupportedConst(i)),
+                };
+                self.stack.push(v);
+            }
+            Op::Pop => {
+                self.pop(pc)?;
+            }
+            Op::LoadLocal(i) => {
+                let var = self.locals[i as usize];
+                let v = self.builder.use_var(var);
+                self.stack.push(v);
+            }
+            Op::StoreLocal(i) => {
+                let v = self.pop(pc)?;
+                let var = self.locals[i as usize];
+                self.builder.def_var(var, v);
+            }
+            Op::IntAdd => {
+                let b = self.pop(pc)?;
+                let a = self.pop(pc)?;
+                self.stack.push(self.builder.ins().iadd(a, b));
+            }
+            Op::IntSub => {
+                let b = self.pop(pc)?;
+                let a = self.pop(pc)?;
+                self.stack.push(self.builder.ins().isub(a, b));
+            }
+            Op::IntMul => {
+                let b = self.pop(pc)?;
+                let a = self.pop(pc)?;
+                self.stack.push(self.builder.ins().imul(a, b));
+            }
+            Op::IntDiv => {
+                let b = self.pop(pc)?;
+                let a = self.pop(pc)?;
+                self.stack.push(self.builder.ins().sdiv(a, b));
+            }
+            Op::IntMod => {
+                let b = self.pop(pc)?;
+                let a = self.pop(pc)?;
+                self.stack.push(self.builder.ins().srem(a, b));
+            }
+            Op::IntNeg => {
+                let a = self.pop(pc)?;
+                let z = self.builder.ins().iconst(types::I64, 0);
+                self.stack.push(self.builder.ins().isub(z, a));
+            }
+            Op::IntEq => self.emit_icmp(pc, IntCC::Equal)?,
+            Op::IntLt => self.emit_icmp(pc, IntCC::SignedLessThan)?,
+            Op::IntLe => self.emit_icmp(pc, IntCC::SignedLessThanOrEqual)?,
+            Op::BoolAnd => {
+                // Bools are 0/1; `iand` matches Rust semantics.
+                let b = self.pop(pc)?;
+                let a = self.pop(pc)?;
+                self.stack.push(self.builder.ins().band(a, b));
+            }
+            Op::BoolOr => {
+                let b = self.pop(pc)?;
+                let a = self.pop(pc)?;
+                self.stack.push(self.builder.ins().bor(a, b));
+            }
+            Op::BoolNot => {
+                let a = self.pop(pc)?;
+                let one = self.builder.ins().iconst(types::I64, 1);
+                self.stack.push(self.builder.ins().bxor(a, one));
+            }
+            Op::Jump(off) => {
+                let t = jump_target(pc, off, self.code.len())?;
+                let (target_block, target_height) = self.blocks[&t];
+                debug_assert_eq!(self.stack.len() as u32, target_height);
+                let args = values_to_block_args(&self.stack);
+                self.builder.ins().jump(target_block, args.iter());
+                self.terminated = true;
+            }
+            Op::JumpIf(off) => self.emit_cond_jump(pc, off, true)?,
+            Op::JumpIfNot(off) => self.emit_cond_jump(pc, off, false)?,
+            Op::Return => {
+                let v = self.pop(pc)?;
+                self.builder.ins().return_(&[v]);
+                self.terminated = true;
+            }
+            other => return Err(JitError::UnsupportedOp(other)),
+        }
+        Ok(())
+    }
+
+    fn emit_icmp(&mut self, pc: usize, cc: IntCC) -> Result<(), JitError> {
+        let b = self.pop(pc)?;
+        let a = self.pop(pc)?;
+        let c = self.builder.ins().icmp(cc, a, b);
+        // icmp produces I8; widen to I64 to match our 0/1 Bool encoding.
+        let w = self.builder.ins().uextend(types::I64, c);
+        self.stack.push(w);
+        Ok(())
+    }
+
+    fn emit_cond_jump(&mut self, pc: usize, off: i32, jump_if_true: bool) -> Result<(), JitError> {
+        let cond = self.pop(pc)?;
+        let target = jump_target(pc, off, self.code.len())?;
+        let ft = pc + 1;
+        let (target_block, t_height) = self.blocks[&target];
+        let (ft_block, ft_height) = self.blocks[&ft];
+        debug_assert_eq!(self.stack.len() as u32, t_height);
+        debug_assert_eq!(self.stack.len() as u32, ft_height);
+        let args = values_to_block_args(&self.stack);
+        let (then_b, else_b) = if jump_if_true {
+            (target_block, ft_block)
+        } else {
+            (ft_block, target_block)
+        };
+        // brif args: (cond, then_block, then_args, else_block, else_args)
+        self.builder
+            .ins()
+            .brif(cond, then_b, args.iter(), else_b, args.iter());
+        self.terminated = true;
+        Ok(())
+    }
+}

--- a/crates/lex-jit/src/lower.rs
+++ b/crates/lex-jit/src/lower.rs
@@ -105,10 +105,13 @@ impl JitContext {
         self.next_id += 1;
         let id = self
             .module
-            .declare_function(&name, Linkage::Export, &self.ctx.func.signature)?;
-        self.module.define_function(id, &mut self.ctx)?;
+            .declare_function(&name, Linkage::Export, &self.ctx.func.signature)
+            .map_err(Box::new)?;
+        self.module
+            .define_function(id, &mut self.ctx)
+            .map_err(Box::new)?;
         self.module.clear_context(&mut self.ctx);
-        self.module.finalize_definitions()?;
+        self.module.finalize_definitions().map_err(Box::new)?;
 
         let code_ptr = self.module.get_finalized_function(id);
         Ok(JittedFn {
@@ -346,7 +349,7 @@ impl<'a> Lowering<'a> {
         let mut locals: Vec<Variable> = Vec::with_capacity(f.locals_count as usize);
         for i in 0..f.locals_count {
             let var = builder.declare_var(types::I64);
-            if (i as u16) < f.arity {
+            if i < f.arity {
                 builder.def_var(var, arg_values[i as usize]);
             } else {
                 let zero = builder.ins().iconst(types::I64, 0);
@@ -392,12 +395,7 @@ impl<'a> Lowering<'a> {
                     self.builder.ins().jump(block, args.iter());
                 }
                 self.builder.switch_to_block(block);
-                self.stack = self
-                    .builder
-                    .block_params(block)
-                    .iter()
-                    .copied()
-                    .collect();
+                self.stack = self.builder.block_params(block).to_vec();
                 self.terminated = false;
             } else if self.terminated {
                 // Unreachable code between blocks. Skip until the

--- a/crates/lex-jit/tests/jit_vs_interpreter.rs
+++ b/crates/lex-jit/tests/jit_vs_interpreter.rs
@@ -1,0 +1,453 @@
+//! End-to-end correctness check for the MVP JIT: every function
+//! we JIT must produce the same i64 result as the bytecode
+//! interpreter on the same inputs.
+//!
+//! Each test builds a hand-crafted `Function` + `Program` (no
+//! source-level compiler involved — these are bytecode literals),
+//! runs the interpreter via `Vm::call`, runs the JIT via
+//! `JitContext::compile(...).call(...)`, and asserts the results
+//! match across a battery of inputs.
+
+#![cfg(feature = "cranelift")]
+
+use indexmap::IndexMap;
+use lex_bytecode::op::{Const, Op};
+use lex_bytecode::program::{Function, Program, ZERO_BODY_HASH};
+use lex_bytecode::value::Value;
+use lex_bytecode::vm::Vm;
+use lex_jit::{is_jit_eligible, JitContext};
+
+fn mk_program(name: &str, arity: u16, locals: u16, code: Vec<Op>, consts: Vec<Const>) -> Program {
+    let mut function_names = IndexMap::new();
+    function_names.insert(name.to_string(), 0);
+    Program {
+        constants: consts,
+        functions: vec![Function {
+            name: name.to_string(),
+            arity,
+            locals_count: locals,
+            code,
+            effects: vec![],
+            body_hash: ZERO_BODY_HASH,
+            refinements: vec![],
+            field_ic_sites: 0,
+        }],
+        function_names,
+        module_aliases: IndexMap::new(),
+        entry: Some(0),
+        record_shapes: vec![],
+    }
+}
+
+fn run_interp(program: &Program, args: Vec<i64>) -> i64 {
+    let mut vm = Vm::new(program);
+    let arg_values: Vec<Value> = args.into_iter().map(Value::Int).collect();
+    let r = vm.call("f", arg_values).expect("interpreter run");
+    match r {
+        Value::Int(n) => n,
+        Value::Bool(b) => if b { 1 } else { 0 },
+        other => panic!("unexpected return type: {other:?}"),
+    }
+}
+
+fn jit_and_call(program: &Program, args: &[i64]) -> i64 {
+    let f = &program.functions[0];
+    assert!(
+        is_jit_eligible(f, &program.constants),
+        "function not JIT-eligible — fix the test or extend the JIT"
+    );
+    let mut ctx = JitContext::new().expect("JitContext init");
+    let jitted = ctx.compile(f, &program.constants).expect("JIT compile");
+    unsafe { jitted.call(args) }
+}
+
+fn assert_jit_matches(program: &Program, inputs: &[Vec<i64>]) {
+    for args in inputs {
+        let interp = run_interp(program, args.clone());
+        let jit = jit_and_call(program, args);
+        assert_eq!(
+            interp, jit,
+            "JIT vs interpreter disagree on args {args:?}: interp={interp}, jit={jit}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Straight-line int arithmetic
+// ---------------------------------------------------------------------------
+
+#[test]
+fn add_two_ints() {
+    // fn f(a, b) -> Int { a + b }
+    let p = mk_program(
+        "f",
+        2,
+        2,
+        vec![Op::LoadLocal(0), Op::LoadLocal(1), Op::IntAdd, Op::Return],
+        vec![],
+    );
+    assert_jit_matches(
+        &p,
+        &[
+            vec![3, 4],
+            vec![100, -50],
+            vec![0, 0],
+            vec![i64::MAX, 0],
+            vec![-1, 1],
+        ],
+    );
+}
+
+#[test]
+fn polynomial_mul_add() {
+    // fn f(a, b, c) -> Int { a * b + c }
+    let p = mk_program(
+        "f",
+        3,
+        3,
+        vec![
+            Op::LoadLocal(0),
+            Op::LoadLocal(1),
+            Op::IntMul,
+            Op::LoadLocal(2),
+            Op::IntAdd,
+            Op::Return,
+        ],
+        vec![],
+    );
+    assert_jit_matches(
+        &p,
+        &[
+            vec![2, 3, 4],   // 2*3 + 4 = 10
+            vec![0, 99, 7],  // 0*99 + 7 = 7
+            vec![-2, 3, 10], // -6 + 10 = 4
+        ],
+    );
+}
+
+#[test]
+fn use_const_pool() {
+    // fn f(a) -> Int { a + 42 }
+    let p = mk_program(
+        "f",
+        1,
+        1,
+        vec![
+            Op::LoadLocal(0),
+            Op::PushConst(0),
+            Op::IntAdd,
+            Op::Return,
+        ],
+        vec![Const::Int(42)],
+    );
+    assert_jit_matches(&p, &[vec![0], vec![8], vec![-100], vec![i64::MAX - 42]]);
+}
+
+#[test]
+fn store_and_reuse_local() {
+    // fn f(a, b) -> Int {
+    //   let t = a + b;      // local 2
+    //   t * t
+    // }
+    let p = mk_program(
+        "f",
+        2,
+        3,
+        vec![
+            Op::LoadLocal(0),
+            Op::LoadLocal(1),
+            Op::IntAdd,
+            Op::StoreLocal(2),
+            Op::LoadLocal(2),
+            Op::LoadLocal(2),
+            Op::IntMul,
+            Op::Return,
+        ],
+        vec![],
+    );
+    assert_jit_matches(&p, &[vec![3, 4], vec![0, 0], vec![-2, 5]]);
+}
+
+#[test]
+fn int_neg_div_mod() {
+    // fn f(a, b) -> Int { (-a) / b + (a % b) }
+    let p = mk_program(
+        "f",
+        2,
+        2,
+        vec![
+            Op::LoadLocal(0),
+            Op::IntNeg,
+            Op::LoadLocal(1),
+            Op::IntDiv,
+            Op::LoadLocal(0),
+            Op::LoadLocal(1),
+            Op::IntMod,
+            Op::IntAdd,
+            Op::Return,
+        ],
+        vec![],
+    );
+    assert_jit_matches(&p, &[vec![10, 3], vec![100, 7], vec![-15, 4]]);
+}
+
+// ---------------------------------------------------------------------------
+// 2. Boolean ops + comparisons
+// ---------------------------------------------------------------------------
+
+#[test]
+fn int_lt_then_extend() {
+    // fn f(a, b) -> Bool { a < b }
+    // The interpreter returns Bool; the JIT returns 0/1 as i64.
+    // run_interp coerces Bool→0/1, so they match.
+    let p = mk_program(
+        "f",
+        2,
+        2,
+        vec![Op::LoadLocal(0), Op::LoadLocal(1), Op::IntLt, Op::Return],
+        vec![],
+    );
+    assert_jit_matches(
+        &p,
+        &[vec![1, 2], vec![5, 5], vec![10, 3], vec![-1, 0]],
+    );
+}
+
+#[test]
+fn bool_logic() {
+    // fn f(a, b) -> Bool { (a < b) && !(a == 0) }
+    let p = mk_program(
+        "f",
+        2,
+        2,
+        vec![
+            // a < b
+            Op::LoadLocal(0),
+            Op::LoadLocal(1),
+            Op::IntLt,
+            // a == 0
+            Op::LoadLocal(0),
+            Op::PushConst(0),
+            Op::IntEq,
+            Op::BoolNot,
+            // and
+            Op::BoolAnd,
+            Op::Return,
+        ],
+        vec![Const::Int(0)],
+    );
+    assert_jit_matches(
+        &p,
+        &[vec![1, 2], vec![0, 1], vec![-5, 3], vec![5, 1]],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. Control flow — forward conditional jump
+// ---------------------------------------------------------------------------
+
+#[test]
+fn abs_via_jumpifnot() {
+    // fn f(a) -> Int { if a < 0 { -a } else { a } }
+    //
+    //   0: LoadLocal(0)
+    //   1: PushConst(0)     -- 0
+    //   2: IntLt             -- (a<0)
+    //   3: JumpIfNot(+3)     -- target = (3+1)+3 = 7 (else arm)
+    //   4: LoadLocal(0)      -- then arm
+    //   5: IntNeg
+    //   6: Jump(+1)          -- target = (6+1)+1 = 8 (return)
+    //   7: LoadLocal(0)      -- else arm
+    //   8: Return
+    let p = mk_program(
+        "f",
+        1,
+        1,
+        vec![
+            Op::LoadLocal(0),
+            Op::PushConst(0),
+            Op::IntLt,
+            Op::JumpIfNot(3),
+            Op::LoadLocal(0),
+            Op::IntNeg,
+            Op::Jump(1),
+            Op::LoadLocal(0),
+            Op::Return,
+        ],
+        vec![Const::Int(0)],
+    );
+    assert_jit_matches(&p, &[vec![5], vec![-7], vec![0], vec![i64::MIN + 1]]);
+}
+
+#[test]
+fn max_via_brif() {
+    // fn f(a, b) -> Int { if a < b { b } else { a } }
+    //
+    //   0: LoadLocal(0)
+    //   1: LoadLocal(1)
+    //   2: IntLt
+    //   3: JumpIfNot(+3)     -- target = 4+3 = 7 (else arm)
+    //   4: LoadLocal(1)       -- then arm
+    //   5: Jump(+2)           -- target = 6+2 = 8 (return)
+    //   6: IntAdd             -- dead-op tombstone, unreachable
+    //   7: LoadLocal(0)       -- else arm
+    //   8: Return
+    let p = mk_program(
+        "f",
+        2,
+        2,
+        vec![
+            Op::LoadLocal(0),
+            Op::LoadLocal(1),
+            Op::IntLt,
+            Op::JumpIfNot(3),
+            Op::LoadLocal(1),
+            Op::Jump(2),
+            Op::IntAdd,
+            Op::LoadLocal(0),
+            Op::Return,
+        ],
+        vec![],
+    );
+    assert_jit_matches(
+        &p,
+        &[vec![1, 2], vec![5, 3], vec![0, 0], vec![-5, -10]],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. Control flow — loop (backward jump)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sum_from_one_to_n_via_loop() {
+    // fn f(n) -> Int {
+    //   let i = 1
+    //   let acc = 0
+    //   loop:
+    //     if !(i <= n) goto end
+    //     acc = acc + i
+    //     i = i + 1
+    //     goto loop
+    //   end:
+    //     return acc
+    //
+    // Locals: 0 = n (arg), 1 = i, 2 = acc.
+    //
+    //   0: PushConst(1) {=1}
+    //   1: StoreLocal(1)           i = 1
+    //   2: PushConst(0) {=0}
+    //   3: StoreLocal(2)           acc = 0
+    //   4: LoadLocal(1)            loop:  i
+    //   5: LoadLocal(0)                   i n
+    //   6: IntLe                          (i<=n)
+    //   7: JumpIfNot(+7)           -> pc 15 (end)
+    //   8: LoadLocal(2)            acc
+    //   9: LoadLocal(1)            acc i
+    //  10: IntAdd                  (acc+i)
+    //  11: StoreLocal(2)           acc=
+    //  12: LoadLocal(1)            i
+    //  13: PushConst(1)            i 1
+    //  14: IntAdd                  (i+1)
+    //  15: StoreLocal(1)           i =
+    //  16: Jump(-13)               -> pc 4
+    //  17: LoadLocal(2)            end:
+    //  18: Return
+    //
+    // Re-check offsets:
+    //   JumpIfNot at pc 7 → target 8+off. We want end = pc 17.
+    //     off = 17 - 8 = +9.
+    //   Jump at pc 16 → target 17+off. We want pc 4.
+    //     off = 4 - 17 = -13.
+    //
+    // (My count above had StoreLocal at pc 15 then Jump at pc 16 —
+    // matching the spec.)
+    let p = mk_program(
+        "f",
+        1,
+        3,
+        vec![
+            Op::PushConst(0), // const slot 0 = 1
+            Op::StoreLocal(1),
+            Op::PushConst(1), // const slot 1 = 0
+            Op::StoreLocal(2),
+            Op::LoadLocal(1),
+            Op::LoadLocal(0),
+            Op::IntLe,
+            Op::JumpIfNot(9),
+            Op::LoadLocal(2),
+            Op::LoadLocal(1),
+            Op::IntAdd,
+            Op::StoreLocal(2),
+            Op::LoadLocal(1),
+            Op::PushConst(0),
+            Op::IntAdd,
+            Op::StoreLocal(1),
+            Op::Jump(-13),
+            Op::LoadLocal(2),
+            Op::Return,
+        ],
+        vec![Const::Int(1), Const::Int(0)],
+    );
+    assert_jit_matches(
+        &p,
+        &[vec![0], vec![1], vec![5], vec![10], vec![100], vec![1000]],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. Eligibility gate
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rejects_unsupported_op_via_eligibility() {
+    // A function with `MakeTuple` is outside the MVP scope — the
+    // gate must say so without trying to compile.
+    let f = lex_bytecode::program::Function {
+        name: "f".into(),
+        arity: 1,
+        locals_count: 1,
+        code: vec![
+            Op::LoadLocal(0),
+            Op::LoadLocal(0),
+            Op::MakeTuple(2),
+            Op::Return,
+        ],
+        effects: vec![],
+        body_hash: ZERO_BODY_HASH,
+        refinements: vec![],
+        field_ic_sites: 0,
+    };
+    assert!(!is_jit_eligible(&f, &[]));
+}
+
+#[test]
+fn rejects_unsupported_const_via_eligibility() {
+    // PushConst(Str) is unsupported — Strs can't be unboxed to i64.
+    let f = lex_bytecode::program::Function {
+        name: "f".into(),
+        arity: 0,
+        locals_count: 0,
+        code: vec![Op::PushConst(0), Op::Return],
+        effects: vec![],
+        body_hash: ZERO_BODY_HASH,
+        refinements: vec![],
+        field_ic_sites: 0,
+    };
+    assert!(!is_jit_eligible(&f, &[Const::Str("nope".into())]));
+}
+
+#[test]
+fn rejects_overlarge_arity() {
+    let f = lex_bytecode::program::Function {
+        name: "f".into(),
+        arity: 7,
+        locals_count: 7,
+        code: vec![Op::LoadLocal(0), Op::Return],
+        effects: vec![],
+        body_hash: ZERO_BODY_HASH,
+        refinements: vec![],
+        field_ic_sites: 0,
+    };
+    assert!(!is_jit_eligible(&f, &[]));
+}

--- a/docs/design/jit-roadmap.md
+++ b/docs/design/jit-roadmap.md
@@ -364,3 +364,96 @@ not start the 2–3 month rework on the strength of the old assumption.
 
 What explicitly should **not** be next: NaN-boxing (de-motivated),
 or #462 slice 2b polymorphic ICs (0% measured polymorphism).
+
+---
+
+## Status update — MVP JIT lands (2026-06-01)
+
+**A first-version JIT now exists in `crates/lex-jit`.** It is a
+proof-of-concept, not a tier — the VM dispatcher is unchanged and
+no caller routes through it. The goal was narrow: prove the
+bytecode → CLIF → native-code → call-back pipeline works on the
+constrained op set we'd plausibly start with.
+
+### Scope
+
+Supported ops: `PushConst(Int|Bool)`, `Pop`, `LoadLocal`,
+`StoreLocal`, all integer arithmetic (`IntAdd/Sub/Mul/Div/Mod/Neg`),
+integer comparisons (`IntEq/Lt/Le`), boolean logic
+(`BoolAnd/Or/Not`), structured control flow (`Jump`, `JumpIf`,
+`JumpIfNot`), and `Return`. Arity capped at 6 to keep the
+trampoline table finite. Every Lex value at the JIT boundary is an
+`i64` — `Int` flows unchanged, `Bool` as `0`/`1`. Anything else
+(records, lists, closures, calls, effects, floats, strings,
+superinstructions) makes the function ineligible via
+`is_jit_eligible`.
+
+### Architecture
+
+Two-pass lowering:
+
+1. `scan_blocks` walks the op stream to find basic-block entries
+   (pc 0, every jump target, every pc after a jump) and computes
+   the abstract-interpretation stack height at each entry.
+2. `Lowering::run` walks ops sequentially, emitting CLIF into the
+   current `Block`. Block-entry stack values are threaded through
+   CLIF `block_params`; jumps pass the current SSA stack as
+   block-call args. Locals are CLIF `Variable`s — Cranelift's SSA
+   frontend handles φ-nodes for joins.
+
+Cranelift is gated behind the `cranelift` cargo feature
+(default-off), so stable builds don't pull cranelift's ~30 crates
+into release artifacts.
+
+### Verification
+
+`tests/jit_vs_interpreter.rs` builds hand-crafted `Function`s,
+runs each via the bytecode VM and via the JIT, and asserts the
+results match across input batteries. 13 tests covering:
+
+- straight-line int arithmetic (add, mul-add, const pool, locals,
+  div/mod/neg);
+- boolean logic with comparisons;
+- forward conditional jumps (abs, max);
+- a backward-jump loop (sum 1..n);
+- rejection of unsupported ops / unsupported consts / overlarge
+  arity via the eligibility gate.
+
+### What this does *not* prove
+
+- **Perf.** No benchmarks. The MVP at this op set may well be
+  slower than the interpreter end-to-end once you count compile
+  cost — that's expected; the work for measurable wins is the
+  phase-1 deliverables below.
+- **Integration.** The JIT is not wired into the VM dispatcher;
+  there is no tier-up trigger, no fallback path, no NodeId
+  side table for deopt, no error mapping back to `VmError`.
+- **Value rep.** Records / closures / strings remain unsupported.
+  That's the wall the MVP hits — every interesting Lex function
+  uses at least one of them. Unboxing requires either the
+  value-rep rework (NaN-boxing) or a runtime calling convention
+  that boxes/unboxes at the JIT boundary.
+
+### Concrete next steps if we want to keep going
+
+In rough order of value:
+
+1. **Wire it into the VM as an opt-in tier.** Add a `JitTier` on
+   `Vm` that, on first `invoke`, calls `is_jit_eligible` and (if
+   yes) compiles + caches by `body_hash`. Dispatch `Op::Call` to
+   the JIT pointer when the cache hits; fall back to the
+   interpreter otherwise. This is the minimum required to put
+   real Lex programs through the JIT and measure anything.
+2. **Add a side-by-side perf bench** (extend `benches/dispatch.rs`)
+   that runs the same arith-loop both ways. Without measured
+   ROI, all further JIT work is speculative.
+3. **Extend the op set to call-into-interpreter** — JIT'd code
+   that hits an unsupported op calls back into the VM with the
+   live frame. This is the bridge that lets us ship JIT for
+   leaf-arith hot paths without first solving value rep.
+4. **NodeId side tables** (per the original phase-1 design). Map
+   native PCs back to bytecode PCs / NodeIds so traces and panics
+   keep working through JIT'd frames.
+
+Phase 2 (records / closures) still needs the value-rep decision —
+the MVP doesn't change that gating.


### PR DESCRIPTION
## Summary

Proof-of-concept that the bytecode → CLIF → native-code → call-back pipeline works end-to-end. New `crates/lex-jit/` behind the `cranelift` cargo feature (default off, so stable builds don't pull cranelift's ~30 dependencies into release artifacts).

This **is not** a tier in the VM. There's no tier-up trigger, no fallback path, no NodeId side tables for deopt, no integration with the dispatcher. The only entry point is `JitContext::compile(&Function, &[Const]) -> JittedFn`, which tests drive directly and compare against the interpreter.

The goal was narrow: close the "is the pipeline tractable on Cranelift 0.132?" question that's been blocking #465 phase-1 scoping. Answer: yes, with caveats documented in `docs/design/jit-roadmap.md`.

## Scope

Supported ops:
- `PushConst(Int|Bool)`, `Pop`, `LoadLocal`, `StoreLocal`
- `IntAdd/Sub/Mul/Div/Mod/Neg`, `IntEq/Lt/Le`
- `BoolAnd/Or/Not`
- `Jump`, `JumpIf`, `JumpIfNot`, `Return`

Arity capped at 6 (trampoline table). Every Lex value at the JIT boundary is `i64` — `Int` unchanged, `Bool` as `0`/`1`. Anything else makes the function ineligible via `is_jit_eligible`.

## Architecture

Two-pass lowering in `crates/lex-jit/src/lower.rs`:

1. **`scan_blocks`** walks the op stream to find basic-block entries (pc 0, every jump target, every pc after a jump) and computes the abstract-interpretation stack height at each entry.
2. **`Lowering::run`** walks ops sequentially, emitting CLIF into the current `Block`. Block-entry stack values are threaded through CLIF `block_params`; jumps pass the current SSA stack as block-call args. Locals are CLIF `Variable`s — Cranelift's SSA frontend handles φ-nodes at joins.

## Test plan

`tests/jit_vs_interpreter.rs` builds hand-crafted `Function`s, runs each via both the bytecode VM and the JIT, asserts results match across input batteries. 13 tests:

- [x] straight-line int arith: add, mul-add, const pool, store/reuse local, neg/div/mod
- [x] boolean logic with int comparisons
- [x] forward conditional jumps: `abs` (if/else with `IntNeg`), `max` (if/else returning the chosen branch)
- [x] backward-jump loop: `sum_from_1_to_n`
- [x] eligibility-gate rejection: unsupported op (`MakeTuple`), unsupported const (`Str`), overlarge arity

Run:
```
cargo test -p lex-jit --features cranelift
cargo test -p lex-jit                       # default build, no cranelift
cargo check --workspace                     # whole workspace still builds
```

## What this does *not* prove

- **Perf** — no benches yet. At this op set the MVP may be slower end-to-end once compile cost is counted; that's expected.
- **Integration** — JIT is not wired into the VM dispatcher; no tier-up, no fallback, no deopt path.
- **Value rep** — records/closures/strings remain unsupported. Every interesting Lex function uses at least one. Either NaN-boxing (#465 phase 2) or a runtime calling convention that boxes/unboxes at the boundary will be needed to extend the op set.

## Next steps if we want to keep going

Documented in the updated `docs/design/jit-roadmap.md` status section. Rough order: (1) wire as opt-in tier behind `body_hash` cache, (2) side-by-side perf bench, (3) call-into-interpreter for unsupported ops, (4) NodeId side tables.

https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk


---
_Generated by [Claude Code](https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk)_