### PR TITLE
pkg: verify registry deps against their signed contracts on install

### DIFF
--- a/crates/lex-cli/Cargo.toml
+++ b/crates/lex-cli/Cargo.toml
@@ -37,3 +37,4 @@ notify = { version = "8", default-features = false, features = ["macos_kqueue"] 
 
 [dev-dependencies]
 tempfile = "3"
+tiny_http = "0.12"

--- a/crates/lex-cli/src/acli.rs
+++ b/crates/lex-cli/src/acli.rs
@@ -173,6 +173,10 @@ fn cmd_pkg() -> CommandInfo {
     )
     .with_examples(vec![
         ("Install deps", "lex pkg install"),
+        (
+            "Install, verifying each registry dep's signed contract against pinned publishers",
+            "lex pkg install --trusted-keys keyring.json --require-contracts",
+        ),
         ("Add a path dep", "lex pkg add mylib --path ../mylib"),
         (
             "Publish with a contract whose grant is derived from the code's effects",

--- a/crates/lex-cli/src/pkg.rs
+++ b/crates/lex-cli/src/pkg.rs
@@ -30,7 +30,7 @@ pub fn cmd_pkg(args: &[String]) -> Result<()> {
         Some("init")    => cmd_init(),
         Some("add")     => cmd_add(&args[1..]),
         Some("list")    => cmd_list(),
-        Some("install") => cmd_install(),
+        Some("install") => cmd_install(&args[1..]),
         Some("publish") => cmd_publish(&args[1..]),
         Some("verify")  => cmd_verify(&args[1..]),
         Some(other)     => bail!("unknown pkg subcommand `{other}`; try: init, add, install, list, publish, verify"),
@@ -154,7 +154,36 @@ fn cmd_add(args: &[String]) -> Result<()> {
 ///
 /// For path dependencies: verify the directory exists.
 /// For git dependencies: clone into the cache directory if not already present.
-fn cmd_install() -> Result<()> {
+/// For registry dependencies: fetch the published **signed contract** and verify
+/// the archive against it (authenticity + content hash) before trusting it —
+/// `--trusted-keys <keyring.json>` additionally pins the signer, and
+/// `--require-contracts` refuses any registry dep the registry serves unsigned.
+fn cmd_install(args: &[String]) -> Result<()> {
+    let mut trusted_keys: Option<String> = None;
+    let mut require_contracts = false;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--trusted-keys" => {
+                i += 1;
+                trusted_keys = Some(args.get(i).cloned().ok_or_else(|| {
+                    anyhow::anyhow!("--trusted-keys requires a path")
+                })?);
+            }
+            "--require-contracts" => require_contracts = true,
+            other => bail!("unknown flag `{other}`"),
+        }
+        i += 1;
+    }
+    let keyring = match &trusted_keys {
+        Some(path) => {
+            let raw = std::fs::read_to_string(path)
+                .with_context(|| format!("reading keyring {path}"))?;
+            Some(serde_json::from_str::<Keyring>(&raw).with_context(|| format!("parsing keyring {path}"))?)
+        }
+        None => None,
+    };
+
     let cwd = std::env::current_dir().unwrap_or_else(|_| ".".into());
     let (toml_path, toml_dir) = lex_syntax::find_manifest(&cwd)
         .ok_or_else(|| anyhow::anyhow!("no lex.toml found (run `lex pkg init` to create one)"))?;
@@ -205,6 +234,36 @@ fn cmd_install() -> Result<()> {
             }
             lex_syntax::workspace::Dependency::Registry { registry, version } => {
                 print!("  {} (registry) {}@{} ... ", name, registry, version);
+                // Provenance gate: verify the published contract binds these
+                // bytes to a (optionally trusted) signer before installing.
+                match verify_registry_dep(registry, name, version, keyring.as_ref()) {
+                    Ok(DepVerification::Verified { signer, signer_trusted, .. }) => {
+                        let trust = if signer_trusted {
+                            " (signer trusted)".to_string()
+                        } else if keyring.is_some() {
+                            String::new()
+                        } else {
+                            " (signer not pinned — pass --trusted-keys)".to_string()
+                        };
+                        print!("contract verified, signer {:.12}…{trust} ... ", signer);
+                    }
+                    Ok(DepVerification::NoContract) => {
+                        if require_contracts {
+                            println!("REFUSED");
+                            let msg = format!("{name}: registry served no contract and --require-contracts is set");
+                            eprintln!("    {msg}");
+                            errors.push(msg);
+                            continue;
+                        }
+                        eprint!("⚠ no contract (unsigned) ... ");
+                    }
+                    Err(e) => {
+                        println!("REFUSED");
+                        eprintln!("    {name}: contract verification failed: {e}");
+                        errors.push(format!("{name}: {e}"));
+                        continue;
+                    }
+                }
                 let dummy_file = toml_dir.join("__install_probe__.lex");
                 match lex_syntax::workspace::resolve_package_import(&dummy_file, name, "__probe__") {
                     Ok(_) | Err(lex_syntax::PackageError::ModuleNotFound { .. }) => {
@@ -607,6 +666,78 @@ fn resolve_pkg_signing_key(spec: &str) -> Result<lex_vcs::Keypair> {
     };
     lex_vcs::Keypair::from_secret_hex(&hex)
         .map_err(|e| anyhow::anyhow!("invalid signing key: {e}"))
+}
+
+/// Outcome of verifying a registry dependency against its published contract.
+enum DepVerification {
+    /// The registry served a contract; its signature binds it to `signer` and
+    /// the archive bytes hash to the contract's `content_hash`. `signer_trusted`
+    /// is set when a `--trusted-keys` keyring was supplied and lists the signer.
+    Verified {
+        signer: String,
+        signer_trusted: bool,
+    },
+    /// The registry served no contract (HTTP 404) — an unsigned dependency.
+    NoContract,
+}
+
+/// Fetch `{registry}/v1/pkg/{name}/{version}/{contract,archive}` and verify the
+/// archive against the signed contract: authenticity (the signature binds the
+/// contract to its signer), integrity (the archive bytes hash to the contract's
+/// `content_hash`), and — when `trusted` is supplied — authorization (the signer
+/// is pinned). The same three gates `lex-os capsule install` applies, now at
+/// `lex pkg install` time, against the same `lex pkg publish`-emitted contract.
+fn verify_registry_dep(
+    registry: &str,
+    name: &str,
+    version: &str,
+    trusted: Option<&Keyring>,
+) -> Result<DepVerification> {
+    let base = registry.trim_end_matches('/');
+    let contract_url = format!("{base}/v1/pkg/{name}/{version}/contract");
+    let signed: SignedContract = match ureq::get(&contract_url).call() {
+        Ok(resp) => {
+            let body = resp
+                .into_body()
+                .read_to_string()
+                .map_err(|e| anyhow::anyhow!("reading contract: {e}"))?;
+            serde_json::from_str(&body)
+                .with_context(|| format!("parsing contract from {contract_url}"))?
+        }
+        // A registry that doesn't publish a contract for this version.
+        Err(ureq::Error::StatusCode(404)) => return Ok(DepVerification::NoContract),
+        Err(e) => bail!("GET {contract_url}: {e}"),
+    };
+
+    let archive_url = format!("{base}/v1/pkg/{name}/{version}/archive");
+    let archive = ureq::get(&archive_url)
+        .call()
+        .map_err(|e| anyhow::anyhow!("GET {archive_url}: {e}"))?
+        .into_body()
+        .read_to_vec()
+        .map_err(|e| anyhow::anyhow!("reading archive: {e}"))?;
+
+    // 1. Authenticity, 2. Integrity (same primitives as `lex pkg verify`).
+    let signer = signed
+        .verify()
+        .map_err(|e| anyhow::anyhow!("authenticity: {e}"))?;
+    signed
+        .matches_artifact(&archive)
+        .map_err(|e| anyhow::anyhow!("integrity: {e}"))?;
+    // 3. Authorization (only when a keyring pins publishers).
+    let signer_trusted = match trusted {
+        Some(k) => {
+            if !k.trusts(&signer) {
+                bail!("authorization: signer {signer} is not in the trusted keyring");
+            }
+            true
+        }
+        None => false,
+    };
+    Ok(DepVerification::Verified {
+        signer,
+        signer_trusted,
+    })
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/crates/lex-cli/tests/cli-skill.txt
+++ b/crates/lex-cli/tests/cli-skill.txt
@@ -768,6 +768,11 @@ lex pkg install
 ```
 
 ```bash
+# Install, verifying each registry dep's signed contract against pinned publishers
+lex pkg install --trusted-keys keyring.json --require-contracts
+```
+
+```bash
 # Add a path dep
 lex pkg add mylib --path ../mylib
 ```

--- a/crates/lex-cli/tests/pkg_registry_verify.rs
+++ b/crates/lex-cli/tests/pkg_registry_verify.rs
@@ -1,0 +1,168 @@
+//! Conformance for `lex pkg install`'s registry provenance gate: a registry
+//! dependency is verified against its published signed contract (authenticity +
+//! content hash + optional signer trust) before it is installed.
+//!
+//! A `tiny_http` mock registry serves the `lex pkg publish`-emitted contract and
+//! archive at `/v1/pkg/{name}/{version}/{contract,archive}`, closing the
+//! publish → verify loop end-to-end across the same contract format `lex-os
+//! capsule install` consumes.
+
+use std::path::Path;
+use std::process::Command;
+use std::thread;
+
+fn lex_bin() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_lex"))
+}
+
+const SECRET: &str = "1122334455667788990011223344556677889900112233445566778899001122";
+
+fn signer_pubkey() -> String {
+    lex_vcs::Keypair::from_secret_hex(SECRET).unwrap().public_hex()
+}
+
+/// Publish a signed package; returns its (contract bytes, archive bytes).
+fn publish(tmp: &Path) -> (Vec<u8>, Vec<u8>) {
+    let pkg = tmp.join("pkg");
+    std::fs::create_dir_all(pkg.join("src")).unwrap();
+    std::fs::write(
+        pkg.join("lex.toml"),
+        "[package]\nname = \"dep\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    std::fs::write(pkg.join("src/lib.lex"), "fn helper(x :: Int) -> Int { x + 1 }\n").unwrap();
+    let grant = tmp.join("grant.json");
+    std::fs::write(
+        &grant,
+        "{\"filesystem\":\"None\",\"network\":\"None\",\"exec\":\"None\"}\n",
+    )
+    .unwrap();
+    let contract = tmp.join("c.json");
+    let archive = tmp.join("a.tar");
+    let out = Command::new(lex_bin())
+        .current_dir(&pkg)
+        .args([
+            "pkg",
+            "publish",
+            "--sign",
+            SECRET,
+            "--requires",
+            grant.to_str().unwrap(),
+            "--contract-out",
+            contract.to_str().unwrap(),
+            "--archive-out",
+            archive.to_str().unwrap(),
+            "--no-upload",
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "publish: {}", String::from_utf8_lossy(&out.stderr));
+    (std::fs::read(&contract).unwrap(), std::fs::read(&archive).unwrap())
+}
+
+/// Spawn a mock registry serving the contract and archive; returns its base URL.
+fn spawn_registry(contract: Vec<u8>, archive: Vec<u8>) -> String {
+    let server = tiny_http::Server::http("127.0.0.1:0").unwrap();
+    let addr = match server.server_addr() {
+        tiny_http::ListenAddr::IP(a) => a,
+        _ => unreachable!("expected IP listener"),
+    };
+    thread::spawn(move || {
+        for req in server.incoming_requests() {
+            let url = req.url().to_string();
+            if url.ends_with("/contract") {
+                let _ = req.respond(tiny_http::Response::from_data(contract.clone()));
+            } else if url.ends_with("/archive") {
+                let _ = req.respond(tiny_http::Response::from_data(archive.clone()));
+            } else {
+                let _ = req.respond(tiny_http::Response::empty(404));
+            }
+        }
+    });
+    format!("http://{addr}")
+}
+
+/// Run `lex pkg install` in a fresh consumer project depending on `dep` from
+/// `registry`, with an isolated package cache.
+fn install(tmp: &Path, registry: &str, keyring: Option<&Path>) -> std::process::Output {
+    let consumer = tmp.join("app");
+    std::fs::create_dir_all(&consumer).unwrap();
+    std::fs::write(
+        consumer.join("lex.toml"),
+        format!(
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n[dependencies]\ndep = {{ registry = \"{registry}\", version = \"0.1.0\" }}\n"
+        ),
+    )
+    .unwrap();
+    let mut args = vec!["pkg".to_string(), "install".to_string()];
+    if let Some(k) = keyring {
+        args.push("--trusted-keys".to_string());
+        args.push(k.to_str().unwrap().to_string());
+    }
+    Command::new(lex_bin())
+        .current_dir(&consumer)
+        .env("LEX_PACKAGES_DIR", tmp.join("cache"))
+        .args(&args)
+        .output()
+        .unwrap()
+}
+
+fn write_keyring(tmp: &Path, key: &str) -> std::path::PathBuf {
+    let p = tmp.join("keyring.json");
+    std::fs::write(&p, format!("{{\"trusted\":[\"{key}\"]}}\n")).unwrap();
+    p
+}
+
+#[test]
+fn install_verifies_a_registry_dep_against_its_contract() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (contract, archive) = publish(tmp.path());
+    let registry = spawn_registry(contract, archive);
+    let keyring = write_keyring(tmp.path(), &signer_pubkey());
+
+    let out = install(tmp.path(), &registry, Some(&keyring));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "install should succeed: stdout={stdout} stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(stdout.contains("contract verified"), "stdout={stdout}");
+    assert!(stdout.contains("signer trusted"), "stdout={stdout}");
+}
+
+#[test]
+fn install_refuses_a_tampered_registry_archive() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (contract, _archive) = publish(tmp.path());
+    // Serve a valid contract but substituted archive bytes.
+    let registry = spawn_registry(contract, b"not the published bytes".to_vec());
+
+    let out = install(tmp.path(), &registry, None);
+    assert!(!out.status.success(), "tampered archive must be refused");
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("integrity"),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn install_refuses_an_untrusted_registry_signer() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (contract, archive) = publish(tmp.path());
+    let registry = spawn_registry(contract, archive);
+    // A keyring that trusts some other key.
+    let other = lex_vcs::Keypair::from_secret_hex(&"aa".repeat(32))
+        .unwrap()
+        .public_hex();
+    let keyring = write_keyring(tmp.path(), &other);
+
+    let out = install(tmp.path(), &registry, Some(&keyring));
+    assert!(!out.status.success(), "untrusted signer must be refused");
+    assert!(
+        String::from_utf8_lossy(&out.stderr).contains("not in the trusted keyring"),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}


### PR DESCRIPTION
Close the supply-chain loop: `lex pkg install` now **verifies each registry dependency against its published signed contract** — the consumer end of the contract format `lex pkg publish` emits and `lex-os capsule install` consumes.

## What's here
For every `registry` dep, install fetches `{registry}/v1/pkg/{name}/{version}/contract` and `.../archive` and applies the **same three gates** `lex-os capsule install` does:
1. **Authenticity** — the signature binds the contract to its signer.
2. **Integrity** — the archive bytes hash to the contract's `content_hash`.
3. **Authorization** — with `--trusted-keys <keyring.json>`, the signer is pinned.

A keyring exported by `lex producer-trust keyring` ties this to **earned trust**: install only deps from publishers whose track record you trust — the same keyring that gates `capsule install`.

- `--trusted-keys <keyring>` — pin acceptable signers.
- `--require-contracts` — refuse a registry dep the registry serves **unsigned** (default: warn and continue, for backward compatibility).
- Any verification failure or untrusted signer **refuses the install**.

## Tested end-to-end
A `tiny_http` mock registry serves a real `lex pkg publish`-emitted contract + archive:
- **verify passes** (`contract verified, signer … (signer trusted)`),
- a **substituted archive** is refused (integrity),
- an **untrusted signer** is refused (authorization).

`cli-skill.txt` snapshot regenerated; `readme_commands` guards + `clippy -D warnings` clean.

## The full supply chain, now closed
```
lex pkg publish --derive-grant --sign     # emit a contract: least-authority grant from typed effects, signed
        ↓ (registry)
lex pkg install --trusted-keys keyring     # ← THIS PR: verify signature + hash + pinned signer before installing
lex-os capsule install --trusted-keys      # run in-box at the contract's least authority, every effect gated
```

No lex-os changes.

https://claude.ai/code/session_01JN3QxEMSBnejE6TCkAF86k

---
_Generated by [Claude Code](https://claude.ai/code/session_01JN3QxEMSBnejE6TCkAF86k)_