### PR TITLE
feat(pkg): registry publish/resolve + versioned package storage

### DIFF
--- a/crates/lex-api/src/handlers.rs
+++ b/crates/lex-api/src/handlers.rs
@@ -397,6 +397,29 @@ fn route(
             let name = &p["/v1/pkg/".len()..p.len() - "/head".len()];
             pkg_head_handler(state, name)
         }
+        (Method::Get, p) if p.starts_with("/v1/pkg/") && p.ends_with("/versions") => {
+            let name = &p["/v1/pkg/".len()..p.len() - "/versions".len()];
+            pkg_versions_handler(state, name)
+        }
+        // /v1/pkg/{name}/{version}/archive — must match before the generic /{name}/{version}
+        (Method::Get, p) if p.starts_with("/v1/pkg/") && p.ends_with("/archive") => {
+            let inner = &p["/v1/pkg/".len()..p.len() - "/archive".len()];
+            // inner = "{name}/{version}"
+            if let Some((name, version)) = inner.split_once('/') {
+                pkg_archive_handler(state, name, version)
+            } else {
+                error_response(400, "expected /v1/pkg/{name}/{version}/archive")
+            }
+        }
+        // /v1/pkg/{name}/{version}
+        (Method::Get, p) if p.starts_with("/v1/pkg/") && p["/v1/pkg/".len()..].contains('/') => {
+            let inner = &p["/v1/pkg/".len()..];
+            if let Some((name, version)) = inner.split_once('/') {
+                pkg_get_version_handler(state, name, version)
+            } else {
+                error_response(400, "expected /v1/pkg/{name}/{version}")
+            }
+        }
         (Method::Get, p) if p.starts_with("/v1/pkg/") => {
             let name = &p["/v1/pkg/".len()..];
             pkg_get_handler(state, name)
@@ -1493,55 +1516,111 @@ pub(crate) fn attestations_since_handler(state: &State, query: &str)
 
 // ── Package concept (#4) ────────────────────────────────────────────────────
 
-/// Persistent record for a published package stored in
-/// `{store_root}/packages/{name}.json`.
+/// Per-version record stored at `{store_root}/packages/{name}/{version}.json`.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 struct PkgRecord {
     name: String,
     version: String,
     head_op: Option<String>,
     published_at: u64,
-    /// Function names introduced or updated by this package (for retract).
+    /// Function names introduced or updated by this version (for retract).
     function_names: Vec<String>,
-    /// Raw op JSON from each file publish (for inspection via GET /v1/pkg/{name}).
+    /// Raw op JSON from each file in this publish.
     ops: Vec<serde_json::Value>,
 }
 
