### PR TITLE
feat(crypto): add P-256 ECDSA (ES256) primitives to std.crypto (#651)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+### Added
+
+- **P-256 ECDSA (ES256) in `std.crypto` (#651).** Four new primitives complete
+  the JWT/SD-JWT signing surface that `lex-jose` (and AP2 Checkout/Payment
+  Mandates) needs:
+  - `crypto.p256_generate() -> [random] Result[Bytes, Str]` — mint a fresh
+    secret key (32-byte scalar) from the OS RNG. Carries the same `[random]`
+    effect as `crypto.random`, so key minting stays visible to
+    `lex audit --effect random`. (The issue sketched `[env]`; `[random]` is the
+    dedicated OS-randomness effect in this codebase.)
+  - `crypto.p256_public_key(sk :: Bytes) -> Result[Bytes, Str]` — derive the
+    33-byte SEC1 compressed public point.
+  - `crypto.p256_sign(sk :: Bytes, msg :: Bytes) -> Result[Bytes, Str]` — sign
+    `msg` (SHA-256 applied internally, per ES256); returns a DER-encoded
+    signature.
+  - `crypto.p256_verify(pk :: Bytes, msg :: Bytes, sig :: Bytes) -> Bool`.
+
+  Keys and signatures are raw bytes; JWK/PEM serialization is left to the
+  downstream `lex-jose` package. Backed by the RustCrypto `p256` crate.
+
 ## [0.9.9] — 2026-06-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,6 +485,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1274,6 +1280,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1411,6 +1429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -1454,6 +1473,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,6 +1515,25 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "equivalent"
@@ -1555,6 +1607,16 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "fiat-crypto"
@@ -1759,6 +1821,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1829,6 +1892,17 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "h2"
@@ -1952,7 +2026,16 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
- "hmac",
+ "hmac 0.13.0",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2559,7 +2642,7 @@ dependencies = [
  "h3-quinn",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.13.0",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -2569,6 +2652,7 @@ dependencies = [
  "lex-syntax",
  "lex-types",
  "md-5",
+ "p256",
  "parquet",
  "pbkdf2",
  "polars",
@@ -3213,6 +3297,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4071,7 +4167,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "fallible-iterator 0.2.0",
- "hmac",
+ "hmac 0.13.0",
  "md-5",
  "memchr",
  "rand 0.10.1",
@@ -4122,6 +4218,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -4498,6 +4603,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4759,6 +4874,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4963,6 +5092,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 

--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -18,6 +18,10 @@ indexmap.workspace = true
 sha2.workspace = true
 hmac = "0.13"
 ed25519-dalek = "2"
+# P-256 ECDSA / ES256 for std.crypto (#651) — JWT / SD-JWT / AP2 signing.
+# `ecdsa` feature brings sign/verify + DER; `pem` is intentionally off
+# (JWK/PEM serialization lives in the downstream `lex-jose` package).
+p256 = { version = "0.13", default-features = false, features = ["ecdsa", "std"] }
 blake2 = "0.10"
 aes-gcm = "0.10"
 chacha20poly1305 = "0.10"

--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -15,6 +15,9 @@ pub fn is_pure_call(kind: &str, op: &str) -> bool {
         (kind, op),
         ("crypto", "random")
         | ("crypto", "random_str_hex")
+        // p256_generate mints key material from the OS RNG → [random]
+        // effect, handled on the effect path (#651).
+        | ("crypto", "p256_generate")
         | ("datetime", "now")
         | ("http", "send")
         | ("http", "get")
@@ -1139,6 +1142,55 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
                 Err(_) => return Ok(Value::Bool(false)),
             };
             let sig = Signature::from_bytes(&sig_arr);
+            Ok(Value::Bool(vk.verify(message, &sig).is_ok()))
+        }
+        // P-256 ECDSA / ES256 (#651). Backs the JWT/SD-JWT signing
+        // primitives `lex-jose` needs for AP2 mandates. Key minting
+        // (`p256_generate`) is effectful (`[random]`) and lives in the
+        // handler; these three ops are deterministic given their inputs.
+        //
+        // - Secret key: 32-byte scalar (`SigningKey::to_bytes`).
+        // - Public key: 33-byte SEC1 *compressed* point.
+        // - Signature: ASN.1 DER-encoded (standard for ES256/JOSE
+        //   producers that emit DER; JWK/raw-r||s conversion is a
+        //   `lex-jose` concern).
+        // Signing hashes `msg` with SHA-256 internally (ES256).
+        ("crypto", "p256_public_key") => {
+            use p256::ecdsa::SigningKey;
+            let secret = expect_bytes(args.first())?;
+            let sk = match SigningKey::from_slice(secret) {
+                Ok(k)  => k,
+                Err(_) => return Ok(err_v(Value::Str(
+                    "p256_public_key: secret must be a 32-byte P-256 scalar".into()))),
+            };
+            let point = sk.verifying_key().to_encoded_point(true);
+            Ok(ok_v(Value::Bytes(point.as_bytes().to_vec())))
+        }
+        ("crypto", "p256_sign") => {
+            use p256::ecdsa::{signature::Signer, Signature, SigningKey};
+            let secret = expect_bytes(args.first())?;
+            let message = expect_bytes(args.get(1))?;
+            let sk = match SigningKey::from_slice(secret) {
+                Ok(k)  => k,
+                Err(_) => return Ok(err_v(Value::Str(
+                    "p256_sign: secret must be a 32-byte P-256 scalar".into()))),
+            };
+            let sig: Signature = sk.sign(message);
+            Ok(ok_v(Value::Bytes(sig.to_der().as_bytes().to_vec())))
+        }
+        ("crypto", "p256_verify") => {
+            use p256::ecdsa::{signature::Verifier, Signature, VerifyingKey};
+            let public = expect_bytes(args.first())?;
+            let message = expect_bytes(args.get(1))?;
+            let sig_bytes = expect_bytes(args.get(2))?;
+            let vk = match VerifyingKey::from_sec1_bytes(public) {
+                Ok(v)  => v,
+                Err(_) => return Ok(Value::Bool(false)),
+            };
+            let sig = match Signature::from_der(sig_bytes) {
+                Ok(s)  => s,
+                Err(_) => return Ok(Value::Bool(false)),
+            };
             Ok(Value::Bool(vk.verify(message, &sig).is_ok()))
         }
         ("crypto", "base64_encode") => {

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -807,6 +807,33 @@ impl EffectHandler for DefaultHandler {
                 .map_err(|e| format!("crypto.random_str_hex: OS RNG: {e}"))?;
             return Ok(Value::Str(hex::encode(&buf).into()));
         }
+        // crypto.p256_generate() — mint a fresh P-256 (ES256) secret
+        // key from the OS RNG (#651). Returns the 32-byte scalar as
+        // `Ok(Bytes)`. Same `[random]` gate as `crypto.random`: key
+        // minting stays visible to `lex audit --effect random`.
+        //
+        // We sample 32 bytes and let `SigningKey::from_slice` reject
+        // the (vanishingly rare, ~2^-32) out-of-range scalar rather
+        // than pulling in p256's own `rand_core` — that crate is on a
+        // different `rand_core` major than the workspace `rand`, so
+        // bridging RNG traits here would mean an extra dependency for
+        // no behavioural gain. Retry a handful of times so a one-in-
+        // four-billion miss never surfaces as a spurious `Err`.
+        if kind == "crypto" && op == "p256_generate" {
+            self.ensure_kind_allowed("random")?;
+            use p256::ecdsa::SigningKey;
+            use rand::{rngs::SysRng, TryRng};
+            for _ in 0..16 {
+                let mut buf = [0u8; 32];
+                SysRng.try_fill_bytes(&mut buf)
+                    .map_err(|e| format!("crypto.p256_generate: OS RNG: {e}"))?;
+                if let Ok(sk) = SigningKey::from_slice(&buf) {
+                    return Ok(ok(Value::Bytes(sk.to_bytes().to_vec())));
+                }
+            }
+            return Ok(err(Value::Str(
+                "crypto.p256_generate: failed to sample a valid scalar".into())));
+        }
         // `std.http` wire ops (send/get/post) gate on the `net`
         // effect kind, not the module name. This matches the
         // declared signature (`http.get :: Str -> [net] ...`) and

--- a/crates/lex-runtime/tests/std_crypto.rs
+++ b/crates/lex-runtime/tests/std_crypto.rs
@@ -343,3 +343,139 @@ fn ed25519_public_key_rejects_bad_length() {
         other => panic!("expected Result, got {other:?}"),
     }
 }
+
+// ─── P-256 ECDSA / ES256 (#651) ──────────────────────────────────────────────
+const P256_SRC: &str = r#"
+import "std.crypto" as crypto
+
+# generate -> sign -> verify round-trip, returns Ok(true) on success.
+fn mint() -> [random] Result[Bytes, Str] { crypto.p256_generate() }
+
+fn pub_of(secret :: Bytes) -> Result[Bytes, Str] { crypto.p256_public_key(secret) }
+
+fn roundtrip(secret :: Bytes, msg :: Bytes) -> Bool {
+  match crypto.p256_public_key(secret) {
+    Err(_) => false,
+    Ok(pk) => match crypto.p256_sign(secret, msg) {
+      Err(_) => false,
+      Ok(sig) => crypto.p256_verify(pk, msg, sig),
+    },
+  }
+}
+fn wrong_msg(secret :: Bytes, msg :: Bytes, other :: Bytes) -> Bool {
+  match crypto.p256_public_key(secret) {
+    Err(_) => false,
+    Ok(pk) => match crypto.p256_sign(secret, msg) {
+      Err(_) => false,
+      Ok(sig) => crypto.p256_verify(pk, other, sig),
+    },
+  }
+}
+fn sign_of(secret :: Bytes, msg :: Bytes) -> Result[Bytes, Str] {
+  crypto.p256_sign(secret, msg)
+}
+"#;
+
+// A fixed, valid 32-byte P-256 scalar (NIST test vector private key).
+fn p256_test_secret() -> Vec<u8> {
+    // 0xC9AFA9D845BA75166B5C215767B1D6934E50C3DB36E89B127B8A622B120F6721
+    hex::decode("c9afa9d845ba75166b5c215767b1d6934e50c3db36e89b127b8a622b120f6721")
+        .expect("valid hex")
+}
+
+#[test]
+fn p256_generate_returns_32_byte_secret() {
+    let v = run_with_policy(P256_SRC, "mint", vec![], random_policy());
+    match v {
+        Value::Variant { name, args } if name == "Ok" => match &args[0] {
+            Value::Bytes(b) => assert_eq!(b.len(), 32, "P-256 secret scalar is 32 bytes"),
+            other => panic!("expected Bytes, got {other:?}"),
+        },
+        other => panic!("expected Ok(Bytes), got {other:?}"),
+    }
+}
+
+#[test]
+fn p256_generate_two_calls_differ() {
+    let mint = || match run_with_policy(P256_SRC, "mint", vec![], random_policy()) {
+        Value::Variant { name, args } if name == "Ok" => bytes(args.into_iter().next().unwrap()),
+        other => panic!("expected Ok, got {other:?}"),
+    };
+    assert_ne!(mint(), mint(), "fresh keys must differ");
+}
+
+#[test]
+fn p256_public_key_is_33_byte_compressed_point() {
+    let v = run(P256_SRC, "pub_of", vec![Value::Bytes(p256_test_secret())]);
+    match v {
+        Value::Variant { name, args } if name == "Ok" => match &args[0] {
+            Value::Bytes(b) => {
+                assert_eq!(b.len(), 33, "SEC1 compressed point is 33 bytes");
+                // Compressed points start with 0x02 or 0x03.
+                assert!(b[0] == 0x02 || b[0] == 0x03, "leading byte tags y-parity");
+            }
+            other => panic!("expected Bytes, got {other:?}"),
+        },
+        other => panic!("expected Ok(Bytes), got {other:?}"),
+    }
+}
+
+#[test]
+fn p256_sign_verify_roundtrip() {
+    let secret = p256_test_secret();
+    let msg = b"checkout mandate: pay 42.00 USD".to_vec();
+    let ok = run(P256_SRC, "roundtrip",
+        vec![Value::Bytes(secret), Value::Bytes(msg)]);
+    assert!(is_true(ok), "valid ES256 signature must verify");
+}
+
+#[test]
+fn p256_rejects_wrong_message() {
+    let secret = p256_test_secret();
+    let msg = b"transfer 100".to_vec();
+    let other = b"transfer 9999".to_vec();
+    let bad = run(P256_SRC, "wrong_msg",
+        vec![Value::Bytes(secret), Value::Bytes(msg), Value::Bytes(other)]);
+    assert!(!is_true(bad), "signature must not verify for a different message");
+}
+
+#[test]
+fn p256_signature_is_der_encoded() {
+    let v = run(P256_SRC, "sign_of",
+        vec![Value::Bytes(p256_test_secret()), Value::Bytes(b"hi".to_vec())]);
+    match v {
+        Value::Variant { name, args } if name == "Ok" => match &args[0] {
+            // DER SEQUENCE of two INTEGERs: leading tag 0x30, and a
+            // P-256 signature DER-encodes to roughly 70-72 bytes.
+            Value::Bytes(b) => {
+                assert_eq!(b[0], 0x30, "DER signature starts with SEQUENCE tag");
+                assert!((68..=72).contains(&b.len()), "P-256 DER sig is ~70 bytes, got {}", b.len());
+            }
+            other => panic!("expected Bytes, got {other:?}"),
+        },
+        other => panic!("expected Ok(Bytes), got {other:?}"),
+    }
+}
+
+#[test]
+fn p256_public_key_rejects_bad_length() {
+    let v = run(P256_SRC, "pub_of", vec![Value::Bytes(vec![1u8; 10])]);
+    match v {
+        Value::Variant { name, .. } => assert_eq!(name, "Err", "10-byte secret must Err"),
+        other => panic!("expected Result, got {other:?}"),
+    }
+}
+
+#[test]
+fn p256_generate_without_grant_is_rejected_by_static_policy_walk() {
+    use lex_runtime::policy::check_program;
+    let prog = parse_source(P256_SRC).expect("parse");
+    let stages = canonicalize_program(&prog);
+    lex_types::check_program(&stages).expect("type-check");
+    let bc = compile_program(&stages);
+    let policy = Policy::pure(); // no [random] grant
+    assert!(
+        check_program(&bc, &policy).is_err(),
+        "expected static policy walk to reject p256_generate's [random] without grant"
+    );
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -1736,6 +1736,47 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 EffectSet::empty(),
                 Ty::bool(),
             ));
+            // P-256 ECDSA / ES256 (#651). The JWT/SD-JWT signature
+            // algorithm for AP2 agent keys; `lex-jose` builds the
+            // token layer on top of these primitives. Key bytes are
+            // raw: a secret key is the 32-byte scalar, a public key is
+            // the 33-byte SEC1 compressed point; JWK serialization
+            // lives downstream in `lex-jose`.
+            //
+            //   p256_generate()                       -> [random] Result[Bytes, Str]
+            //   p256_public_key(sk :: Bytes)          -> Result[Bytes, Str]
+            //   p256_sign(sk :: Bytes, msg :: Bytes)  -> Result[Bytes, Str]
+            //   p256_verify(pk :: Bytes, msg :: Bytes, sig :: Bytes) -> Bool
+            //
+            // `p256_generate` mints fresh key material from the OS RNG,
+            // so it carries the same fine-grained `[random]` effect as
+            // `crypto.random` — every key-minting call stays visible to
+            // `lex audit --effect random`. (The issue sketched `[env]`;
+            // `[random]` is the dedicated effect for OS randomness in
+            // this codebase, so we use that for consistency.)
+            // `sign`/`verify` are pure: signing hashes `msg` with
+            // SHA-256 internally (standard ES256) and the signature is
+            // DER-encoded.
+            fields.insert("p256_generate".into(), Ty::function(
+                vec![],
+                EffectSet::singleton("random"),
+                Ty::Con("Result".into(), vec![Ty::bytes(), Ty::str()]),
+            ));
+            fields.insert("p256_public_key".into(), Ty::function(
+                vec![Ty::bytes()],
+                EffectSet::empty(),
+                Ty::Con("Result".into(), vec![Ty::bytes(), Ty::str()]),
+            ));
+            fields.insert("p256_sign".into(), Ty::function(
+                vec![Ty::bytes(), Ty::bytes()],
+                EffectSet::empty(),
+                Ty::Con("Result".into(), vec![Ty::bytes(), Ty::str()]),
+            ));
+            fields.insert("p256_verify".into(), Ty::function(
+                vec![Ty::bytes(), Ty::bytes(), Ty::bytes()],
+                EffectSet::empty(),
+                Ty::bool(),
+            ));
             // base64 / hex
             fields.insert("base64_encode".into(), Ty::function(
                 vec![Ty::bytes()], EffectSet::empty(), Ty::str()));

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -271,6 +271,16 @@ fn run(url :: Str) -> [net, time, concurrent] Result[Unit, Str] {
 ### `std.crypto`
 `hash`, `random` — `random` requires `[random]` effect.
 
+Asymmetric signatures:
+- Ed25519: `ed25519_public_key`, `ed25519_sign`, `ed25519_verify` (raw 32-byte
+  keys, 64-byte signatures; all pure).
+- P-256 / ES256 (#651): `p256_generate :: () -> [random] Result[Bytes, Str]`
+  (mints a 32-byte secret scalar — `[random]` effect, like `crypto.random`),
+  `p256_public_key :: Bytes -> Result[Bytes, Str]` (33-byte SEC1 compressed
+  point), `p256_sign :: (Bytes, Bytes) -> Result[Bytes, Str]` (SHA-256 applied
+  internally; DER-encoded signature), `p256_verify :: (Bytes, Bytes, Bytes) ->
+  Bool`. JWK/PEM serialization lives in the downstream `lex-jose` package.
+
 ### `std.arrow`
 Apache Arrow `RecordBatch` as a first-class `Value::ArrowTable`. Column
 reductions and slicing run as one Rust call over the flat buffer, bypassing


### PR DESCRIPTION
Closes #651.

## What

Adds the four P-256 ECDSA (ES256) primitives `lex-jose` needs to implement the full JWT / SD-JWT / AP2-mandate signing layer in pure Lex on top of `std.crypto`:

```lex
crypto.p256_generate()                                   -> [random] Result[Bytes, Str]
crypto.p256_public_key(sk :: Bytes)                      -> Result[Bytes, Str]
crypto.p256_sign(sk :: Bytes, msg :: Bytes)              -> Result[Bytes, Str]
crypto.p256_verify(pk :: Bytes, msg :: Bytes, sig :: Bytes) -> Bool
```

- **Keys are raw bytes**: secret = 32-byte scalar, public = 33-byte SEC1 *compressed* point. JWK/PEM serialization is deliberately left to the downstream `lex-jose` package.
- **Signatures are DER-encoded**; signing applies SHA-256 internally (standard for ES256).
- **`sign`/`verify` are pure** and deterministic (RFC 6979 nonces).
- Backed by the RustCrypto **`p256`** crate (`default-features = false, features = ["ecdsa", "std"]`).

## Effect choice — `[random]`, not `[env]`

The issue sketched `crypto.p256_generate() -> [env] ...`, noting "no new effect needed." This codebase already has the dedicated fine-grained **`[random]`** effect for OS randomness (`crypto.random` / `crypto.random_str_hex`), whose stated purpose is *"so reviewers can find every token-generating call via `lex audit --effect random`."* Key minting is exactly such a call, so `p256_generate` uses `[random]` for consistency and auditability rather than `[env]`. Happy to switch to `[env]` if you'd prefer to match the issue text verbatim.

## Implementation notes

- `p256_generate` lives on the effect-handler path (gated on `random`), sampling 32 bytes from the OS RNG (`SysRng`) and letting `SigningKey::from_slice` reject the vanishingly-rare out-of-range scalar (retried up to 16×). This avoids bridging the workspace `rand` (rand_core 0.9) to p256's own `rand_core` 0.6 — no behavioural difference, one fewer dep tangle.
- `p256_public_key` / `p256_sign` / `p256_verify` are pure-builtin dispatch arms alongside the existing `ed25519_*` ops.
- Updated the `std.crypto` type signatures, `docs/AGENT.md` reference, and `CHANGELOG.md`.

## Tests

7 new tests in `crates/lex-runtime/tests/std_crypto.rs` (28 total in the file, all green):

- `p256_generate_returns_32_byte_secret`, `p256_generate_two_calls_differ`
- `p256_public_key_is_33_byte_compressed_point`, `p256_public_key_rejects_bad_length`
- `p256_sign_verify_roundtrip`, `p256_rejects_wrong_message`, `p256_signature_is_der_encoded`
- `p256_generate_without_grant_is_rejected_by_static_policy_walk` (verifies the `[random]` gate)

`cargo test -p lex-runtime --test std_crypto` → **28 passed**; `cargo test -p lex-types` green; clippy clean on `lex-runtime`.

> **CI note:** the local sandbox shipped rustc 1.94.1, which can't build the (pre-existing, unchanged) `libsqlite3-sys 0.38.1` build script (`cfg_select!`); I validated against rustc 1.96.0. This is an environment quirk, not a change in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FTX8xEw5NuJiTDRi3XQtnL)_