### PR TITLE
std.crypto: add ed25519 sign/verify (asymmetric signatures)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2553,6 +2553,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "csv",
+ "ed25519-dalek",
  "glob",
  "h3",
  "h3-quinn",

--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -17,6 +17,7 @@ thiserror.workspace = true
 indexmap.workspace = true
 sha2.workspace = true
 hmac = "0.13"
+ed25519-dalek = "2"
 blake2 = "0.10"
 aes-gcm = "0.10"
 chacha20poly1305 = "0.10"

--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -1097,6 +1097,50 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             mac.update(data);
             Ok(Value::Bytes(mac.finalize().into_bytes().to_vec()))
         }
+        // ed25519 asymmetric signatures (#643). A secret key is its 32-byte
+        // seed — generate one with the effectful `crypto.random(32)`. These three
+        // ops are pure (deterministic given their inputs).
+        ("crypto", "ed25519_public_key") => {
+            use ed25519_dalek::SigningKey;
+            let secret = expect_bytes(args.first())?;
+            let seed: [u8; 32] = match secret.as_slice().try_into() {
+                Ok(s)  => s,
+                Err(_) => return Ok(err_v(Value::Str("ed25519_public_key: secret must be 32 bytes".into()))),
+            };
+            let sk = SigningKey::from_bytes(&seed);
+            Ok(ok_v(Value::Bytes(sk.verifying_key().to_bytes().to_vec())))
+        }
+        ("crypto", "ed25519_sign") => {
+            use ed25519_dalek::{Signer, SigningKey};
+            let secret = expect_bytes(args.first())?;
+            let message = expect_bytes(args.get(1))?;
+            let seed: [u8; 32] = match secret.as_slice().try_into() {
+                Ok(s)  => s,
+                Err(_) => return Ok(err_v(Value::Str("ed25519_sign: secret must be 32 bytes".into()))),
+            };
+            let sk = SigningKey::from_bytes(&seed);
+            Ok(ok_v(Value::Bytes(sk.sign(message).to_bytes().to_vec())))
+        }
+        ("crypto", "ed25519_verify") => {
+            use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+            let public = expect_bytes(args.first())?;
+            let message = expect_bytes(args.get(1))?;
+            let sig_bytes = expect_bytes(args.get(2))?;
+            let pk_arr: [u8; 32] = match public.as_slice().try_into() {
+                Ok(p)  => p,
+                Err(_) => return Ok(Value::Bool(false)),
+            };
+            let sig_arr: [u8; 64] = match sig_bytes.as_slice().try_into() {
+                Ok(s)  => s,
+                Err(_) => return Ok(Value::Bool(false)),
+            };
+            let vk = match VerifyingKey::from_bytes(&pk_arr) {
+                Ok(v)  => v,
+                Err(_) => return Ok(Value::Bool(false)),
+            };
+            let sig = Signature::from_bytes(&sig_arr);
+            Ok(Value::Bool(vk.verify(message, &sig).is_ok()))
+        }
         ("crypto", "base64_encode") => {
             use base64::{Engine, engine::general_purpose::STANDARD};
             let data = expect_bytes(args.first())?;

--- a/crates/lex-runtime/tests/std_crypto.rs
+++ b/crates/lex-runtime/tests/std_crypto.rs
@@ -262,3 +262,84 @@ fn random_without_grant_is_rejected_by_static_policy_walk() {
         "expected static policy walk to reject [random] without grant"
     );
 }
