### PR TITLE
fix(vm): skip memo on arena args (#621); fix str.slice codepoint indices (#620)

### DIFF
--- a/crates/lex-bytecode/src/value.rs
+++ b/crates/lex-bytecode/src/value.rs
@@ -354,6 +354,32 @@ impl Value {
         match self { Value::Str(s) => s, other => panic!("expected Str, got {other:?}") }
     }
 
+    /// Returns `true` if this value is, or transitively contains, an
+    /// `ArenaRecord` or `ArenaTuple`. Used by the memo gate to skip
+    /// memoization when request-scoped arena handles are present in the
+    /// call arguments — such values cannot be safely hashed because the
+    /// memo cache outlives the request arena (#621).
+    pub fn contains_arena_record(&self) -> bool {
+        match self {
+            Value::ArenaRecord { .. } | Value::ArenaTuple { .. } => true,
+            Value::List(items) =>
+                items.iter().any(|v| v.contains_arena_record()),
+            Value::Tuple(items) =>
+                items.iter().any(|v| v.contains_arena_record()),
+            Value::Deque(items) =>
+                items.iter().any(|v| v.contains_arena_record()),
+            Value::Variant { args, .. } =>
+                args.iter().any(|v| v.contains_arena_record()),
+            Value::Record { fields, .. } =>
+                fields.values().any(|v| v.contains_arena_record()),
+            Value::Closure { captures, .. } =>
+                captures.iter().any(|v| v.contains_arena_record()),
+            Value::Map(m) =>
+                m.values().any(|v| v.contains_arena_record()),
+            _ => false,
+        }
+    }
+
     /// Render this `Value` as a `serde_json::Value` for emission to
     /// CLI output, the agent API, conformance harness reports, etc.
     /// Canonical mapping shared across crates; previously every

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -2399,6 +2399,10 @@ impl<'a> Vm<'a> {
                     let memo_key: Option<(u32, [u8; 16])> =
                         if self.program.functions[fid].effects.is_empty()
                             && self.memo_fn_state[fid].enabled
+                            // #621: skip memo if any arg contains a request-scoped
+                            // arena handle. The memo cache outlives the request arena,
+                            // so hashing such a handle would dangle.
+                            && !self.stack[args_base..].iter().any(|v| v.contains_arena_record())
                         {
                             Some((fn_id, hash_call_args(&self.stack[args_base..])))
                         } else {

--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -162,29 +162,24 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             })
         }
         ("str", "slice") => {
-            // Half-open byte-range slice. `hi` is clamped to `s.len()`
-            // and a negative `lo` / `hi` clamps to `0`, mirroring
-            // Python's `s[lo:hi]` semantics (and matching what
-            // production users expect when slicing fixed sizes off
-            // a possibly-shorter string — e.g. the first 64 chars
-            // of a license header). Reversed ranges (`lo > hi` after
-            // clamping) error since that's a caller logic bug. A
-            // mid-codepoint `lo` after clamping still errors so
-            // silent UTF-8 truncation never sneaks through.
+            // Half-open codepoint-index slice. `lo` and `hi` are Unicode
+            // scalar value (codepoint) indices, not byte offsets. Out-of-range
+            // indices clamp to the codepoint count, mirroring Python's `s[lo:hi]`
+            // semantics. Reversed ranges error as a caller logic bug. (#620)
             let s = expect_str(args.first())?;
             let lo_i = expect_int(args.get(1))?;
             let hi_i = expect_int(args.get(2))?;
-            let lo = (lo_i.max(0) as usize).min(s.len());
-            let hi = (hi_i.max(0) as usize).min(s.len());
-            if lo > hi {
+            let lo_cp = lo_i.max(0) as usize;
+            let hi_cp = hi_i.max(0) as usize;
+            if lo_cp > hi_cp {
                 return Err(format!(
-                    "str.slice: reversed range [{lo}..{hi}] (after clamping to len {})",
-                    s.len()));
+                    "str.slice: reversed range [{lo_cp}..{hi_cp}]"));
             }
-            if !s.is_char_boundary(lo) || !s.is_char_boundary(hi) {
-                return Err(format!("str.slice: [{lo}..{hi}] not on char boundaries"));
-            }
-            Ok(Value::Str(s[lo..hi].into()))
+            // Resolve codepoint indices to byte offsets in a single pass.
+            // Indices past the end clamp to s.len(), yielding an empty slice.
+            let lo_byte = s.char_indices().nth(lo_cp).map(|(b, _)| b).unwrap_or(s.len());
+            let hi_byte = s.char_indices().nth(hi_cp).map(|(b, _)| b).unwrap_or(s.len());
+            Ok(Value::Str(s[lo_byte..hi_byte].into()))
         }
 
         // -- int / float --

