### PR TITLE
feat(#465): JIT Op::Call interception — internal calls JIT too

### DIFF
--- a/crates/lex-bytecode/src/jit_hook.rs
+++ b/crates/lex-bytecode/src/jit_hook.rs
@@ -1,0 +1,64 @@
+//! JIT hook trait — the seam through which `lex-bytecode`'s
+//! dispatch loop can delegate eligible `Op::Call` invocations to
+//! a JIT tier without taking a compile-time dependency on the
+//! JIT crate.
+//!
+//! ## Why a trait
+//!
+//! `lex-jit` already depends on `lex-bytecode` (for `Op`,
+//! `Function`, `Value`, etc.), so `lex-bytecode` cannot in turn
+//! depend on `lex-jit` directly. The trait inverts that: callers
+//! that want JIT register a [`JitHook`] implementation on the
+//! [`Vm`](crate::vm::Vm) at construction; the dispatch loop
+//! consults the hook on each `Op::Call` and falls through to the
+//! interpreter if it returns `Ok(None)`. No JIT in the build →
+//! `vm.jit_hook` stays `None` and the hook check is one branch
+//! on a null option (the optimizer should fold it).
+//!
+//! ## Contract
+//!
+//! Implementations must be *observationally equivalent* to the
+//! interpreter on the calls they accept:
+//!
+//! - **Effects.** Don't accept calls into effectful functions —
+//!   the dispatcher doesn't route effect ops through the hook,
+//!   so any effect call would be silently dropped.
+//! - **Refinements.** The dispatch arm runs refinement checks
+//!   *before* calling the hook (`Op::Call`'s existing path);
+//!   hook implementors don't need to re-check them, but must
+//!   decline (return `Ok(None)`) for functions whose refinement
+//!   evaluation could change observable behavior of the call.
+//!   The MVP JIT's eligibility predicate (`is_jit_eligible`)
+//!   excludes any function with non-`None` refinements precisely
+//!   for this reason.
+//! - **Memoization.** The hook fires *after* the memo cache
+//!   check, so a JIT call only happens on memo misses (or
+//!   functions with memo disabled). This preserves the memo's
+//!   observable behavior (same trace-event shape on a hit).
+//! - **Tracing.** The dispatch arm emits `tracer.enter_call` for
+//!   the call before invoking the hook; on a hook hit, the arm
+//!   emits `tracer.exit_ok` itself. Hook implementors must not
+//!   touch the tracer.
+
+use crate::value::Value;
+use crate::vm::VmError;
+
+/// Hook into the VM dispatch loop for `Op::Call`.
+///
+/// See the module docs for the contract.
+pub trait JitHook: Send {
+    /// The dispatch loop has just verified refinements and missed
+    /// the memo cache for `fn_id`. The arguments are at the top
+    /// of the value stack — `args` is a borrowed view; do not
+    /// mutate.
+    ///
+    /// Return:
+    /// - `Ok(Some(v))` — hook handled the call; the dispatcher
+    ///   will pop `args.len()` values from the stack, push `v`,
+    ///   emit the synthetic `exit_ok` trace event, and continue.
+    /// - `Ok(None)` — hook declines; the dispatcher proceeds with
+    ///   normal frame setup as if the hook weren't installed.
+    /// - `Err(e)` — JITed code raised an error. The dispatcher
+    ///   surfaces it as the call's error.
+    fn try_call(&mut self, fn_id: u32, args: &[Value]) -> Result<Option<Value>, VmError>;
+}

--- a/crates/lex-bytecode/src/lib.rs
+++ b/crates/lex-bytecode/src/lib.rs
@@ -11,6 +11,7 @@ pub mod vm;
 pub mod verify;
 pub mod escape;
 pub mod arena;
+pub mod jit_hook;
 
 pub use compiler::compile_program;
 pub use op::{Const, Op};
@@ -22,3 +23,4 @@ pub use escape::{analyze_program as analyze_escapes, EscapeReport, EscapeSite, P
 pub use arena::{
     analyze_program as analyze_arena, build_arena_index, ArenaReport, ArenaSite,
 };
+pub use jit_hook::JitHook;

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -374,6 +374,12 @@ pub struct Vm<'a> {
     /// slice 2a since codegen doesn't emit the ops yet.
     pub arena_record_allocs: u64,
     pub arena_record_heap_fallbacks: u64,
+    /// Optional JIT tier hook (#465 phase-1 integration). Consulted
+    /// by the `Op::Call` dispatch arm after refinements + memo. See
+    /// `crate::jit_hook` for the trait contract. `None` means
+    /// "interpreter-only" — that branch in the dispatch arm folds
+    /// to a single null-pointer check the optimizer can hoist.
+    jit_hook: Option<Box<dyn crate::jit_hook::JitHook + 'a>>,
 }
 
 struct Frame {
@@ -884,11 +890,21 @@ impl<'a> Vm<'a> {
             arena_scope_starts: Vec::new(),
             arena_record_allocs: 0,
             arena_record_heap_fallbacks: 0,
+            jit_hook: None,
         }
     }
 
     pub fn set_tracer(&mut self, tracer: Box<dyn Tracer + 'a>) {
         self.tracer = tracer;
+    }
+
+    /// Install (or replace) the JIT hook consulted by `Op::Call`'s
+    /// dispatch arm. With `None`, dispatch behaves exactly as before
+    /// — the hook check is a single null-option branch the optimizer
+    /// can hoist. See the [`crate::jit_hook`] module for the
+    /// contract callers must uphold.
+    pub fn set_jit_hook(&mut self, hook: Option<Box<dyn crate::jit_hook::JitHook + 'a>>) {
+        self.jit_hook = hook;
     }
 
     /// Cap the number of opcode dispatches before the VM aborts with
@@ -1471,6 +1487,17 @@ impl<'a> Vm<'a> {
                         reason,
                     }),
                 }
+            }
+        }
+        // #465 JIT tier hook at the public entry — same contract as
+        // the `Op::Call` dispatch arm. Pure-fn memo is not consulted
+        // at this layer (memo is per-Op::Call); the hook fires
+        // unconditionally for refinement-clean calls.
+        if let Some(mut hook) = self.jit_hook.take() {
+            let hook_result = hook.try_call(fn_id, &args);
+            self.jit_hook = Some(hook);
+            if let Some(result) = hook_result? {
+                return Ok(result);
             }
         }
         let f = &self.program.functions[fn_id as usize];
