### PR TITLE
feat(store): content-addressed blob store + ref namespace (M6.1a)

### DIFF
--- a/crates/lex-store/src/store.rs
+++ b/crates/lex-store/src/store.rs
@@ -31,6 +31,10 @@ pub enum StoreError {
     InvalidTransition(String),
     #[error("unknown branch `{0}`")]
     UnknownBranch(String),
+    #[error("unknown blob `{0}`")]
+    UnknownBlob(String),
+    #[error("unknown blob ref `{namespace}/{key}`")]
+    UnknownBlobRef { namespace: String, key: String },
     #[error("unknown op_id `{0}`")]
     UnknownOp(lex_vcs::OpId),
     /// A typed AST transform (#280) — e.g. `ReplaceMatchArm` — was
@@ -153,6 +157,141 @@ impl Store {
 
     pub fn root(&self) -> &Path {
         &self.root
+    }
+
+    // ── Generic content-addressed blobs (#5 / M6.1) ──────────────────────────
+    //
+    // The stage store holds typed Lex ASTs; loom-style artifacts (generated
+    // code, JSON, prose) are opaque text. These blob methods give the store a
+    // generic content-addressed object alongside stages, plus a lightweight
+    // ref namespace so callers can bind names (e.g. a sprint's node ids) to
+    // blob shas without touching the operation-log branch machinery.
+    //
+    // The sha is the lowercase hex SHA-256 of the content's UTF-8 bytes —
+    // identical to Lex's `crypto.sha256_str`, so a blob written here and an
+    // artifact content-addressed in loom's SQLite store share the same id and
+    // are interchangeable by reference. Store-scoped, so under lex-hub each
+    // tenant store gets its own blob space for free.
+
+    fn blobs_dir(&self) -> PathBuf {
+        self.root.join("blobs")
+    }
+
+    fn blob_refs_dir(&self) -> PathBuf {
+        self.root.join("blobrefs")
+    }
+
+    /// Content-address `content` and persist it under `<root>/blobs/<sha>`.
+    /// Returns the sha. Idempotent: re-putting identical content is a no-op.
+    /// Concurrency-safe — writes to a unique temp file then atomically renames
+    /// onto the content-addressed path, so parallel writers of the same content
+    /// can't corrupt it.
+    pub fn put_blob(&self, content: &str) -> Result<String, StoreError> {
+        use sha2::{Digest, Sha256};
+        let sha = hex::encode(Sha256::digest(content.as_bytes()));
+        let dir = self.blobs_dir();
+        let path = dir.join(&sha);
+        if path.exists() {
+            return Ok(sha);
+        }
+        fs::create_dir_all(&dir)?;
+        static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let n = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let tmp = dir.join(format!(".{sha}.{}.{n}.tmp", std::process::id()));
+        fs::write(&tmp, content.as_bytes())?;
+        // rename is atomic on the same filesystem; identical content makes a
+        // last-writer-wins race harmless.
+        fs::rename(&tmp, &path)?;
+        Ok(sha)
+    }
+
+    /// Read a blob by its sha. `UnknownBlob` if absent.
+    pub fn get_blob(&self, sha: &str) -> Result<String, StoreError> {
+        match fs::read_to_string(self.blobs_dir().join(sha)) {
+            Ok(s) => Ok(s),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                Err(StoreError::UnknownBlob(sha.to_string()))
+            }
+            Err(e) => Err(StoreError::Io(e)),
+        }
+    }
+
+    /// Whether a blob with this sha exists.
+    pub fn has_blob(&self, sha: &str) -> bool {
+        self.blobs_dir().join(sha).exists()
+    }
+
+    /// Bind `key` to a blob `sha` within `namespace` (e.g. namespace
+    /// `"loom/sprint-abc"`, key `"build-node"`). Overwrites an existing
+    /// binding. The namespace may contain `/`; neither namespace nor key may
+    /// contain a `..` path component.
+    pub fn set_blob_ref(&self, namespace: &str, key: &str, sha: &str) -> Result<(), StoreError> {
+        let dir = self.blob_ref_namespace_dir(namespace, key)?;
+        fs::create_dir_all(&dir)?;
+        fs::write(dir.join(key), sha.as_bytes())?;
+        Ok(())
+    }
+
+    /// Resolve `namespace`/`key` to a blob sha. `UnknownBlobRef` if unbound.
+    pub fn get_blob_ref(&self, namespace: &str, key: &str) -> Result<String, StoreError> {
+        let dir = self.blob_ref_namespace_dir(namespace, key)?;
+        match fs::read_to_string(dir.join(key)) {
+            Ok(s) => Ok(s.trim().to_string()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(StoreError::UnknownBlobRef {
+                namespace: namespace.to_string(),
+                key: key.to_string(),
+            }),
+            Err(e) => Err(StoreError::Io(e)),
+        }
+    }
+
+    /// All `key → sha` bindings in a namespace (e.g. every artifact in a
+    /// sprint). Empty map if the namespace has no bindings yet.
+    pub fn list_blob_refs(
+        &self,
+        namespace: &str,
+    ) -> Result<std::collections::BTreeMap<String, String>, StoreError> {
+        let dir = self.blob_ref_namespace_dir(namespace, "x")?;
+        let mut out = std::collections::BTreeMap::new();
+        let entries = match fs::read_dir(&dir) {
+            Ok(e) => e,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(out),
+            Err(e) => return Err(StoreError::Io(e)),
+        };
+        for entry in entries {
+            let entry = entry?;
+            if entry.file_type()?.is_file() {
+                let key = entry.file_name().to_string_lossy().to_string();
+                let sha = fs::read_to_string(entry.path())?.trim().to_string();
+                out.insert(key, sha);
+            }
+        }
+        Ok(out)
+    }
+
+    // Resolve the on-disk dir for a (namespace, key), rejecting `..` traversal
+    // and `/` in the key. `key` is validated but not joined here (callers join
+    // it themselves so `list_blob_refs` can pass a dummy).
+    fn blob_ref_namespace_dir(&self, namespace: &str, key: &str) -> Result<PathBuf, StoreError> {
+        if key.contains('/') || key.contains('\\') || key.split('/').any(|c| c == "..") {
+            return Err(StoreError::UnknownBlobRef {
+                namespace: namespace.to_string(),
+                key: key.to_string(),
+            });
+        }
+        let mut dir = self.blob_refs_dir();
+        for comp in namespace.split('/') {
+            if comp == ".." || comp.contains('\\') {
+                return Err(StoreError::UnknownBlobRef {
+                    namespace: namespace.to_string(),
+                    key: key.to_string(),
+                });
+            }
+            if !comp.is_empty() {
+                dir.push(comp);
+            }
+        }
+        Ok(dir)
     }
 
     fn now() -> u64 {

--- a/crates/lex-store/tests/blob_cas.rs
+++ b/crates/lex-store/tests/blob_cas.rs
@@ -1,0 +1,103 @@
+//! Generic content-addressed blob store + ref namespace (#5 / M6.1a).
+//!
+//! The blob sha must equal Lex's `crypto.sha256_str(content)` so blobs are
+//! interchangeable with loom's content-addressed SQLite artifacts.
+
+use lex_store::{Store, StoreError};
+
+fn fresh() -> (Store, tempfile::TempDir) {
+    let tmp = tempfile::tempdir().unwrap();
+    let s = Store::open(tmp.path()).unwrap();
+    (s, tmp)
+}
+
+#[test]
+fn put_blob_sha_matches_crypto_sha256_str() {
+    let (s, _tmp) = fresh();
+    let sha = s.put_blob("hello world").unwrap();
+    // sha256("hello world"), lowercase hex — the same value Lex's
+    // crypto.sha256_str produces and that loom's M6.0 SQLite store keys on.
+    assert_eq!(
+        sha,
+        "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+    );
+    assert_eq!(s.get_blob(&sha).unwrap(), "hello world");
+}
+
+#[test]
+fn put_blob_is_idempotent_and_dedups() {
+    let (s, tmp) = fresh();
+    let a = s.put_blob("same content").unwrap();
+    let b = s.put_blob("same content").unwrap();
+    assert_eq!(a, b, "identical content yields identical sha");
+    // exactly one file on disk for the deduped content
+    let count = std::fs::read_dir(tmp.path().join("blobs"))
+        .unwrap()
+        .filter(|e| e.as_ref().unwrap().file_type().unwrap().is_file())
+        .count();
+    assert_eq!(count, 1, "duplicate content must not create a second blob");
+}
+
+#[test]
+fn distinct_content_distinct_sha() {
+    let (s, _tmp) = fresh();
+    assert_ne!(s.put_blob("a").unwrap(), s.put_blob("b").unwrap());
+}
+
+#[test]
+fn get_blob_unknown_errors() {
+    let (s, _tmp) = fresh();
+    assert!(matches!(
+        s.get_blob("deadbeef"),
+        Err(StoreError::UnknownBlob(_))
+    ));
+    assert!(!s.has_blob("deadbeef"));
+}
+
+#[test]
+fn blob_refs_round_trip_and_list() {
+    let (s, _tmp) = fresh();
+    let ns = "loom/sprint-abc";
+    let h_build = s.put_blob("build output").unwrap();
+    let h_qa = s.put_blob("qa verdict").unwrap();
+    s.set_blob_ref(ns, "build-node", &h_build).unwrap();
+    s.set_blob_ref(ns, "qa-node", &h_qa).unwrap();
+
+    assert_eq!(s.get_blob_ref(ns, "build-node").unwrap(), h_build);
+    assert_eq!(s.get_blob_ref(ns, "qa-node").unwrap(), h_qa);
+
+    let all = s.list_blob_refs(ns).unwrap();
+    assert_eq!(all.len(), 2);
+    assert_eq!(all.get("build-node"), Some(&h_build));
+
+    // a different sprint namespace is isolated
+    assert!(s.list_blob_refs("loom/sprint-other").unwrap().is_empty());
+}
+
+#[test]
+fn blob_ref_overwrite() {
+    let (s, _tmp) = fresh();
+    let h1 = s.put_blob("v1").unwrap();
+    let h2 = s.put_blob("v2").unwrap();
+    s.set_blob_ref("ns", "k", &h1).unwrap();
+    s.set_blob_ref("ns", "k", &h2).unwrap();
+    assert_eq!(s.get_blob_ref("ns", "k").unwrap(), h2);
+}
+
+#[test]
+fn unknown_ref_errors() {
+    let (s, _tmp) = fresh();
+    assert!(matches!(
+        s.get_blob_ref("ns", "missing"),
+        Err(StoreError::UnknownBlobRef { .. })
+    ));
+}
+
+#[test]
+fn path_traversal_is_rejected() {
+    let (s, _tmp) = fresh();
+    let h = s.put_blob("x").unwrap();
+    assert!(s.set_blob_ref("ns", "../escape", &h).is_err());
+    assert!(s.set_blob_ref("../escape", "k", &h).is_err());
+    assert!(s.set_blob_ref("ns", "a/b", &h).is_err());
+}


### PR DESCRIPTION
First slice of lex-loom M6.1 (branch-per-sprint artifact store). lex-loom issue: alpibrusl/lex-loom#5.

The store held only typed-AST `Stage`s; loom artifacts (generated code, JSON, prose) are opaque text with no home. This adds a generic content-addressed blob object to `lex-store`:

- **`put_blob`/`get_blob`/`has_blob`** — content-addressed by lowercase hex SHA-256 of the content's UTF-8 bytes. **Identical to Lex's `crypto.sha256_str`**, so a blob here and a content-addressed artifact in loom's SQLite store (M6.0) share the same id and are interchangeable by reference. `put_blob` is idempotent (dedup) and concurrency-safe (unique temp + atomic rename) — matters under loom's parallel layers (#6).
- **`set_blob_ref`/`get_blob_ref`/`list_blob_refs`** — a lightweight `name → sha` namespace (e.g. namespace `loom/sprint-{id}`, key = node id), kept separate from the operation-log branch machinery, with path-traversal rejection.

Store-scoped, so under lex-hub each tenant store gets its own blob space for free — the local foundation a future hosted `/v1/blob` endpoint would sit on.

### Why separate from the op-log branches
The existing branch system is an operation-log/merge model (publish ops, `head_op`, `OpId`). Binding `node_id → blob_sha` isn't an "operation", so a lightweight ref namespace is the lower-risk primitive; op-log integration can come later if needed.

### Tests
8 new (`tests/blob_cas.rs`), incl. a hard assertion that `put_blob("hello world")` == `sha256("hello world")` hex. Full `lex-store` suite green; `lex-cli`/`lex-api` build.

Foundation for M6.1b (a `std.vcs` effect exposing these) and M6.1c (loom transport writing artifacts here, SQLite as fallback).