### PR TITLE
feat(check): accumulate independent errors within a function body (#566)

### DIFF
--- a/crates/lex-types/src/checker.rs
+++ b/crates/lex-types/src/checker.rs
@@ -456,6 +456,12 @@ struct Checker {
     /// this side-table keeps the pre-stripped `TypeExpr` available
     /// for static discharge of literal arguments.
     fn_params: IndexMap<String, Vec<a::Param>>,
+    /// Errors recovered from independent sub-expressions within a
+    /// function body (discarded `Block` statements, `Let` binding
+    /// values) so a single `lex check` run surfaces every independent
+    /// error instead of stopping at the first (#566). Drained by
+    /// `check_fn` after each body/example check.
+    recovered_errors: Vec<TypeError>,
 }
 
 impl Checker {
@@ -467,6 +473,30 @@ impl Checker {
             module_aliases: IndexMap::new(),
             pending_parse_calls: Vec::new(),
             fn_params: IndexMap::new(),
+            recovered_errors: Vec::new(),
+        }
+    }
+
+    /// Check an independent sub-expression but, on error, record it and
+    /// continue with a fresh type variable rather than aborting the whole
+    /// body. Used for positions whose result type does not flow into a
+    /// strict constraint — a discarded `Block` statement, or a `Let`
+    /// binding's value — so `check_fn` can surface every independent error
+    /// in one pass (#566). A fresh var unifies with anything, so recovery
+    /// does not manufacture spurious follow-on mismatches.
+    fn check_expr_recover(
+        &mut self,
+        e: &a::CExpr,
+        node_id: &str,
+        locals: &mut IndexMap<String, Ty>,
+        effs: &mut EffectSet,
+    ) -> Ty {
+        match self.check_expr(e, node_id, locals, effs) {
+            Ok(ty) => ty,
+            Err(err) => {
+                self.recovered_errors.push(err);
+                self.u.fresh()
+            }
         }
     }
 
@@ -689,7 +719,17 @@ impl Checker {
             Err(e) => { errors.push(e); false }
         };
 
-        if body_ok && !inferred_effects.is_subset(&declared_effects) {
+        // Surface errors recovered from independent positions in the body
+        // (discarded `Block` statements, `Let` values) so every independent
+        // error is reported in one pass (#566), not just the first.
+        let body_had_recovered = !self.recovered_errors.is_empty();
+        errors.append(&mut self.recovered_errors);
+
+        // Skip the effect-not-declared check when the body had recovered
+        // errors: effect inference is incomplete (recovered sub-exprs became
+        // fresh vars that contribute no effects), so a missing/extra effect
+        // would be misleading noise next to the real errors.
+        if body_ok && !body_had_recovered && !inferred_effects.is_subset(&declared_effects) {
             for e in inferred_effects.concrete.iter() {
                 if !declared_effects.concrete.iter().any(|d| d.subsumes(e)) {
                     errors.push(TypeError::EffectNotDeclared {
@@ -769,6 +809,8 @@ impl Checker {
             }
         }
 
+        // Catch any errors recovered while checking example sub-expressions.
+        errors.append(&mut self.recovered_errors);
         if errors.is_empty() { Ok(scheme) } else { Err(errors) }
     }
 
@@ -793,7 +835,10 @@ impl Checker {
             a::CExpr::Constructor { name, args } => self.check_constructor(name, args, node_id, locals, effs),
             a::CExpr::Call { callee, args } => self.check_call(e, callee, args, node_id, locals, effs),
             a::CExpr::Let { name, ty, value, body } => {
-                let v_ty = self.check_expr(value, node_id, locals, effs)?;
+                // Recover if the bound value fails to check: record the error
+                // and bind the name to a fresh var so the `let` body (which
+                // may hold further independent errors) is still checked (#566).
+                let v_ty = self.check_expr_recover(value, node_id, locals, effs);
                 if let Some(declared) = ty {
                     let d = ty_from_canon_env(declared, &[], &self.type_env);
                     if let Err(err) = self.unify_with_record_coercion(&v_ty, &d) {
@@ -827,8 +872,11 @@ impl Checker {
                 Ok(result_ty)
             }
             a::CExpr::Block { statements, result } => {
+                // Each statement's value is discarded, so an error in one
+                // doesn't feed a later type — recover and keep checking the
+                // rest so every independent error surfaces in one pass (#566).
                 for s in statements {
-                    self.check_expr(s, node_id, locals, effs)?;
+                    let _ = self.check_expr_recover(s, node_id, locals, effs);
                 }
                 self.check_expr(result, node_id, locals, effs)
             }

--- a/crates/lex-types/tests/all_errors_566.rs
+++ b/crates/lex-types/tests/all_errors_566.rs
@@ -1,0 +1,49 @@
+//! #566: `lex check` accumulates every independent error in one pass.
+//!
+//! Cross-function accumulation shipped in #582; these pin the within-body
+//! "safe subset" — independent errors in discarded `Block` statements and
+//! `Let` binding values are recovered so they all surface at once, without
+//! manufacturing spurious follow-on errors in correct code.
+
+use lex_ast::canonicalize_program;
+use lex_syntax::parse_source;
+use lex_types::check_program;
+
+fn nerrs(src: &str) -> usize {
+    let p = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&p);
+    match check_program(&stages) {
+        Ok(_) => 0,
+        Err(e) => e.len(),
+    }
+}
+
+#[test]
+fn let_chain_reports_both_independent_errors() {
+    // Two `let` bindings whose values are both unknown identifiers. Before
+    // #566's within-body recovery this reported only the first.
+    let src = "fn c() -> Int {\n  let _x := nope_one()\n  let _y := nope_two()\n  0\n}\n";
+    assert_eq!(nerrs(src), 2, "both bad let values should be reported");
+}
+
+#[test]
+fn cross_function_still_accumulates() {
+    // The #582 behaviour is preserved: one error per function, both reported.
+    let src = "fn a() -> Int { \"x\" }\nfn b() -> Int { \"y\" }\n";
+    assert_eq!(nerrs(src), 2);
+}
+
+#[test]
+fn correct_multi_statement_body_has_no_spurious_errors() {
+    // Recovery must not manufacture errors in correct code.
+    let src = "fn ok() -> Int {\n  let a := 1\n  let b := 2\n  a\n}\n";
+    assert_eq!(nerrs(src), 0);
+}
+
+#[test]
+fn one_bad_let_then_valid_body_reports_one() {
+    // A single bad value recovers to a fresh var; the rest of the body
+    // checks cleanly, so exactly one error is reported (no cascade).
+    let src = "fn d() -> Int {\n  let _x := nope_one()\n  0\n}\n";
+    assert_eq!(nerrs(src), 1);
+}


### PR DESCRIPTION
Implements the remaining slice of #566.

## Context

`lex check` reporting "all errors, not just the first" was **partly shipped in #582** — the program loop accumulates one error per function and the CLI already prints the whole `errors` array. The gap that remained: **multiple independent errors inside a single function body** still collapsed to one, because `check_expr` short-circuits on the first `?`.

Empirically, before this PR:

| Case | Errors reported |
|---|---|
| Two functions, one error each | 2 ✅ |
| One body, two bad `let` values | **1** ❌ |

That's the case that multiplies agent repair-loop turns: a `main()` with three independent mistakes took three `lex check` rounds.

## Change (the "safe subset")

Add error recovery for the **independent within-body positions** only — a discarded `Block` statement and a `Let` binding's value. `check_expr_recover` runs the sub-expression and, on error, records it and continues with a **fresh type variable**. A fresh var unifies with anything, so recovery surfaces every independent error in one pass **without manufacturing spurious follow-on mismatches**.

- `check_fn` drains the recovered errors alongside its existing body/effect/example errors.
- The effect-not-declared check is skipped when the body recovered (effect inference is then incomplete — recovered sub-exprs became fresh vars that contribute no effects), so it can't emit misleading effect noise next to the real errors.

**Deliberately out of scope:** sibling positions whose result type flows *outward* — record fields, list/tuple items, call args — still short-circuit. Recovering those risks cascading/spurious errors and needs more care; left for a follow-up.

## Tests (`crates/lex-types/tests/all_errors_566.rs`)

- ✅ two bad `let` values → **2** errors (was 1)
- ✅ cross-function accumulation still → 2 (no regression to #582)
- ✅ correct multi-statement body → **0** (recovery invents no spurious errors)
- ✅ one bad value then a valid body → exactly **1** (no cascade)

Full `lex-types` suite passes (4 new + all existing, no regressions); `cargo clippy -p lex-types --all-targets -D warnings` clean.

> Sandbox note: I verified `lex-types` (the only crate changed) — its consumers use `check_program` unchanged in signature, and the CLI already renders the full error array. Heavier downstream suites (conformance/cli) weren't rebuilt here due to a disk constraint in the sandbox, but the change is confined to error-recovery paths that previously aborted.

https://claude.ai/code/session_012ru4nBvtgFnoezcH4Pf3Tf

---
_Generated by [Claude Code](https://claude.ai/code/session_012ru4nBvtgFnoezcH4Pf3Tf)_