### PR TITLE
fix(#465): refuse `--jit` + `--max-steps` (cursor security finding on #608)

### DIFF
--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -632,6 +632,25 @@ fn cmd_run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
         .with_program_args(f.program_args.clone());
     let mut vm = Vm::with_handler(&bc, Box::new(handler));
     if let Some(n) = f.max_steps { vm.set_step_limit(n); }
+    // #465 / cursor[bot] medium-severity review on #608: JIT'd code
+    // runs in native loops (the self-tail-call backward jump, any
+    // backward `Jump(-N)` in iterative loops) that do **not**
+    // increment `Vm::steps`, so an explicit `--max-steps` cap would
+    // be silently bypassed once a hot loop tiers up. The
+    // `set_step_limit` doc explicitly calls out untrusted code (the
+    // `agent-tool` sandbox) as the threat model — so refuse the
+    // combination rather than degrade the guarantee. The
+    // architectural fix (pass the counter into JIT'd code, abort
+    // via a multi-return ABI) is a separate slice; this is the
+    // immediate guardrail.
+    if f.jit && f.max_steps.is_some() {
+        bail!(
+            "--jit and --max-steps are mutually exclusive: the JIT \
+             runs native loops that bypass the per-op step counter, so \
+             an explicit step limit would not be honored. Drop one of \
+             the two flags."
+        );
+    }
     // #465: install the JIT tier as a hook on the Vm. Eligible
     // functions (pure-int arith subset) compile to native code on
     // first call; everything else flows through the interpreter

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -659,6 +659,25 @@ fn cmd_run(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     // rather than silently falling back, so a `--jit` invocation that
     // can't actually JIT is loud.
     if f.jit {
+        // The explicit `--max-steps` bail above protects users who
+        // asked for a step cap. But `Vm::new` *also* installs a
+        // default 10M cap that the JIT silently bypasses once a hot
+        // loop tiers up — cursor[bot]'s follow-up review on this PR
+        // called that out. Saturate the cap to `u64::MAX` so the VM
+        // state honestly reflects "no step counting under --jit"
+        // instead of pretending a guard exists, and print a stderr
+        // warning so interactive users notice. The architectural fix
+        // (in-JIT counter check via multi-return ABI) is the same
+        // for both the explicit-cap and default-cap cases and is
+        // filed as a follow-up.
+        vm.set_step_limit(u64::MAX);
+        eprintln!(
+            "warning: --jit disables the VM step-limit DoS guard. \
+             JIT'd code runs native loops that bypass the per-op \
+             counter — do not pass untrusted Lex code to a host \
+             running with --jit unless you've sandboxed it some \
+             other way."
+        );
         let tier = lex_jit::JitTier::new(&bc)
             .map_err(|e| anyhow!("--jit: constructing JIT tier: {e}"))?;
         vm.set_jit_hook(Some(Box::new(tier)));

--- a/crates/lex-cli/tests/run_jit.rs
+++ b/crates/lex-cli/tests/run_jit.rs
@@ -117,8 +117,11 @@ fn greet(p :: Person) -> Str {
 }
 
 #[test]
-fn jit_flag_works_with_other_run_flags() {
-    // Smoke: --jit composes with --max-steps.
+fn jit_refuses_explicit_max_steps() {
+    // Security guard (cursor[bot] medium-severity review on #608):
+    // JIT'd code runs native loops that don't bump `Vm::steps`, so
+    // `--max-steps` would be silently bypassed. The CLI rejects the
+    // combination rather than degrade the documented DoS guard.
     let path = write_tempfile(
         "arith2.lex",
         r#"
@@ -127,7 +130,7 @@ fn double(n :: Int) -> Int {
 }
 "#,
     );
-    let (code, out, err) = run(&[
+    let (code, _out, err) = run(&[
         "run",
         "--jit",
         "--max-steps",
@@ -136,6 +139,29 @@ fn double(n :: Int) -> Int {
         "double",
         "21",
     ]);
-    assert_eq!(code, 0, "jit + --max-steps failed: {err}");
+    assert_ne!(code, 0, "expected --jit + --max-steps to fail, succeeded: {err}");
+    assert!(
+        err.contains("mutually exclusive"),
+        "expected error to explain the incompatibility, got: {err:?}"
+    );
+}
+
+#[test]
+fn jit_composes_with_unrelated_flags() {
+    // Sanity: `--jit` alone works (no `--max-steps`). This is the
+    // common-path replacement for the prior test that combined
+    // `--jit --max-steps`, which is now rejected.
+    let path = write_tempfile(
+        "arith3.lex",
+        r#"
+fn double(n :: Int) -> Int {
+  n + n
+}
+"#,
+    );
+    let (code, out, err) = run(&[
+        "run", "--jit", path.to_str().unwrap(), "double", "21",
+    ]);
+    assert_eq!(code, 0, "--jit alone failed: {err}");
     assert!(out.trim().contains("42"), "expected 42, got {out:?}");
 }

--- a/crates/lex-cli/tests/run_jit.rs
+++ b/crates/lex-cli/tests/run_jit.rs
@@ -159,9 +159,35 @@ fn double(n :: Int) -> Int {
 }
 "#,
     );
-    let (code, out, err) = run(&[
+    let (code, out, _err) = run(&[
         "run", "--jit", path.to_str().unwrap(), "double", "21",
     ]);
-    assert_eq!(code, 0, "--jit alone failed: {err}");
+    assert_eq!(code, 0, "--jit alone failed");
     assert!(out.trim().contains("42"), "expected 42, got {out:?}");
+}
+
+#[test]
+fn jit_warns_about_step_limit_bypass() {
+    // Cursor[bot] follow-up: even without explicit `--max-steps`,
+    // `--jit` disables the VM's default step-limit DoS guard
+    // because JIT'd native loops don't bump the counter. We
+    // surface this as a stderr warning so interactive users see
+    // they've opted out of the guard; scripts that swallow stderr
+    // get the same opt-out but quietly.
+    let path = write_tempfile(
+        "arith4.lex",
+        r#"
+fn ident(n :: Int) -> Int {
+  n
+}
+"#,
+    );
+    let (code, _out, err) = run(&[
+        "run", "--jit", path.to_str().unwrap(), "ident", "1",
+    ]);
+    assert_eq!(code, 0, "--jit alone failed: {err}");
+    assert!(
+        err.contains("step-limit") || err.contains("step limit"),
+        "expected stderr warning about step-limit bypass, got: {err:?}"
+    );
 }


### PR DESCRIPTION
## Summary

Addresses cursor[bot]'s medium-severity security review on PR #608 (comment was on `crates/lex-jit/src/lower.rs:563`, the self-tail-call backward-jump emit). The vulnerability lives in shipped `main` from #599/#602, not the probe PR — opening as a separate PR per discussion.

## The issue (accurately diagnosed by the bot)

JIT'd code runs native loops (the `Op::TailCall` → `ins.jump` backward edge, and any backward `Jump(-N)` in iterative patterns like `sum_loop`) that do **not** call back into `Vm::run_to`. `Vm::steps` therefore never increments while the loop is hot. `--max-steps`, documented as a DoS guard for untrusted code (the `agent-tool` sandbox specifically), is silently bypassed once a hot loop tiers up.

## The fix

This is the pragmatic guardrail — refuse the combination at the CLI rather than degrade the guarantee:

```rust
if f.jit && f.max_steps.is_some() {
    bail!(
        "--jit and --max-steps are mutually exclusive: the JIT \
         runs native loops that bypass the per-op step counter, \
         so an explicit step limit would not be honored. Drop \
         one of the two flags."
    );
}
```

A user that explicitly asked for a step cap gets it; one that wants raw speed drops `--max-steps`. Neither gets the worst-of-both-worlds of "I asked for a cap but the JIT silently ignored it."

## What this is NOT

This is **not** the architectural fix. Properly honoring `--max-steps` from inside JIT'd code needs:
- Pass the `Vm::steps` / `step_limit` pointers into JIT'd functions (signature change — extra args)
- Lower a counter-bump-and-check at every backward jump
- Define a multi-return ABI `(result, aborted_flag)` so the wrapper can surface `VmError::StepLimitExceeded`
- Update the trampoline table and `JitTier::try_call`

That's a real session of work and a Cranelift API change — filed as a follow-up. This PR is the immediate guardrail.

## Known weaker spot (documented, not fixed here)

`Vm::new` sets a default `step_limit` of 10M. This patch only refuses *explicit* `--max-steps`; the default cap is still bypassed by `--jit`. That's a knowingly weaker floor (10M ops at native speed is microseconds) and the architectural fix addresses both at once. The threat model that motivated this fix (untrusted code in the `agent-tool` sandbox) sets `--max-steps` explicitly anyway.

## Test plan

- [x] `cargo test -p lex-cli --test run_jit` — 4 passing:
  - `jit_pure_arith_matches_interpreter` (unchanged)
  - `jit_falls_through_for_ineligible_program` (unchanged)
  - `jit_refuses_explicit_max_steps` (new — asserts the fail path)
  - `jit_composes_with_unrelated_flags` (new — happy-path smoke for `--jit` alone, replaces prior `jit_flag_works_with_other_run_flags` that incorrectly asserted `--jit --max-steps` worked)
- [x] `cargo test -p lex-bytecode` — full suite passes
- [x] `cargo clippy -p lex-cli --all-targets -- -D warnings` clean

https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiyRit8fcxagzHYYBk61dk)_