### PR TITLE
attest: promote lex-os capsule installs into durable attestations

### DIFF
--- a/crates/lex-api/src/web.rs
+++ b/crates/lex-api/src/web.rs
@@ -866,6 +866,9 @@ fn kind_short(k: &AttestationKind) -> String {
         AttestationKind::ProducerTrust { tool_id, score_thousandths, .. } => {
             format!("ProducerTrust({tool_id}, {:.3})", *score_thousandths as f64 / 1000.0)
         }
+        AttestationKind::CapsuleInstall { artifact, signer, .. } => {
+            format!("CapsuleInstall({artifact} by {signer:.12}…)")
+        }
         AttestationKind::TrustWaived { producer, kind_tag, .. } => {
             format!("TrustWaived({producer}/{kind_tag})")
         }

--- a/crates/lex-cli/src/acli.rs
+++ b/crates/lex-cli/src/acli.rs
@@ -592,7 +592,7 @@ fn cmd_attest() -> CommandInfo {
     .add_option(
         "--kind",
         "string",
-        "attestation kind: type_check | spec | examples | diff_body | effect_audit | sandbox_run",
+        "attestation kind: type_check | spec | examples | diff_body | effect_audit | sandbox_run | capsule_install",
         None,
     )
     .add_option("--result", "string", "passed | failed | inconclusive", None)
@@ -600,6 +600,18 @@ fn cmd_attest() -> CommandInfo {
         "--since",
         "string",
         "epoch seconds or YYYY-MM-DD; only attestations on or after this time",
+        None,
+    )
+    .add_option("--store", "string", "store root directory", None);
+    let import_install = CommandInfo::new(
+        "import-install",
+        "promote lex-os capsule-install records into durable attestations (signer-keyed; feeds producer-trust)",
+    )
+    .idempotent(true)
+    .add_option(
+        "--audit",
+        "string",
+        "lex-os audit log JSON (from `lex-os capsule install --audit-out`)",
         None,
     )
     .add_option("--store", "string", "store root directory", None);
@@ -617,12 +629,16 @@ fn cmd_attest() -> CommandInfo {
             "lex attest filter --kind type_check --since 2026-05-01",
         ),
         (
+            "Promote capsule installs to attestations",
+            "lex attest import-install --audit install.audit.json",
+        ),
+        (
             "Machine-readable",
             "lex --output json attest filter --kind spec",
         ),
     ])
-    .with_see_also(vec!["stage", "blame"]);
-    info.subcommands = vec![filter];
+    .with_see_also(vec!["stage", "blame", "producer-trust"]);
+    info.subcommands = vec![filter, import_install];
     info
 }
 

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -3436,6 +3436,11 @@ fn cmd_stage(fmt: &OutputFormat, args: &[String]) -> Result<()> {
                     } => {
                         format!("TrustWaived({producer}/{kind_tag})")
                     }
