### PR TITLE
pkg: derive the contract grant from typed effects (--derive-grant)

### DIFF
--- a/crates/lex-cli/src/acli.rs
+++ b/crates/lex-cli/src/acli.rs
@@ -175,8 +175,8 @@ fn cmd_pkg() -> CommandInfo {
         ("Install deps", "lex pkg install"),
         ("Add a path dep", "lex pkg add mylib --path ../mylib"),
         (
-            "Publish with a signed contract",
-            "lex pkg publish --sign <key> --requires grant.json --contract-out c.json --archive-out pkg.tar",
+            "Publish with a contract whose grant is derived from the code's effects",
+            "lex pkg publish --sign <key> --derive-grant --contract-out c.json --archive-out pkg.tar",
         ),
         (
             "Verify a package against its contract",

--- a/crates/lex-cli/src/capsule_contract.rs
+++ b/crates/lex-cli/src/capsule_contract.rs
@@ -210,6 +210,59 @@ impl Keyring {
     }
 }
 
+/// Derive the minimal capability [`Grant`] and egress allowlist a package
+/// entrypoint needs, **from its typed effect rows**.
+///
+/// This is lex-lang's edge over a hand-declared `--requires`: a function's
+/// effect row already includes every effect of everything it calls (the type
+/// checker propagates them and enforces honesty), so the union over the
+/// entrypoint file's declarations is the *least authority* that admits the
+/// code. It reads the same declared rows lex-os's `collect_effects` reads, and
+/// maps them through the very same `lex_types::trust::effect_requirement` table
+/// that `lex-os capsule install` checks a grant against — the two are one source
+/// of truth and cannot disagree, so a derived contract installs by construction.
+///
+/// Honesty of the rows (a `[io]` signature must not hide a `[net]` body) is
+/// enforced by the type checker at `lex check` and re-applied by lex-os at
+/// `install --run`; this reads the rows rather than re-checking them, so it
+/// stays robust to package-relative imports the single-file checker can't yet
+/// resolve.
+pub fn derive_grant_from_source(src: &str) -> Result<(Grant, Vec<String>), String> {
+    use lex_types::trust::{effect_requirement, is_net_effect, Dimension, Level};
+
+    let program = lex_syntax::parse_source(src).map_err(|e| format!("parse error: {e:?}"))?;
+    let stages = lex_ast::canonicalize_program(&program);
+
+    let mut grant = Grant {
+        filesystem: Level::None,
+        network: Level::None,
+        exec: Level::None,
+    };
+    let mut egress = std::collections::BTreeSet::new();
+    for stage in &stages {
+        if let lex_ast::Stage::FnDecl(fd) = stage {
+            for e in &fd.effects {
+                if let Some((dim, level)) = effect_requirement(&e.name) {
+                    match dim {
+                        Dimension::Filesystem => grant.filesystem = grant.filesystem.join(level),
+                        Dimension::Network => grant.network = grant.network.join(level),
+                        Dimension::Exec => grant.exec = grant.exec.join(level),
+                    }
+                }
+                // Host-scoped `net("host")` effects contribute to the egress
+                // allowlist; a bare `[net]` raises the network level but names
+                // no host (the consumer's egress bounds it at install).
+                if is_net_effect(&e.name) {
+                    if let Some(lex_ast::EffectArg::Str { value }) = &e.arg {
+                        egress.insert(value.clone());
+                    }
+                }
+            }
+        }
+    }
+    Ok((grant, egress.into_iter().collect()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -276,6 +329,35 @@ mod tests {
         let signed = c.sign(&lex_vcs::Keypair::from_seed(&[3u8; 32]));
         assert!(signed.matches_artifact(bytes).is_ok());
         assert!(signed.matches_artifact(b"different bytes").is_err());
+    }
+
+    #[test]
+    fn derive_grant_pure_program_needs_nothing() {
+        let (g, egress) =
+            derive_grant_from_source("fn add(a :: Int, b :: Int) -> Int { a + b }").unwrap();
+        assert_eq!((g.filesystem.rank(), g.network.rank(), g.exec.rank()), (0, 0, 0));
+        assert!(egress.is_empty());
+    }
+
+    #[test]
+    fn derive_grant_joins_effects_to_least_authority() {
+        // Declared effect rows across the file are unioned per dimension and
+        // mapped through the shared effect_requirement table.
+        let src = "\
+fn reads() -> [fs_read] Int { 0 }
+fn writes() -> [fs_write] Int { 0 }
+fn calls() -> [net(\"api.example\"), proc] Int { 0 }
+fn main() -> [net] Int { 0 }";
+        let (g, egress) = derive_grant_from_source(src).unwrap();
+        assert_eq!(g.filesystem.rank(), 2, "fs_read ∨ fs_write → read-write");
+        assert_eq!(g.network.rank(), 2, "net (bare ∨ host-scoped) → allowlist");
+        assert_eq!(g.exec.rank(), 1, "proc → sandboxed exec");
+        assert_eq!(egress, vec!["api.example".to_string()], "host-scoped net → egress");
+    }
+
+    #[test]
+    fn derive_grant_rejects_unparseable_source() {
+        assert!(derive_grant_from_source("fn (((").is_err());
     }
 
     #[test]

--- a/crates/lex-cli/src/pkg.rs
+++ b/crates/lex-cli/src/pkg.rs
@@ -293,6 +293,10 @@ fn cmd_publish(args: &[String]) -> Result<()> {
     let mut egress_arg:   Vec<String>    = Vec::new();
     let mut contract_out: Option<String> = None;
     let mut archive_out:  Option<String> = None;
+    // Derive the required grant from the entrypoint's typed effects instead of
+    // declaring it with --requires.
+    let mut derive_grant = false;
+    let mut entrypoint:   Option<String> = None;
     let mut no_upload = false;
     let mut i = 0;
     while i < args.len() {
@@ -340,6 +344,13 @@ fn cmd_publish(args: &[String]) -> Result<()> {
                     anyhow::anyhow!("--archive-out requires a path")
                 })?);
             }
+            "--derive-grant" => derive_grant = true,
+            "--entrypoint" => {
+                i += 1;
+                entrypoint = Some(args.get(i).cloned().ok_or_else(|| {
+                    anyhow::anyhow!("--entrypoint requires a path (relative to lex.toml, default src/main.lex)")
+                })?);
+            }
             "--no-upload" => no_upload = true,
             other => bail!("unknown flag `{other}`"),
         }
@@ -371,10 +382,41 @@ fn cmd_publish(args: &[String]) -> Result<()> {
 
     // ── Provenance: emit a signed capability contract ──────────────────────
     if let Some(key_spec) = &sign_arg {
-        let requires_path = requires_arg.as_ref().ok_or_else(|| anyhow::anyhow!(
-            "--sign requires --requires <grant.json> (the capability the package needs)"
-        ))?;
-        let requires = load_grant(requires_path)?;
+        if derive_grant && requires_arg.is_some() {
+            bail!("--derive-grant and --requires are mutually exclusive (derive from code, or declare)");
+        }
+        // The grant the contract requires: derived from the entrypoint's typed
+        // effects, or declared via --requires.
+        let (requires, mut egress) = if derive_grant {
+            let entry_rel = entrypoint.as_deref().unwrap_or("src/main.lex");
+            let entry_path = toml_dir.join(entry_rel);
+            let source = std::fs::read_to_string(&entry_path).with_context(|| {
+                format!("reading entrypoint {} for --derive-grant", entry_path.display())
+            })?;
+            let (grant, derived_egress) =
+                crate::capsule_contract::derive_grant_from_source(&source)
+                    .map_err(|e| anyhow::anyhow!("deriving grant from {entry_rel}: {e}"))?;
+            println!(
+                "derived grant from {entry_rel}:  fs={}  net={}  exec={}",
+                grant.filesystem.as_str(),
+                grant.network.as_str(),
+                grant.exec.as_str(),
+            );
+            (grant, derived_egress)
+        } else {
+            let requires_path = requires_arg.as_ref().ok_or_else(|| anyhow::anyhow!(
+                "--sign needs --requires <grant.json> or --derive-grant (the capability the package needs)"
+            ))?;
+            (load_grant(requires_path)?, Vec::new())
+        };
+        // Any explicit --egress hosts are unioned in (e.g. for bare `[net]`).
+        for h in &egress_arg {
+            if !egress.contains(h) {
+                egress.push(h.clone());
+            }
+        }
+        egress.sort();
+        egress.dedup();
         let keypair = resolve_pkg_signing_key(key_spec)?;
 
         let contract = CapabilityContract {
@@ -384,7 +426,7 @@ fn cmd_publish(args: &[String]) -> Result<()> {
                 content_hash: content_hash.clone(),
             },
             requires,
-            egress: egress_arg.clone(),
+            egress,
         };
         let contract_id = contract.content_id();
         let signed = contract.sign(&keypair);
@@ -403,8 +445,13 @@ fn cmd_publish(args: &[String]) -> Result<()> {
             signed.signer,
         );
         println!("  -> {out_path}  (install with: lex-os capsule install --contract {out_path} --artifact <archive>)");
-    } else if contract_out.is_some() || requires_arg.is_some() || !egress_arg.is_empty() {
-        bail!("--requires / --egress / --contract-out only apply with --sign");
+    } else if contract_out.is_some()
+        || requires_arg.is_some()
+        || !egress_arg.is_empty()
+        || derive_grant
+        || entrypoint.is_some()
+    {
+        bail!("--requires / --derive-grant / --entrypoint / --egress / --contract-out only apply with --sign");
     }
 
     // ── Registry upload ────────────────────────────────────────────────────

--- a/crates/lex-cli/tests/cli-skill.txt
+++ b/crates/lex-cli/tests/cli-skill.txt
@@ -773,8 +773,8 @@ lex pkg add mylib --path ../mylib
 ```
 
 ```bash
-# Publish with a signed contract
-lex pkg publish --sign <key> --requires grant.json --contract-out c.json --archive-out pkg.tar
+# Publish with a contract whose grant is derived from the code's effects
+lex pkg publish --sign <key> --derive-grant --contract-out c.json --archive-out pkg.tar
 ```
 
 ```bash

--- a/crates/lex-cli/tests/pkg_contract.rs
+++ b/crates/lex-cli/tests/pkg_contract.rs
@@ -159,6 +159,98 @@ fn verify_rejects_a_tampered_contract() {
 }
 
 #[test]
+fn publish_can_derive_the_grant_from_typed_effects() {
+    let tmp = tempfile::tempdir().unwrap();
+    let pkg = tmp.path().join("pkg");
+    std::fs::create_dir_all(pkg.join("src")).unwrap();
+    std::fs::write(
+        pkg.join("lex.toml"),
+        "[package]\nname = \"lex-weather\"\nversion = \"1.2.0\"\n",
+    )
+    .unwrap();
+    // Declared effect rows: fs_read + host-scoped + bare net. No --requires.
+    std::fs::write(
+        pkg.join("src/main.lex"),
+        "fn fetch() -> [net(\"api.weather.example\"), fs_read] Int { 0 }\nfn main() -> [net] Int { fetch() }\n",
+    )
+    .unwrap();
+
+    let contract = tmp.path().join("contract.json");
+    let archive = tmp.path().join("art.tar");
+    let out = Command::new(lex_bin())
+        .current_dir(&pkg)
+        .args([
+            "pkg",
+            "publish",
+            "--sign",
+            SECRET,
+            "--derive-grant",
+            "--contract-out",
+            contract.to_str().unwrap(),
+            "--archive-out",
+            archive.to_str().unwrap(),
+            "--no-upload",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "derive publish failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // The contract requires exactly the least authority the effects imply.
+    let signed: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&contract).unwrap()).unwrap();
+    let c = &signed["contract"];
+    assert_eq!(c["requires"]["filesystem"], "ReadOnly");
+    assert_eq!(c["requires"]["network"], "Allowlist");
+    assert_eq!(c["requires"]["exec"], "None");
+    assert_eq!(c["egress"][0], "api.weather.example");
+
+    // And it verifies (signature + content_hash) under the publisher's key.
+    let keyring = write_keyring(tmp.path(), &[&signer_pubkey()]);
+    let v = verify(&contract, &archive, Some(&keyring));
+    assert!(
+        v.status.success(),
+        "derived contract should verify: {}",
+        String::from_utf8_lossy(&v.stderr)
+    );
+}
+
+#[test]
+fn publish_rejects_requires_and_derive_together() {
+    let tmp = tempfile::tempdir().unwrap();
+    let pkg = tmp.path().join("pkg");
+    std::fs::create_dir_all(pkg.join("src")).unwrap();
+    std::fs::write(
+        pkg.join("lex.toml"),
+        "[package]\nname = \"x\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    std::fs::write(pkg.join("src/main.lex"), "fn main() -> Int { 0 }\n").unwrap();
+    let grant = tmp.path().join("grant.json");
+    std::fs::write(&grant, "{\"filesystem\":\"None\",\"network\":\"None\",\"exec\":\"None\"}\n").unwrap();
+
+    let out = Command::new(lex_bin())
+        .current_dir(&pkg)
+        .args([
+            "pkg",
+            "publish",
+            "--sign",
+            SECRET,
+            "--derive-grant",
+            "--requires",
+            grant.to_str().unwrap(),
+            "--no-upload",
+        ])
+        .output()
+        .unwrap();
+    assert!(!out.status.success());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("mutually exclusive"));
+}
+
+#[test]
 fn verify_rejects_an_untrusted_signer() {
     let tmp = tempfile::tempdir().unwrap();
     let (contract, archive) = publish_signed(tmp.path());


### PR DESCRIPTION
Item 2, slice 2 — **derive the contract grant from the entrypoint's typed effects**. `lex pkg publish --derive-grant` now infers the capability a package needs *from the code itself* instead of trusting a hand-written `--requires`.

## Why this is the lex-lang superpower
A function's effect row already includes every effect of everything it calls (the type checker propagates them), so the union over the entrypoint file's declared rows is the **least authority that admits the code**. And it's mapped through the *same* `lex_types::trust::effect_requirement` table that `lex-os capsule install` checks a grant against — one source of truth, so a derived contract **installs by construction**. The publisher can't over- or under-declare.

This was the slice I flagged as needing care for a cross-repo coupling — but the mapping turned out to already live in the shared `lex-types` crate, so there's no reproduction and no new coupling.

## What's here
- **`capsule_contract::derive_grant_from_source`** — parse + canonicalize the entrypoint, union the declared effect rows per dimension via `effect_requirement`, seed egress from host-scoped `net("host")` effects. Reads the same rows lex-os's `collect_effects` reads; honesty is enforced by the type checker at `lex check` / lex-os `install --run`, so this stays robust to package-relative imports the single-file checker can't yet resolve.
- **`lex pkg publish --derive-grant [--entrypoint src/main.lex]`** — mutually exclusive with `--requires`; prints the inferred grant; `--egress` still unions in extra hosts for bare `[net]`.

## Verified end-to-end
A package whose entrypoint declares `fs_read` + bare `[net]` + host-scoped `net("api.weather.example")` derives:
```
requires = { filesystem: ReadOnly, network: Allowlist, exec: None }   egress = ["api.weather.example"]
```
and `lex-os capsule install` accepts it at exactly that authority (`installed=true`, `effective_egress=["api.weather.example"]`).

## Tests
- Units: pure→nothing, `fs_read ∨ fs_write → read-write` / bare∨host-scoped net → allowlist / `proc → sandboxed` join, egress from host-scoped effects, unparseable→error.
- Integration: `publish --derive-grant` produces the least-authority contract and verifies; `--derive-grant` + `--requires` is rejected.
- cli-skill snapshot regenerated; `readme_commands` green; clippy `-D warnings` clean.

No lex-os changes. Builds on #628 (the registry leg). Follow-up: `install`-time fetch+verify of registry contracts; a `lex.toml [capsule]` table.

https://claude.ai/code/session_01JN3QxEMSBnejE6TCkAF86k

---
_Generated by [Claude Code](https://claude.ai/code/session_01JN3QxEMSBnejE6TCkAF86k)_