### PR TITLE
perf(#465): JIT vs interpreter microbench — 84-194× on supported ops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2513,6 +2513,7 @@ dependencies = [
  "cranelift-jit",
  "cranelift-module",
  "cranelift-native",
+ "criterion",
  "indexmap",
  "lex-bytecode",
  "thiserror 2.0.18",

--- a/crates/lex-jit/Cargo.toml
+++ b/crates/lex-jit/Cargo.toml
@@ -36,3 +36,9 @@ cranelift-native = { version = "0.132", optional = true }
 [dev-dependencies]
 lex-bytecode = { path = "../lex-bytecode", version = "0.9.7" }
 indexmap.workspace = true
+criterion = { version = "0.8", default-features = false, features = ["cargo_bench_support"] }
+
+[[bench]]
+name = "jit_vs_interp"
+harness = false
+required-features = ["cranelift"]

--- a/crates/lex-jit/benches/jit_vs_interp.rs
+++ b/crates/lex-jit/benches/jit_vs_interp.rs
@@ -1,0 +1,201 @@
+//! Steady-state JIT vs interpreter micro-benchmark for the MVP op set.
+//!
+//! Runs the same hand-crafted Function — a `sum_from_1_to_n` loop
+//! built from `LoadLocal` / `StoreLocal` / `IntAdd` / `IntLe` /
+//! `Jump` / `JumpIfNot` — through both paths and reports ns per
+//! call. The function is compiled / `Vm` is constructed once,
+//! *outside* the iter loop, so the numbers exclude:
+//!
+//! - JIT compile time (Cranelift codegen). For a single one-shot
+//!   call the JIT loses by milliseconds; only the steady-state
+//!   ratio is meaningful at this stage, before tier-up integration
+//!   amortizes compile cost over many invocations.
+//! - `Program` build + `Vm::new`. Captured once and reused per
+//!   iter — same shape as `crates/lex-bytecode/benches/dispatch.rs`.
+//!
+//! What this bench shows is the **lower bound** for JIT ROI on
+//! Lex's hot path: pure-int arithmetic in a loop, no boxed `Value`
+//! traffic, no records or closures. Real Lex programs will land
+//! somewhere between this and 1× (per the roadmap, until the
+//! value-rep / NaN-boxing decision lands).
+//!
+//! Run with `cargo bench -p lex-jit --features cranelift --bench jit_vs_interp`.
+//! The `required-features = ["cranelift"]` gate in `Cargo.toml` means
+//! cargo silently skips this bench when the feature is off, so the
+//! file body assumes cranelift is on.
+
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use indexmap::IndexMap;
+use lex_bytecode::op::{Const, Op};
+use lex_bytecode::program::{Function, Program, ZERO_BODY_HASH};
+use lex_bytecode::value::Value;
+use lex_bytecode::vm::Vm;
+use lex_jit::JitContext;
+
+/// Build the loop `fn f(n :: Int) -> Int { let acc=0, i=1; while i<=n
+/// { acc+=i; i+=1 }; acc }` — the same bytecode the JIT MVP test
+/// `sum_from_one_to_n_via_loop` covers. Op set is entirely in the
+/// MVP-supported subset.
+fn sum_loop_program() -> Program {
+    let code = vec![
+        Op::PushConst(0), // const 0 = 1
+        Op::StoreLocal(1),
+        Op::PushConst(1), // const 1 = 0
+        Op::StoreLocal(2),
+        Op::LoadLocal(1),
+        Op::LoadLocal(0),
+        Op::IntLe,
+        Op::JumpIfNot(9),
+        Op::LoadLocal(2),
+        Op::LoadLocal(1),
+        Op::IntAdd,
+        Op::StoreLocal(2),
+        Op::LoadLocal(1),
+        Op::PushConst(0),
+        Op::IntAdd,
+        Op::StoreLocal(1),
+        Op::Jump(-13),
+        Op::LoadLocal(2),
+        Op::Return,
+    ];
+    let mut function_names = IndexMap::new();
+    function_names.insert("f".to_string(), 0);
+    Program {
+        constants: vec![Const::Int(1), Const::Int(0)],
+        functions: vec![Function {
+            name: "f".into(),
+            arity: 1,
+            locals_count: 3,
+            code,
+            effects: vec![],
+            body_hash: ZERO_BODY_HASH,
+            refinements: vec![],
+            field_ic_sites: 0,
+        }],
+        function_names,
+        module_aliases: IndexMap::new(),
+        entry: Some(0),
+        record_shapes: vec![],
+    }
+}
+
+/// Straight-line int polynomial — no jumps, no per-iter dispatch
+/// loop in the bytecode. Tests the dispatch-floor case: the
+/// interpreter ought to be near its limit here (every op is a
+/// trivial-handler arm), so the JIT win is purely from removing
+/// the dispatch loop and unboxing values.
+fn polynomial_program() -> Program {
+    // fn f(a, b, c) -> Int { a*a + b*b + c*c + a*b + b*c }
+    let code = vec![
+        Op::LoadLocal(0),
+        Op::LoadLocal(0),
+        Op::IntMul, // a*a
+        Op::LoadLocal(1),
+        Op::LoadLocal(1),
+        Op::IntMul, // b*b
+        Op::IntAdd, // a*a + b*b
+        Op::LoadLocal(2),
+        Op::LoadLocal(2),
+        Op::IntMul, // c*c
+        Op::IntAdd, // a*a + b*b + c*c
+        Op::LoadLocal(0),
+        Op::LoadLocal(1),
+        Op::IntMul, // a*b
+        Op::IntAdd,
+        Op::LoadLocal(1),
+        Op::LoadLocal(2),
+        Op::IntMul, // b*c
+        Op::IntAdd,
+        Op::Return,
+    ];
+    let mut function_names = IndexMap::new();
+    function_names.insert("f".to_string(), 0);
+    Program {
+        constants: vec![],
+        functions: vec![Function {
+            name: "f".into(),
+            arity: 3,
+            locals_count: 3,
+            code,
+            effects: vec![],
+            body_hash: ZERO_BODY_HASH,
+            refinements: vec![],
+            field_ic_sites: 0,
+        }],
+        function_names,
+        module_aliases: IndexMap::new(),
+        entry: Some(0),
+        record_shapes: vec![],
+    }
+}
+
+fn bench_sum_loop(c: &mut Criterion) {
+    let prog = sum_loop_program();
+    let mut ctx = JitContext::new().expect("jit ctx");
+    let jitted = ctx
+        .compile(&prog.functions[0], &prog.constants)
+        .expect("jit compile");
+
+    let mut group = c.benchmark_group("jit_vs_interp/sum_loop");
+    for &n in &[100i64, 1_000, 10_000, 100_000] {
+        group.throughput(Throughput::Elements(n as u64));
+
+        group.bench_function(format!("interp/n={n}"), |b| {
+            let mut vm = Vm::new(&prog);
+            vm.set_step_limit(u64::MAX);
+            b.iter(|| {
+                black_box(
+                    vm.call("f", vec![Value::Int(black_box(n))])
+                        .expect("interp call"),
+                )
+            });
+        });
+
+        group.bench_function(format!("jit/n={n}"), |b| {
+            b.iter(|| black_box(unsafe { jitted.call(&[black_box(n)]) }));
+        });
+    }
+    group.finish();
+}
+
+fn bench_polynomial(c: &mut Criterion) {
+    let prog = polynomial_program();
+    let mut ctx = JitContext::new().expect("jit ctx");
+    let jitted = ctx
+        .compile(&prog.functions[0], &prog.constants)
+        .expect("jit compile");
+
+    let mut group = c.benchmark_group("jit_vs_interp/polynomial");
+
+    group.bench_function("interp", |b| {
+        let mut vm = Vm::new(&prog);
+        vm.set_step_limit(u64::MAX);
+        b.iter(|| {
+            black_box(
+                vm.call(
+                    "f",
+                    vec![
+                        Value::Int(black_box(7)),
+                        Value::Int(black_box(11)),
+                        Value::Int(black_box(13)),
+                    ],
+                )
+                .expect("interp call"),
+            )
+        });
+    });
+
+    group.bench_function("jit", |b| {
+        b.iter(|| {
+            black_box(unsafe {
+                jitted.call(&[black_box(7), black_box(11), black_box(13)])
+            })
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_sum_loop, bench_polynomial);
+criterion_main!(benches);

--- a/docs/design/jit-roadmap.md
+++ b/docs/design/jit-roadmap.md
@@ -457,3 +457,62 @@ In rough order of value:
 
 Phase 2 (records / closures) still needs the value-rep decision —
 the MVP doesn't change that gating.
+
+---
+
+## Status update — first JIT-vs-interpreter measurement (2026-06-01)
+
+Added `crates/lex-jit/benches/jit_vs_interp.rs` (criterion). Same
+hand-crafted bytecode compiled once outside the iter loop, then run
+through both paths. **Steady-state only** — compile cost excluded.
+
+### Numbers (release build, default opt_level=none for cranelift)
+
+| Workload                  | Interp        | JIT         | Ratio |
+|---------------------------|---------------|-------------|-------|
+| `sum_loop / n=1_000`      | 120.46 µs     | 621.78 ns   | 194× |
+| `sum_loop / n=10_000`     | 1.1898 ms     | 6.137 µs    | 194× |
+| `sum_loop / n=100_000`    | 12.004 ms     | 61.917 µs   | 194× |
+| `polynomial(7, 11, 13)`   | 312.55 ns     | 3.7391 ns   | 84× |
+
+The `sum_loop` ratio is rock-stable across three orders of magnitude
+of `n` — both paths scale linearly in iteration count, so the
+constant factor is the JIT win. The straight-line `polynomial` is
+smaller (84×) because there's no loop body to amortize the per-call
+overhead over; each call is one dispatch through 20 bytecode ops vs
+one native function call to ~20 register instructions.
+
+### What the ratio actually means
+
+**~200× is a steady-state lower bound for the supported op set, on
+the work the JIT can do today — pure int arithmetic, locals, control
+flow.** That's the regime where (a) the interpreter is doing
+boxed-`Value` arithmetic via a `match`-dispatched op handler, and
+(b) the JIT is running unboxed `i64` register arithmetic. The
+disparity is exactly what the §"What the interpreter ceiling is"
+analysis predicted at the bottom of the workload spectrum.
+
+It is **not** a prediction for real Lex programs. Crucially, the
+roadmap's 1.5× ceiling caveat applies once records / closures /
+strings enter the picture — every `MakeRecord` / `Call` makes the
+function ineligible today, and unboxing those requires the
+value-rep rework or a boxing calling convention at the JIT
+boundary. The 1.5× number was about programs *dominated* by those
+allocation-heavy ops, where the JIT can't unbox anything.
+
+### What this is concrete evidence of
+
+1. The Cranelift backend choice (vs. LLVM / hand-rolled) is
+   validated for the MVP scope — 84-194× on supported workloads at
+   `opt_level=none`. Higher opt levels probably claw back another
+   1.3-2×, but for the integration question (does the pipeline
+   work, is it worth wiring up?) the answer is unambiguously yes.
+2. The bottom of the JIT-ROI distribution — leaf-arith hot paths
+   — pays the engineering off without value-rep. A
+   "JIT-the-eligible-functions-only" tier could ship before the
+   NaN-boxing decision, hitting a meaningful fraction of
+   `arith_loop`-class workloads.
+3. Compile cost is *still* unmeasured. Cranelift takes ~ms; the
+   break-even is somewhere around 10k-100k calls. The next slice
+   (tier-up integration with a `body_hash`-keyed cache) needs to
+   measure this in situ to set the warmup threshold.


### PR DESCRIPTION
## Summary

First measurement of JIT vs interpreter on the supported op set. New `crates/lex-jit/benches/jit_vs_interp.rs` (criterion). Two workloads:

- **`sum_loop`** — the loop function from the JIT MVP test (`PushConst`, `StoreLocal`, `LoadLocal`, `IntLe`, `JumpIfNot`, `IntAdd`, `Jump`, `Return`). Compiled once outside the iter loop.
- **`polynomial`** — straight-line `a*a + b*b + c*c + a*b + b*c`. No control flow, pure dispatch.

Both paths get `Vm::new` / `JitContext::compile` done once; the iter loop only times the call.

## Numbers (release build, cranelift `opt_level=none`)

| Workload                  | Interp        | JIT         | Ratio |
|---------------------------|---------------|-------------|-------|
| `sum_loop / n=1_000`      | 120.46 µs     | 621.78 ns   | **194×** |
| `sum_loop / n=10_000`     | 1.1898 ms     | 6.137 µs    | **194×** |
| `sum_loop / n=100_000`    | 12.004 ms     | 61.917 µs   | **194×** |
| `polynomial(7, 11, 13)`   | 312.55 ns     | 3.7391 ns   | **84×** |

194× is rock-stable across three orders of magnitude — both paths scale linearly in `n`, so the constant factor *is* the JIT win. The straight-line polynomial is smaller (84×) because there's no body to amortize per-call overhead.

## What this measures and what it doesn't

**Steady-state lower bound** for what the MVP can JIT today — pure int arith + locals + control flow. That's the regime where the interpreter is doing boxed-`Value` arithmetic via `match`-dispatched op handlers, and the JIT is running unboxed `i64` register arithmetic.

**Not** a prediction for real Lex programs. The roadmap's 1.5× ceiling caveat kicks in once records / closures / strings enter the picture — every `MakeRecord` / `Call` makes the function ineligible today, and unboxing those requires the value-rep rework. The 1.5× was about programs *dominated* by allocation-heavy ops, where the JIT can't unbox anything.

**Doesn't measure compile cost.** Cranelift takes ~ms per function; the break-even is somewhere around 10k-100k calls for the loop workload. The next slice (tier-up integration with a `body_hash`-keyed cache) needs to measure this in situ to set the warmup threshold.

## Concrete takeaways for the next slice

1. Cranelift backend is validated for the MVP scope. Higher opt levels probably claw back another 1.3-2×, but the integration question is answered.
2. Leaf-arith hot paths pay engineering off without value-rep. A "JIT-the-eligible-functions-only" tier could ship before the NaN-boxing decision.
3. Compile cost is the remaining unknown — needs measurement once the tier-up wire-up lands.

## Test plan

- [x] `cargo bench -p lex-jit --features cranelift --bench jit_vs_interp` reports the numbers above
- [x] `cargo check -p lex-jit` (no feature) — bench is silently skipped via `required-features`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo clippy -p lex-jit --features cranelift --all-targets -- -D warnings` clean

Full results commentary appended to `docs/design/jit-roadmap.md`.

https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk)_