+                    lex_vcs::AttestationKind::CapsuleInstall {
+                        artifact, signer, ..
+                    } => {
+                        format!("CapsuleInstall({artifact} by {signer:.12}…)")
+                    }
                 };
                 let result = match &a.result {
                     lex_vcs::AttestationResult::Passed => "passed".to_string(),
@@ -3816,7 +3821,7 @@ fn cmd_stage_decision(
 fn cmd_attest(fmt: &OutputFormat, args: &[String]) -> Result<()> {
     let sub = args
         .first()
-        .ok_or_else(|| anyhow!("usage: lex attest {{filter|push}} ..."))?;
+        .ok_or_else(|| anyhow!("usage: lex attest {{filter|import-install|push|pull|retro-block|retro-unblock}} ..."))?;
     let rest = &args[1..];
     if sub == "push" {
         return cmd_attest_push(fmt, rest);
@@ -3925,10 +3930,128 @@ fn cmd_attest(fmt: &OutputFormat, args: &[String]) -> Result<()> {
             });
             Ok(())
         }
+        "import-install" => cmd_attest_import_install(fmt, rest),
         "retro-block" => cmd_attest_retro_block(fmt, rest),
         "retro-unblock" => cmd_attest_retro_unblock(fmt, rest),
         other => bail!("unknown `lex attest` subcommand: {other}"),
     }
+}
+
+/// `lex attest import-install --audit <lex-os-audit.json> [--store DIR]`
+/// (lex-os#36 / #38). Promotes lex-os capsule-install records into the
+/// durable attestation graph so an install becomes queryable evidence —
+/// not a throwaway audit file.
+///
+/// Reads a tamper-evident audit log (as written by `lex-os capsule
+/// install --audit-out`) and, for every `capsule_installed` event,
+/// emits a [`lex_vcs::AttestationKind::CapsuleInstall`] under
+/// `stage_id == signer` with `produced_by.tool == signer`. That keys the
+/// record by the publisher in both the by-stage index and the
+/// producer-trust scorer, so `lex producer-trust recompute --tool
+/// <signer>` folds real installs into the signer's earned trust and the
+/// keyring `capsule install --trusted-keys` consumes.
+///
+/// Idempotent: the content-addressed attestation id dedups re-imports of
+/// the same log (two installs of identical bytes by the same signer are
+/// one fact). The audit log is *not* re-verified here — promotion records
+/// what lex-os decided; verifying the chain remains `lex-os audit verify`.
+fn cmd_attest_import_install(fmt: &OutputFormat, args: &[String]) -> Result<()> {
+    let (root, rest, _, _) = parse_store_flag(args);
+    let mut audit_path: Option<PathBuf> = None;
+    let mut i = 0;
+    while i < rest.len() {
+        match rest[i].as_str() {
+            "--audit" => {
+                audit_path = rest.get(i + 1).map(PathBuf::from);
+                i += 2;
+            }
+            other => bail!("unexpected arg `{other}`"),
+        }
+    }
+    let audit_path = audit_path.ok_or_else(|| {
+        anyhow!("usage: lex attest import-install --audit <lex-os-audit.json> [--store DIR]")
+    })?;
+    let raw = std::fs::read_to_string(&audit_path)
+        .with_context(|| format!("reading audit log {}", audit_path.display()))?;
+    let parsed: serde_json::Value = serde_json::from_str(&raw)
+        .with_context(|| format!("parsing audit log {} as JSON", audit_path.display()))?;
+    let entries = parsed.as_array().ok_or_else(|| {
+        anyhow!(
+            "audit log {} is not a JSON array of entries",
+            audit_path.display()
+        )
+    })?;
+
+    let store =
+        Store::open(&root).with_context(|| format!("opening store at {}", root.display()))?;
+    let log = store.attestation_log()?;
+
+    let mut imported: Vec<serde_json::Value> = Vec::new();
+    let mut already_present = 0usize;
+    for entry in entries {
+        let event = &entry["event"];
+        if event["kind"].as_str() != Some("capsule_installed") {
+            continue;
+        }
+        // A malformed install event is a hard error: refuse to mint a
+        // half-attributed trust record rather than silently skip it.
+        let signer = event["signer"]
+            .as_str()
+            .ok_or_else(|| anyhow!("capsule_installed event missing `signer`"))?;
+        let artifact = event["artifact"]
+            .as_str()
+            .ok_or_else(|| anyhow!("capsule_installed event missing `artifact`"))?;
+        let effective_grant = event["effective_grant"].as_str().unwrap_or("").to_string();
+        // content_hash names the exact bytes. Older logs predate it; we
+        // import them with an empty hash rather than refusing.
+        let content_hash = event["content_hash"].as_str().unwrap_or("").to_string();
+
+        let producer = lex_vcs::ProducerDescriptor {
+            tool: signer.to_string(),
+            version: "lex-os-capsule".into(),
+            model: None,
+        };
+        let attestation = lex_vcs::Attestation::new(
+            signer.to_string(),
+            None,
+            None,
+            lex_vcs::AttestationKind::CapsuleInstall {
+                artifact: artifact.to_string(),
+                content_hash: content_hash.clone(),
+                signer: signer.to_string(),
+                effective_grant,
+            },
+            lex_vcs::AttestationResult::Passed,
+            producer,
+            None,
+        );
+        let existed = log.get(&attestation.attestation_id)?.is_some();
+        log.put(&attestation)?;
+        if existed {
+            already_present += 1;
+        }
+        imported.push(serde_json::json!({
+            "attestation_id": attestation.attestation_id,
+            "artifact": artifact,
+            "signer": signer,
+            "content_hash": content_hash,
+            "already_present": existed,
+        }));
+    }
+
+    let count = imported.len();
+    let data = serde_json::json!({
+        "audit_log": audit_path.display().to_string(),
+        "imported": count,
+        "already_present": already_present,
+        "attestations": imported,
+    });
+    acli::emit_or_text("attest", data, fmt, move || {
+        println!(
+            "→ imported {count} capsule-install attestation(s) ({already_present} already present)"
+        );
+    });
+    Ok(())
 }
 
 /// `lex attest retro-block --producer <tool_id> --reason "..."` (#248).