@@ -2398,6 +2425,37 @@ impl<'a> Vm<'a> {
                         let st = &mut self.memo_fn_state[fid];
                         if st.calls >= MEMO_WARMUP_CALLS && st.hits == 0 {
                             st.enabled = false;
+                        }
+                    }
+                    // #465 JIT tier hook. Consulted after refinements +
+                    // memo. The hook contract (see `crate::jit_hook`)
+                    // requires the dispatcher to emit the synthetic
+                    // tracer events itself — we do that on hit, then
+                    // truncate the args off the stack and push the
+                    // result, mirroring the memo-hit path above.
+                    //
+                    // Take/restore around the call so the hook can
+                    // borrow `&self.stack` for its args slice while
+                    // we hold `&mut hook`. Cheaper than cloning the
+                    // args; the take/put is two pointer writes.
+                    if let Some(mut hook) = self.jit_hook.take() {
+                        let hook_result = hook.try_call(fn_id, &self.stack[args_base..]);
+                        self.jit_hook = Some(hook);
+                        match hook_result? {
+                            Some(result) => {
+                                self.tracer.enter_call(&node_id, &self.program.functions[fid].name, &self.stack[args_base..]);
+                                self.tracer.exit_ok(&result);
+                                // Memoize the result if memo is enabled
+                                // for this fn — same semantics as a
+                                // regular call's Return path.
+                                if let Some(key) = memo_key {
+                                    self.pure_memo.insert(key, result.clone());
+                                }
+                                self.stack.truncate(args_base);
+                                self.stack.push(result);
+                                continue;
+                            }
+                            None => { /* hook declined; fall through */ }
                         }
                     }
                     self.tracer.enter_call(&node_id, &self.program.functions[fid].name, &self.stack[args_base..]);

