### PR TITLE
pkg: publish + verify signed capability contracts (registry leg)

### DIFF
--- a/crates/lex-cli/src/acli.rs
+++ b/crates/lex-cli/src/acli.rs
@@ -162,20 +162,28 @@ fn cmd_init() -> CommandInfo {
 fn cmd_pkg() -> CommandInfo {
     CommandInfo::new(
         "pkg",
-        "package manager: init, add, install, list dependencies",
+        "package manager: init, add, install, list deps; publish/verify signed capability contracts",
     )
     .idempotent(false)
     .add_argument(
         "subcommand",
-        "enum[init|add|install|list]",
+        "enum[init|add|install|list|publish|verify]",
         "what to do",
         true,
     )
     .with_examples(vec![
         ("Install deps", "lex pkg install"),
         ("Add a path dep", "lex pkg add mylib --path ../mylib"),
+        (
+            "Publish with a signed contract",
+            "lex pkg publish --sign <key> --requires grant.json --contract-out c.json --archive-out pkg.tar",
+        ),
+        (
+            "Verify a package against its contract",
+            "lex pkg verify --archive pkg.tar --contract c.json --trusted-keys keyring.json",
+        ),
     ])
-    .with_see_also(vec!["init", "ci"])
+    .with_see_also(vec!["init", "ci", "keygen"])
 }
 
 fn cmd_fmt() -> CommandInfo {

--- a/crates/lex-cli/src/capsule_contract.rs
+++ b/crates/lex-cli/src/capsule_contract.rs
@@ -1,0 +1,292 @@
+//! The capsule **capability contract** — lex-lang's emitter/verifier for the
+//! signed contract that `lex-os capsule install` consumes (the registry leg of
+//! lex-os#36).
+//!
+//! This is a faithful, byte-compatible reimplementation of the versioned
+//! `lex.os.capsule.contract.v1` format defined in `lex-os-capsule`. lex-lang
+//! and lex-os are deliberately separate repos with a one-way dependency
+//! (lex-os → lex-lang), so the contract type cannot simply be imported here.
+//! Instead we reproduce the *versioned* wire format exactly; the one non-trivial
+//! shared type — [`lex_types::trust::Grant`] — really is the same crate (lex-lang
+//! owns it, lex-os imports it), so its serialization cannot drift. Only the thin
+//! wrapper structs and the canonical-byte construction are mirrored here, and
+//! `tests/pkg_contract.rs::canonical_form_is_pinned` locks those bytes against a
+//! golden vector so a divergence fails CI rather than silently breaking install.
+//!
+//! What lex-lang produces (`lex pkg publish --sign`) is the same `SignedContract`
+//! JSON `lex-os capsule install --contract` already verifies, signed over the
+//! same domain-separated payload. The interop is proven end-to-end by the
+//! cross-binary test that feeds a lex-lang-signed contract to `lex-os capsule
+//! verify`/`install`.
+
+use lex_types::trust::Grant;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// Domain separator mixed into the signed payload and the content id, so a
+/// contract signature can never be confused with a signature over any other
+/// lex-os structure. Must match `lex-os-capsule`'s `CONTRACT_DOMAIN` exactly.
+pub const CONTRACT_DOMAIN: &[u8] = b"lex.os.capsule.contract.v1";
+
+/// A handle to the distributable bits: a `lex pkg` artifact identified by name,
+/// version, and the content hash of its published archive. The hash is
+/// authoritative — name/version are for humans and discovery.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArtifactRef {
+    pub name: String,
+    pub version: String,
+    /// Hex SHA-256 of the published package archive. The signature binds the
+    /// contract to *these* bytes.
+    pub content_hash: String,
+}
+
+/// The capability envelope an artifact declares it needs to run as intended:
+/// the trust [`Grant`] and the network egress allowlist. A *declared
+/// requirement* bound to a specific artifact, never a grant of authority.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapabilityContract {
+    pub artifact: ArtifactRef,
+    /// The grant the artifact needs. Same `lex_types::trust::Grant` lex-os
+    /// uses, so the on-disk JSON (`{"filesystem":"ReadOnly",…}`) is identical.
+    pub requires: Grant,
+    /// Network hosts the artifact must reach. Subset of the consumer's egress
+    /// at install time.
+    #[serde(default)]
+    pub egress: Vec<String>,
+}
+
+/// A capability contract plus the publisher's Ed25519 signature over its
+/// canonical bytes — the unit that travels with (or alongside) a published
+/// artifact. Field order matches `lex-os-capsule::SignedContract` so the JSON
+/// round-trips between the two.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SignedContract {
+    pub contract: CapabilityContract,
+    /// Hex-encoded Ed25519 public key (32 bytes) of the signer.
+    pub signer: String,
+    /// Hex-encoded Ed25519 signature (64 bytes) over [`signing_payload`].
+    ///
+    /// [`signing_payload`]: CapabilityContract::signing_payload
+    pub signature: String,
+}
+
+impl CapabilityContract {
+    /// The canonical JSON used for signing and content-addressing. Mirrors
+    /// `lex-os-capsule::CapabilityContract::canonical_json` byte-for-byte: a
+    /// dedicated `#[derive(Serialize)]` struct (never `serde_json::Value`, whose
+    /// key order depends on a build flag), grant levels as integer **ranks**,
+    /// and egress sorted.
+    pub fn canonical_json(&self) -> String {
+        #[derive(Serialize)]
+        struct CanonArtifact<'a> {
+            name: &'a str,
+            version: &'a str,
+            content_hash: &'a str,
+        }
+        #[derive(Serialize)]
+        struct CanonRequires {
+            filesystem: u8,
+            network: u8,
+            exec: u8,
+        }
+        #[derive(Serialize)]
+        struct Canon<'a> {
+            artifact: CanonArtifact<'a>,
+            requires: CanonRequires,
+            egress: Vec<String>,
+        }
+        let mut egress = self.egress.clone();
+        egress.sort();
+        let canon = Canon {
+            artifact: CanonArtifact {
+                name: &self.artifact.name,
+                version: &self.artifact.version,
+                content_hash: &self.artifact.content_hash,
+            },
+            requires: CanonRequires {
+                filesystem: self.requires.filesystem.rank(),
+                network: self.requires.network.rank(),
+                exec: self.requires.exec.rank(),
+            },
+            egress,
+        };
+        serde_json::to_string(&canon).expect("contract canonical json is always serializable")
+    }
+
+    /// The exact bytes that get signed and verified: the domain separator, a
+    /// null byte, then the canonical JSON.
+    pub fn signing_payload(&self) -> Vec<u8> {
+        let mut payload = Vec::with_capacity(CONTRACT_DOMAIN.len() + 1 + self.canonical_json().len());
+        payload.extend_from_slice(CONTRACT_DOMAIN);
+        payload.push(b'\0');
+        payload.extend_from_slice(self.canonical_json().as_bytes());
+        payload
+    }
+
+    /// Content address of the contract — SHA-256 over the domain separator and
+    /// the canonical form (independent of who signed it). Matches
+    /// `lex-os-capsule::CapabilityContract::content_id`.
+    pub fn content_id(&self) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(CONTRACT_DOMAIN);
+        hasher.update(self.canonical_json().as_bytes());
+        hex_lower(&hasher.finalize())
+    }
+
+    /// Sign this contract with `key`, producing a [`SignedContract`] the
+    /// consumer verifies with the corresponding public key.
+    pub fn sign(self, key: &lex_vcs::Keypair) -> SignedContract {
+        let signature = key.sign_message(&self.signing_payload());
+        SignedContract {
+            signer: key.public_hex(),
+            signature,
+            contract: self,
+        }
+    }
+}
+
+impl SignedContract {
+    /// Verify the signature binds *this* contract to the declared signer key.
+    /// Returns the signer's hex public key on success; trusting that *key* is a
+    /// separate decision (see the keyring check in `lex pkg verify`).
+    pub fn verify(&self) -> Result<String, String> {
+        lex_vcs::verify_message(
+            &self.signer,
+            &self.contract.signing_payload(),
+            &self.signature,
+        )
+        .map_err(|e| format!("signature does not verify for signer {}: {e}", self.signer))?;
+        Ok(self.signer.clone())
+    }
+
+    /// Check that `bytes` are the artifact this contract was signed over: their
+    /// SHA-256 must equal `artifact.content_hash`. The signature only *promises*
+    /// the declared hash; this closes the loop on the bytes you actually have.
+    pub fn matches_artifact(&self, bytes: &[u8]) -> Result<(), String> {
+        let actual = hash_artifact_bytes(bytes);
+        if actual.eq_ignore_ascii_case(&self.contract.artifact.content_hash) {
+            Ok(())
+        } else {
+            Err(format!(
+                "artifact bytes do not match the contract: content_hash is {} but the supplied bytes hash to {actual}",
+                self.contract.artifact.content_hash
+            ))
+        }
+    }
+}
+
+/// SHA-256 of an artifact archive as lowercase hex — the value
+/// [`ArtifactRef::content_hash`] holds. Matches
+/// `lex-os-capsule::CapabilityContract::hash_artifact_bytes`.
+pub fn hash_artifact_bytes(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex_lower(&hasher.finalize())
+}
+
+/// Lowercase-hex of a byte slice (lex-cli has no `hex` crate; this mirrors
+/// `lex-vcs::canonical::hash_bytes`'s encoding).
+fn hex_lower(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push_str(&format!("{b:02x}"));
+    }
+    out
+}
+
+/// A trusted-signer keyring: `{"trusted":[<hex pubkey>, …]}`. Same shape as
+/// `lex-os-capsule::Keyring` and what `lex producer-trust keyring` emits, so a
+/// keyring earned from track record gates `lex pkg verify` too.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Keyring {
+    #[serde(default)]
+    pub trusted: Vec<String>,
+}
+
+impl Keyring {
+    /// Whether `signer` (hex public key) is in the trusted set (case-insensitive).
+    pub fn trusts(&self, signer: &str) -> bool {
+        self.trusted.iter().any(|k| k.eq_ignore_ascii_case(signer))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lex_types::trust::{Grant, Level};
+
+    fn sample() -> CapabilityContract {
+        CapabilityContract {
+            artifact: ArtifactRef {
+                name: "pdf-extract".into(),
+                version: "2.0.0".into(),
+                content_hash: "ff".repeat(32),
+            },
+            requires: Grant {
+                filesystem: Level::ReadOnly,
+                network: Level::Allowlist,
+                exec: Level::None,
+            },
+            // Intentionally unsorted: canonical form must sort it.
+            egress: vec!["b.example".into(), "a.example".into()],
+        }
+    }
+
+    #[test]
+    fn canonical_form_is_pinned() {
+        // Locks the `lex.os.capsule.contract.v1` wire bytes lex-os signs and
+        // verifies over: grant levels as integer ranks, egress sorted, fixed
+        // field order. If this assertion changes, every `lex-os capsule install`
+        // of a lex-pkg-published contract silently breaks — so it must only
+        // change in lock-step with lex-os-capsule's `canonical_form_is_pinned`.
+        let expected = format!(
+            "{{\"artifact\":{{\"name\":\"pdf-extract\",\"version\":\"2.0.0\",\"content_hash\":\"{}\"}},\"requires\":{{\"filesystem\":1,\"network\":2,\"exec\":0}},\"egress\":[\"a.example\",\"b.example\"]}}",
+            "ff".repeat(32)
+        );
+        assert_eq!(sample().canonical_json(), expected);
+
+        let payload = sample().signing_payload();
+        assert!(payload.starts_with(CONTRACT_DOMAIN));
+        assert_eq!(payload[CONTRACT_DOMAIN.len()], 0, "domain is NUL-separated");
+        assert_eq!(&payload[CONTRACT_DOMAIN.len() + 1..], expected.as_bytes());
+
+        let id = sample().content_id();
+        assert_eq!(id.len(), 64);
+        assert!(id.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn sign_then_verify_roundtrips_and_detects_tamper() {
+        let kp = lex_vcs::Keypair::from_seed(&[9u8; 32]);
+        let signed = sample().sign(&kp);
+        assert_eq!(signed.signer, kp.public_hex());
+        assert_eq!(signed.verify().unwrap(), kp.public_hex());
+
+        // Tampering any signed field (here the declared hash) breaks the bind.
+        let mut bad = signed.clone();
+        bad.contract.artifact.content_hash = "00".repeat(32);
+        assert!(bad.verify().is_err(), "tampered contract must not verify");
+    }
+
+    #[test]
+    fn matches_artifact_checks_the_actual_bytes() {
+        let bytes = b"the real archive bytes";
+        let mut c = sample();
+        c.artifact.content_hash = hash_artifact_bytes(bytes);
+        let signed = c.sign(&lex_vcs::Keypair::from_seed(&[3u8; 32]));
+        assert!(signed.matches_artifact(bytes).is_ok());
+        assert!(signed.matches_artifact(b"different bytes").is_err());
+    }
+
+    #[test]
+    fn json_roundtrips_with_grant_as_enum_names() {
+        // The on-disk SignedContract must use Grant enum names (not ranks) so
+        // lex-os deserializes it into the identical lex_types::Grant.
+        let signed = sample().sign(&lex_vcs::Keypair::from_seed(&[1u8; 32]));
+        let json = serde_json::to_string(&signed).unwrap();
+        assert!(json.contains("\"filesystem\":\"ReadOnly\""));
+        assert!(json.contains("\"network\":\"Allowlist\""));
+        let back: SignedContract = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, signed);
+    }
+}

--- a/crates/lex-cli/src/main.rs
+++ b/crates/lex-cli/src/main.rs
@@ -15,6 +15,7 @@ mod agent_guidelines;
 mod ast_merge;
 mod audit;
 mod branch;
+mod capsule_contract;
 mod ci;
 mod diff;
 mod docs;

--- a/crates/lex-cli/src/pkg.rs
+++ b/crates/lex-cli/src/pkg.rs
@@ -8,9 +8,22 @@
 //!   lex pkg add <name> --registry <url> --version <v>  — add a registry dependency
 //!   lex pkg list                                       — list dependencies in lex.toml
 //!   lex pkg publish [--registry <url>] [--token <jwt>] — publish package to a registry
+//!       [--sign <key>] [--requires <grant.json>] [--egress h,h] [--contract-out <file>]
+//!                                                      — also emit a signed capability
+//!                                                        contract (the lex-os capsule
+//!                                                        format) binding the published
+//!                                                        bytes to the grant it needs
+//!   lex pkg verify --archive <tar> --contract <c.json> [--trusted-keys <keyring.json>]
+//!                                                      — verify a package against its
+//!                                                        signed contract (signature +
+//!                                                        content hash + signer trust)
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use std::path::Path;
+
+use crate::capsule_contract::{
+    ArtifactRef, CapabilityContract, Keyring, SignedContract,
+};
 
 pub fn cmd_pkg(args: &[String]) -> Result<()> {
     match args.first().map(|s| s.as_str()) {
@@ -19,8 +32,9 @@ pub fn cmd_pkg(args: &[String]) -> Result<()> {
         Some("list")    => cmd_list(),
         Some("install") => cmd_install(),
         Some("publish") => cmd_publish(&args[1..]),
-        Some(other)     => bail!("unknown pkg subcommand `{other}`; try: init, add, install, list, publish"),
-        None            => bail!("usage: lex pkg <init|add|install|list|publish>"),
+        Some("verify")  => cmd_verify(&args[1..]),
+        Some(other)     => bail!("unknown pkg subcommand `{other}`; try: init, add, install, list, publish, verify"),
+        None            => bail!("usage: lex pkg <init|add|install|list|publish|verify>"),
     }
 }
 
@@ -272,6 +286,14 @@ fn build_archive(toml_dir: &std::path::Path) -> Result<Vec<u8>> {
 fn cmd_publish(args: &[String]) -> Result<()> {
     let mut registry_arg: Option<String> = None;
     let mut token_arg:    Option<String> = None;
+    // Provenance: when --sign is given, emit a signed capability contract
+    // (the lex-os capsule format) alongside / instead of uploading.
+    let mut sign_arg:     Option<String> = None;
+    let mut requires_arg: Option<String> = None;
+    let mut egress_arg:   Vec<String>    = Vec::new();
+    let mut contract_out: Option<String> = None;
+    let mut archive_out:  Option<String> = None;
+    let mut no_upload = false;
     let mut i = 0;
     while i < args.len() {
         match args[i].as_str() {
@@ -287,6 +309,38 @@ fn cmd_publish(args: &[String]) -> Result<()> {
                     anyhow::anyhow!("--token requires a value")
                 })?);
             }
+            "--sign" => {
+                i += 1;
+                sign_arg = Some(args.get(i).cloned().ok_or_else(|| {
+                    anyhow::anyhow!("--sign requires a key (64-hex secret, or @path / env LEX_SIGNING_KEY)")
+                })?);
+            }
+            "--requires" => {
+                i += 1;
+                requires_arg = Some(args.get(i).cloned().ok_or_else(|| {
+                    anyhow::anyhow!("--requires requires a path to a grant JSON file")
+                })?);
+            }
+            "--egress" => {
+                i += 1;
+                let v = args.get(i).cloned().ok_or_else(|| {
+                    anyhow::anyhow!("--egress requires a comma-separated host list")
+                })?;
+                egress_arg.extend(v.split(',').filter(|s| !s.is_empty()).map(String::from));
+            }
+            "--contract-out" => {
+                i += 1;
+                contract_out = Some(args.get(i).cloned().ok_or_else(|| {
+                    anyhow::anyhow!("--contract-out requires a path")
+                })?);
+            }
+            "--archive-out" => {
+                i += 1;
+                archive_out = Some(args.get(i).cloned().ok_or_else(|| {
+                    anyhow::anyhow!("--archive-out requires a path")
+                })?);
+            }
+            "--no-upload" => no_upload = true,
             other => bail!("unknown flag `{other}`"),
         }
         i += 1;
@@ -302,46 +356,210 @@ fn cmd_publish(args: &[String]) -> Result<()> {
     let pkg = manifest.package.as_ref()
         .ok_or_else(|| anyhow::anyhow!("lex.toml must have a [package] section"))?;
 
-    let registry = registry_arg
-        .or_else(|| pkg.registry.clone())
-        .ok_or_else(|| anyhow::anyhow!(
-            "no registry URL: pass --registry <url> or set `registry` in [package]"
-        ))?;
-
-    let token = token_arg
-        .or_else(|| std::env::var("LEX_PUBLISH_TOKEN").ok())
-        .ok_or_else(|| anyhow::anyhow!(
-            "no publish token: pass --token <jwt> or set LEX_PUBLISH_TOKEN"
-        ))?;
-
-    println!("publishing {}@{} to {} ...", pkg.name, pkg.version, registry);
-
+    // Build the archive once: the same bytes are hashed for the contract and
+    // uploaded to the registry, so the content_hash binds what installs.
     let archive = build_archive(&toml_dir)
         .map_err(|e| anyhow::anyhow!("building archive: {e}"))?;
+    let content_hash = crate::capsule_contract::hash_artifact_bytes(&archive);
 
-    let url = format!("{}/v1/pkg/publish", registry.trim_end_matches('/'));
-    let response = ureq::post(&url)
-        .header("Authorization", &format!("Bearer {token}"))
-        .header("Content-Type", "application/octet-stream")
-        .send(&archive[..])
-        .map_err(|e| anyhow::anyhow!("POST {url}: {e}"))?;
-
-    let status = response.status().as_u16();
-    let body: serde_json::Value = response
-        .into_body()
-        .read_json()
-        .map_err(|e| anyhow::anyhow!("reading response: {e}"))?;
-
-    if status != 200 {
-        bail!(
-            "publish failed (HTTP {status}): {}",
-            body.get("error").and_then(|v| v.as_str()).unwrap_or("unknown error")
-        );
+    // Emit the exact bytes the content_hash binds, so a consumer can verify and
+    // `lex-os capsule install --artifact <archive>` can run them.
+    if let Some(path) = &archive_out {
+        std::fs::write(path, &archive)
+            .with_context(|| format!("writing archive to {path}"))?;
     }
 
-    let head_op = body.get("head_op").and_then(|v| v.as_str()).unwrap_or("(none)");
-    println!("published  head_op = {head_op}");
+    // ── Provenance: emit a signed capability contract ──────────────────────
+    if let Some(key_spec) = &sign_arg {
+        let requires_path = requires_arg.as_ref().ok_or_else(|| anyhow::anyhow!(
+            "--sign requires --requires <grant.json> (the capability the package needs)"
+        ))?;
+        let requires = load_grant(requires_path)?;
+        let keypair = resolve_pkg_signing_key(key_spec)?;
+
+        let contract = CapabilityContract {
+            artifact: ArtifactRef {
+                name: pkg.name.clone(),
+                version: pkg.version.clone(),
+                content_hash: content_hash.clone(),
+            },
+            requires,
+            egress: egress_arg.clone(),
+        };
+        let contract_id = contract.content_id();
+        let signed = contract.sign(&keypair);
+        let json = serde_json::to_string_pretty(&signed)
+            .map_err(|e| anyhow::anyhow!("serializing contract: {e}"))?;
+
+        let out_path = contract_out
+            .clone()
+            .unwrap_or_else(|| format!("{}-{}.contract.json", pkg.name, pkg.version));
+        std::fs::write(&out_path, format!("{json}\n"))
+            .with_context(|| format!("writing contract to {out_path}"))?;
+        println!(
+            "signed contract  {}@{}  contract_id={contract_id}  content_hash={content_hash}  signer={}",
+            pkg.name,
+            pkg.version,
+            signed.signer,
+        );
+        println!("  -> {out_path}  (install with: lex-os capsule install --contract {out_path} --artifact <archive>)");
+    } else if contract_out.is_some() || requires_arg.is_some() || !egress_arg.is_empty() {
+        bail!("--requires / --egress / --contract-out only apply with --sign");
+    }
+
+    // ── Registry upload ────────────────────────────────────────────────────
+    // Resolve the registry/token; if a contract was emitted and no registry is
+    // configured, that's a complete local publish — don't force an upload.
+    let registry = registry_arg.or_else(|| pkg.registry.clone());
+    let token = token_arg.or_else(|| std::env::var("LEX_PUBLISH_TOKEN").ok());
+
+    if no_upload {
+        return Ok(());
+    }
+    match (registry, token) {
+        (Some(registry), Some(token)) => {
+            println!("publishing {}@{} to {} ...", pkg.name, pkg.version, registry);
+            let url = format!("{}/v1/pkg/publish", registry.trim_end_matches('/'));
+            let response = ureq::post(&url)
+                .header("Authorization", &format!("Bearer {token}"))
+                .header("Content-Type", "application/octet-stream")
+                .send(&archive[..])
+                .map_err(|e| anyhow::anyhow!("POST {url}: {e}"))?;
+
+            let status = response.status().as_u16();
+            let body: serde_json::Value = response
+                .into_body()
+                .read_json()
+                .map_err(|e| anyhow::anyhow!("reading response: {e}"))?;
+            if status != 200 {
+                bail!(
+                    "publish failed (HTTP {status}): {}",
+                    body.get("error").and_then(|v| v.as_str()).unwrap_or("unknown error")
+                );
+            }
+            let head_op = body.get("head_op").and_then(|v| v.as_str()).unwrap_or("(none)");
+            println!("published  head_op = {head_op}");
+            Ok(())
+        }
+        // Contract emitted but no registry: a complete local publish.
+        _ if sign_arg.is_some() => Ok(()),
+        _ => bail!(
+            "no registry URL: pass --registry <url> or set `registry` in [package] \
+             (or use --sign … to emit a contract locally without uploading)"
+        ),
+    }
+}
+
+// ── lex pkg verify ────────────────────────────────────────────────────────────
+
+/// Verify a published package against its signed capability contract: the
+/// signature binds the contract to its declared signer, the archive bytes hash
+/// to the contract's `content_hash`, and — with `--trusted-keys` — the signer
+/// is one the consumer pinned. The same three gates `lex-os capsule install`
+/// applies, available to the package manager before a dependency is trusted.
+fn cmd_verify(args: &[String]) -> Result<()> {
+    let mut archive_path: Option<String> = None;
+    let mut contract_path: Option<String> = None;
+    let mut trusted_keys: Option<String> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--archive" => {
+                i += 1;
+                archive_path = Some(args.get(i).cloned().ok_or_else(|| {
+                    anyhow::anyhow!("--archive requires a path")
+                })?);
+            }
+            "--contract" => {
+                i += 1;
+                contract_path = Some(args.get(i).cloned().ok_or_else(|| {
+                    anyhow::anyhow!("--contract requires a path")
+                })?);
+            }
+            "--trusted-keys" => {
+                i += 1;
+                trusted_keys = Some(args.get(i).cloned().ok_or_else(|| {
+                    anyhow::anyhow!("--trusted-keys requires a path")
+                })?);
+            }
+            other => bail!("unknown flag `{other}`"),
+        }
+        i += 1;
+    }
+    let archive_path = archive_path.ok_or_else(|| anyhow::anyhow!(
+        "usage: lex pkg verify --archive <tar> --contract <c.json> [--trusted-keys <keyring.json>]"
+    ))?;
+    let contract_path = contract_path.ok_or_else(|| anyhow::anyhow!(
+        "usage: lex pkg verify --archive <tar> --contract <c.json> [--trusted-keys <keyring.json>]"
+    ))?;
+
+    let contract_raw = std::fs::read_to_string(&contract_path)
+        .with_context(|| format!("reading contract {contract_path}"))?;
+    let signed: SignedContract = serde_json::from_str(&contract_raw)
+        .with_context(|| format!("parsing contract {contract_path}"))?;
+    let archive = std::fs::read(&archive_path)
+        .with_context(|| format!("reading archive {archive_path}"))?;
+
+    // 1. Authenticity: the signature binds the contract to its signer.
+    let signer = signed.verify().map_err(|e| anyhow::anyhow!("authenticity: {e}"))?;
+    // 2. Integrity: the bytes are the ones the contract was signed over.
+    signed.matches_artifact(&archive).map_err(|e| anyhow::anyhow!("integrity: {e}"))?;
+    // 3. Authorization: the signer is trusted (if a keyring was supplied).
+    let trust_checked = match &trusted_keys {
+        Some(path) => {
+            let raw = std::fs::read_to_string(path)
+                .with_context(|| format!("reading keyring {path}"))?;
+            let keyring: Keyring = serde_json::from_str(&raw)
+                .with_context(|| format!("parsing keyring {path}"))?;
+            if !keyring.trusts(&signer) {
+                bail!("authorization: signer {signer} is not in the trusted keyring {path}");
+            }
+            true
+        }
+        None => {
+            eprintln!(
+                "⚠  signer NOT checked against a trusted keyring — any valid signature is \
+                 accepted. Pass --trusted-keys <keyring.json> to pin publishers."
+            );
+            false
+        }
+    };
+
+    let a = &signed.contract.artifact;
+    println!(
+        "verified  {}@{}  content_hash={}  signer={signer}  signer_trust_checked={trust_checked}",
+        a.name, a.version, a.content_hash,
+    );
     Ok(())
+}
+
+/// Load a `lex_types::trust::Grant` from a JSON file (the `--requires` shape:
+/// `{"filesystem":"ReadOnly","network":"Allowlist","exec":"None"}`).
+fn load_grant(path: &str) -> Result<lex_types::trust::Grant> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("reading grant file {path}"))?;
+    serde_json::from_str(&raw)
+        .with_context(|| format!("parsing grant {path} (expected {{\"filesystem\":…,\"network\":…,\"exec\":…}})"))
+}
+
+/// Resolve a signing key for `lex pkg publish --sign`. Accepts a 64-hex secret
+/// directly, `@<path>` to read it from a file, or falls back to
+/// `LEX_SIGNING_KEY` when the literal `env` is passed — mirroring how
+/// `lex publish` resolves its signer.
+fn resolve_pkg_signing_key(spec: &str) -> Result<lex_vcs::Keypair> {
+    let hex = if let Some(path) = spec.strip_prefix('@') {
+        std::fs::read_to_string(path)
+            .with_context(|| format!("reading signing key from {path}"))?
+            .trim()
+            .to_string()
+    } else if spec == "env" {
+        std::env::var("LEX_SIGNING_KEY")
+            .map_err(|_| anyhow::anyhow!("--sign env requires LEX_SIGNING_KEY to be set"))?
+    } else {
+        spec.to_string()
+    };
+    lex_vcs::Keypair::from_secret_hex(&hex)
+        .map_err(|e| anyhow::anyhow!("invalid signing key: {e}"))
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/crates/lex-cli/tests/cli-skill.txt
+++ b/crates/lex-cli/tests/cli-skill.txt
@@ -38,7 +38,7 @@ description: "Invoke the `lex` CLI. Commands: parse, check, run, hash…"
 - `lex watch` — re-run check or run on file save (agent inner loop)
 - `lex agent-guidelines` — emit the AI-agent authoring contract (idiom rules) for this Lex toolchain (idempotent)
 - `lex init` — scaffold a new project (lex.toml, src/, tests/, CI)
-- `lex pkg` — package manager: init, add, install, list dependencies
+- `lex pkg` — package manager: init, add, install, list deps; publish/verify signed capability contracts
 - `lex fmt` — format .lex files; --check exits 1 if any need it
 - `lex ci` — run the full pipeline: pkg install, check --strict, fmt --check, test
 - `lex test` — run tests/test_*.lex files (calls run_all in each) (idempotent)
@@ -754,11 +754,11 @@ lex init my-proj
 
 ## `lex pkg`
 
-package manager: init, add, install, list dependencies
+package manager: init, add, install, list deps; publish/verify signed capability contracts
 
 ### Arguments
 
-- `subcommand` (enum[init|add|install|list], required) — what to do
+- `subcommand` (enum[init|add|install|list|publish|verify], required) — what to do
 
 ### Examples
 
@@ -772,7 +772,17 @@ lex pkg install
 lex pkg add mylib --path ../mylib
 ```
 
-**See also:** `lex init`, `lex ci`
+```bash
+# Publish with a signed contract
+lex pkg publish --sign <key> --requires grant.json --contract-out c.json --archive-out pkg.tar
+```
+
+```bash
+# Verify a package against its contract
+lex pkg verify --archive pkg.tar --contract c.json --trusted-keys keyring.json
+```
+
+**See also:** `lex init`, `lex ci`, `lex keygen`
 
 ## `lex fmt`
 

--- a/crates/lex-cli/tests/pkg_contract.rs
+++ b/crates/lex-cli/tests/pkg_contract.rs
@@ -1,0 +1,173 @@
+//! Conformance for `lex pkg publish --sign` + `lex pkg verify` — the registry
+//! leg of lex-os#36: a published package carries a signed capability contract
+//! (the lex-os capsule format) binding its bytes to the grant it needs, and the
+//! package manager verifies that contract before trusting a dependency.
+//!
+//! Byte-compatibility with `lex-os capsule install` is locked by
+//! `capsule_contract::tests::canonical_form_is_pinned` (the v1 golden vector);
+//! lex-os's binary isn't available here, so these tests cover lex-lang's own
+//! publish/verify surface and its three refusal paths.
+
+use std::path::Path;
+use std::process::Command;
+
+fn lex_bin() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_lex"))
+}
+
+/// A fixed 32-byte seed (64 hex) so the signer key is deterministic.
+const SECRET: &str = "1122334455667788990011223344556677889900112233445566778899001122";
+
+fn signer_pubkey() -> String {
+    lex_vcs::Keypair::from_secret_hex(SECRET).unwrap().public_hex()
+}
+
+fn setup_pkg(dir: &Path) {
+    std::fs::create_dir_all(dir.join("src")).unwrap();
+    std::fs::write(
+        dir.join("lex.toml"),
+        "[package]\nname = \"lex-weather\"\nversion = \"1.2.0\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("src/main.lex"),
+        "fn main() -> [net(\"api.weather.example\")] Unit { net.fetch(\"api.weather.example\") }\n",
+    )
+    .unwrap();
+}
+
+/// Publish with a signed contract; returns (contract_path, archive_path).
+fn publish_signed(work: &Path) -> (std::path::PathBuf, std::path::PathBuf) {
+    let pkg = work.join("pkg");
+    setup_pkg(&pkg);
+    let grant = work.join("grant.json");
+    std::fs::write(
+        &grant,
+        "{\"filesystem\":\"None\",\"network\":\"Allowlist\",\"exec\":\"None\"}\n",
+    )
+    .unwrap();
+    let contract = work.join("contract.json");
+    let archive = work.join("art.tar");
+
+    let out = Command::new(lex_bin())
+        .current_dir(&pkg)
+        .args([
+            "pkg",
+            "publish",
+            "--sign",
+            SECRET,
+            "--requires",
+            grant.to_str().unwrap(),
+            "--egress",
+            "api.weather.example",
+            "--contract-out",
+            contract.to_str().unwrap(),
+            "--archive-out",
+            archive.to_str().unwrap(),
+            "--no-upload",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "publish failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    (contract, archive)
+}
+
+fn write_keyring(work: &Path, keys: &[&str]) -> std::path::PathBuf {
+    let path = work.join("keyring.json");
+    let trusted = keys
+        .iter()
+        .map(|k| format!("\"{k}\""))
+        .collect::<Vec<_>>()
+        .join(",");
+    std::fs::write(&path, format!("{{\"trusted\":[{trusted}]}}\n")).unwrap();
+    path
+}
+
+fn verify(contract: &Path, archive: &Path, keyring: Option<&Path>) -> std::process::Output {
+    let mut args = vec![
+        "pkg".to_string(),
+        "verify".to_string(),
+        "--archive".to_string(),
+        archive.to_str().unwrap().to_string(),
+        "--contract".to_string(),
+        contract.to_str().unwrap().to_string(),
+    ];
+    if let Some(k) = keyring {
+        args.push("--trusted-keys".to_string());
+        args.push(k.to_str().unwrap().to_string());
+    }
+    Command::new(lex_bin()).args(&args).output().unwrap()
+}
+
+#[test]
+fn publish_emits_a_contract_that_verifies() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (contract, archive) = publish_signed(tmp.path());
+
+    // The emitted contract binds the right artifact, grant, and signer.
+    let signed: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&contract).unwrap()).unwrap();
+    assert_eq!(signed["contract"]["artifact"]["name"], "lex-weather");
+    assert_eq!(signed["contract"]["artifact"]["version"], "1.2.0");
+    assert_eq!(signed["contract"]["requires"]["network"], "Allowlist");
+    assert_eq!(signed["contract"]["egress"][0], "api.weather.example");
+    assert_eq!(signed["signer"], signer_pubkey());
+
+    // With the publisher's key pinned, verification passes all three gates.
+    let keyring = write_keyring(tmp.path(), &[&signer_pubkey()]);
+    let out = verify(&contract, &archive, Some(&keyring));
+    assert!(
+        out.status.success(),
+        "verify should pass: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("verified  lex-weather@1.2.0"));
+    assert!(stdout.contains("signer_trust_checked=true"));
+}
+
+#[test]
+fn verify_rejects_a_substituted_archive() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (contract, archive) = publish_signed(tmp.path());
+    // Swap the archive bytes for something else: integrity gate must fire.
+    std::fs::write(&archive, b"not the published bytes").unwrap();
+    let keyring = write_keyring(tmp.path(), &[&signer_pubkey()]);
+    let out = verify(&contract, &archive, Some(&keyring));
+    assert!(!out.status.success());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("integrity"));
+}
+
+#[test]
+fn verify_rejects_a_tampered_contract() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (contract, archive) = publish_signed(tmp.path());
+    // Edit a signed field (the required grant) after signing: signature breaks.
+    let raw = std::fs::read_to_string(&contract).unwrap();
+    // The emitted contract is pretty-printed: `"network": "Allowlist"`.
+    let tampered = raw.replace("\"network\": \"Allowlist\"", "\"network\": \"Full\"");
+    assert_ne!(raw, tampered, "the replace must actually change the contract");
+    std::fs::write(&contract, tampered).unwrap();
+    let keyring = write_keyring(tmp.path(), &[&signer_pubkey()]);
+    let out = verify(&contract, &archive, Some(&keyring));
+    assert!(!out.status.success());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("authenticity"));
+}
+
+#[test]
+fn verify_rejects_an_untrusted_signer() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (contract, archive) = publish_signed(tmp.path());
+    // A keyring that trusts some other key: authorization gate must fire.
+    let other = lex_vcs::Keypair::from_secret_hex(&"aa".repeat(32))
+        .unwrap()
+        .public_hex();
+    let keyring = write_keyring(tmp.path(), &[&other]);
+    let out = verify(&contract, &archive, Some(&keyring));
+    assert!(!out.status.success());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("not in the trusted keyring"));
+}

--- a/crates/lex-vcs/src/lib.rs
+++ b/crates/lex-vcs/src/lib.rs
@@ -61,7 +61,7 @@ pub use merge_session::{
     Resolution, ResolutionRejection,
 };
 pub use predicate::{evaluate, evaluate_with_resolver, IntentResolver, Predicate};
-pub use signing::{verify_stage_id, Keypair, SigningError};
+pub use signing::{verify_message, verify_stage_id, Keypair, SigningError};
 pub use op_log::OpLog;
 pub use operation::{
     budget_from_effects as operation_budget_from_effects, EffectSet, ModuleRef, OpId, Operation,

--- a/crates/lex-vcs/src/signing.rs
+++ b/crates/lex-vcs/src/signing.rs
@@ -122,6 +122,15 @@ impl Keypair {
             signature: hex::encode(sig.to_bytes()),
         }
     }
+
+    /// Sign arbitrary `msg` bytes, returning the lowercase-hex of the
+    /// 64-byte Ed25519 signature. Unlike [`Keypair::sign_stage_id`], the
+    /// caller controls the exact bytes — used for signing a capability
+    /// contract's domain-separated payload (`lex pkg publish`), which is
+    /// not a StageId. Verify with [`verify_message`].
+    pub fn sign_message(&self, msg: &[u8]) -> String {
+        hex::encode(self.inner.sign(msg).to_bytes())
+    }
 }
 
 /// Verify that `signature` is a valid Ed25519 signature over the
@@ -156,6 +165,40 @@ pub fn verify_stage_id(stage_id: &str, signature: &Signature) -> Result<(), Sign
     let sig = ed25519_dalek::Signature::from_bytes(&sig_arr);
     pk.verify(stage_id.as_bytes(), &sig)
         .map_err(|_| SigningError::VerifyFailed)
+}
+
+/// Verify a raw Ed25519 signature (lowercase hex, 128 chars) over `msg`
+/// against `public_key_hex` (64 chars). The byte-level twin of
+/// [`verify_stage_id`] for callers that signed a domain-separated
+/// payload rather than a StageId string (e.g. a capability contract).
+pub fn verify_message(
+    public_key_hex: &str,
+    msg: &[u8],
+    signature_hex: &str,
+) -> Result<(), SigningError> {
+    const PK_HEX_LEN: usize = 64;
+    const SIG_HEX_LEN: usize = 128;
+    if public_key_hex.len() != PK_HEX_LEN {
+        return Err(SigningError::PublicKeyLength {
+            expected: PK_HEX_LEN,
+            got: public_key_hex.len(),
+        });
+    }
+    if signature_hex.len() != SIG_HEX_LEN {
+        return Err(SigningError::SignatureLength {
+            expected: SIG_HEX_LEN,
+            got: signature_hex.len(),
+        });
+    }
+    let pk_bytes =
+        hex::decode(public_key_hex).map_err(|e| SigningError::BadHex(e.to_string()))?;
+    let sig_bytes =
+        hex::decode(signature_hex).map_err(|e| SigningError::BadHex(e.to_string()))?;
+    let pk_arr: [u8; 32] = pk_bytes.try_into().expect("length-checked");
+    let sig_arr: [u8; 64] = sig_bytes.try_into().expect("length-checked");
+    let pk = VerifyingKey::from_bytes(&pk_arr).map_err(|_| SigningError::BadPublicKey)?;
+    let sig = ed25519_dalek::Signature::from_bytes(&sig_arr);
+    pk.verify(msg, &sig).map_err(|_| SigningError::VerifyFailed)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Item 2, slice 1 — the **registry leg**: `lex pkg publish` emits the signed capability contract; `lex pkg verify` checks it. A package published through lex's package manager now carries the **same signed contract `lex-os capsule install` consumes**, unifying the lex supply chain with the capsule runtime.

Per the architecture call, this is **Option B**: lex-lang reproduces the *versioned* `lex.os.capsule.contract.v1` wire format (the repos are one-way coupled, so the type can't be imported). The one non-trivial shared type — `lex_types::trust::Grant` — *is* the same crate, so its serialization can't drift; a golden-vector test pins the rest.

## What's here
- **`lex-vcs`** — `Keypair::sign_message` + `verify_message`: raw-payload Ed25519 (the contract payload isn't a StageId).
- **`lex-cli` `capsule_contract`** (new) — byte-faithful `ArtifactRef`/`CapabilityContract`/`SignedContract` over the real `Grant`; `canonical_json` + `signing_payload` (`lex.os.capsule.contract.v1` + `\0` + canonical JSON: integer grant ranks, sorted egress) + `content_id` + `sign`/`verify`.
- **`lex pkg publish`** — `--sign <key>` · `--requires <grant.json>` · `--egress h,h` · `--contract-out` · `--archive-out` · `--no-upload`: hashes the archive, builds + signs the contract, emits it (and the bytes it binds). Registry upload stays backward-compatible.
- **`lex pkg verify --archive <tar> --contract <c.json> [--trusted-keys <k>]`** — the three gates `lex-os capsule install` applies: signature authenticity, content_hash integrity, signer authorization.

## Interop — proven end-to-end with both binaries
A lex-lang-signed contract is accepted by `lex-os capsule verify` (**identical `contract_id`**) and installs cleanly:
```
lex pkg publish --sign … --requires grant.json --contract-out c.json --archive-out art.tar --no-upload
lex-os capsule verify  --contract c.json                      # verified: true, contract_id matches
lex-os capsule install --contract c.json --artifact art.tar … # installed=true, bytes verified, grant narrowed
```

## Tests
- `capsule_contract` units: **golden-vector `canonical_form_is_pinned`** (locks the v1 bytes), sign/verify roundtrip + tamper, content_hash match, JSON round-trip (Grant as enum names).
- `pkg_contract` integration: publish→verify, plus the three refusals (substituted archive, tampered contract, untrusted signer).
- `cli-skill.txt` snapshot regenerated; `readme_commands` guards green; clippy `-D warnings` clean on lex-vcs + lex-cli.

## Scope / follow-ups
Grant is **declared** via `--requires` here. **Deriving the minimal grant from the package's typed effects** (lex-lang's superpower — provably least-authority) is the deliberate next slice; it introduces a second cross-repo coupling (effect→grant mapping) that deserves its own tested change. Also follow-up: `install`-time fetch+verify of registry contracts; a `lex.toml [capsule]` table.

No lex-os changes — it verifies the emitted contract as-is.

https://claude.ai/code/session_01JN3QxEMSBnejE6TCkAF86k

---
_Generated by [Claude Code](https://claude.ai/code/session_01JN3QxEMSBnejE6TCkAF86k)_