### PR TITLE
feat(#465): JIT tier-up — `JitVm` wraps `Vm::call`, 227× steady-state

### DIFF
--- a/crates/lex-jit/benches/jit_vs_interp.rs
+++ b/crates/lex-jit/benches/jit_vs_interp.rs
@@ -32,7 +32,7 @@ use lex_bytecode::op::{Const, Op};
 use lex_bytecode::program::{Function, Program, ZERO_BODY_HASH};
 use lex_bytecode::value::Value;
 use lex_bytecode::vm::Vm;
-use lex_jit::JitContext;
+use lex_jit::{JitContext, JitVm};
 
 /// Build the loop `fn f(n :: Int) -> Int { let acc=0, i=1; while i<=n
 /// { acc+=i; i+=1 }; acc }` — the same bytecode the JIT MVP test
@@ -153,8 +153,27 @@ fn bench_sum_loop(c: &mut Criterion) {
             });
         });
 
-        group.bench_function(format!("jit/n={n}"), |b| {
+        group.bench_function(format!("jit_raw/n={n}"), |b| {
             b.iter(|| black_box(unsafe { jitted.call(&[black_box(n)]) }));
+        });
+
+        // The tiered path — `JitVm::call`. Includes the wrapper's
+        // per-call overhead (lookup, cache hit, arg unbox, result
+        // re-box). Measures what a real caller of the public API
+        // would actually see, vs the raw fn-pointer call above.
+        group.bench_function(format!("jit_vm/n={n}"), |b| {
+            let mut jitvm = JitVm::new(&prog).expect("JitVm::new");
+            // Prime the cache so we're measuring steady-state.
+            jitvm
+                .call("f", vec![Value::Int(n)])
+                .expect("prime jit_vm cache");
+            b.iter(|| {
+                black_box(
+                    jitvm
+                        .call("f", vec![Value::Int(black_box(n))])
+                        .expect("jit_vm call"),
+                )
+            });
         });
     }
     group.finish();
@@ -187,13 +206,38 @@ fn bench_polynomial(c: &mut Criterion) {
         });
     });
 
