### PR TITLE
chore: release v0.9.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,74 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
-## [0.9.7] — 2026-05-30
+## [0.9.8] — 2026-06-04
+
+### Added
+
+- **Package registry — `lex pkg publish`.** Authors run `lex pkg publish
+  [--registry <url>] [--token <jwt>]` to pack `src/` + `lex.toml` into a
+  tar.gz and POST it to a LexHub registry. The registry URL and publish token
+  fall back to `[package].registry` in `lex.toml` and the
+  `LEX_PUBLISH_TOKEN` env var respectively, keeping CI friction low.
+- **`Dependency::Registry` in `lex.toml`.** Consumers declare
+  `pkg = { registry = "https://lexhub.alpibru.com", version = "0.9.2" }`;
+  the resolver downloads and caches the source archive on first use under
+  `~/.lex/packages/{name}-{version}/`.
+- **`lex pkg add --registry <url> --version <v>`.** Adds a registry
+  dependency entry from the CLI, alongside the existing `--path` and
+  `--git` forms.
+- **Versioned package storage in the API.** `PkgRecord` is now stored as
+  `packages/{name}/index.json` + `packages/{name}/{version}.json` +
+  `packages/{name}/{version}.tar.gz`, replacing the flat single-file
+  layout. Re-publishing the same `(name, version)` returns HTTP 409 to
+  keep the op log stable — bump the semver label to ship a new release.
+- **New package API endpoints.**
+  - `GET /v1/pkg/{name}/versions` — list all published versions + head_ops.
+  - `GET /v1/pkg/{name}/{version}` — specific version details.
+  - `GET /v1/pkg/{name}/{version}/archive` — download source tar.gz (used
+    by the registry resolver to populate the local cache).
+- **JIT tier-up — Cranelift MVP.** Hot bytecode functions are promoted to
+  native code via Cranelift through a trait-inversion hook on `JitVm`.
+  Benchmark: 84–194× on arithmetic-heavy ops over the interpreter baseline.
+  Feature-gated; opt in with `--features jit`. Slices 4–5 (inlining,
+  loop hoisting) are deferred.
+- **Trust lattice.** Effect-narrowing as subtyping: `[net("api.example.com")]
+  <: [net]`. Per-host egress allowlist for `net` effects; host matching in
+  the trust scoring path. Enables fine-grained capability delegation without
+  broadening signatures.
+- **`[package].description` and `[package].registry` fields in `lex.toml`.**
+  `description` is surfaced in registry listings; `registry` is the default
+  publish target so `lex pkg publish` works without a flag.
+- **Claude Code plugin** — lex-lang and lex-hub now ship a `.claude/`
+  plugin directory with pre-configured MCP server integration and agent
+  guidelines so Claude Code sessions start with the full toolchain context.
+
+### Performance
+
+- **Arena/slab lowering pass** — slice 2a/2b-i. Non-escaping values
+  allocated in a bump arena; `materialize-at-boundary` helper limits
+  heap spill to response edges. `alloc_heavy` −36%, `response_build` −10.7%.
+- **Slab-direct wire-up** — `net.serve_fn` skips `materialize` on the
+  common path; `Vm::get_record_field` / `get_tuple_elem` / `value_to_json`
+  operate directly on slab slots. `response_build` −59.2%.
+- **Deep-leaf widening (containment-tracking).** Escape lattice tracks
+  containment depth; deep trees widen to heap only at the outermost
+  boundary. `deep_tree` −55%.
+- **Per-path precision in escape lattice.** Each data-flow path carries
+  its own escape verdict instead of the join. `response_build` −10.7%
+  additional.
+
+### Fixed
+
+- **rcgen 0.14 API compatibility.** QUIC self-signed cert generation updated
+  to `rcgen 0.14`'s renamed `CertifiedKey::key_pair`.
+- **Criterion 0.8 deprecated `black_box`.** Replaced with
+  `std::hint::black_box` across all bench crates.
+- **CI de-flake.** Workspace tests run single-threaded (`-- --test-threads
+  1`); wall-clock budgets widened across the load-sensitive suite; HTTP
+  client test made load-tolerant.
+
+
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "conformance"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "core-compiler"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "indexmap",
  "lex-ast",