-fn pkg_index_dir(root: &std::path::Path) -> PathBuf {
-    root.join("packages")
+/// Index stored at `{store_root}/packages/{name}/index.json`.
+///
+/// Tracks which versions have been published and which is "latest", so
+/// consumers can resolve `{name}@latest` without listing every file.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
+struct PkgIndex {
+    /// The most recently published version string (human label, not OpId).
+    latest: Option<String>,
+    /// All published versions, newest-last.
+    versions: Vec<PkgVersionSummary>,
 }
 
-fn pkg_record_path(root: &std::path::Path, name: &str) -> PathBuf {
-    pkg_index_dir(root).join(format!("{}.json", name))
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct PkgVersionSummary {
+    version: String,
+    head_op: Option<String>,
+    published_at: u64,
 }
 
-fn load_pkg_record(root: &std::path::Path, name: &str) -> Option<PkgRecord> {
-    let bytes = std::fs::read(pkg_record_path(root, name)).ok()?;
+fn pkg_name_dir(root: &std::path::Path, name: &str) -> PathBuf {
+    root.join("packages").join(name)
+}
+
+fn pkg_index_path(root: &std::path::Path, name: &str) -> PathBuf {
+    pkg_name_dir(root, name).join("index.json")
+}
+
+fn pkg_version_path(root: &std::path::Path, name: &str, version: &str) -> PathBuf {
+    pkg_name_dir(root, name).join(format!("{version}.json"))
+}
+
+fn pkg_archive_path(root: &std::path::Path, name: &str, version: &str) -> PathBuf {
+    pkg_name_dir(root, name).join(format!("{version}.tar.gz"))
+}
+
+fn load_pkg_index(root: &std::path::Path, name: &str) -> Option<PkgIndex> {
+    let bytes = std::fs::read(pkg_index_path(root, name)).ok()?;
     serde_json::from_slice(&bytes).ok()
 }
 
-fn save_pkg_record(root: &std::path::Path, record: &PkgRecord) -> std::io::Result<()> {
-    let dir = pkg_index_dir(root);
-    std::fs::create_dir_all(&dir)?;
-    let bytes = serde_json::to_vec_pretty(record).unwrap_or_default();
-    std::fs::write(pkg_record_path(root, &record.name), bytes)
+fn load_pkg_record(root: &std::path::Path, name: &str, version: &str) -> Option<PkgRecord> {
+    let bytes = std::fs::read(pkg_version_path(root, name, version)).ok()?;
+    serde_json::from_slice(&bytes).ok()
 }
 
-fn list_pkg_records(root: &std::path::Path) -> Vec<PkgRecord> {
-    let dir = pkg_index_dir(root);
+fn load_latest_pkg_record(root: &std::path::Path, name: &str) -> Option<PkgRecord> {
+    let index = load_pkg_index(root, name)?;
+    let latest = index.latest?;
+    load_pkg_record(root, name, &latest)
+}
+
+fn save_pkg_record(
+    root: &std::path::Path,
+    record: &PkgRecord,
+    archive: &[u8],
+) -> std::io::Result<()> {
+    let dir = pkg_name_dir(root, &record.name);
+    std::fs::create_dir_all(&dir)?;
+
+    // Per-version record.
+    let rec_bytes = serde_json::to_vec_pretty(record).unwrap_or_default();
+    std::fs::write(pkg_version_path(root, &record.name, &record.version), rec_bytes)?;
+
+    // Archive (tar.gz) for the download endpoint.
+    std::fs::write(pkg_archive_path(root, &record.name, &record.version), archive)?;
+
+    // Update the index.
+    let mut index = load_pkg_index(root, &record.name).unwrap_or_default();
+    index.latest = Some(record.version.clone());
+    if !index.versions.iter().any(|v| v.version == record.version) {
+        index.versions.push(PkgVersionSummary {
+            version: record.version.clone(),
+            head_op: record.head_op.clone(),
+            published_at: record.published_at,
+        });
+    }
+    let idx_bytes = serde_json::to_vec_pretty(&index).unwrap_or_default();
+    std::fs::write(pkg_index_path(root, &record.name), idx_bytes)
+}
+
+fn list_pkg_names(root: &std::path::Path) -> Vec<String> {
+    let dir = root.join("packages");
     let Ok(entries) = std::fs::read_dir(&dir) else {
         return Vec::new();
     };
-    let mut records: Vec<PkgRecord> = entries
+    let mut names: Vec<String> = entries
         .filter_map(|e| e.ok())
-        .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("json"))
-        .filter_map(|e| {
-            let bytes = std::fs::read(e.path()).ok()?;
-            serde_json::from_slice(&bytes).ok()
-        })
+        .filter(|e| e.path().is_dir())
+        .filter_map(|e| e.file_name().into_string().ok())
         .collect();
-    records.sort_by(|a, b| a.name.cmp(&b.name));
-    records
+    names.sort();
+    names
 }
 
 fn collect_lex_files(dir: &std::path::Path, out: &mut Vec<PathBuf>) {
@@ -1675,6 +1754,17 @@ fn pkg_publish_handler(state: &State, body: &[u8]) -> Response<std::io::Cursor<V
         }
     }
 
+    // Reject re-publish of the same (name, version) to keep the op log stable.
+    if load_pkg_record(&state.root, &pkg_name, &pkg_version).is_some() {
+        return error_response(
+            409,
+            format!(
+                "package {pkg_name}@{pkg_version} already published; \
+                 bump the version in lex.toml to publish a new release"
+            ),
+        );
+    }
+
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
@@ -1687,7 +1777,7 @@ fn pkg_publish_handler(state: &State, body: &[u8]) -> Response<std::io::Cursor<V
         function_names: all_function_names,
         ops: all_ops.clone(),
     };
-    if let Err(e) = save_pkg_record(&state.root, &record) {
+    if let Err(e) = save_pkg_record(&state.root, &record, body) {
         return error_response(500, format!("save package index: {e}"));
     }
 
@@ -1698,21 +1788,28 @@ fn pkg_publish_handler(state: &State, body: &[u8]) -> Response<std::io::Cursor<V
     }))
 }
 