--- a/crates/lex-runtime/tests/str_slice_clamp.rs
+++ b/crates/lex-runtime/tests/str_slice_clamp.rs
@@ -7,10 +7,10 @@
 //! license header that may itself be only 32 chars. A real Rubric
 //! port tripped on this against a 32-char LICENSE file.
 //!
-//! New behaviour: `hi` is clamped to `s.len()`, `lo` is clamped to
-//! `[0, s.len()]`. `lo > hi` after clamping still errors (caller
-//! logic bug). A mid-codepoint `lo` after clamping still errors so
-//! silent UTF-8 truncation never sneaks through.
+//! New behaviour (updated 2026-06-09, #620): indices are codepoint
+//! (Unicode scalar value) positions, not byte offsets. `hi` past the
+//! codepoint count clamps to the end; negative `lo`/`hi` clamp to 0.
+//! `lo > hi` after clamping still errors (caller logic bug).
 
 use lex_ast::canonicalize_program;
 use lex_bytecode::{compile_program, vm::Vm, Value};
@@ -100,17 +100,25 @@ fn lo_greater_than_hi_after_clamping_errors() {
 }
 
 #[test]
-fn mid_codepoint_lo_still_errors() {
-    // "héllo" is 6 bytes (h-é(0xc3 0xa9)-l-l-o). lo=2 lands inside
-    // 'é'. Clamping is purely length-based; UTF-8 boundary errors
-    // remain so callers don't accidentally produce ill-formed
-    // strings.
-    let err = run(SRC, "slice", vec![
+fn multibyte_codepoint_slice_works() {
+    // "héllo" is 6 bytes (h=1B, é=2B, l=1B, l=1B, o=1B).
+    // Codepoint indices: h=0, é=1, l=2, l=3, o=4.
+    // slice(s, 1, 4) should return "éll" (codepoints 1..4). (#620)
+    let v = run(SRC, "slice", vec![
         Value::Str("héllo".into()),
-        Value::Int(2), Value::Int(5),
-    ]).unwrap_err();
-    assert!(err.contains("char boundaries"),
-        "expected char-boundary error, got: {err}");
+        Value::Int(1), Value::Int(4),
+    ]).unwrap();
+    assert_eq!(v, Value::Str("éll".into()));
+}
+
+#[test]
+fn multibyte_full_string_slice() {
+    // Slicing the full codepoint range of a multi-byte string returns it unchanged.
+    let v = run(SRC, "slice", vec![
+        Value::Str("héllo".into()),
+        Value::Int(0), Value::Int(5),
+    ]).unwrap();
+    assert_eq!(v, Value::Str("héllo".into()));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- **#621** — `ArenaRecord` / `ArenaTuple` values in call arguments now skip memoization instead of panicking. Adds `Value::contains_arena_record()` and guards the memo gate with it. The root cause (effects analysis producing wrong purity for the `mw.otel()` fold closure depending on service call-graph size) remains a compiler bug to fix separately; this is the safe minimal fix described in the issue.
- **#620** — `str.slice` now treats `lo`/`hi` as **codepoint** (Unicode scalar value) indices, not raw byte offsets. Multi-byte UTF-8 content (em-dashes, currency symbols, etc. from LLM responses) no longer triggers the "not on char boundaries" panic.

## Changes

| File | What changed |
|------|-------------|
| `crates/lex-bytecode/src/value.rs` | Add `Value::contains_arena_record()` — shallow/deep check for arena handles |
| `crates/lex-bytecode/src/vm.rs` | Memo gate: add `!args.any(contains_arena_record)` guard before `hash_call_args` |
| `crates/lex-runtime/src/builtins.rs` | `str.slice`: resolve codepoint indices to byte offsets via `char_indices().nth()` |

## Test plan

- [ ] `cargo check -p lex-bytecode --no-default-features` passes (verified locally)
- [ ] Service using `mw.otel()` middleware no longer panics on health check requests
- [ ] `str.slice` on a string containing multi-byte UTF-8 returns the correct substring
- [ ] `str.slice` on ASCII strings behaves identically to before (codepoint == byte for ASCII)

https://claude.ai/code/session_015iTn8yeVfQkrea8ebX1PF7

---
_Generated by [Claude Code](https://claude.ai/code/session_015iTn8yeVfQkrea8ebX1PF7)_