### PR TITLE
fix(runtime): restore newline in io.print (StdoutSink::print_line)

### DIFF
--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -26,7 +26,7 @@ pub struct StdoutSink;
 impl IoSink for StdoutSink {
     fn print_line(&mut self, s: &str) {
         use std::io::Write;
-        print!("{s}");
+        println!("{s}");
         let _ = std::io::stdout().flush();
     }
 }


### PR DESCRIPTION
## Problem

`io.print` runs every call together on one line — the `hello` demo, lex-loom's `sprint_status`/`trail`/`digest`, and any CLI output are all unreadable.

## Root cause

#514 ("Ollama local-model integration") added an explicit stdout flush to `StdoutSink::print_line` but changed `println!` → `print!` in the process, dropping the trailing newline:

```rust
-        println!("{s}");
+        print!("{s}");
         let _ = std::io::stdout().flush();
```

The method is named `print_line` and every caller assumes one line per call; `CapturedSink` (test sink) already stores one entry per call.

## Fix

Restore `println!`, keep the flush. No behavior change for tests (CapturedSink unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)