### PR TITLE
fix(http): honor timeout_ms for slow first responses (#646)

### DIFF
--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -3538,18 +3538,30 @@ fn http_stream_agent() -> ureq::Agent {
 /// timeout (None → use the same defaults as the legacy `net.{get,post}`
 /// path). Separate from `http_request` so the rich `http.send` flow
 /// can supply per-request overrides.
+///
+/// When the caller supplies `timeout_ms` we apply it as a single
+/// `timeout_global` covering the whole operation (connect + send + recv)
+/// and drop the per-phase caps — exactly like `http_stream_agent`. A
+/// per-phase cap (notably the bound on waiting for the *first* response
+/// byte) would otherwise fire long before the caller's budget: a slow
+/// first response — e.g. an LLM cold-loading a multi-GB model — then
+/// fails at ~10s even though `timeout_ms` was set to 120000. (#646)
 fn http_agent(timeout_ms: Option<u64>) -> ureq::Agent {
     use std::time::Duration;
-    let mut b = ureq::Agent::config_builder()
-        .timeout_connect(Some(Duration::from_secs(10)))
-        .timeout_recv_body(Some(Duration::from_secs(30)))
-        .timeout_send_body(Some(Duration::from_secs(10)))
-        .http_status_as_error(false);
-    if let Some(ms) = timeout_ms {
-        let d = Duration::from_millis(ms);
-        b = b.timeout_global(Some(d));
+    match timeout_ms {
+        Some(ms) => ureq::Agent::config_builder()
+            .timeout_global(Some(Duration::from_millis(ms)))
+            .http_status_as_error(false)
+            .build()
+            .into(),
+        None => ureq::Agent::config_builder()
+            .timeout_connect(Some(Duration::from_secs(10)))
+            .timeout_recv_body(Some(Duration::from_secs(30)))
+            .timeout_send_body(Some(Duration::from_secs(10)))
+            .http_status_as_error(false)
+            .build()
+            .into(),
     }
-    b.build().into()
 }
 
 /// Map ureq's transport error to the structured `HttpError` variant

--- a/crates/lex-runtime/tests/std_http.rs
+++ b/crates/lex-runtime/tests/std_http.rs
@@ -93,6 +93,28 @@ fn spawn_oneshot(
     port
 }
 
+/// Like `spawn_oneshot`, but waits `delay` before sending the *first*
+/// byte of the response — modelling a slow upstream (e.g. an LLM
+/// cold-loading a model) whose first response byte arrives well after
+/// the connection is established. Used to exercise the `timeout_ms`
+/// budget on slow first responses (#646).
+fn spawn_oneshot_delayed(response: &'static str, delay: std::time::Duration) -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    thread::spawn(move || {
+        if let Ok((mut s, _)) = listener.accept() {
+            // Drain the request so the client finishes its send phase and
+            // is genuinely blocked waiting for the response.
+            let _ = s.set_read_timeout(Some(std::time::Duration::from_millis(200)));
+            let mut tmp = [0u8; 4096];
+            let _ = s.read(&mut tmp);
+            thread::sleep(delay);
+            let _ = s.write_all(response.as_bytes());
+        }
+    });
+    port
+}
+
 fn err_variant_name(v: &Value) -> Option<&str> {
     match v {
         Value::Variant { name, args } if name == "Err" && !args.is_empty() => match &args[0] {
@@ -587,6 +609,72 @@ fn assert_method_round_trip(method: &str, body: &str, expect_body_on_wire: bool)
             "{method}: expected body {body:?} at end of {captured:?}",
         );
     }
+}
+
+// ---- #646 — timeout_ms governs slow first responses ----------------
+//
+// A response whose first byte is slow to arrive (an LLM cold-loading a
+// model is the motivating case) must be bounded by `timeout_ms`, not by
+// a shorter per-phase default underneath. The agent now applies the
+// caller's budget as a single global timeout so the whole operation —
+// including the wait for the first response byte — gets the full budget.
+
+#[test]
+fn http_send_waits_for_slow_first_response_within_timeout() {
+    // First byte arrives ~600ms after connect; SEND_VIA_RECORD_SRC sets
+    // timeout_ms: Some(2000). 600ms < 2000ms, so the call must succeed
+    // rather than give up early on the slow first response.
+    let port = spawn_oneshot_delayed(
+        "HTTP/1.0 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+        std::time::Duration::from_millis(600),
+    );
+    let url = format!("http://127.0.0.1:{port}/slow");
+    let v = run(
+        SEND_VIA_RECORD_SRC,
+        "send",
+        vec![
+            Value::Str("GET".into()),
+            Value::Str(url.into()),
+            Value::Str("".into()),
+        ],
+        allow_net(),
+    );
+    let r = unwrap_ok_record(v);
+    assert_eq!(r.get("status"), Some(&Value::Int(200)));
+    match r.get("body") {
+        Some(Value::Bytes(b)) => assert_eq!(b, b"ok"),
+        other => panic!("body was {other:?}"),
+    }
+}
+
+#[test]
+fn http_send_times_out_when_first_response_exceeds_budget() {
+    // First byte would arrive after ~1.5s, but the budget is 300ms, so
+    // `timeout_ms` is honoured as the upper bound and a TimeoutError is
+    // surfaced rather than hanging or ignoring the budget.
+    let port = spawn_oneshot_delayed(
+        "HTTP/1.0 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+        std::time::Duration::from_millis(1500),
+    );
+    let url = format!("http://127.0.0.1:{port}/tooslow");
+    let src = r#"
+import "std.bytes" as bytes
+import "std.http"  as http
+import "std.map"   as map
+
+fn send(u :: Str) -> [net] Result[HttpResponse, HttpError] {
+  let req := {
+    method:     "GET",
+    url:        u,
+    headers:    map.new(),
+    body:       None,
+    timeout_ms: Some(300),
+  }
+  http.send(req)
+}
+"#;
+    let v = run(src, "send", vec![Value::Str(url.into())], allow_net());
+    assert_eq!(err_variant_name(&v), Some("TimeoutError"));
 }
 
 #[test]


### PR DESCRIPTION
Fixes #646.

## Problem

`std.http.send` returned `Err` (`TimeoutError`) at ~10s on a POST whose first response byte is slow to arrive, even with `timeout_ms: Some(120000)`. The motivating case: a pure-Lex LLM agent's first `/api/chat` call triggers a **cold model load** (a ~15GB model takes >10s to load) — `curl`/`urllib` to the same endpoint wait and succeed, but `http.send` gave up early and the agent saw an empty response.

## Root cause

`http_agent` (`crates/lex-runtime/src/handler.rs`) set per-phase timeouts (`timeout_connect`, `timeout_recv_body`, `timeout_send_body`) **alongside** `timeout_global`. A per-phase cap bounds its individual phase — including the wait for the first response byte — *below* the caller's global budget, so a slow first response failed at the per-phase limit (~10s) regardless of `timeout_ms`.

The codebase already learned this lesson for streaming: `http_stream_agent` uses `timeout_global` **alone** specifically so local models that "take minutes to load before they start responding" work.

## Fix

When `timeout_ms` is supplied, apply it as a single `timeout_global` covering connect + send + recv and drop the per-phase caps — mirroring `http_stream_agent`. When `timeout_ms` is `None`, keep the conservative per-phase defaults (matching the legacy `net.{get,post}` path).

```rust
match timeout_ms {
    Some(ms) => /* timeout_global(ms) only */,
    None     => /* per-phase connect/recv_body/send_body defaults */,
}
```

## Tests

Adds a `spawn_oneshot_delayed` test server (delays the first response byte) and two regression tests in `crates/lex-runtime/tests/std_http.rs`:

- ✅ `http_send_waits_for_slow_first_response_within_timeout` — a 600ms-delayed first byte under a 2000ms budget succeeds.
- ✅ `http_send_times_out_when_first_response_exceeds_budget` — a 1500ms delay under a 300ms budget surfaces `TimeoutError` (budget honored as the upper bound).

Full `std_http` suite: **22 passed, 0 failed** (on stable 1.96.0 — `main` requires a newer Rust than the 1.94.1 first provisioned here, due to `libsqlite3-sys`).

## Notes

- Scope is intentionally limited to `http.send`/`http.get`/`http.post` (the `timeout_ms`-bearing path). The legacy `net.{get,post}` `http_request` agent (no timeout knob) is unchanged.
- No dependency or lockfile changes.

https://claude.ai/code/session_012ru4nBvtgFnoezcH4Pf3Tf

---
_Generated by [Claude Code](https://claude.ai/code/session_012ru4nBvtgFnoezcH4Pf3Tf)_