-    group.bench_function("jit", |b| {
+    group.bench_function("jit_raw", |b| {
         b.iter(|| {
             black_box(unsafe {
                 jitted.call(&[black_box(7), black_box(11), black_box(13)])
             })
         });
     });
+
+    group.bench_function("jit_vm", |b| {
+        let mut jitvm = JitVm::new(&prog).expect("JitVm::new");
+        jitvm
+            .call(
+                "f",
+                vec![Value::Int(7), Value::Int(11), Value::Int(13)],
+            )
+            .expect("prime jit_vm cache");
+        b.iter(|| {
+            black_box(
+                jitvm
+                    .call(
+                        "f",
+                        vec![
+                            Value::Int(black_box(7)),
+                            Value::Int(black_box(11)),
+                            Value::Int(black_box(13)),
+                        ],
+                    )
+                    .expect("jit_vm call"),
+            )
+        });
+    });
+
     group.finish();
 }
 

--- a/crates/lex-jit/src/lib.rs
+++ b/crates/lex-jit/src/lib.rs
@@ -130,9 +130,13 @@ pub(crate) fn op_supported(op: &Op, consts: &[Const]) -> bool {
 
 #[cfg(feature = "cranelift")]
 mod lower;
+#[cfg(feature = "cranelift")]
+pub mod tier;
 
 #[cfg(feature = "cranelift")]
 pub use lower::{JitContext, JittedFn};
+#[cfg(feature = "cranelift")]
+pub use tier::{CacheStats, JitVm};
 
 #[cfg(not(feature = "cranelift"))]
 mod stub {

--- a/crates/lex-jit/src/lower.rs
+++ b/crates/lex-jit/src/lower.rs
@@ -70,8 +70,15 @@ impl JitContext {
     }
 
     /// Compile `f` against `consts`. Returns a callable
-    /// [`JittedFn`] bound to the lifetime of `self`.
-    pub fn compile(&mut self, f: &Function, consts: &[Const]) -> Result<JittedFn<'_>, JitError> {
+    /// [`JittedFn`] whose lifetime is *implicitly* bounded by
+    /// `self` — the JITed code lives in `self.module`'s
+    /// executable mmap, which is freed on [`JitContext`] drop.
+    /// Callers must not invoke a [`JittedFn`] after dropping the
+    /// owning context; this is documented as a safety contract on
+    /// [`JittedFn::call`] rather than enforced through a borrow
+    /// lifetime, because the borrow form blocks self-referential
+    /// caches (e.g. [`tier::JitVm`]) from holding both at once.
+    pub fn compile(&mut self, f: &Function, consts: &[Const]) -> Result<JittedFn, JitError> {
         if !is_jit_eligible(f, consts) {
             // Surface the first offender for callers that didn't
             // pre-check, matching the doc-comment on JitContext::compile.
@@ -114,24 +121,20 @@ impl JitContext {
         self.module.finalize_definitions().map_err(Box::new)?;
 
         let code_ptr = self.module.get_finalized_function(id);
-        Ok(JittedFn {
-            code_ptr,
-            arity: f.arity,
-            _phantom: std::marker::PhantomData,
-        })
+        Ok(JittedFn { code_ptr, arity: f.arity })
     }
 }
 
 /// Handle to a JITed function. The code lives in the parent
-/// [`JitContext`]'s `JITModule`; `'ctx` ties the lifetime so calling
-/// after the context drops won't compile.
-pub struct JittedFn<'ctx> {
+/// [`JitContext`]'s `JITModule` and is freed when that context
+/// drops. No lifetime parameter — see the safety note on
+/// [`JittedFn::call`].
+pub struct JittedFn {
     code_ptr: *const u8,
     arity: u16,
-    _phantom: std::marker::PhantomData<&'ctx JitContext>,
 }
 
-impl<'ctx> JittedFn<'ctx> {
+impl JittedFn {
     pub fn arity(&self) -> u16 {
         self.arity
     }
@@ -145,8 +148,12 @@ impl<'ctx> JittedFn<'ctx> {
     /// - `args.len()` must equal `self.arity()` — otherwise we
     ///   transmute to the wrong fn signature and undefined behavior
     ///   follows.
-    /// - The parent [`JitContext`] must still be alive (enforced
-    ///   by the `'ctx` lifetime borrow at construction).
+    /// - The parent [`JitContext`] must still be alive. The lifetime
+    ///   is *not* enforced by the borrow checker (see the doc on
+    ///   the struct); callers must uphold it themselves. The
+    ///   intended pattern is to colocate the context and the
+    ///   [`JittedFn`] in the same owning struct (e.g.
+    ///   [`tier::JitVm`]).
     pub unsafe fn call(&self, args: &[i64]) -> i64 {
         assert_eq!(args.len(), self.arity as usize, "JittedFn arity mismatch");
         let p = self.code_ptr;
@@ -187,8 +194,8 @@ impl<'ctx> JittedFn<'ctx> {
 
 // SAFETY: code_ptr points into the JITModule's executable mmap,
 // which is `Send + Sync` for read-execute access.
-unsafe impl<'ctx> Send for JittedFn<'ctx> {}
-unsafe impl<'ctx> Sync for JittedFn<'ctx> {}
+unsafe impl Send for JittedFn {}
+unsafe impl Sync for JittedFn {}
 
 // ---------------------------------------------------------------------------
 // Block-discovery pre-pass

--- a/crates/lex-jit/src/tier.rs
+++ b/crates/lex-jit/src/tier.rs
@@ -1,0 +1,205 @@
+//! Tier-up integration: a [`JitVm`] wrapper that intercepts
+//! [`Vm::call`] and routes eligible workloads through the JIT.
+//!
+//! ## What it does
+//!
+//! [`JitVm`] wraps an existing `Vm` plus an owned [`JitContext`]
+//! and a per-function `JitFnState` cache (keyed by `fn_id` within
+//! the wrapped `Program`). When `JitVm::call(name, args)` is
+//! invoked:
+//!
+//! 1. Look up `fn_id` from the program. If unknown, surface
+//!    `VmError::UnknownFunction` (same shape as `Vm::call`).
+//! 2. Bump the per-fn call counter. If the function's
+//!    `JitFnState::compiled` is still `None` and the counter has
+//!    reached `threshold`, attempt compilation:
+//!    - If `is_jit_eligible` returns false → mark as `Ineligible`,
+//!      fall through to the interpreter from now on.
+//!    - If compilation fails for any reason → also mark as
+//!      `Ineligible` (defensive; the eligibility predicate should
+//!      have caught it, but Cranelift codegen has its own failure
+//!      modes).
+//!    - On success → cache the [`JittedFn`].
+//! 3. If the function is JITed *and* all args unbox cleanly to
+//!    `i64` (`Value::Int(_)` or `Value::Bool(_)`), invoke the
+//!    native code and wrap the result back into a `Value`.
+//! 4. Otherwise — eligible but args don't unbox, or never JITed —
+//!    forward to `Vm::call`.
+//!
+//! ## What it does NOT do
+//!
+//! - **`Op::Call` interception.** Internal calls between Lex
+//!   functions still flow through the interpreter even when the
+//!   callee has been JITed. The wrapper only fires on the
+//!   outermost `JitVm::call` entry. A real tier-up integration
+//!   needs to hook the dispatch loop's `Op::Call` arm, which
+//!   would require either restructuring the crate graph
+//!   (lex-bytecode would need to depend on lex-jit, which depends
+//!   on lex-bytecode — currently circular) or threading a runtime
+//!   callback through. Deferred.
+//! - **Tier-down / deopt.** Once a function is `Ineligible` it
+//!   stays that way for the life of the `JitVm`. Programs that
+//!   would benefit from re-evaluation (e.g. an eligible function
+//!   first called with a non-int arg, then later called with int
+//!   args) are not retroactively JITed — they just stay on the
+//!   interpreter path.
+//! - **Effect handler hand-off.** The wrapper uses whatever
+//!   handler the underlying `Vm` was constructed with for the
+//!   interp path. JITed code can't invoke effects (the op set is
+//!   the MVP arith subset), so this is a non-issue today.
+
+use lex_bytecode::program::Program;
+use lex_bytecode::value::Value;
+use lex_bytecode::vm::{Vm, VmError};
+
+use crate::{is_jit_eligible, JitContext, JitError, JittedFn};
+
+/// JIT cache state for a single function in the wrapped program.
+///
+/// `counter` ticks each time `JitVm::call` lands on this fn. On
+/// reaching `threshold` we evaluate eligibility — that gate is
+/// only consulted *once* per function, after which `compiled`
+/// transitions to a terminal state (either a [`JittedFn`] or
+/// `Ineligible`).
+enum CompileState {
+    /// Not yet evaluated. Holds the call counter so we can
+    /// implement a tier-up threshold without recomputing.
+    Pending { counter: u32 },
+    /// Tried and rejected — either `is_jit_eligible` said no, or
+    /// codegen errored. Routes through the interpreter forever.
+    Ineligible,
+    /// Compiled. The pointer lives in the parent `JitContext`'s
+    /// `JITModule`; safe to call as long as the `JitVm` is alive.
+    Compiled(JittedFn),
+}
+
+/// JIT tier wrapping a [`Vm`]. Owns a [`JitContext`] and a
+/// per-function cache; intercepts [`JitVm::call`] to route
+/// eligible workloads through native code while forwarding
+/// everything else to the interpreter unchanged.
+pub struct JitVm<'a> {
+    vm: Vm<'a>,
+    ctx: JitContext,
+    /// Cache indexed by `fn_id`. Length matches
+    /// `program.functions.len()` at construction.
+    cache: Vec<CompileState>,
+    /// Number of `JitVm::call` invocations a function must accrue
+    /// before we attempt compilation. Default `1` — eager — so
+    /// the first eligible call already runs native.
+    threshold: u32,
+    program: &'a Program,
+}
+
+impl<'a> JitVm<'a> {
+    /// Build a tier over `program` using the standard
+    /// `Vm::new(program)` interpreter (no custom effect handler).
+    /// Threshold defaults to `1` (eager). Use
+    /// [`JitVm::with_threshold`] to defer compilation.
+    pub fn new(program: &'a Program) -> Result<Self, JitError> {
+        Self::with_threshold(program, 1)
+    }
+
+    pub fn with_threshold(program: &'a Program, threshold: u32) -> Result<Self, JitError> {
+        let cache = (0..program.functions.len())
+            .map(|_| CompileState::Pending { counter: 0 })
+            .collect();
+        Ok(Self {
+            vm: Vm::new(program),
+            ctx: JitContext::new()?,
+            cache,
+            threshold: threshold.max(1),
+            program,
+        })
+    }
+
+    /// Borrow the underlying interpreter — exposed so callers can
+    /// drive `Vm::set_step_limit` and similar one-shot config.
+    pub fn vm_mut(&mut self) -> &mut Vm<'a> {
+        &mut self.vm
+    }
+
+    /// Same shape as [`Vm::call`]. Routes through the JIT when
+    /// possible (see module docs), otherwise to the interpreter.
+    pub fn call(&mut self, name: &str, args: Vec<Value>) -> Result<Value, VmError> {
+        let fn_id = self
+            .program
+            .lookup(name)
+            .ok_or_else(|| VmError::UnknownFunction(name.to_string()))?
+            as usize;
+
+        // Step 1 — bump counter, maybe transition Pending → Compiled / Ineligible.
+        if let CompileState::Pending { counter } = &mut self.cache[fn_id] {
+            *counter += 1;
+            if *counter >= self.threshold {
+                self.cache[fn_id] = self.attempt_compile(fn_id);
+            }
+        }
+
+        // Step 2 — dispatch.
+        match &self.cache[fn_id] {
+            CompileState::Compiled(jitted) => {
+                if let Some(unboxed) = unbox_args(&args, jitted.arity()) {
+                    let r = unsafe { jitted.call(&unboxed) };
+                    return Ok(Value::Int(r));
+                }
+                // Eligible but the arg shape doesn't fit (e.g. a
+                // record was passed where Int was expected, which
+                // shouldn't normally happen for an eligible
+                // function — but be defensive).
+                self.vm.call(name, args)
+            }
+            CompileState::Ineligible | CompileState::Pending { .. } => self.vm.call(name, args),
+        }
+    }
+
+    fn attempt_compile(&mut self, fn_id: usize) -> CompileState {
+        let f = &self.program.functions[fn_id];
+        if !is_jit_eligible(f, &self.program.constants) {
+            return CompileState::Ineligible;
+        }
+        match self.ctx.compile(f, &self.program.constants) {
+            Ok(jitted) => CompileState::Compiled(jitted),
+            Err(_) => CompileState::Ineligible,
+        }
+    }
+
+    /// Diagnostic: how many functions in the cache are in each
+    /// state right now. Useful for tests and benches.
+    pub fn cache_stats(&self) -> CacheStats {
+        let mut s = CacheStats::default();
+        for st in &self.cache {
+            match st {
+                CompileState::Pending { .. } => s.pending += 1,
+                CompileState::Ineligible => s.ineligible += 1,
+                CompileState::Compiled(_) => s.compiled += 1,
+            }
+        }
+        s
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct CacheStats {
+    pub pending: usize,
+    pub ineligible: usize,
+    pub compiled: usize,
+}
+
+/// Try to unbox a `Vec<Value>` to a fixed-size `[i64]` matching
+/// the JIT calling convention. Returns `None` if any arg isn't
+/// `Int` / `Bool` or the count mismatches.
+fn unbox_args(args: &[Value], expected_arity: u16) -> Option<Vec<i64>> {
+    if args.len() != expected_arity as usize {
+        return None;
+    }
+    let mut out = Vec::with_capacity(args.len());
+    for v in args {
+        match v {
+            Value::Int(n) => out.push(*n),
+            Value::Bool(b) => out.push(if *b { 1 } else { 0 }),
+            _ => return None,
+        }
+    }
+    Some(out)
+}
+

--- a/crates/lex-jit/tests/jitvm_vs_vm.rs
+++ b/crates/lex-jit/tests/jitvm_vs_vm.rs
@@ -1,0 +1,275 @@
+//! End-to-end correctness check for the tier-up integration:
+//! `JitVm::call` must produce the same result as `Vm::call` on
+//! every function, regardless of whether the function gets JITed
+//! or stays on the interpreter path.
+//!
+//! Each test asserts both the equivalence and (where relevant)
+//! the post-call cache state, so a regression that silently
+//! routes through the interpreter when it should be JITing
+//! shows up as a test failure rather than a hidden perf cliff.
+
+#![cfg(feature = "cranelift")]
+
+use indexmap::IndexMap;
+use lex_bytecode::op::{Const, Op};
+use lex_bytecode::program::{Function, Program, ZERO_BODY_HASH};
+use lex_bytecode::value::Value;
+use lex_bytecode::vm::Vm;
+use lex_jit::JitVm;
+
+fn mk_fn(name: &str, arity: u16, locals: u16, code: Vec<Op>) -> Function {
+    Function {
+        name: name.to_string(),
+        arity,
+        locals_count: locals,
+        code,
+        effects: vec![],
+        body_hash: ZERO_BODY_HASH,
+        refinements: vec![],
+        field_ic_sites: 0,
+    }
+}
+
+fn mk_program(funcs: Vec<Function>, consts: Vec<Const>) -> Program {
+    let mut function_names = IndexMap::new();
+    for (i, f) in funcs.iter().enumerate() {
+        function_names.insert(f.name.clone(), i as u32);
+    }
+    Program {
+        constants: consts,
+        functions: funcs,
+        function_names,
+        module_aliases: IndexMap::new(),
+        entry: Some(0),
+        record_shapes: vec![],
+    }
+}
+
+fn assert_jitvm_matches_vm(program: &Program, calls: &[(&str, Vec<Value>)]) {
+    let mut interp = Vm::new(program);
+    let mut jitvm = JitVm::new(program).expect("JitVm::new");
+
+    for (name, args) in calls {
+        let interp_r = interp.call(name, args.clone()).expect("interp call");
+        let jit_r = jitvm.call(name, args.clone()).expect("jitvm call");
+        // Value implements PartialEq (Int / Bool / Tuple / etc.
+        // structural equality), so this works across every result
+        // shape — eligible-and-JITed (returns Value::Int from the
+        // unbox path) and ineligible (returns whatever the
+        // interpreter would).
+        assert!(
+            interp_r == jit_r,
+            "JitVm vs Vm disagree on {name}({args:?}): interp={interp_r:?}, jit={jit_r:?}"
+        );
+    }
+}
+
+fn value_to_i64(v: &Value) -> i64 {
+    match v {
+        Value::Int(n) => *n,
+        Value::Bool(b) => if *b { 1 } else { 0 },
+        other => panic!("unexpected result variant: {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Eligible function — JitVm should JIT it on first call (threshold=1).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn eligible_function_routes_through_jit() {
+    // fn add(a, b) -> Int { a + b }
+    let prog = mk_program(
+        vec![mk_fn(
+            "add",
+            2,
+            2,
+            vec![Op::LoadLocal(0), Op::LoadLocal(1), Op::IntAdd, Op::Return],
+        )],
+        vec![],
+    );
+    let mut jitvm = JitVm::new(&prog).expect("JitVm::new");
+    assert_eq!(jitvm.cache_stats().pending, 1);
+    assert_eq!(
+        jitvm.call("add", vec![Value::Int(3), Value::Int(4)]).unwrap(),
+        Value::Int(7)
+    );
+    // After one call at threshold=1, the fn should be JITed.
+    assert_eq!(jitvm.cache_stats().compiled, 1);
+    assert_eq!(jitvm.cache_stats().pending, 0);
+    assert_eq!(jitvm.cache_stats().ineligible, 0);
+}
+
+// ---------------------------------------------------------------------------
+// 2. Threshold defers compilation until the counter ticks.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn threshold_defers_compile() {
+    let prog = mk_program(
+        vec![mk_fn(
+            "add",
+            2,
+            2,
+            vec![Op::LoadLocal(0), Op::LoadLocal(1), Op::IntAdd, Op::Return],
+        )],
+        vec![],
+    );
+    let mut jitvm = JitVm::with_threshold(&prog, 3).expect("JitVm::with_threshold");
+
+    // Two warm-up calls should not trigger compile.
+    for _ in 0..2 {
+        let r = jitvm.call("add", vec![Value::Int(1), Value::Int(2)]).unwrap();
+        assert_eq!(r, Value::Int(3));
+    }
+    assert_eq!(jitvm.cache_stats().pending, 1);
+    assert_eq!(jitvm.cache_stats().compiled, 0);
+
+    // Third call — threshold reached, compile fires.
+    let r = jitvm.call("add", vec![Value::Int(10), Value::Int(20)]).unwrap();
+    assert_eq!(r, Value::Int(30));
+    assert_eq!(jitvm.cache_stats().compiled, 1);
+}
+
+// ---------------------------------------------------------------------------
+// 3. Ineligible function — JitVm must fall through to the interpreter
+//    AND mark the cache so future calls don't re-evaluate.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ineligible_function_falls_through_to_interp() {
+    // fn pair(a, b) -> (Int, Int) { (a, b) }  — uses MakeTuple, not JIT-eligible
+    let prog = mk_program(
+        vec![mk_fn(
+            "pair",
+            2,
+            2,
+            vec![
+                Op::LoadLocal(0),
+                Op::LoadLocal(1),
+                Op::MakeTuple(2),
+                Op::Return,
+            ],
+        )],
+        vec![],
+    );
+    let mut jitvm = JitVm::new(&prog).expect("JitVm::new");
+    let r = jitvm.call("pair", vec![Value::Int(5), Value::Int(7)]).unwrap();
+    match r {
+        Value::Tuple(ref v) => {
+            assert_eq!(v.len(), 2);
+            assert_eq!(value_to_i64(&v[0]), 5);
+            assert_eq!(value_to_i64(&v[1]), 7);
+        }
+        other => panic!("expected Tuple, got {other:?}"),
+    }
+    assert_eq!(jitvm.cache_stats().ineligible, 1);
+}
+
+// ---------------------------------------------------------------------------
+// 4. Mixed program — one eligible, one not. Cache must contain one of each.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mixed_program_partial_jit() {
+    let prog = mk_program(
+        vec![
+            mk_fn(
+                "add",
+                2,
+                2,
+                vec![Op::LoadLocal(0), Op::LoadLocal(1), Op::IntAdd, Op::Return],
+            ),
+            mk_fn(
+                "pair",
+                2,
+                2,
+                vec![
+                    Op::LoadLocal(0),
+                    Op::LoadLocal(1),
+                    Op::MakeTuple(2),
+                    Op::Return,
+                ],
+            ),
+        ],
+        vec![],
+    );
+    assert_jitvm_matches_vm(
+        &prog,
+        &[
+            ("add", vec![Value::Int(1), Value::Int(2)]),
+            ("pair", vec![Value::Int(3), Value::Int(4)]),
+            ("add", vec![Value::Int(10), Value::Int(-5)]),
+        ],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. Unknown function — must surface VmError::UnknownFunction exactly like
+//    Vm::call would, no panic, no detour.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn unknown_function_errors_cleanly() {
+    let prog = mk_program(
+        vec![mk_fn(
+            "add",
+            2,
+            2,
+            vec![Op::LoadLocal(0), Op::LoadLocal(1), Op::IntAdd, Op::Return],
+        )],
+        vec![],
+    );
+    let mut jitvm = JitVm::new(&prog).expect("JitVm::new");
+    let r = jitvm.call("nonexistent", vec![]);
+    assert!(
+        matches!(r, Err(lex_bytecode::vm::VmError::UnknownFunction(_))),
+        "expected UnknownFunction, got {r:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 6. Same loop as the bench — proves the heavier shape also matches.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sum_loop_matches_via_jitvm() {
+    let prog = mk_program(
+        vec![mk_fn(
+            "f",
+            1,
+            3,
+            vec![
+                Op::PushConst(0),
+                Op::StoreLocal(1),
+                Op::PushConst(1),
+                Op::StoreLocal(2),
+                Op::LoadLocal(1),
+                Op::LoadLocal(0),
+                Op::IntLe,
+                Op::JumpIfNot(9),
+                Op::LoadLocal(2),
+                Op::LoadLocal(1),
+                Op::IntAdd,
+                Op::StoreLocal(2),
+                Op::LoadLocal(1),
+                Op::PushConst(0),
+                Op::IntAdd,
+                Op::StoreLocal(1),
+                Op::Jump(-13),
+                Op::LoadLocal(2),
+                Op::Return,
+            ],
+        )],
+        vec![Const::Int(1), Const::Int(0)],
+    );
+    assert_jitvm_matches_vm(
+        &prog,
+        &[
+            ("f", vec![Value::Int(0)]),
+            ("f", vec![Value::Int(10)]),
+            ("f", vec![Value::Int(100)]),
+            ("f", vec![Value::Int(1000)]),
+        ],
+    );
+}

--- a/docs/design/jit-roadmap.md
+++ b/docs/design/jit-roadmap.md
@@ -516,3 +516,72 @@ allocation-heavy ops, where the JIT can't unbox anything.
    break-even is somewhere around 10k-100k calls. The next slice
    (tier-up integration with a `body_hash`-keyed cache) needs to
    measure this in situ to set the warmup threshold.
+
+---
+
+## Status update — tier integration lands (2026-06-01)
+
+`crates/lex-jit/src/tier.rs` adds `JitVm<'a>`, a wrapper around `Vm`
+that owns a `JitContext` plus a per-function `CompileState` cache.
+`JitVm::call(name, args)` looks up `fn_id`, bumps a counter, and at
+the `threshold`-th call (default `1` — eager) attempts compilation:
+ineligible functions are marked terminally and forwarded to the
+interpreter; compiled ones run native with arg unbox + result re-box
+at the boundary.
+
+What it does **not** do: hook `Op::Call` inside the dispatch loop.
+Internal calls between Lex functions still flow through the
+interpreter. That extension needs either a callback indirection or
+a crate-graph restructure (lex-bytecode and lex-jit currently can't
+both depend on each other), so it's deferred.
+
+### Numbers (release build, opt_level=none)
+
+| Workload                  | Interp     | `jit_raw`   | `jit_vm`    | `jit_vm` vs Interp |
+|---------------------------|------------|-------------|-------------|--------------------|
+| `sum_loop / n=100`        | 14.020 µs  | 73.219 ns   | 126.98 ns   | **110×** |
+| `sum_loop / n=1_000`      | 138.47 µs  | 623.93 ns   | 674.92 ns   | **205×** |
+| `sum_loop / n=10_000`     | 1.4220 ms  | 6.1470 µs   | 6.2484 µs   | **228×** |
+| `sum_loop / n=100_000`    | 13.918 ms  | 61.567 µs   | 61.343 µs   | **227×** |
+| `polynomial(7, 11, 13)`   | 344.05 ns  | 4.6524 ns   | 68.500 ns   | **5.0×** |
+
+(`jit_raw` calls the function pointer directly; `jit_vm` goes
+through `JitVm::call` — same path a real consumer of the public
+API would take.)
+
+### What the new numbers tell us
+
+The wrapper costs ~50-65 ns per call — Vec<Value> arg materialization,
+fn_id lookup, cache indexing, and Value::Int return wrapping. Reading
+the table:
+
+- For loop workloads where the body does meaningful work (n ≥ 1000),
+  the wrapper overhead is amortized and `jit_vm` is within a few
+  percent of the raw fn-pointer call. **At n=100k, the wrapper is
+  measurement noise — the table even shows `jit_vm` 0.4% faster than
+  `jit_raw`, well inside criterion's ~1% confidence interval.**
+- For one-shot ultra-short calls (the polynomial), the wrapper
+  dominates: `jit_raw` runs in 4.7 ns, but `jit_vm`'s 64 ns of
+  fixed-cost dispatch knocks the realized speedup from 84× down to
+  5×. **This is the boundary cost the value-rep rework was supposed
+  to address** — when args and returns are themselves unboxed
+  i64-sized tagged values, the wrap/unwrap step disappears.
+
+### Where this leaves the JIT story
+
+Three things are now true that weren't before this slice:
+
+1. **End-to-end consumer API works.** Any `Vm` user can swap `Vm`
+   for `JitVm` and get JIT speedups on eligible functions
+   transparently. No code generation, no special-casing.
+2. **The boundary cost is measured, not theoretical.** ~64 ns per
+   call to wrap/unwrap. Concrete number to compare against any
+   future value-rep proposal.
+3. **The `Op::Call` integration is the remaining piece of the
+   phase-1 deliverable.** Without it, `JitVm` only helps when the
+   *outermost* call is eligible — internal hot loops calling
+   eligible leaf functions still pay full dispatch cost. The
+   measured wrapper overhead suggests that an inline-cache-style
+   integration at `Op::Call` (where the dispatch already exists and
+   args don't need to be re-built into a Vec) would close most of
+   the remaining gap. That's the next slice.


### PR DESCRIPTION
## Summary

Tier-up integration for the MVP JIT. New `JitVm` wrapper around `Vm` that owns a `JitContext` and a per-function compile-state cache. `JitVm::call(name, args)` routes eligible functions through the JIT (compiling on first call by default), forwards everything else to the interpreter unchanged. Any existing `Vm` user can swap `Vm` for `JitVm` to opt in.

## What this slice does

- `crates/lex-jit/src/tier.rs` — `JitVm<'a>` plus `CompileState` (`Pending { counter }` / `Ineligible` / `Compiled(JittedFn)`) and a small `CacheStats` diagnostic struct.
- Configurable threshold via `JitVm::with_threshold(prog, n)`. Default is 1 (eager — compile on first call). Higher thresholds let callers measure compile-cost amortization curves.
- `Vec<i64>`-style argument unboxing at the boundary. If any arg isn't `Value::Int` or `Value::Bool` we fall through to the interpreter for that call (defensive — eligibility should have caught it).
- Dropped the `'ctx` lifetime parameter from `JittedFn`. It was preventing `JitVm` from holding both the context and the compiled handles. The safety invariant ("don't outlive your `JitContext`") is documented on `JittedFn::call` instead; the intended pattern is to hold both inside an owning struct, exactly like `JitVm`.

## What this slice does NOT do

- **`Op::Call` interception.** Internal Lex-to-Lex calls still flow through the interpreter even when the callee is JITed. That extension needs either a callback indirection or a crate-graph restructure (lex-bytecode and lex-jit can't both depend on each other today). Deferred as a follow-up — flagged in the roadmap doc.
- **Tier-down / deopt.** Once `Ineligible`, a function stays that way for the life of the `JitVm`.

## Measurements

Release build, `opt_level=none`. `jit_raw` = calling the fn pointer directly; `jit_vm` = going through the public `JitVm::call` API.

| Workload                  | Interp     | `jit_raw`   | `jit_vm`    | `jit_vm` vs Interp |
|---------------------------|------------|-------------|-------------|--------------------|
| `sum_loop / n=100`        | 14.020 µs  | 73.219 ns   | 126.98 ns   | **110×** |
| `sum_loop / n=1_000`      | 138.47 µs  | 623.93 ns   | 674.92 ns   | **205×** |
| `sum_loop / n=10_000`     | 1.4220 ms  | 6.1470 µs   | 6.2484 µs   | **228×** |
| `sum_loop / n=100_000`    | 13.918 ms  | 61.567 µs   | 61.343 µs   | **227×** |
| `polynomial(7, 11, 13)`   | 344.05 ns  | 4.6524 ns   | 68.500 ns   | **5.0×** |

Reading the table: the wrapper costs **~50-65 ns per call** (Vec<Value> arg materialization + fn_id lookup + Value::Int return). On loop workloads this is amortized — at n=100k `jit_vm` is *measurement-equal* to `jit_raw`, even slightly faster than it inside criterion's confidence interval. On one-shot straight-line arith the wrapper dominates: 84× raw collapses to 5× through the public API. That's the boundary cost the value-rep rework was supposed to address — now a concrete number rather than theoretical.

## Test plan

- [x] `cargo test -p lex-jit --features cranelift` — 13 + 6 = 19 passing
  - The 6 new tier tests (`tests/jitvm_vs_vm.rs`): eligible routing, threshold-defers-compile, ineligible fallback, mixed programs, unknown-function error mapping, the loop workload from the previous bench
  - All 13 existing JIT tests still pass against the refactored `JittedFn`
- [x] `cargo bench -p lex-jit --features cranelift --bench jit_vs_interp` reproduces the table above
- [x] `cargo check -p lex-jit` (no feature) — bench/tests silently skipped, default build unaffected
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo clippy -p lex-jit --features cranelift --all-targets -- -D warnings` clean

Full results commentary appended to `docs/design/jit-roadmap.md`.

https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk)_