@@ -2426,7 +2426,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lex-api"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "flate2",
@@ -2448,7 +2448,7 @@ dependencies = [
 
 [[package]]
 name = "lex-ast"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "indexmap",
  "lex-syntax",
@@ -2460,7 +2460,7 @@ dependencies = [
 
 [[package]]
 name = "lex-bytecode"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2478,11 +2478,12 @@ dependencies = [
 
 [[package]]
 name = "lex-cli"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "acli",
  "anyhow",
  "conformance",
+ "flate2",
  "indexmap",
  "lex-api",
  "lex-ast",
@@ -2499,6 +2500,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "spec-checker",
+ "tar",
  "tempfile",
  "tiny_http",
  "ureq",
@@ -2506,7 +2508,7 @@ dependencies = [
 
 [[package]]
 name = "lex-jit"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -2521,7 +2523,7 @@ dependencies = [
 
 [[package]]
 name = "lex-lsp"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "lex-ast",
  "lex-store",
@@ -2537,7 +2539,7 @@ dependencies = [
 
 [[package]]
 name = "lex-runtime"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -2600,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "lex-search"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "hex",
  "lex-ast",
@@ -2617,7 +2619,7 @@ dependencies = [
 
 [[package]]
 name = "lex-store"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "fs2",
  "hex",
@@ -2636,21 +2638,24 @@ dependencies = [
 
 [[package]]
 name = "lex-syntax"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
+ "flate2",
  "indexmap",
  "logos",
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "tar",
  "tempfile",
  "thiserror 2.0.18",
  "toml",
+ "ureq",
 ]
 
 [[package]]
 name = "lex-trace"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "indexmap",
  "lex-ast",
@@ -2665,7 +2670,7 @@ dependencies = [
 
 [[package]]
 name = "lex-types"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "hex",
  "indexmap",
@@ -2679,7 +2684,7 @@ dependencies = [
 
 [[package]]
 name = "lex-vcs"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "ed25519-dalek",
  "getrandom 0.4.2",
@@ -4965,7 +4970,7 @@ dependencies = [
 
 [[package]]
 name = "spec-checker"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "indexmap",
  "lex-ast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.9.7"
+version = "0.9.8"
 edition = "2021"
 license = "EUPL-1.2"
 repository = "https://github.com/alpibrusl/lex-lang"

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ The store is an append-only log of typed operations (`AddFunction`, `ModifyBody`
 **4. Coordination — session budgets, ProducerTrust, multi-agent.**
 Multiple proposers race via `Candidate / Promote` without CAS contention. Per-session budget gates cost across all participating agents. `ProducerTrust` scores tools against a rolling window of attestations.
 
+**5. JIT tier-up — Cranelift native compilation.**
+Hot functions are promoted from the bytecode interpreter to native code via Cranelift. Benchmark: 84–194× on arithmetic-heavy ops; pure computation falls through to native without interpreter overhead.
+
+**6. Package registry — publish and consume via LexHub.**
+`lex pkg publish` packs a `lex.toml` project and ships it to a registry. Consumers declare `{ registry = "…", version = "…" }` dependencies; the resolver downloads and caches the archive on first use. The canonical registry is [LexHub](https://lexhub.alpibru.com).
+
 ## Quickstart
 
 ```sh
@@ -62,6 +68,10 @@ curl -sX POST localhost:4040/v1/check \
   -H 'content-type: application/json' \
   -d '{"source":"fn add(x :: Int, y :: Int) -> Int { x + y }"}'
 # → {"ok": true}
+
+# Publish a package to LexHub.
+cd my-lex-project
+lex pkg publish --token $LEX_PUBLISH_TOKEN   # registry = "..." in lex.toml
 ```
 
 ## Examples
@@ -76,10 +86,36 @@ curl -sX POST localhost:4040/v1/check \
 | [`inbox_app.lex`](examples/inbox_app.lex) | Webhook router — adding a network call to the spam handler is a type error |
 | [`agent_dispatcher.lex`](examples/agent_dispatcher.lex) | `[proc]` effect with binary allow-list; typed argv |
 
+## Packages
+
+Packages published to [LexHub](https://lexhub.alpibru.com) — the canonical Lex package registry. Add them to `lex.toml` and run `lex pkg install`.
+
+| Package | Version | What it is |
+|---|---|---|
+| [**lex-schema**](https://github.com/alpibrusl/lex-schema) | 0.9.2 | Pydantic-style runtime validation, codegen, and schema utilities. `required_str`, `optional_*`, `ModelSchema`, JSON validation. |
+
+```toml
+# lex.toml
+[dependencies]
+lex-schema = { registry = "https://lexhub.alpibru.com", version = "0.9.2" }
+```
+
+**Publishing your own package:**
+
+```sh
+# lex.toml must have [package] name, version, and registry fields.
+lex pkg publish --token $LEX_PUBLISH_TOKEN
+```
+
+Tokens are issued by the LexHub operator. See [`lex-hub`](https://github.com/alpibrusl/lex-hub) for self-hosting.
+
 ## Ecosystem
+
+Tooling and runtime libraries that extend the Lex platform:
 
 | Package | What it is |
 |---|---|
+| [**lex-hub**](https://github.com/alpibrusl/lex-hub) | Multi-tenant SaaS gateway — JWT auth, per-tenant stores, package registry host |
 | [**lex-agent**](https://github.com/alpibrusl/lex-agent) | Google Agent2Agent (A2A) protocol — AgentCard, JSON-RPC 2.0, SSE streaming |
 | [**lex-llm**](https://github.com/alpibrusl/lex-llm) | LLM-agent runtime — Anthropic / OpenAI / Google / Ollama, multi-step tool-call loop |
 | [**lex-spec**](https://github.com/alpibrusl/lex-spec) | Capability-precondition DSL — randomized property check + SMT-LIB export |
@@ -93,7 +129,7 @@ curl -sX POST localhost:4040/v1/check \
 **Pre-built binaries** for Linux (x86_64 / aarch64), macOS (x86_64 / aarch64), and Windows are on [GitHub Releases](https://github.com/alpibrusl/lex-lang/releases):
 
 ```sh
-tar -xzf lex-v0.9.7-x86_64-unknown-linux-gnu.tar.gz
+tar -xzf lex-v0.9.8-x86_64-unknown-linux-gnu.tar.gz
 mv lex /usr/local/bin/
 lex version
 ```
@@ -101,8 +137,8 @@ lex version
 **Container image** — multi-arch (`linux/amd64` + `linux/arm64`):
 
 ```sh
-docker run -p 4040:4040 -v lex-store:/data ghcr.io/alpibrusl/lex:v0.9.7
-docker run --rm -v "$(pwd):/work" -w /work ghcr.io/alpibrusl/lex:v0.9.7 check src/main.lex
+docker run -p 4040:4040 -v lex-store:/data ghcr.io/alpibrusl/lex:v0.9.8
+docker run --rm -v "$(pwd):/work" -w /work ghcr.io/alpibrusl/lex:v0.9.8 check src/main.lex
 ```
 
 **From source** — requires Rust 1.80+:
@@ -120,12 +156,15 @@ All core capabilities are production-ready. Key highlights:
 - Content-addressed AST + typed Operation log (VCS tier-2)
 - Typed transforms: `ReplaceMatchArm`, `RenameLocal`, `InlineLet`, `ExtractFunction`
 - Closed repair loop: `lex repair --apply` + `RepairAttempt` attestation
+- JIT tier-up — Cranelift native compilation, 84–194× on hot arithmetic paths
+- Trust lattice — effect-narrowing as subtyping + per-host net egress allowlist
+- Package registry — `lex pkg publish` + `GET /v1/pkg/{name}/{version}/archive`
 - `std.conc` actors, `std.sql` (SQLite + Postgres), `std.crypto`, `std.redis`, `std.http`
 - Multi-agent `Candidate / Promote` + per-session budget gate
 - `lex-lsp` (VS Code), `lex-tea` web UI, ACLI compliance
 - Spec checker (randomized + SMT-LIB export), fuzz CI, conformance harness
 
-Deferred: `flow.parallel_record` (needs row polymorphism), VCS tier-3 federation, JIT slice 5, in-process Z3, store-native imports. Full table: [`docs/STATUS.md`](docs/STATUS.md).
+Deferred: `flow.parallel_record` (needs row polymorphism), VCS tier-3 federation, JIT slices 4–5, in-process Z3, store-native imports. Full table: [`docs/STATUS.md`](docs/STATUS.md).
 
 ## Docs
 


### PR DESCRIPTION
Version bump to 0.9.8. Once merged, tag `v0.9.8` to trigger the release workflow which builds and attaches binaries to a GitHub Release.

## What's in this release (since v0.9.7)

### New
- **`lex pkg publish`** — publish packages to a LexHub registry; `Dependency::Registry` in `lex.toml`; versioned on-disk package storage; `GET /v1/pkg/{name}/{version}/archive` download endpoint (lex-lang#604)
- **JIT tier-up** — Cranelift MVP integrated via trait-inversion hook; 84–194× on supported ops (lex-lang#465)
- **Trust lattice** — effect-narrowing as subtyping + net egress allowlist + host matching (lex-lang#581, #587)
- Claude Code plugin for lex toolchain + lex-hub

### Performance
- Arena/slab lowering pass + acceptance gate
- Slab-direct wire-up: `net.serve_fn` skips materialize on the common path
- Deep-leaf widening (containment-tracking) — deep_tree -55%
- Per-path precision in escape lattice

### Fixes
- rcgen 0.14 API compat (QUIC self-signed cert, `CertifiedKey::key_pair`)
- Criterion 0.8 deprecated `black_box` → `std::hint::black_box`
- CI de-flake: single-threaded workspace tests, widened wall-clock budgets

## Release steps (after merging)

```sh
git checkout main && git pull
git tag v0.9.8
git push origin v0.9.8
```

The `release.yml` workflow builds linux-gnu, linux-aarch64, darwin, darwin-arm64, and windows binaries and attaches them to the GitHub Release automatically.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CeVvNb9szxfzagdf3Snabv)_