--- a/crates/lex-jit/benches/jit_vs_interp.rs
+++ b/crates/lex-jit/benches/jit_vs_interp.rs
@@ -241,5 +241,120 @@ fn bench_polynomial(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_sum_loop, bench_polynomial);
+/// Outer loop that calls an inner eligible function many times.
+/// This is the shape `Op::Call` interception was built for:
+///
+///   `outer(n)` is ineligible (contains a `MakeTuple`), so the
+///   *outer* call lands on the interpreter; but its tight loop
+///   calls `square(i)` via `Op::Call`, and `square` *is*
+///   eligible. The JIT tier intercepts each inner call.
+fn sum_of_squares_program() -> Program {
+    let outer = Function {
+        name: "outer".into(),
+        arity: 1,
+        locals_count: 3,
+        code: vec![
+            Op::PushConst(0),            // acc = 0
+            Op::StoreLocal(1),
+            Op::PushConst(0),            // i = 0
+            Op::StoreLocal(2),
+            Op::LoadLocal(2),            // loop:
+            Op::LoadLocal(0),
+            Op::IntLt,
+            Op::JumpIfNot(10),           // -> after-loop block at pc 18
+            Op::LoadLocal(1),
+            Op::LoadLocal(2),
+            Op::Call { fn_id: 1, arity: 1, node_id_idx: 2 },
+            Op::IntAdd,
+            Op::StoreLocal(1),
+            Op::LoadLocal(2),
+            Op::PushConst(1),
+            Op::IntAdd,
+            Op::StoreLocal(2),
+            Op::Jump(-14),               // -> pc 4
+            Op::PushConst(0),            // dummy tuple to keep `outer` ineligible
+            Op::PushConst(0),
+            Op::MakeTuple(2),
+            Op::Pop,
+            Op::LoadLocal(1),
+            Op::Return,
+        ],
+        effects: vec![],
+        body_hash: ZERO_BODY_HASH,
+        refinements: vec![],
+        field_ic_sites: 0,
+    };
+    let square = Function {
+        name: "square".into(),
+        arity: 1,
+        locals_count: 1,
+        code: vec![
+            Op::LoadLocal(0),
+            Op::LoadLocal(0),
+            Op::IntMul,
+            Op::Return,
+        ],
+        effects: vec![],
+        body_hash: ZERO_BODY_HASH,
+        refinements: vec![],
+        field_ic_sites: 0,
+    };
+    let mut function_names = IndexMap::new();
+    function_names.insert("outer".to_string(), 0);
+    function_names.insert("square".to_string(), 1);
+    Program {
+        constants: vec![
+            Const::Int(0),
+            Const::Int(1),
+            Const::NodeId("outer_calls_square".into()),
+        ],
+        functions: vec![outer, square],
+        function_names,
+        module_aliases: IndexMap::new(),
+        entry: Some(0),
+        record_shapes: vec![],
+    }
+}
+
+fn bench_sum_of_squares(c: &mut Criterion) {
+    let prog = sum_of_squares_program();
+    let mut group = c.benchmark_group("jit_vs_interp/sum_of_squares");
+
+    for &n in &[100i64, 1_000, 10_000] {
+        group.throughput(Throughput::Elements(n as u64));
+
+        // Interpreter: outer interpreted, every `square(i)` also
+        // interpreted via Op::Call frame setup.
+        group.bench_function(format!("interp/n={n}"), |b| {
+            let mut vm = Vm::new(&prog);
+            vm.set_step_limit(u64::MAX);
+            b.iter(|| {
+                black_box(
+                    vm.call("outer", vec![Value::Int(black_box(n))])
+                        .expect("interp call"),
+                )
+            });
+        });
+
+        // jit_vm: outer interpreted (it's ineligible), but each
+        // `square(i)` dispatches through the JIT via the hook.
+        // This is the Op::Call interception story.
+        group.bench_function(format!("jit_vm/n={n}"), |b| {
+            let mut jitvm = JitVm::new(&prog).expect("JitVm::new");
+            jitvm
+                .call("outer", vec![Value::Int(n)])
+                .expect("prime cache");
+            b.iter(|| {
+                black_box(
+                    jitvm
+                        .call("outer", vec![Value::Int(black_box(n))])
+                        .expect("jit_vm call"),
+                )
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_sum_loop, bench_polynomial, bench_sum_of_squares);
 criterion_main!(benches);

--- a/crates/lex-jit/src/lib.rs
+++ b/crates/lex-jit/src/lib.rs
@@ -91,6 +91,24 @@ pub fn is_jit_eligible(f: &Function, consts: &[Const]) -> bool {
     if f.arity > 6 {
         return false;
     }
+    // Refinements run at the call boundary; bypassing them via JIT
+    // would silently change observable behavior (a refinement
+    // failure would no longer raise `VmError::RefinementFailed`).
+    // The interpreter checks refinements *before* consulting the
+    // hook, so by-the-letter-of-the-contract a refinement-bearing
+    // function could be JITed safely — but we reject conservatively
+    // to keep the eligibility predicate independent of where the
+    // hook fires.
+    if f.refinements.iter().any(|r| r.is_some()) {
+        return false;
+    }
+    // Effects: the MVP op set excludes EffectCall, so any function
+    // with declared effects could only be eligible by accident
+    // (effects could still appear in tracer/handler interactions).
+    // Reject to keep the contract simple.
+    if !f.effects.is_empty() {
+        return false;
+    }
     for op in &f.code {
         if !op_supported(op, consts) {
             return false;
@@ -136,7 +154,7 @@ pub mod tier;
 #[cfg(feature = "cranelift")]
 pub use lower::{JitContext, JittedFn};
 #[cfg(feature = "cranelift")]
-pub use tier::{CacheStats, JitVm};
+pub use tier::{CacheStats, JitTier, JitVm};
 
 #[cfg(not(feature = "cranelift"))]
 mod stub {

--- a/crates/lex-jit/src/tier.rs
+++ b/crates/lex-jit/src/tier.rs
@@ -1,100 +1,87 @@
-//! Tier-up integration: a [`JitVm`] wrapper that intercepts
-//! [`Vm::call`] and routes eligible workloads through the JIT.
+//! Tier-up integration.
 //!
-//! ## What it does
+//! ## Architecture
 //!
-//! [`JitVm`] wraps an existing `Vm` plus an owned [`JitContext`]
-//! and a per-function `JitFnState` cache (keyed by `fn_id` within
-//! the wrapped `Program`). When `JitVm::call(name, args)` is
-//! invoked:
+//! Two layers:
 //!
-//! 1. Look up `fn_id` from the program. If unknown, surface
-//!    `VmError::UnknownFunction` (same shape as `Vm::call`).
-//! 2. Bump the per-fn call counter. If the function's
-//!    `JitFnState::compiled` is still `None` and the counter has
-//!    reached `threshold`, attempt compilation:
-//!    - If `is_jit_eligible` returns false → mark as `Ineligible`,
-//!      fall through to the interpreter from now on.
-//!    - If compilation fails for any reason → also mark as
-//!      `Ineligible` (defensive; the eligibility predicate should
-//!      have caught it, but Cranelift codegen has its own failure
-//!      modes).
-//!    - On success → cache the [`JittedFn`].
-//! 3. If the function is JITed *and* all args unbox cleanly to
-//!    `i64` (`Value::Int(_)` or `Value::Bool(_)`), invoke the
-//!    native code and wrap the result back into a `Value`.
-//! 4. Otherwise — eligible but args don't unbox, or never JITed —
-//!    forward to `Vm::call`.
+//! - [`JitTier`] — the [`JitHook`] implementation. Owns a
+//!   [`JitContext`] plus a per-function `CompileState` cache. Can
+//!   be installed on any [`Vm`] via [`Vm::set_jit_hook`]; once
+//!   installed, every `Op::Call` to an eligible function (and the
+//!   outer `Vm::call` entry too) dispatches through native code.
 //!
-//! ## What it does NOT do
+//! - [`JitVm`] — a convenience wrapper that constructs a `Vm` and
+//!   a `JitTier` together, installs the latter on the former, and
+//!   exposes a `call(name, args)` surface mirroring `Vm::call`.
+//!   Callers that just want JIT on a fresh program use this; users
+//!   with a pre-built `Vm` (custom effect handler, tracer, etc.)
+//!   build a `JitTier` directly and call `Vm::set_jit_hook`.
 //!
-//! - **`Op::Call` interception.** Internal calls between Lex
-//!   functions still flow through the interpreter even when the
-//!   callee has been JITed. The wrapper only fires on the
-//!   outermost `JitVm::call` entry. A real tier-up integration
-//!   needs to hook the dispatch loop's `Op::Call` arm, which
-//!   would require either restructuring the crate graph
-//!   (lex-bytecode would need to depend on lex-jit, which depends
-//!   on lex-bytecode — currently circular) or threading a runtime
-//!   callback through. Deferred.
-//! - **Tier-down / deopt.** Once a function is `Ineligible` it
-//!   stays that way for the life of the `JitVm`. Programs that
-//!   would benefit from re-evaluation (e.g. an eligible function
-//!   first called with a non-int arg, then later called with int
-//!   args) are not retroactively JITed — they just stay on the
-//!   interpreter path.
-//! - **Effect handler hand-off.** The wrapper uses whatever
-//!   handler the underlying `Vm` was constructed with for the
-//!   interp path. JITed code can't invoke effects (the op set is
-//!   the MVP arith subset), so this is a non-issue today.
+//! ## What this slice covers
+//!
+//! - `Op::Call` (in-program function calls).
+//! - `Vm::call` / `Vm::invoke` (the public entry).
+//!
+//! ## What it does NOT cover
+//!
+//! - **`Op::TailCall`** — frame-replacement semantics need careful
+//!   tracer + memo coordination; deferred to the next slice.
+//! - **`Op::CallClosure`** — needs `body_hash` keyed cache (closure
+//!   bodies don't have a `fn_id`); deferred.
+//! - **Tier-down / deopt** — once `Ineligible`, terminal for the
+//!   life of the tier.
+//!
+//! ## Cache state
+//!
+//! A function's `CompileState` transitions through:
+//!
+//! ```text
+//!   Pending { counter: 0 }
+//!         |
+//!         | call N: counter += 1
+//!         v
+//!   Pending { counter >= threshold }
+//!         |
+//!         | attempt_compile
+//!         |
+//!         +---> Compiled(JittedFn) — native dispatch from here on
+//!         |
+//!         +---> Ineligible          — interpreter forever
+//! ```
+//!
+//! The `Pending`/`Compiled`/`Ineligible` distinction lets us
+//! report cache health via [`JitTier::cache_stats`] for tests and
+//! benches without exposing the internal enum.
 
+use lex_bytecode::jit_hook::JitHook;
 use lex_bytecode::program::Program;
 use lex_bytecode::value::Value;
 use lex_bytecode::vm::{Vm, VmError};
 
 use crate::{is_jit_eligible, JitContext, JitError, JittedFn};
 
-/// JIT cache state for a single function in the wrapped program.
-///
-/// `counter` ticks each time `JitVm::call` lands on this fn. On
-/// reaching `threshold` we evaluate eligibility — that gate is
-/// only consulted *once* per function, after which `compiled`
-/// transitions to a terminal state (either a [`JittedFn`] or
-/// `Ineligible`).
+/// JIT cache state for a single function.
 enum CompileState {
-    /// Not yet evaluated. Holds the call counter so we can
-    /// implement a tier-up threshold without recomputing.
     Pending { counter: u32 },
-    /// Tried and rejected — either `is_jit_eligible` said no, or
-    /// codegen errored. Routes through the interpreter forever.
     Ineligible,
-    /// Compiled. The pointer lives in the parent `JitContext`'s
-    /// `JITModule`; safe to call as long as the `JitVm` is alive.
     Compiled(JittedFn),
 }
 
-/// JIT tier wrapping a [`Vm`]. Owns a [`JitContext`] and a
-/// per-function cache; intercepts [`JitVm::call`] to route
-/// eligible workloads through native code while forwarding
-/// everything else to the interpreter unchanged.
-pub struct JitVm<'a> {
-    vm: Vm<'a>,
+/// JIT-hook implementation. Installable on any [`Vm`] via
+/// [`Vm::set_jit_hook`]. Routes eligible calls through native code,
+/// declines (returns `Ok(None)`) for everything else so the
+/// interpreter handles them normally.
+pub struct JitTier<'a> {
     ctx: JitContext,
-    /// Cache indexed by `fn_id`. Length matches
-    /// `program.functions.len()` at construction.
     cache: Vec<CompileState>,
-    /// Number of `JitVm::call` invocations a function must accrue
-    /// before we attempt compilation. Default `1` — eager — so
-    /// the first eligible call already runs native.
     threshold: u32,
     program: &'a Program,
 }
 
-impl<'a> JitVm<'a> {
-    /// Build a tier over `program` using the standard
-    /// `Vm::new(program)` interpreter (no custom effect handler).
-    /// Threshold defaults to `1` (eager). Use
-    /// [`JitVm::with_threshold`] to defer compilation.
+impl<'a> JitTier<'a> {
+    /// Build a tier over `program` with the default threshold (1 —
+    /// eager: compile on first call). Use [`JitTier::with_threshold`]
+    /// to defer.
     pub fn new(program: &'a Program) -> Result<Self, JitError> {
         Self::with_threshold(program, 1)
     }
@@ -104,7 +91,6 @@ impl<'a> JitVm<'a> {
             .map(|_| CompileState::Pending { counter: 0 })
             .collect();
         Ok(Self {
-            vm: Vm::new(program),
             ctx: JitContext::new()?,
             cache,
             threshold: threshold.max(1),
@@ -112,44 +98,17 @@ impl<'a> JitVm<'a> {
         })
     }
 
-    /// Borrow the underlying interpreter — exposed so callers can
-    /// drive `Vm::set_step_limit` and similar one-shot config.
-    pub fn vm_mut(&mut self) -> &mut Vm<'a> {
-        &mut self.vm
-    }
-
-    /// Same shape as [`Vm::call`]. Routes through the JIT when
-    /// possible (see module docs), otherwise to the interpreter.
-    pub fn call(&mut self, name: &str, args: Vec<Value>) -> Result<Value, VmError> {
-        let fn_id = self
-            .program
-            .lookup(name)
-            .ok_or_else(|| VmError::UnknownFunction(name.to_string()))?
-            as usize;
-
-        // Step 1 — bump counter, maybe transition Pending → Compiled / Ineligible.
-        if let CompileState::Pending { counter } = &mut self.cache[fn_id] {
-            *counter += 1;
-            if *counter >= self.threshold {
-                self.cache[fn_id] = self.attempt_compile(fn_id);
+    /// How many functions are in each cache state right now.
+    pub fn cache_stats(&self) -> CacheStats {
+        let mut s = CacheStats::default();
+        for st in &self.cache {
+            match st {
+                CompileState::Pending { .. } => s.pending += 1,
+                CompileState::Ineligible => s.ineligible += 1,
+                CompileState::Compiled(_) => s.compiled += 1,
             }
         }
-
-        // Step 2 — dispatch.
-        match &self.cache[fn_id] {
-            CompileState::Compiled(jitted) => {
-                if let Some(unboxed) = unbox_args(&args, jitted.arity()) {
-                    let r = unsafe { jitted.call(&unboxed) };
-                    return Ok(Value::Int(r));
-                }
-                // Eligible but the arg shape doesn't fit (e.g. a
-                // record was passed where Int was expected, which
-                // shouldn't normally happen for an eligible
-                // function — but be defensive).
-                self.vm.call(name, args)
-            }
-            CompileState::Ineligible | CompileState::Pending { .. } => self.vm.call(name, args),
-        }
+        s
     }
 
     fn attempt_compile(&mut self, fn_id: usize) -> CompileState {
@@ -162,19 +121,34 @@ impl<'a> JitVm<'a> {
             Err(_) => CompileState::Ineligible,
         }
     }
+}
 
-    /// Diagnostic: how many functions in the cache are in each
-    /// state right now. Useful for tests and benches.
-    pub fn cache_stats(&self) -> CacheStats {
-        let mut s = CacheStats::default();
-        for st in &self.cache {
-            match st {
-                CompileState::Pending { .. } => s.pending += 1,
-                CompileState::Ineligible => s.ineligible += 1,
-                CompileState::Compiled(_) => s.compiled += 1,
+impl<'a> JitHook for JitTier<'a> {
+    fn try_call(&mut self, fn_id: u32, args: &[Value]) -> Result<Option<Value>, VmError> {
+        let fid = fn_id as usize;
+        if fid >= self.cache.len() {
+            return Ok(None);
+        }
+        // Bump counter / maybe transition Pending → Compiled/Ineligible.
+        if let CompileState::Pending { counter } = &mut self.cache[fid] {
+            *counter += 1;
+            if *counter >= self.threshold {
+                self.cache[fid] = self.attempt_compile(fid);
             }
         }
-        s
+        match &self.cache[fid] {
+            CompileState::Compiled(jitted) => {
+                if let Some(unboxed) = unbox_args(args, jitted.arity()) {
+                    let r = unsafe { jitted.call(&unboxed) };
+                    Ok(Some(Value::Int(r)))
+                } else {
+                    // Eligible but arg shape doesn't fit at the call
+                    // site — decline so the interpreter handles it.
+                    Ok(None)
+                }
+            }
+            CompileState::Ineligible | CompileState::Pending { .. } => Ok(None),
+        }
     }
 }
 
@@ -185,9 +159,6 @@ pub struct CacheStats {
     pub compiled: usize,
 }
 
-/// Try to unbox a `Vec<Value>` to a fixed-size `[i64]` matching
-/// the JIT calling convention. Returns `None` if any arg isn't
-/// `Int` / `Bool` or the count mismatches.
 fn unbox_args(args: &[Value], expected_arity: u16) -> Option<Vec<i64>> {
     if args.len() != expected_arity as usize {
         return None;
@@ -203,3 +174,43 @@ fn unbox_args(args: &[Value], expected_arity: u16) -> Option<Vec<i64>> {
     Some(out)
 }
 
+// ---------------------------------------------------------------------------
+// JitVm — convenience wrapper that pairs a fresh `Vm` with a `JitTier`.
+// ---------------------------------------------------------------------------
+
+/// Convenience: a `Vm` with a `JitTier` already installed. Users
+/// who need a custom effect handler / tracer should build the
+/// `Vm` themselves and call `Vm::set_jit_hook(Some(Box::new(
+/// JitTier::new(program)?)))` directly.
+///
+/// The tier lives inside the `Vm`'s `jit_hook` slot, so cache
+/// stats and other tier methods aren't directly reachable through
+/// `JitVm`. If you need them, build the `Vm` + `JitTier` yourself
+/// and keep a shared handle.
+pub struct JitVm<'a> {
+    vm: Vm<'a>,
+}
+
+impl<'a> JitVm<'a> {
+    pub fn new(program: &'a Program) -> Result<Self, JitError> {
+        Self::with_threshold(program, 1)
+    }
+
+    pub fn with_threshold(program: &'a Program, threshold: u32) -> Result<Self, JitError> {
+        let tier = JitTier::with_threshold(program, threshold)?;
+        let mut vm = Vm::new(program);
+        vm.set_jit_hook(Some(Box::new(tier)));
+        Ok(Self { vm })
+    }
+
+    pub fn vm_mut(&mut self) -> &mut Vm<'a> {
+        &mut self.vm
+    }
+
+    /// Same shape as [`Vm::call`]. The JIT tier is installed as a
+    /// hook on the underlying VM, so eligible top-level calls *and*
+    /// internal `Op::Call`s are routed through native code.
+    pub fn call(&mut self, name: &str, args: Vec<Value>) -> Result<Value, VmError> {
+        self.vm.call(name, args)
+    }
+}

--- a/crates/lex-jit/tests/jitvm_vs_vm.rs
+++ b/crates/lex-jit/tests/jitvm_vs_vm.rs
@@ -15,7 +15,7 @@ use lex_bytecode::op::{Const, Op};
 use lex_bytecode::program::{Function, Program, ZERO_BODY_HASH};
 use lex_bytecode::value::Value;
 use lex_bytecode::vm::Vm;
-use lex_jit::JitVm;
+use lex_jit::{JitTier, JitVm};
 
 fn mk_fn(name: &str, arity: u16, locals: u16, code: Vec<Op>) -> Function {
     Function {
@@ -88,16 +88,18 @@ fn eligible_function_routes_through_jit() {
         )],
         vec![],
     );
+    // Build tier separately so we can inspect cache_stats after
+    // installation (the tier moves into the Vm, but we re-build
+    // a sibling tier with identical state to read its stats — see
+    // the threshold test for the same pattern).
     let mut jitvm = JitVm::new(&prog).expect("JitVm::new");
-    assert_eq!(jitvm.cache_stats().pending, 1);
     assert_eq!(
         jitvm.call("add", vec![Value::Int(3), Value::Int(4)]).unwrap(),
         Value::Int(7)
     );
-    // After one call at threshold=1, the fn should be JITed.
-    assert_eq!(jitvm.cache_stats().compiled, 1);
-    assert_eq!(jitvm.cache_stats().pending, 0);
-    assert_eq!(jitvm.cache_stats().ineligible, 0);
+    // Routed through JIT — result matches. Cache-state assertions
+    // moved to `tier_threshold_state_machine` (uses the tier
+    // directly so it can read `cache_stats`).
 }
 
 // ---------------------------------------------------------------------------
@@ -105,7 +107,10 @@ fn eligible_function_routes_through_jit() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn threshold_defers_compile() {
+fn tier_threshold_state_machine() {
+    // Drive the `JitTier` directly so we can inspect `cache_stats`
+    // — `JitVm` installs the tier into the underlying `Vm` and
+    // doesn't expose it back through `as_ref` / downcast.
     let prog = mk_program(
         vec![mk_fn(
             "add",
@@ -115,20 +120,24 @@ fn threshold_defers_compile() {
         )],
         vec![],
     );
-    let mut jitvm = JitVm::with_threshold(&prog, 3).expect("JitVm::with_threshold");
+    use lex_bytecode::jit_hook::JitHook;
+    let mut tier = JitTier::with_threshold(&prog, 3).expect("JitTier::with_threshold");
+    assert_eq!(tier.cache_stats().pending, 1);
 
-    // Two warm-up calls should not trigger compile.
+    // Two warm-up calls below threshold — still Pending.
+    let args = vec![Value::Int(1), Value::Int(2)];
     for _ in 0..2 {
-        let r = jitvm.call("add", vec![Value::Int(1), Value::Int(2)]).unwrap();
-        assert_eq!(r, Value::Int(3));
+        assert_eq!(tier.try_call(0, &args).unwrap(), None);
     }
-    assert_eq!(jitvm.cache_stats().pending, 1);
-    assert_eq!(jitvm.cache_stats().compiled, 0);
+    assert_eq!(tier.cache_stats().pending, 1);
+    assert_eq!(tier.cache_stats().compiled, 0);
 
-    // Third call — threshold reached, compile fires.
-    let r = jitvm.call("add", vec![Value::Int(10), Value::Int(20)]).unwrap();
-    assert_eq!(r, Value::Int(30));
-    assert_eq!(jitvm.cache_stats().compiled, 1);
+    // Third call — threshold reached. The eligible function
+    // compiles, and try_call returns Some(7) — the JIT result.
+    let r = tier.try_call(0, &args).unwrap();
+    assert_eq!(r, Some(Value::Int(3)));
+    assert_eq!(tier.cache_stats().compiled, 1);
+    assert_eq!(tier.cache_stats().pending, 0);
 }
 
 // ---------------------------------------------------------------------------
@@ -163,7 +172,14 @@ fn ineligible_function_falls_through_to_interp() {
         }
         other => panic!("expected Tuple, got {other:?}"),
     }
-    assert_eq!(jitvm.cache_stats().ineligible, 1);
+    // Cache-state assertion: build a sibling tier and probe it,
+    // since the one inside JitVm isn't reachable through the
+    // wrapper. The eligibility predicate is pure, so a tier
+    // built from the same program reaches the same conclusion.
+    let mut tier = JitTier::new(&prog).expect("JitTier::new");
+    use lex_bytecode::jit_hook::JitHook;
+    let _ = tier.try_call(0, &[Value::Int(5), Value::Int(7)]);
+    assert_eq!(tier.cache_stats().ineligible, 1);
 }
 
 // ---------------------------------------------------------------------------
@@ -222,15 +238,169 @@ fn unknown_function_errors_cleanly() {
     );
     let mut jitvm = JitVm::new(&prog).expect("JitVm::new");
     let r = jitvm.call("nonexistent", vec![]);
+    // JitVm forwards to Vm::call, which surfaces unknown names
+    // as `VmError::Panic("no function ...")`. The shape matches
+    // `Vm::call` exactly — that's the property we care about.
     assert!(
-        matches!(r, Err(lex_bytecode::vm::VmError::UnknownFunction(_))),
-        "expected UnknownFunction, got {r:?}"
+        matches!(&r, Err(lex_bytecode::vm::VmError::Panic(msg)) if msg.contains("nonexistent")),
+        "expected Panic mentioning the missing fn, got {r:?}"
     );
 }
 
 // ---------------------------------------------------------------------------
 // 6. Same loop as the bench — proves the heavier shape also matches.
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// 7. Op::Call interception — an ineligible outer function calling an
+//    eligible inner one must still benefit from the JIT for the inner.
+//    This is the test that proves the new hook path actually fires
+//    inside the dispatch loop (not just at the outermost Vm::call).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn op_call_intercepts_inner_eligible() {
+    // outer(n) = sum_{i=0..n} square(i)
+    //   — outer uses MakeTuple at some point so it's ineligible
+    //   — square is `x => x*x`, eligible
+    //
+    // Hand-rolled bytecode:
+    //   outer (fn_id=0, arity=1, locals: n=0, acc=1, i=2):
+    //     0: PushConst(0) {=0}     -- 0
+    //     1: StoreLocal(1)         -- acc = 0
+    //     2: PushConst(0) {=0}
+    //     3: StoreLocal(2)         -- i = 0
+    //     4: LoadLocal(2)          -- loop: i
+    //     5: LoadLocal(0)          -- n
+    //     6: IntLt                 -- i<n
+    //     7: JumpIfNot(+9)         -- target = 8+9 = 17 (after loop)
+    //     8: LoadLocal(1)          -- acc
+    //     9: LoadLocal(2)          -- i
+    //    10: Call { square, arity=1 }   -- square(i)
+    //    11: IntAdd                -- acc += square(i)
+    //    12: StoreLocal(1)         -- acc =
+    //    13: LoadLocal(2)
+    //    14: PushConst(1) {=1}
+    //    15: IntAdd
+    //    16: StoreLocal(2)         -- i += 1
+    //    17: Jump(-14)             -- target = 18-14 = 4
+    //    18: PushConst(2) {=0}     -- dummy tuple to keep outer ineligible
+    //    19: PushConst(2)
+    //    20: MakeTuple(2)
+    //    21: Pop                   -- discard the tuple; doesn't affect result
+    //    22: LoadLocal(1)          -- return acc
+    //    23: Return
+    //
+    // Offsets recomputed:
+    //   JumpIfNot at pc 7, target after-loop. After-loop should be the
+    //   MakeTuple block at pc 18. off = (target=18) - (7+1=8) = +10.
+    //   Jump at pc 17 → loop top pc 4. off = (4) - (17+1=18) = -14.
+
+    let outer = mk_fn(
+        "outer",
+        1,
+        3,
+        vec![
+            Op::PushConst(0),          // 0  acc = 0
+            Op::StoreLocal(1),
+            Op::PushConst(0),          // 2  i = 0
+            Op::StoreLocal(2),
+            Op::LoadLocal(2),          // 4  loop: i
+            Op::LoadLocal(0),
+            Op::IntLt,
+            Op::JumpIfNot(10),         // 7  -> 8+10=18
+            Op::LoadLocal(1),          // 8
+            Op::LoadLocal(2),
+            Op::Call { fn_id: 1, arity: 1, node_id_idx: 0 },
+            Op::IntAdd,
+            Op::StoreLocal(1),         // 12
+            Op::LoadLocal(2),
+            Op::PushConst(1),          // 14  push 1
+            Op::IntAdd,
+            Op::StoreLocal(2),         // 16
+            Op::Jump(-14),             // 17  -> 18-14=4
+            Op::PushConst(0),          // 18  dummy
+            Op::PushConst(0),
+            Op::MakeTuple(2),
+            Op::Pop,
+            Op::LoadLocal(1),
+            Op::Return,
+        ],
+    );
+
+    let square = mk_fn(
+        "square",
+        1,
+        1,
+        vec![
+            Op::LoadLocal(0),
+            Op::LoadLocal(0),
+            Op::IntMul,
+            Op::Return,
+        ],
+    );
+
+    let prog = mk_program(vec![outer, square], vec![
+        Const::Int(0),
+        Const::Int(1),
+        Const::NodeId("outer_calls_square".into()),
+    ]);
+
+    // First: confirm interp and JIT agree.
+    assert_jitvm_matches_vm(
+        &prog,
+        &[
+            ("outer", vec![Value::Int(0)]),
+            ("outer", vec![Value::Int(1)]),
+            ("outer", vec![Value::Int(5)]),
+            ("outer", vec![Value::Int(10)]),
+        ],
+    );
+
+    // Second: a parallel JitTier shows that after running outer
+    // (which triggers many internal Op::Calls into square), the
+    // square fn ends up Compiled — proving the Op::Call hook is
+    // what triggered the compile, not the outer Vm::call.
+    let mut tier = JitTier::new(&prog).expect("JitTier");
+    {
+        let mut vm = Vm::new(&prog);
+        vm.set_jit_hook(Some(Box::new(JitTierShared::new(&mut tier as *mut _))));
+        let r = vm.call("outer", vec![Value::Int(5)]).unwrap();
+        assert_eq!(r, Value::Int(30)); // 0+1+4+9+16
+    }
+    // vm drops here, releasing the shim before `tier` goes out of scope.
+    let stats = tier.cache_stats();
+    assert_eq!(stats.compiled, 1, "square should be Compiled via Op::Call");
+    assert_eq!(stats.ineligible, 1, "outer should be Ineligible (MakeTuple)");
+}
+
+// Tiny shim that lets a parallel `JitTier` get into the `Vm`'s
+// hook slot via a raw pointer. ONLY used in the test above to
+// inspect cache state after the run — the tier outlives the Vm,
+// and the Vm releases the hook box (with the shim inside) on drop.
+struct JitTierShared {
+    inner: *mut lex_jit::JitTier<'static>,
+}
+impl JitTierShared {
+    fn new<'a>(p: *mut lex_jit::JitTier<'a>) -> Self {
+        // SAFETY: the test transmutes the lifetime back to 'static
+        // for the shim, then drops the Vm before the tier moves
+        // out of scope. Acceptable for a test-local hack; not
+        // exposed as a public API.
+        Self { inner: p.cast::<lex_jit::JitTier<'static>>() }
+    }
+}
+unsafe impl Send for JitTierShared {}
+impl lex_bytecode::jit_hook::JitHook for JitTierShared {
+    fn try_call(
+        &mut self,
+        fn_id: u32,
+        args: &[Value],
+    ) -> Result<Option<Value>, lex_bytecode::vm::VmError> {
+        // SAFETY: see JitTierShared::new.
+        unsafe { (*self.inner).try_call(fn_id, args) }
+    }
+}
 
 #[test]
 fn sum_loop_matches_via_jitvm() {

--- a/docs/design/jit-roadmap.md
+++ b/docs/design/jit-roadmap.md
@@ -585,3 +585,117 @@ Three things are now true that weren't before this slice:
    integration at `Op::Call` (where the dispatch already exists and
    args don't need to be re-built into a Vec) would close most of
    the remaining gap. That's the next slice.
+
+---
+
+## Status update — `Op::Call` interception lands (2026-06-02)
+
+The previous tier integration (#599 / 2026-06-01) only fired on the
+outermost `Vm::call`. Internal `Op::Call`s between Lex functions
+still flowed through the interpreter even when the callee was
+eligible. This slice closes that gap.
+
+### Architecture
+
+The "crate-graph circularity" called out in the prior status update
+is sidestepped via trait inversion:
+
+- `lex-bytecode` defines `trait JitHook` (new module `jit_hook.rs`),
+  plus `Vm::set_jit_hook(Option<Box<dyn JitHook + 'a>>)` and a
+  field on `Vm` that holds it.
+- The dispatch loop calls `self.jit_hook.as_mut().and_then(|h|
+  h.try_call(...))` at two seams: `Op::Call` (right after the memo
+  miss path) and `Vm::invoke` (right after refinement check).
+  Hook returns `Ok(Some(v))` → dispatcher emits synthetic
+  `tracer.enter_call` + `exit_ok`, truncates args, pushes the
+  result, continues. Hook returns `Ok(None)` → normal frame setup.
+- `lex-jit::JitTier` impls `JitHook`. Owns the `JitContext` +
+  per-fn `CompileState` cache.
+- `lex-jit::JitVm` is a convenience wrapper that constructs a
+  `Vm` and `JitTier` together and installs the latter on the
+  former.
+
+`lex-bytecode` has no compile-time dep on `lex-jit`. The hook
+field is `None` in default builds; the dispatch-loop check is a
+single null-Option branch the optimizer can hoist.
+
+### Eligibility tightening
+
+`is_jit_eligible` now also rejects functions with **any** non-`None`
+refinement or declared effect. The interpreter checks refinements
+*before* the hook fires, so JITing a refinement-bearing function
+would be correct in principle — but the predicate stays
+conservative to keep the contract independent of dispatcher
+ordering.
+
+### Verification — new test
+
+`tests/jitvm_vs_vm.rs::op_call_intercepts_inner_eligible`:
+
+```text
+outer(n):                    -- ineligible (MakeTuple)
+  acc = 0; i = 0
+  while i < n:
+    acc += square(i)         -- Op::Call → hook fires
+    i += 1
+  return acc
+
+square(x): x * x             -- eligible
+```
+
+After running, the parallel tier's `cache_stats()` reports:
+- `square`: **Compiled** — proves the Op::Call hook triggered the
+  compile (not the outermost `JitVm::call`, which only sees
+  `outer`)
+- `outer`: **Ineligible** — confirms the MakeTuple correctly
+  blocked it
+
+### Numbers (release build, opt_level=none)
+
+Three workloads, all run via `JitVm::call`:
+
+| Workload                                  | Interp        | `jit_vm`      | Speedup |
+|-------------------------------------------|---------------|---------------|---------|
+| `sum_loop / n=100_000`                    | 11.117 ms     | 62.27 µs      | **179×** |
+| `polynomial(7, 11, 13)`                   | 302.81 ns     | 51.61 ns      | **5.9×** |
+| `sum_of_squares / n=100` (Op::Call)       | 20.58 µs      | 17.11 µs      | **1.20×** |
+| `sum_of_squares / n=1_000` (Op::Call)     | 204.22 µs     | 176.79 µs     | **1.16×** |
+| `sum_of_squares / n=10_000` (Op::Call)    | 2.041 ms      | 1.697 ms      | **1.20×** |
+
+The `polynomial` row also went from 68.50 ns → 51.61 ns (25%
+faster) compared to PR #599 — the `Vm::invoke` hook bypasses
+some frame setup the wrapper-only path still went through.
+
+### What this slice does and does NOT prove
+
+**Proves:**
+1. The trait-inversion design works — no crate-graph restructure
+   needed, dispatch-loop overhead is one branch when off.
+2. `Op::Call` interception is wired up and demonstrably routes
+   `square(i)` through native code on every iteration of an
+   interpreter loop.
+
+**Doesn't prove:**
+1. **Large speedups on real Lex code.** `sum_of_squares` shows the
+   honest range: when the JITed callee is trivial relative to the
+   surrounding interpreter loop, the hook saves ~30-40 ns per call
+   (out of ~200 ns total per-iter cost), netting ~1.2×. The big
+   wins come when the inner work is heavier OR the outer is also
+   JITed (closing more of the dispatch loop).
+2. **`Op::TailCall` / `Op::CallClosure`.** Tail calls need
+   frame-replacement coordination with the tracer; closures need
+   `body_hash` keyed caching (no `fn_id`). Both deferred.
+
+### Where this leaves the JIT story
+
+Phase-1 baseline JIT acceptance per `#465`: "all prereqs done +
+arch decisions resolved + scope re-evaluated + re-file with
+deliverables." The three slices shipped this session
+(`#597`/`#598`/`#599` + this one) cover everything except
+`Op::TailCall`, which is the standard Lex idiom for arithmetic
+loops. Without it, hand-rolled iterative arith (like
+`sum_loop`) hits 179×, but tail-recursive sums hit interpreter
+speed. That's the next slice if we keep going.
+
+Phase 2 (records / closures) still needs the value-rep decision,
+unchanged from prior status updates.


### PR DESCRIPTION
## Summary

Closes the gap from #599: previously the JIT only fired on the outermost `Vm::call`. Internal `Op::Call`s between Lex functions still ran through the interpreter even when the callee was eligible. This slice intercepts both `Op::Call` and `Vm::invoke` via a new `JitHook` trait owned by `lex-bytecode` — the crate-graph circularity flagged in the prior status update is sidestepped by trait inversion, no restructure needed.

## Architecture

- **`lex-bytecode/src/jit_hook.rs`** — `trait JitHook { try_call(fn_id, args) -> Result<Option<Value>, VmError> }`. `Vm` gains an optional `Box<dyn JitHook + 'a>` field plus `set_jit_hook(...)`.
- **Dispatch loop hooks** at two seams:
  - `Op::Call` arm, right after the memo-miss path
  - `Vm::invoke` public entry, right after refinement check
  
  On `Ok(Some(v))`: dispatcher emits synthetic tracer enter/exit, truncates args, pushes result, continues. On `Ok(None)`: normal frame setup. Default builds with no hook pay one branch on a null Option per `Op::Call`.

- **`lex-jit/src/tier.rs`** refactored. Extracted `JitTier<'a>` (impls `JitHook`) holds the `JitContext` + per-fn `CompileState` cache. `JitVm` is now a thin convenience wrapper that constructs `Vm` + `JitTier` and installs the latter via `set_jit_hook`. Both top-level and internal `Op::Call`s now dispatch through native code.

- **`is_jit_eligible` tightened** — rejects functions with any non-None refinement or declared effect, since the hook fires alongside those checks and JITing them would change observable behavior.

## What this proves

New test `op_call_intercepts_inner_eligible`:

```text
outer(n):                    -- ineligible (MakeTuple at bottom)
  acc = 0; i = 0
  while i < n:
    acc += square(i)         -- Op::Call → hook fires
    i += 1
  return acc

square(x): x * x             -- eligible
```

After running through `JitVm`, a parallel `JitTier`'s `cache_stats()` reports `square: Compiled, outer: Ineligible` — proving the **Op::Call hook** triggered the compile, not the outermost call path which only sees `outer`.

## Numbers (release build, `opt_level=none`)

| Workload                                  | Interp        | `jit_vm`      | Speedup |
|-------------------------------------------|---------------|---------------|---------|
| `sum_loop / n=100_000`                    | 11.117 ms     | 62.27 µs      | **179×** |
| `polynomial(7, 11, 13)`                   | 302.81 ns     | 51.61 ns      | **5.9×** |
| `sum_of_squares / n=100`                  | 20.58 µs      | 17.11 µs      | **1.20×** |
| `sum_of_squares / n=1_000`                | 204.22 µs     | 176.79 µs     | **1.16×** |
| `sum_of_squares / n=10_000`               | 2.041 ms      | 1.697 ms      | **1.20×** |

`polynomial` is **25% faster than #599** (was 68.5 ns) — the `Vm::invoke` hook bypasses frame setup the wrapper-only path still went through.

`sum_of_squares` is the new Op::Call workload: outer interpreted, every `square(i)` dispatches through JIT. **1.20× is the honest ratio when the JIT'd callee is trivial relative to the outer loop**; bigger wins need heavier inner work or `Op::TailCall` (deferred — frame-replacement coordination with tracer/memo is delicate).

## What this slice does NOT do

- **`Op::TailCall`** — most Lex hot loops are tail-recursive, so this is the largest remaining lever. Frame replacement + tracer hand-off make it non-trivial; deferred.
- **`Op::CallClosure`** — needs `body_hash`-keyed caching (no `fn_id`); deferred.
- **Tier-down / deopt** — once `Ineligible`, terminal for the life of the tier.

## Test plan

- [x] `cargo test -p lex-jit --features cranelift` — **13 + 7 = 20 passing** (the new `op_call_intercepts_inner_eligible` is the 7th tier test)
- [x] `cargo test -p lex-bytecode` — all 16 test files pass; the trait + hook field didn't regress anything
- [x] `cargo bench -p lex-jit --features cranelift --bench jit_vs_interp -- --quick` reproduces the table above
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo clippy -p lex-jit --features cranelift --all-targets -- -D warnings` clean

Full results in `docs/design/jit-roadmap.md` (new status section).

## Note on force-push

Same situation as PRs #597 / #598 / #599: the previously-merged PR's commits sat on the remote branch with their old hashes (they're now in main via squash). I force-pushed-with-lease to overwrite — nothing destructive since the overwritten commits are preserved in main. If you'd prefer I always ask first or move to fresh branches per PR, just say.

https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk)_