### PR TITLE
fix(web): harden esc() (single quotes) + document escaping contract (#553)

### DIFF
--- a/crates/lex-api/src/web.rs
+++ b/crates/lex-api/src/web.rs
@@ -112,11 +112,22 @@ fn page(title: &str, current: &str, body: &str) -> String {
     )
 }
 
+/// HTML-escape store-derived text before interpolating it into markup.
+///
+/// **Contract:** every dynamic (client- or store-supplied) value that
+/// reaches HTML — text nodes *and* quoted attribute values — must pass
+/// through `esc()`. Numeric values (`u64` timestamps/counts) and
+/// `&'static str` labels are safe as-is. Escapes the full OWASP set for
+/// quoted-attribute and text contexts (`& < > " '`), so a value is safe
+/// in both `"…"` and `'…'` attributes. Do not interpolate unescaped data
+/// into unquoted attributes, `<script>`/`<style>`, event handlers, or
+/// `javascript:` URLs — `esc()` does not make those contexts safe.
 fn esc(s: &str) -> String {
     s.replace('&', "&amp;")
         .replace('<', "&lt;")
         .replace('>', "&gt;")
         .replace('"', "&quot;")
+        .replace('\'', "&#39;")
 }
 
 // ---- Activity stream (`GET /`) -----------------------------------
@@ -902,5 +913,15 @@ mod xss_tests {
     #[test]
     fn esc_covers_html_metacharacters() {
         assert_eq!(esc(r#"<a href="x">&y"#), "&lt;a href=&quot;x&quot;&gt;&amp;y");
+    }
+
+    #[test]
+    fn esc_escapes_single_quote() {
+        // Single quotes are escaped too, so an esc()'d value is safe in
+        // both double- and single-quoted attribute contexts. A store
+        // value like `' onmouseover='alert(1)` cannot close a
+        // single-quoted attribute and inject an event handler.
+        assert_eq!(esc("' onmouseover='x"), "&#39; onmouseover=&#39;x");
+        assert!(!esc("a'b").contains('\''));
     }
 }


### PR DESCRIPTION
Refs #553. Audit + defense-in-depth hardening of the `web.rs` HTML handlers.

## Audit result: no stored XSS found

I swept every `format!`/`push_str` that interpolates dynamic data into HTML in `crates/lex-api/src/web.rs`. Every dynamic (client-/store-supplied) value reaching HTML is one of:

- **`esc()`-wrapped** — activity feed, trust table, attention/merge rows, branch list & detail, stage detail, attestation rows, all error pages, and the POST/triage handlers (actor, stage id, errors). The `kind_short()` helper embeds dynamic data (actor/tool_id/artifact/signer) but its output is `esc()`-wrapped at all three call sites.
- **`u64` numeric** — `timestamp`, `published_at`, `latest_failure_ts`, counts, percentages. Can't carry markup (confirmed field types in `lex-vcs`/`lex-store`).
- **`&'static str`** — `result_short()` returns `(&'static str, &'static str)`; markers/predicate spans are static literals.
- **page title** — escaped inside `page()`.

The specific sites the issue flagged (branch names ~478, merge `src`/`dst`/`id` ~409, attestation detail) are all escaped. No single-quoted attribute contexts, no `<script>`/event-handler/`javascript:` interpolation. An existing regression test already covers title injection.

## Hardening (this PR)

Escaping is correct today but relies on every author remembering `esc()` — so two low-risk, defense-in-depth changes:

1. **`esc()` now also escapes `'` → `&#39;`**, completing the OWASP quoted-attribute/text set (`& < > " '`). All attributes today are double-quoted, but this keeps an `esc()`'d value safe in single-quoted attributes too, so a future handler can't introduce a breakout via `'`.
2. **Documented the `esc()` contract** in a doc comment: escape every dynamic value in text and quoted attributes; numerics/`&'static str` are safe; `esc()` does **not** make unquoted attributes, `<script>`/`<style>`, event handlers, or `javascript:` URLs safe.

+ a regression test (`esc_escapes_single_quote`). All 3 `xss_tests` pass; clippy clean on `lex-api`.

## Deliberately *not* in this PR

The issue also suggests a structural guard (an `Html(String)` newtype / escape-by-default templating) so unescaped interpolation becomes impossible. That's a ~900-line refactor across every handler — architecturally significant for a Low, currently-safe issue. Happy to do it as a dedicated follow-up if you want the structural guarantee; this PR closes the immediate audit + hardens the one-function escaper.

> Note: unrelated `lex-api` integration-test binaries (`web_users_json`, `m8`) hit a linker bus error in my sandbox (`ld signal 7`, an environment/memory flake) — not caused by this change; the lib `xss_tests` and `cargo clippy` both pass.

https://claude.ai/code/session_012ru4nBvtgFnoezcH4Pf3Tf

---
_Generated by [Claude Code](https://claude.ai/code/session_012ru4nBvtgFnoezcH4Pf3Tf)_