+
+// ─── ed25519 asymmetric signatures (#643) ────────────────────────────────────
+const ED25519_SRC: &str = r#"
+import "std.crypto" as crypto
+
+fn roundtrip(secret :: Bytes, msg :: Bytes) -> Bool {
+  match crypto.ed25519_public_key(secret) {
+    Err(_) => false,
+    Ok(pk) => match crypto.ed25519_sign(secret, msg) {
+      Err(_) => false,
+      Ok(sig) => crypto.ed25519_verify(pk, msg, sig),
+    },
+  }
+}
+fn wrong_msg(secret :: Bytes, msg :: Bytes, other :: Bytes) -> Bool {
+  match crypto.ed25519_public_key(secret) {
+    Err(_) => false,
+    Ok(pk) => match crypto.ed25519_sign(secret, msg) {
+      Err(_) => false,
+      Ok(sig) => crypto.ed25519_verify(pk, other, sig),
+    },
+  }
+}
+fn pub_of(secret :: Bytes) -> Result[Bytes, Str] { crypto.ed25519_public_key(secret) }
+"#;
+
+fn is_true(v: Value) -> bool {
+    match v {
+        Value::Bool(b) => b,
+        other => panic!("expected Bool, got {other:?}"),
+    }
+}
+
+#[test]
+fn ed25519_sign_verify_roundtrip() {
+    let secret = vec![7u8; 32];
+    let msg = b"transfer authorized".to_vec();
+    let ok = run(ED25519_SRC, "roundtrip",
+        vec![Value::Bytes(secret.clone()), Value::Bytes(msg.clone())]);
+    assert!(is_true(ok), "valid signature must verify");
+}
+
+#[test]
+fn ed25519_rejects_wrong_message() {
+    let secret = vec![7u8; 32];
+    let msg = b"transfer 100".to_vec();
+    let other = b"transfer 9999".to_vec();
+    let bad = run(ED25519_SRC, "wrong_msg",
+        vec![Value::Bytes(secret), Value::Bytes(msg), Value::Bytes(other)]);
+    assert!(!is_true(bad), "signature must not verify for a different message");
+}
+
+#[test]
+fn ed25519_public_key_is_deterministic_and_32_bytes() {
+    let secret = vec![3u8; 32];
+    let a = run(ED25519_SRC, "pub_of", vec![Value::Bytes(secret.clone())]);
+    let b = run(ED25519_SRC, "pub_of", vec![Value::Bytes(secret)]);
+    match (a, b) {
+        (Value::Variant { name: n1, args: a1 }, Value::Variant { name: n2, args: a2 }) => {
+            assert_eq!(n1, "Ok");
+            assert_eq!(n2, "Ok");
+            match (&a1[0], &a2[0]) {
+                (Value::Bytes(p1), Value::Bytes(p2)) => {
+                    assert_eq!(p1.len(), 32, "public key must be 32 bytes");
+                    assert_eq!(p1, p2, "derivation must be deterministic");
+                }
+                other => panic!("expected Bytes, got {other:?}"),
+            }
+        }
+        other => panic!("expected Ok variants, got {other:?}"),
+    }
+}
+
+#[test]
+fn ed25519_public_key_rejects_bad_length() {
+    let v = run(ED25519_SRC, "pub_of", vec![Value::Bytes(vec![1u8; 10])]);
+    match v {
+        Value::Variant { name, .. } => assert_eq!(name, "Err", "10-byte secret must Err"),
+        other => panic!("expected Result, got {other:?}"),
+    }
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -1716,6 +1716,26 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                     Ty::bytes(),
                 ));
             }
+            // ed25519 asymmetric signatures (#643). A secret key is its 32-byte
+            // seed (generate via `crypto.random(32)`); all three ops are pure.
+            //   ed25519_public_key(secret :: Bytes) -> Result[Bytes, Str]
+            //   ed25519_sign(secret :: Bytes, message :: Bytes) -> Result[Bytes, Str]
+            //   ed25519_verify(public :: Bytes, message :: Bytes, sig :: Bytes) -> Bool
+            fields.insert("ed25519_public_key".into(), Ty::function(
+                vec![Ty::bytes()],
+                EffectSet::empty(),
+                Ty::Con("Result".into(), vec![Ty::bytes(), Ty::str()]),
+            ));
+            fields.insert("ed25519_sign".into(), Ty::function(
+                vec![Ty::bytes(), Ty::bytes()],
+                EffectSet::empty(),
+                Ty::Con("Result".into(), vec![Ty::bytes(), Ty::str()]),
+            ));
+            fields.insert("ed25519_verify".into(), Ty::function(
+                vec![Ty::bytes(), Ty::bytes(), Ty::bytes()],
+                EffectSet::empty(),
+                Ty::bool(),
+            ));
             // base64 / hex
             fields.insert("base64_encode".into(), Ty::function(
                 vec![Ty::bytes()], EffectSet::empty(), Ty::str()));
@@ -2265,11 +2285,11 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
             fields.insert("get_float".into(), Ty::function(
                 vec![Ty::Var(0), Ty::str()],
                 EffectSet::empty(),
-                Ty::Con("Option".into(), vec![Ty::Con("Float".into(), vec![])])));
+                Ty::Con("Option".into(), vec![Ty::float()])));
             fields.insert("get_bool".into(), Ty::function(
                 vec![Ty::Var(0), Ty::str()],
                 EffectSet::empty(),
-                Ty::Con("Option".into(), vec![Ty::Con("Bool".into(), vec![])])));
+                Ty::Con("Option".into(), vec![Ty::bool()])));
 
             Some(Ty::Record(fields))
         }


### PR DESCRIPTION
Closes #643.

Adds three **pure** builtins (an ed25519 secret key is its 32-byte seed — generate via the existing `crypto.random(32)`):

- `crypto.ed25519_public_key(secret :: Bytes) -> Result[Bytes, Str]`
- `crypto.ed25519_sign(secret :: Bytes, message :: Bytes) -> Result[Bytes, Str]`
- `crypto.ed25519_verify(public :: Bytes, message :: Bytes, signature :: Bytes) -> Bool`

Implemented via `ed25519-dalek` 2 (`SigningKey::from_bytes`, no RNG dependency on the crate). Runtime in `crates/lex-runtime/src/builtins.rs`, type signatures in `crates/lex-types/src/builtins.rs`.

### Tests
4 new tests in `crates/lex-runtime/tests/std_crypto.rs` (sign/verify roundtrip, wrong-message rejection, deterministic 32-byte pubkey, bad-length `Err`). Full `std_crypto` suite: **20 passed**.

### Why
Unblocks third-party-verifiable identity (ed25519-signed AgentCards / catalogs) for the agent-federation work, beyond symmetric HMAC/JWT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)