-/// `GET /v1/pkg` — list packages published by this tenant.
+/// `GET /v1/pkg` — list packages published by this tenant (latest version of each).
 fn pkg_list_handler(state: &State) -> Response<std::io::Cursor<Vec<u8>>> {
-    let records = list_pkg_records(&state.root);
-    let packages: Vec<serde_json::Value> = records.iter().map(|r| serde_json::json!({
-        "name": r.name,
-        "version": r.version,
-        "head_op": r.head_op,
-        "published_at": r.published_at,
-    })).collect();
+    let names = list_pkg_names(&state.root);
+    let packages: Vec<serde_json::Value> = names.iter()
+        .filter_map(|name| {
+            let idx = load_pkg_index(&state.root, name)?;
+            let latest = idx.latest.as_deref()?;
+            let r = load_pkg_record(&state.root, name, latest)?;
+            Some(serde_json::json!({
+                "name": r.name,
+                "version": r.version,
+                "head_op": r.head_op,
+                "published_at": r.published_at,
+            }))
+        })
+        .collect();
     json_response(200, &serde_json::json!({ "packages": packages }))
 }
 
-/// `GET /v1/pkg/{name}` — list stages belonging to a package.
+/// `GET /v1/pkg/{name}` — latest version details for a package.
 fn pkg_get_handler(state: &State, name: &str) -> Response<std::io::Cursor<Vec<u8>>> {
-    match load_pkg_record(&state.root, name) {
+    match load_latest_pkg_record(&state.root, name) {
         Some(r) => json_response(200, &serde_json::json!({
             "name": r.name,
             "version": r.version,
@@ -1725,20 +1822,65 @@ fn pkg_get_handler(state: &State, name: &str) -> Response<std::io::Cursor<Vec<u8
     }
 }
 
-/// `GET /v1/pkg/{name}/head` — head op for a package's branch.
-fn pkg_head_handler(state: &State, name: &str) -> Response<std::io::Cursor<Vec<u8>>> {
-    match load_pkg_record(&state.root, name) {
+/// `GET /v1/pkg/{name}/versions` — all published versions for a package.
+fn pkg_versions_handler(state: &State, name: &str) -> Response<std::io::Cursor<Vec<u8>>> {
+    match load_pkg_index(&state.root, name) {
+        Some(idx) => json_response(200, &serde_json::json!({
+            "name": name,
+            "latest": idx.latest,
+            "versions": idx.versions,
+        })),
+        None => error_response(404, format!("package {name:?} not found")),
+    }
+}
+
+/// `GET /v1/pkg/{name}/{version}` — specific version details.
+fn pkg_get_version_handler(state: &State, name: &str, version: &str) -> Response<std::io::Cursor<Vec<u8>>> {
+    match load_pkg_record(&state.root, name, version) {
         Some(r) => json_response(200, &serde_json::json!({
             "name": r.name,
+            "version": r.version,
+            "head_op": r.head_op,
+            "published_at": r.published_at,
+            "function_names": r.function_names,
+            "ops": r.ops,
+        })),
+        None => error_response(404, format!("package {name:?}@{version:?} not found")),
+    }
+}
+
+/// `GET /v1/pkg/{name}/{version}/archive` — download the source tar.gz.
+fn pkg_archive_handler(state: &State, name: &str, version: &str) -> Response<std::io::Cursor<Vec<u8>>> {
+    let path = pkg_archive_path(&state.root, name, version);
+    match std::fs::read(&path) {
+        Ok(bytes) => Response::from_data(bytes)
+            .with_status_code(200)
+            .with_header(
+                tiny_http::Header::from_bytes(
+                    &b"Content-Type"[..],
+                    &b"application/gzip"[..],
+                )
+                .unwrap(),
+            ),
+        Err(_) => error_response(404, format!("archive for {name:?}@{version:?} not found")),
+    }
+}
+
+/// `GET /v1/pkg/{name}/head` — head op for a package's latest version.
+fn pkg_head_handler(state: &State, name: &str) -> Response<std::io::Cursor<Vec<u8>>> {
+    match load_latest_pkg_record(&state.root, name) {
+        Some(r) => json_response(200, &serde_json::json!({
+            "name": r.name,
+            "version": r.version,
             "head_op": r.head_op,
         })),
         None => error_response(404, format!("package {name:?} not found")),
     }
 }
 
-/// `DELETE /v1/pkg/{name}` — retract all stages introduced by a package.
+/// `DELETE /v1/pkg/{name}` — retract the latest version of a package.
 fn pkg_delete_handler(state: &State, name: &str) -> Response<std::io::Cursor<Vec<u8>>> {
-    let record = match load_pkg_record(&state.root, name) {
+    let record = match load_latest_pkg_record(&state.root, name) {
         Some(r) => r,
         None => return error_response(404, format!("package {name:?} not found")),
     };
@@ -1767,9 +1909,24 @@ fn pkg_delete_handler(state: &State, name: &str) -> Response<std::io::Cursor<Vec
 
     match store.publish_program(&branch, &[], &report, &empty_imports, false) {
         Ok(outcome) => {
-            let _ = std::fs::remove_file(pkg_record_path(&state.root, name));
+            // Remove the version record and archive, then update the index.
+            let ver = record.version.clone();
+            let _ = std::fs::remove_file(pkg_version_path(&state.root, name, &ver));
+            let _ = std::fs::remove_file(pkg_archive_path(&state.root, name, &ver));
+            // Update index: remove this version, set latest to previous if any.
+            if let Some(mut idx) = load_pkg_index(&state.root, name) {
+                idx.versions.retain(|v| v.version != ver);
+                idx.latest = idx.versions.last().map(|v| v.version.clone());
+                if idx.versions.is_empty() {
+                    let _ = std::fs::remove_dir_all(pkg_name_dir(&state.root, name));
+                } else {
+                    let bytes = serde_json::to_vec_pretty(&idx).unwrap_or_default();
+                    let _ = std::fs::write(pkg_index_path(&state.root, name), bytes);
+                }
+            }
             json_response(200, &serde_json::json!({
                 "deleted": name,
+                "version": ver,
                 "ops": outcome.ops,
                 "head_op": outcome.head_op,
             }))

--- a/crates/lex-cli/Cargo.toml
+++ b/crates/lex-cli/Cargo.toml
@@ -16,6 +16,8 @@ anyhow.workspace = true
 indexmap.workspace = true
 sha2.workspace = true
 ureq = { version = "3.3", default-features = false, features = ["rustls", "platform-verifier", "json"] }
+flate2 = "1"
+tar = "0.4"
 tiny_http = "0.12"
 lex-syntax = { path = "../lex-syntax" }
 lex-ast = { path = "../lex-ast" }

--- a/crates/lex-cli/src/pkg.rs
+++ b/crates/lex-cli/src/pkg.rs
@@ -1,10 +1,12 @@
 //! `lex pkg` subcommands — package manifest management.
 //!
 //! Commands:
-//!   lex pkg init                    — create a starter lex.toml in the CWD
-//!   lex pkg add <name> --path <p>   — add a path dependency
-//!   lex pkg add <name> --git  <url> — add a git dependency (clones on first use)
-//!   lex pkg list                    — list dependencies in lex.toml
+//!   lex pkg init                                       — create a starter lex.toml in the CWD
+//!   lex pkg add <name> --path <p>                      — add a path dependency
+//!   lex pkg add <name> --git  <url>                    — add a git dependency (clones on first use)
+//!   lex pkg add <name> --registry <url> --version <v>  — add a registry dependency
+//!   lex pkg list                                       — list dependencies in lex.toml
+//!   lex pkg publish [--registry <url>] [--token <jwt>] — publish package to a registry
 
 use anyhow::{bail, Result};
 use std::path::Path;
@@ -15,8 +17,9 @@ pub fn cmd_pkg(args: &[String]) -> Result<()> {
         Some("add")     => cmd_add(&args[1..]),
         Some("list")    => cmd_list(),
         Some("install") => cmd_install(),
-        Some(other)     => bail!("unknown pkg subcommand `{other}`; try: init, add, install, list"),
-        None            => bail!("usage: lex pkg <init|add|install|list>"),
+        Some("publish") => cmd_publish(&args[1..]),
+        Some(other)     => bail!("unknown pkg subcommand `{other}`; try: init, add, install, list, publish"),
+        None            => bail!("usage: lex pkg <init|add|install|list|publish>"),
     }
 }
 
@@ -49,12 +52,14 @@ version = "0.1.0"
 // ── lex pkg add ───────────────────────────────────────────────────────────────
 
 fn cmd_add(args: &[String]) -> Result<()> {
-    // Usage: lex pkg add <name> (--path <p> | --git <url>)
+    // Usage: lex pkg add <name> (--path <p> | --git <url> | --registry <url> --version <v>)
     let name = args.first().ok_or_else(|| anyhow::anyhow!(
-        "usage: lex pkg add <name> (--path <p> | --git <url>)"))?;
+        "usage: lex pkg add <name> (--path <p> | --git <url> | --registry <url> --version <v>)"))?;
 
-    let mut path_val: Option<String> = None;
-    let mut git_val:  Option<String> = None;
+    let mut path_val:     Option<String> = None;
+    let mut git_val:      Option<String> = None;
+    let mut registry_val: Option<String> = None;
+    let mut version_val:  Option<String> = None;
     let mut i = 1;
     while i < args.len() {
         match args[i].as_str() {
@@ -70,16 +75,30 @@ fn cmd_add(args: &[String]) -> Result<()> {
                     anyhow::anyhow!("--git requires a value")
                 })?);
             }
+            "--registry" => {
+                i += 1;
+                registry_val = Some(args.get(i).cloned().ok_or_else(|| {
+                    anyhow::anyhow!("--registry requires a value")
+                })?);
+            }
+            "--version" => {
+                i += 1;
+                version_val = Some(args.get(i).cloned().ok_or_else(|| {
+                    anyhow::anyhow!("--version requires a value")
+                })?);
+            }
             other => bail!("unknown flag `{other}`"),
         }
         i += 1;
     }
 
-    let dep_entry = match (path_val, git_val) {
-        (Some(p), None) => format!(r#"{{ path = "{p}" }}"#),
-        (None, Some(u)) => format!(r#"{{ git = "{u}" }}"#),
-        (Some(_), Some(_)) => bail!("specify either --path or --git, not both"),
-        (None, None) => bail!("usage: lex pkg add <name> (--path <p> | --git <url>)"),
+    let dep_entry = match (path_val, git_val, registry_val, version_val) {
+        (Some(p), None, None, None) => format!(r#"{{ path = "{p}" }}"#),
+        (None, Some(u), None, None) => format!(r#"{{ git = "{u}" }}"#),
+        (None, None, Some(r), Some(v)) => format!(r#"{{ registry = "{r}", version = "{v}" }}"#),
+        (None, None, Some(_), None) => bail!("--registry requires --version"),
+        (None, None, None, Some(_)) => bail!("--version requires --registry"),
+        _ => bail!("specify exactly one of --path, --git, or --registry (with --version)"),
     };
 
     upsert_dependency(name, &dep_entry)
@@ -120,9 +139,21 @@ fn cmd_install() -> Result<()> {
                 }
             }
             lex_syntax::workspace::Dependency::Git { git } => {
-                print!("  {} (git)   {} ... ", name, git);
-                // resolve_package_import triggers git_ensure_cached internally.
-                // We use a dummy module name — we only care about the side-effect.
+                print!("  {} (git)      {} ... ", name, git);
+                let dummy_file = toml_dir.join("__install_probe__.lex");
+                match lex_syntax::workspace::resolve_package_import(&dummy_file, name, "__probe__") {
+                    Ok(_) | Err(lex_syntax::PackageError::ModuleNotFound { .. }) => {
+                        println!("ok");
+                    }
+                    Err(e) => {
+                        println!("FAILED");
+                        eprintln!("    {e}");
+                        errors.push(format!("{name}: {e}"));
+                    }
+                }
+            }
+            lex_syntax::workspace::Dependency::Registry { registry, version } => {
+                print!("  {} (registry) {}@{} ... ", name, registry, version);
                 let dummy_file = toml_dir.join("__install_probe__.lex");
                 match lex_syntax::workspace::resolve_package_import(&dummy_file, name, "__probe__") {
                     Ok(_) | Err(lex_syntax::PackageError::ModuleNotFound { .. }) => {
@@ -164,11 +195,110 @@ fn cmd_list() -> Result<()> {
     for (name, dep) in &manifest.dependencies {
         match dep {
             lex_syntax::workspace::Dependency::Path { path } =>
-                println!("  {name}  path = {path}"),
+                println!("  {name}  path     = {path}"),
             lex_syntax::workspace::Dependency::Git { git } =>
-                println!("  {name}  git  = {git}"),
+                println!("  {name}  git      = {git}"),
+            lex_syntax::workspace::Dependency::Registry { registry, version } =>
+                println!("  {name}  registry = {registry}  version = {version}"),
         }
     }
+    Ok(())
+}
+
+// ── lex pkg publish ───────────────────────────────────────────────────────────
+
+/// Pack `lex.toml` + `src/**` into a gzipped tar archive in memory.
+fn build_archive(toml_dir: &std::path::Path) -> Result<Vec<u8>> {
+    let buf = Vec::new();
+    let gz = flate2::write::GzEncoder::new(buf, flate2::Compression::default());
+    let mut ar = tar::Builder::new(gz);
+
+    // Include lex.toml at archive root.
+    let toml_path = toml_dir.join("lex.toml");
+    ar.append_path_with_name(&toml_path, "lex.toml")?;
+
+    // Include every file under src/.
+    let src_dir = toml_dir.join("src");
+    if src_dir.exists() {
+        ar.append_dir_all("src", &src_dir)?;
+    }
+
+    let gz = ar.into_inner()?;
+    Ok(gz.finish()?)
+}
+
+fn cmd_publish(args: &[String]) -> Result<()> {
+    let mut registry_arg: Option<String> = None;
+    let mut token_arg:    Option<String> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--registry" => {
+                i += 1;
+                registry_arg = Some(args.get(i).cloned().ok_or_else(|| {
+                    anyhow::anyhow!("--registry requires a value")
+                })?);
+            }
+            "--token" => {
+                i += 1;
+                token_arg = Some(args.get(i).cloned().ok_or_else(|| {
+                    anyhow::anyhow!("--token requires a value")
+                })?);
+            }
+            other => bail!("unknown flag `{other}`"),
+        }
+        i += 1;
+    }
+
+    let cwd = std::env::current_dir().unwrap_or_else(|_| ".".into());
+    let (toml_path, toml_dir) = lex_syntax::find_manifest(&cwd)
+        .ok_or_else(|| anyhow::anyhow!("no lex.toml found (run `lex pkg init` to create one)"))?;
+
+    let manifest = lex_syntax::Manifest::load(&toml_path)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    let pkg = manifest.package.as_ref()
+        .ok_or_else(|| anyhow::anyhow!("lex.toml must have a [package] section"))?;
+
+    let registry = registry_arg
+        .or_else(|| pkg.registry.clone())
+        .ok_or_else(|| anyhow::anyhow!(
+            "no registry URL: pass --registry <url> or set `registry` in [package]"
+        ))?;
+
+    let token = token_arg
+        .or_else(|| std::env::var("LEX_PUBLISH_TOKEN").ok())
+        .ok_or_else(|| anyhow::anyhow!(
+            "no publish token: pass --token <jwt> or set LEX_PUBLISH_TOKEN"
+        ))?;
+
+    println!("publishing {}@{} to {} ...", pkg.name, pkg.version, registry);
+
+    let archive = build_archive(&toml_dir)
+        .map_err(|e| anyhow::anyhow!("building archive: {e}"))?;
+
+    let url = format!("{}/v1/pkg/publish", registry.trim_end_matches('/'));
+    let response = ureq::post(&url)
+        .header("Authorization", &format!("Bearer {token}"))
+        .header("Content-Type", "application/octet-stream")
+        .send(&archive[..])
+        .map_err(|e| anyhow::anyhow!("POST {url}: {e}"))?;
+
+    let status = response.status().as_u16();
+    let body: serde_json::Value = response
+        .into_body()
+        .read_json()
+        .map_err(|e| anyhow::anyhow!("reading response: {e}"))?;
+
+    if status != 200 {
+        bail!(
+            "publish failed (HTTP {status}): {}",
+            body.get("error").and_then(|v| v.as_str()).unwrap_or("unknown error")
+        );
+    }
+
+    let head_op = body.get("head_op").and_then(|v| v.as_str()).unwrap_or("(none)");
+    println!("published  head_op = {head_op}");
     Ok(())
 }
 

--- a/crates/lex-syntax/Cargo.toml
+++ b/crates/lex-syntax/Cargo.toml
@@ -18,6 +18,9 @@ logos.workspace = true
 indexmap.workspace = true
 sha2.workspace = true
 toml = "1"
+ureq = { version = "3.3", default-features = false, features = ["rustls", "platform-verifier"] }
+flate2 = "1"
+tar = "0.4"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/lex-syntax/src/workspace.rs
+++ b/crates/lex-syntax/src/workspace.rs
@@ -15,6 +15,8 @@
 //! lex-schema = { path = "../lex-schema" }
 //! # or:
 //! lex-schema = { git = "https://github.com/alpibrusl/lex-schema" }
+//! # or:
+//! lex-schema = { registry = "https://lexhub.alpibru.com", version = "0.9.2" }
 //! ```
 //!
 //! ## Module resolution
@@ -47,13 +49,19 @@ pub struct PackageMeta {
     pub name: String,
     #[serde(default)]
     pub version: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Default registry URL for `lex pkg publish` when `--registry` is not supplied.
+    #[serde(default)]
+    pub registry: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 pub enum Dependency {
-    Path { path: String },
-    Git  { git:  String },
+    Path     { path: String },
+    Git      { git:  String },
+    Registry { registry: String, version: String },
 }
 
 impl Manifest {
@@ -124,6 +132,9 @@ pub fn resolve_package_import(
             })?
         }
         Dependency::Git { git } => git_ensure_cached(pkg_name, git)?,
+        Dependency::Registry { registry, version } => {
+            registry_ensure_cached(pkg_name, registry, version)?
+        }
     };
 
     find_module_file(&pkg_root, module_path).ok_or_else(|| PackageError::ModuleNotFound {
@@ -183,6 +194,75 @@ fn git_ensure_cached(pkg_name: &str, url: &str) -> Result<PathBuf, PackageError>
     })
 }
 
+/// Download a registry package archive and extract it to the local cache.
+///
+/// Cache path: `$LEX_PACKAGES_DIR/{name}-{version}/` (versioned to avoid
+/// collisions with git-cached packages at `{name}/`).
+///
+/// Download URL: `{registry}/v1/pkg/{name}/{version}/archive`
+fn registry_ensure_cached(
+    pkg_name: &str,
+    registry: &str,
+    version: &str,
+) -> Result<PathBuf, PackageError> {
+    let cache_root = packages_cache_dir()?;
+    // Registry packages are cached under `{name}-{version}` to keep multiple
+    // versions side-by-side and separate from git-cached directories.
+    let pkg_dir = cache_root.join(format!("{pkg_name}-{version}"));
+    if pkg_dir.exists() {
+        return Ok(pkg_dir);
+    }
+    std::fs::create_dir_all(&cache_root).map_err(|e| PackageError::Io {
+        path: cache_root.display().to_string(),
+        detail: e.to_string(),
+    })?;
+
+    let url = format!(
+        "{}/v1/pkg/{}/{}/archive",
+        registry.trim_end_matches('/'),
+        pkg_name,
+        version,
+    );
+    let response = ureq::get(&url).call().map_err(|e| PackageError::RegistryFailed {
+        name: pkg_name.to_string(),
+        registry: registry.to_string(),
+        version: version.to_string(),
+        detail: format!("GET {url}: {e}"),
+    })?;
+    if response.status() != 200 {
+        return Err(PackageError::RegistryFailed {
+            name: pkg_name.to_string(),
+            registry: registry.to_string(),
+            version: version.to_string(),
+            detail: format!("GET {url} returned HTTP {}", response.status()),
+        });
+    }
+
+    let archive_bytes = response
+        .into_body()
+        .read_to_vec()
+        .map_err(|e| PackageError::RegistryFailed {
+            name: pkg_name.to_string(),
+            registry: registry.to_string(),
+            version: version.to_string(),
+            detail: format!("reading response body: {e}"),
+        })?;
+
+    let gz = flate2::read::GzDecoder::new(std::io::Cursor::new(&archive_bytes));
+    let mut ar = tar::Archive::new(gz);
+    ar.unpack(&pkg_dir).map_err(|e| PackageError::RegistryFailed {
+        name: pkg_name.to_string(),
+        registry: registry.to_string(),
+        version: version.to_string(),
+        detail: format!("extracting archive: {e}"),
+    })?;
+
+    pkg_dir.canonicalize().map_err(|e| PackageError::Io {
+        path: pkg_dir.display().to_string(),
+        detail: e.to_string(),
+    })
+}
+
 fn packages_cache_dir() -> Result<PathBuf, PackageError> {
     if let Ok(dir) = std::env::var("LEX_PACKAGES_DIR") {
         return Ok(PathBuf::from(dir));
@@ -214,6 +294,9 @@ pub enum PackageError {
 
     #[error("git clone of {url} failed: {detail}")]
     GitFailed { url: String, detail: String },
+
+    #[error("registry fetch of {name}@{version} from {registry} failed: {detail}")]
+    RegistryFailed { name: String, registry: String, version: String, detail: String },
 
     #[error("I/O error at {path}: {detail}")]
     Io { path: String, detail: String },


### PR DESCRIPTION
Closes #604

## What this does

Implements the first milestone of package publishing: a developer can run `lex pkg publish` to ship a package to LexHub, and consumers can declare `{ registry = "...", version = "..." }` dependencies that resolve automatically.

## Key design decisions

**Publishing is not versioned like git.** A lex-vcs publish is a deterministic sequence of semantic Ops (AddFunction, ModifyBody, etc.) that advance a branch head. The `head_op` is the canonical identity of a published version — semver is a human label that maps to it. The registry stores `(name, version) → head_op` and rejects re-publishing the same pair (HTTP 409) to keep the op log stable.

**Versioned on-disk layout** (`packages/{name}/index.json` + `packages/{name}/{version}.json` + `packages/{name}/{version}.tar.gz`) replaces the old flat `packages/{name}.json` that was overwritten on each publish. Multiple versions coexist; the index tracks `latest`.

## Changes

### `crates/lex-syntax/src/workspace.rs`
- `Dependency::Registry { registry, version }` — new variant parsed from `lex.toml`
- `PackageMeta.registry` / `.description` — optional manifest fields
- `registry_ensure_cached()` — downloads archive from `GET /v1/pkg/{name}/{version}/archive`, extracts to `~/.lex/packages/{name}-{version}/` (versioned path, no collision with git cache)

### `crates/lex-cli/src/pkg.rs`
- `lex pkg publish [--registry <url>] [--token <jwt>]` — packs `src/` + `lex.toml` into tar.gz, POSTs to registry; falls back to `[package].registry` and `LEX_PUBLISH_TOKEN` env var
- `lex pkg add <name> --registry <url> --version <v>` — new dep form
- `lex pkg list` and `lex pkg install` extended for registry deps

### `crates/lex-api/src/handlers.rs`
- **Versioned `PkgRecord` layout** (breaking storage change — old flat files won't be read)
- Re-publish of existing `(name, version)` → HTTP 409
- New endpoints:
  - `GET /v1/pkg/{name}/versions` — all published versions + head_ops
  - `GET /v1/pkg/{name}/{version}` — specific version details
  - `GET /v1/pkg/{name}/{version}/archive` — download source tar.gz
- `DELETE /v1/pkg/{name}` now retracts the latest version and rolls back the index pointer

## Test plan
- [ ] `cargo test -p lex-syntax -p lex-api -p lex-cli` passes
- [ ] `lex pkg publish --registry https://lexhub.alpibru.com --token $TOKEN` against lex-schema produces a `head_op`
- [ ] `GET /v1/pkg/lex-schema/versions` returns the published version
- [ ] `GET /v1/pkg/lex-schema/0.9.2/archive` downloads a valid tar.gz
- [ ] Re-publishing same version returns 409
- [ ] Consumer project with `lex-schema = { registry = "...", version = "0.9.2" }` resolves on `lex pkg install`

---
_Generated by [Claude Code](https://claude.ai/code/session_01CeVvNb9szxfzagdf3Snabv)_