### PR TITLE
chore(release): bump workspace version to 0.9.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "conformance"
-version = "0.9.8"
+version = "0.9.10"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -966,7 +966,7 @@ dependencies = [
 
 [[package]]
 name = "core-compiler"
-version = "0.9.8"
+version = "0.9.10"
 dependencies = [
  "indexmap",
  "lex-ast",
@@ -2419,7 +2419,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lex-api"
-version = "0.9.8"
+version = "0.9.10"
 dependencies = [
  "anyhow",
  "flate2",
@@ -2441,7 +2441,7 @@ dependencies = [
 
 [[package]]
 name = "lex-ast"
-version = "0.9.8"
+version = "0.9.10"
 dependencies = [
  "indexmap",
  "lex-syntax",
@@ -2453,7 +2453,7 @@ dependencies = [
 
 [[package]]
 name = "lex-bytecode"
-version = "0.9.8"
+version = "0.9.10"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2471,7 +2471,7 @@ dependencies = [
 
 [[package]]
 name = "lex-cli"
-version = "0.9.8"
+version = "0.9.10"
 dependencies = [
  "acli",
  "anyhow",
@@ -2502,7 +2502,7 @@ dependencies = [
 
 [[package]]
 name = "lex-jit"
-version = "0.9.8"
+version = "0.9.10"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -2520,7 +2520,7 @@ dependencies = [
 
 [[package]]
 name = "lex-lsp"
-version = "0.9.8"
+version = "0.9.10"
 dependencies = [
  "lex-ast",
  "lex-store",
@@ -2536,7 +2536,7 @@ dependencies = [
 
 [[package]]
 name = "lex-runtime"
-version = "0.9.8"
+version = "0.9.10"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -2599,7 +2599,7 @@ dependencies = [
 
 [[package]]
 name = "lex-search"
-version = "0.9.8"
+version = "0.9.10"
 dependencies = [
  "hex",
  "lex-ast",
@@ -2616,7 +2616,7 @@ dependencies = [
 
 [[package]]
 name = "lex-store"
-version = "0.9.8"
+version = "0.9.10"
 dependencies = [
  "fs2",
  "hex",
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "lex-syntax"
-version = "0.9.8"
+version = "0.9.10"
 dependencies = [
  "flate2",
  "indexmap",
@@ -2652,7 +2652,7 @@ dependencies = [
 
 [[package]]
 name = "lex-trace"
-version = "0.9.8"
+version = "0.9.10"
 dependencies = [
  "indexmap",
  "lex-ast",
@@ -2667,7 +2667,7 @@ dependencies = [
 
 [[package]]
 name = "lex-types"
-version = "0.9.8"
+version = "0.9.10"
 dependencies = [
  "hex",
  "indexmap",
@@ -2681,7 +2681,7 @@ dependencies = [
 
 [[package]]
 name = "lex-vcs"
-version = "0.9.8"
+version = "0.9.10"
 dependencies = [
  "ed25519-dalek",
  "getrandom 0.4.2",
@@ -5048,7 +5048,7 @@ dependencies = [
 
 [[package]]
 name = "spec-checker"
-version = "0.9.8"
+version = "0.9.10"
 dependencies = [
  "indexmap",
  "lex-ast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.9.8"
+version = "0.9.10"
 edition = "2021"
 license = "EUPL-1.2"
 repository = "https://github.com/alpibrusl/lex-lang"


### PR DESCRIPTION
Prep for the **v0.9.10** release — ships recursive `lex pkg install` (#634/#635) and everything merged since v0.9.9. Bumps the workspace version (0.9.8 → 0.9.10) so `lex --version` matches the tag; `Cargo.lock` synced. Tag `v0.9.10` after merge to trigger `release.yml` (binaries + crates.io + `ghcr.io/alpibrusl/lex:v0.9.10`).