@@ -4401,6 +4524,7 @@ fn attestation_kind_tag(k: &lex_vcs::AttestationKind) -> &'static str {
         RepairAttempt { .. } => "repair_attempt",
         ProducerTrust { .. } => "producer_trust",
         TrustWaived { .. } => "trust_waived",
+        CapsuleInstall { .. } => "capsule_install",
     }
 }
 

--- a/crates/lex-cli/tests/attest_import_install.rs
+++ b/crates/lex-cli/tests/attest_import_install.rs
@@ -1,0 +1,177 @@
+//! Conformance for `lex attest import-install` (lex-os#36 / #38).
+//!
+//! Promotes a lex-os capsule-install audit log into the durable
+//! attestation graph, and proves the loop it closes: the imported
+//! `CapsuleInstall` records are signer-keyed, so `producer-trust` scores
+//! the signer and the trusted-keys keyring exports it.
+
+use std::process::Command;
+
+fn lex_bin() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_lex"))
+}
+
+const SIGNER: &str = "f9b439837a3d0c1e2b4a5c6d7e8f90112233445566778899aabbccddeeff0011";
+
+/// A minimal lex-os audit log (the shape `AuditLog::to_json()` writes):
+/// an array of `{seq, prev_hash, event, hash}` entries. The importer only
+/// reads `event`; one install is wrapped in request/refuse noise to prove
+/// it imports exactly the `capsule_installed` events.
+fn sample_audit_log() -> String {
+    serde_json::json!([
+        {
+            "seq": 0,
+            "prev_hash": "",
+            "event": { "kind": "capsule_requested", "artifact": "pdf-extract@2.0.0", "signer": SIGNER },
+            "hash": "aaa"
+        },
+        {
+            "seq": 1,
+            "prev_hash": "aaa",
+            "event": {
+                "kind": "capsule_installed",
+                "artifact": "pdf-extract@2.0.0",
+                "signer": SIGNER,
+                "content_hash": "deadbeefcafe0000111122223333444455556666777788889999aaaabbbbcccc",
+                "effective_grant": "fs=read-only net=allowlist exec=none"
+            },
+            "hash": "bbb"
+        },
+        {
+            "seq": 2,
+            "prev_hash": "bbb",
+            "event": { "kind": "capsule_refused", "artifact": "evil@0.1.0", "reason": "untrusted signer" },
+            "hash": "ccc"
+        }
+    ])
+    .to_string()
+}
+
+#[test]
+fn import_install_promotes_and_is_idempotent() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    let audit = tmp.path().join("install.audit.json");
+    std::fs::write(&audit, sample_audit_log()).unwrap();
+
+    let import = || {
+        let out = Command::new(lex_bin())
+            .args([
+                "--output",
+                "json",
+                "attest",
+                "import-install",
+                "--audit",
+                audit.to_str().unwrap(),
+                "--store",
+                store.to_str().unwrap(),
+            ])
+            .output()
+            .unwrap();
+        assert!(
+            out.status.success(),
+            "stderr={}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        serde_json::from_slice::<serde_json::Value>(&out.stdout).unwrap()
+    };
+
+    // First import: exactly the one `capsule_installed` event lands.
+    let first = import();
+    assert_eq!(first["data"]["imported"], 1, "one install event imported");
+    assert_eq!(first["data"]["already_present"], 0);
+    let att = &first["data"]["attestations"][0];
+    assert_eq!(att["signer"], SIGNER);
+    assert_eq!(att["already_present"], false);
+
+    // Second import of the same log: content-addressed dedup → no new fact.
+    let second = import();
+    assert_eq!(second["data"]["imported"], 1);
+    assert_eq!(
+        second["data"]["already_present"], 1,
+        "re-import dedups by content-addressed id"
+    );
+}
+
+#[test]
+fn imported_installs_are_blame_queryable_and_feed_producer_trust() {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = tmp.path().join("store");
+    let audit = tmp.path().join("install.audit.json");
+    std::fs::write(&audit, sample_audit_log()).unwrap();
+
+    let run = |args: &[&str]| {
+        let out = Command::new(lex_bin()).args(args).output().unwrap();
+        assert!(
+            out.status.success(),
+            "args={args:?} stderr={}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        serde_json::from_slice::<serde_json::Value>(&out.stdout).unwrap()
+    };
+    let store_s = store.to_str().unwrap();
+
+    run(&[
+        "--output",
+        "json",
+        "attest",
+        "import-install",
+        "--audit",
+        audit.to_str().unwrap(),
+        "--store",
+        store_s,
+    ]);
+
+    // Queryable by kind, keyed under the signer's stage.
+    let filtered = run(&[
+        "--output",
+        "json",
+        "attest",
+        "filter",
+        "--kind",
+        "capsule_install",
+        "--store",
+        store_s,
+    ]);
+    assert_eq!(filtered["data"]["count"], 1);
+    assert_eq!(
+        filtered["data"]["attestations"][0]["stage_id"], SIGNER,
+        "the install attestation is keyed under the signer"
+    );
+    assert_eq!(
+        filtered["data"]["attestations"][0]["produced_by"]["tool"], SIGNER,
+        "produced_by.tool == signer so producer-trust scores the publisher"
+    );
+
+    // The install is earned track record: recompute trust for the signer,
+    // then the keyring exports it — the loop #626's keyring consumes.
+    run(&[
+        "--output",
+        "json",
+        "producer-trust",
+        "recompute",
+        "--tool",
+        SIGNER,
+        "--store",
+        store_s,
+    ]);
+    let keyring = run(&[
+        "producer-trust",
+        "keyring",
+        "--store",
+        store_s,
+        "--min-trust",
+        "700",
+    ]);
+    let trusted: Vec<&str> = keyring["trusted"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert_eq!(
+        trusted,
+        vec![SIGNER],
+        "a clean install earns the signer a place in the trusted-keys keyring"
+    );
+}

--- a/crates/lex-cli/tests/cli-skill.txt
+++ b/crates/lex-cli/tests/cli-skill.txt
@@ -276,11 +276,16 @@ lex attest filter --kind type_check --since 2026-05-01
 ```
 
 ```bash
+# Promote capsule installs to attestations
+lex attest import-install --audit install.audit.json
+```
+
+```bash
 # Machine-readable
 lex --output json attest filter --kind spec
 ```
 
-**See also:** `lex stage`, `lex blame`
+**See also:** `lex stage`, `lex blame`, `lex producer-trust`
 
 ## `lex trace`
 

--- a/crates/lex-vcs/src/attestation.rs
+++ b/crates/lex-vcs/src/attestation.rs
@@ -295,6 +295,35 @@ pub enum AttestationKind {
         /// (e.g. `spec`, `type_check`).
         kind_tag: String,
     },
+    /// A capsule installed cleanly under lex-os (lex-os#36 / #38).
+    /// Promotes the tamper-evident `CapsuleInstalled` record from a
+    /// `lex-os capsule install --audit-out` log into a durable,
+    /// content-addressed attestation, via `lex attest import-install`.
+    ///
+    /// In the capsule distribution model the publisher's signing key
+    /// *is* the producer identity, so these records are stored under
+    /// `stage_id == signer` **and** carry `produced_by.tool == signer`
+    /// — the same convention `ProducerBlock` / `ProducerTrust` use.
+    /// That makes a publisher's install track record feed
+    /// `recompute_producer_trust` (which scores `produced_by.tool`)
+    /// and, through it, the trusted-keys keyring that `capsule install
+    /// --trusted-keys` consumes. The loop closes: install → attestation
+    /// → earned trust → keyring → next install.
+    CapsuleInstall {
+        /// `name@version` label of the installed artifact.
+        artifact: String,
+        /// Hex SHA-256 of the published archive bytes — the
+        /// publish-time identity of exactly which bytes installed.
+        /// Empty when imported from a pre-content-hash audit log.
+        content_hash: ContentHash,
+        /// The publisher's Ed25519 public key (hex): the verified
+        /// signer of the capability contract. Duplicated from
+        /// `stage_id` / `produced_by.tool` for clarity in the JSON.
+        signer: String,
+        /// The grant the box actually ran at — `meet(consumer,
+        /// requires)`, pretty-printed.
+        effective_grant: String,
+    },
 }
 
 /// Walk a tool's `ProducerBlock` / `ProducerUnblock` attestations


### PR DESCRIPTION
The lex-lang half of the cross-repo item: **make the lex-os capsule install record durable + `lex blame`-queryable** (the attestation follow-up named in lex-os#36 / #38).

Today a `lex-os capsule install` decision lands only in lex-os's local hash-chained audit log — a throwaway file. This promotes it into the durable, content-addressed **attestation graph**, closing the loop with the #626 ProducerTrust keyring.

## What's here
- **`lex-vcs`** — new `AttestationKind::CapsuleInstall { artifact, content_hash, signer, effective_grant }`. Stored under `stage_id == signer` with `produced_by.tool == signer` — the same per-producer-index convention `ProducerBlock`/`ProducerTrust` use. In the capsule model the publisher's signing key *is* the producer identity (as #626 already assumes), so these records feed `recompute_producer_trust` (which scores `produced_by.tool`) with **zero scoring changes**.
- **`lex-cli`** — `lex attest import-install --audit <lex-os-audit.json> [--store DIR]`: reads a lex-os audit log and emits a `CapsuleInstall` attestation for every `capsule_installed` event. **Idempotent** — the content-addressed id dedups re-imports.
- Wired into `attestation_kind_tag`, the `lex stage --attestations` printer, the lex-api activity feed, and the acli surface (`lex attest filter --kind capsule_install`, `lex blame` are JSON-tag generic and surface it automatically).

## The loop it closes
```
lex-os capsule install … --audit-out install.audit.json   # records the install
lex attest import-install --audit install.audit.json       # → durable attestation (keyed by signer)
lex producer-trust recompute --tool <signer>               # install becomes earned track record
lex producer-trust keyring --min-trust 700 --out trusted.json
lex-os capsule install … --trusted-keys trusted.json       # next install authorized by track record
```
Verified end-to-end with real binaries across both repos: a real `capsule install` audit log → imported attestation (real `content_hash`) → `producer-trust` → the signer exported in the keyring.

## Tests
- `attest_import_install.rs`: promote + idempotent re-import; signer-keyed and `produced_by.tool == signer`; queryable via `attest filter --kind capsule_install`; earns a place in the `producer-trust keyring`.
- `cli-skill.txt` snapshot regenerated; `readme_commands` guards green.
- `clippy -p lex-vcs -p lex-cli -p lex-api --all-targets -- -D warnings` clean.

Pairs with the lex-os PR that adds `content_hash` to the install audit event.

https://claude.ai/code/session_01JN3QxEMSBnejE6TCkAF86k

---
_Generated by [Claude Code](https://claude.ai/code/session_01JN3QxEMSBnejE6TCkAF86k)_