### PR TITLE
std.crypto: x402 signing primitives — secp256k1 + keccak256 (EVM) and base58 (Solana)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,6 +610,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2654,6 +2663,7 @@ dependencies = [
  "arrow-select",
  "base64 0.22.1",
  "blake2",
+ "bs58",
  "bytes",
  "chacha20poly1305",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2469,6 +2469,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2647,6 +2670,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "indexmap",
+ "k256",
  "lex-ast",
  "lex-bytecode",
  "lex-syntax",
@@ -2669,6 +2693,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2 0.11.0",
+ "sha3",
  "sled",
  "smol_str",
  "subtle",
@@ -5058,6 +5083,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "digest 0.11.3",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
 ]
 
 [[package]]

--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -22,6 +22,13 @@ ed25519-dalek = "2"
 # `ecdsa` feature brings sign/verify + DER; `pem` is intentionally off
 # (JWK/PEM serialization lives in the downstream `lex-jose` package).
 p256 = { version = "0.13", default-features = false, features = ["ecdsa", "std"] }
+# secp256k1 ECDSA + public-key recovery for EVM / EIP-712 / x402 signing (#655).
+# `ecdsa` brings sign/verify + recoverable signatures (sign_prehash_recoverable /
+# recover_from_prehash); PEM/JWK serialization stays out (downstream concern).
+k256 = { version = "0.13", default-features = false, features = ["ecdsa", "std"] }
+# Keccak-256 (Ethereum padding, distinct from SHA3-256) for EIP-712 / address
+# derivation (#655).
+sha3 = "0.11"
 blake2 = "0.10"
 aes-gcm = "0.10"
 chacha20poly1305 = "0.10"

--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -43,6 +43,8 @@ chrono = "0.4"
 chrono-tz = "0.10"
 md-5 = "0.11"
 base64 = "0.22"
+# base58 (Bitcoin/Solana alphabet, no checksum) for Solana / x402 (#658).
+bs58 = "0.5"
 hex = "0.4"
 subtle = "2.6"
 rand = { version = "0.10", features = ["sys_rng"] }

--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -18,6 +18,8 @@ pub fn is_pure_call(kind: &str, op: &str) -> bool {
         // p256_generate mints key material from the OS RNG → [random]
         // effect, handled on the effect path (#651).
         | ("crypto", "p256_generate")
+        // secp256k1_generate likewise mints from the OS RNG → [random] (#655).
+        | ("crypto", "secp256k1_generate")
         | ("datetime", "now")
         | ("http", "send")
         | ("http", "get")
@@ -1063,6 +1065,17 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             h.update(data);
             Ok(Value::Bytes(h.finalize().to_vec()))
         }
+        // Keccak-256 (#655) — Ethereum's hash. This is the original
+        // Keccak padding (0x01), NOT NIST SHA3-256 (0x06); they produce
+        // different digests for the same input. Used for EIP-712 struct
+        // hashing, the final signing digest, and address derivation.
+        ("crypto", "keccak256") => {
+            use sha3::{Digest, Keccak256};
+            let data = expect_bytes(args.first())?;
+            let mut h = Keccak256::new();
+            h.update(data);
+            Ok(Value::Bytes(h.finalize().to_vec()))
+        }
         // Hex-string convenience hashers (#382). Equivalent to
         // `hex_encode(shaN(bytes_of_str(s)))` for the common case
         // where the caller has a Str and wants a hex Str digest.
@@ -1192,6 +1205,106 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
                 Err(_) => return Ok(Value::Bool(false)),
             };
             Ok(Value::Bool(vk.verify(message, &sig).is_ok()))
+        }
+        // secp256k1 ECDSA + recovery (#655) — the EVM curve, for EIP-712
+        // typed-data signing (EIP-3009 / x402 `exact`). Key minting
+        // (`secp256k1_generate`) is effectful (`[random]`) and lives in
+        // the handler; these ops are deterministic given their inputs.
+        //
+        // Unlike `p256_*`, sign/verify take a PRE-HASHED 32-byte digest
+        // (EIP-712 already hashed) and do not hash again.
+        // - Secret key: 32-byte scalar.
+        // - Public key: 65-byte uncompressed SEC1 point (0x04‖X‖Y).
+        // - Signature: 65 bytes `r‖s‖v`, v ∈ {27,28}, low-S (EIP-2).
+        ("crypto", "secp256k1_public_key") => {
+            use k256::ecdsa::SigningKey;
+            let secret = expect_bytes(args.first())?;
+            let sk = match SigningKey::from_slice(secret) {
+                Ok(k)  => k,
+                Err(_) => return Ok(err_v(Value::Str(
+                    "secp256k1_public_key: secret must be a 32-byte secp256k1 scalar".into()))),
+            };
+            // Uncompressed SEC1 so callers can derive an Ethereum address
+            // as keccak256(point[1..])[12..] without decompressing.
+            let point = sk.verifying_key().to_encoded_point(false);
+            Ok(ok_v(Value::Bytes(point.as_bytes().to_vec())))
+        }
+        ("crypto", "secp256k1_sign_digest") => {
+            use k256::ecdsa::SigningKey;
+            let secret = expect_bytes(args.first())?;
+            let digest = expect_bytes(args.get(1))?;
+            if digest.len() != 32 {
+                return Ok(err_v(Value::Str(
+                    "secp256k1_sign_digest: digest must be exactly 32 bytes".into())));
+            }
+            let sk = match SigningKey::from_slice(secret) {
+                Ok(k)  => k,
+                Err(_) => return Ok(err_v(Value::Str(
+                    "secp256k1_sign_digest: secret must be a 32-byte secp256k1 scalar".into()))),
+            };
+            // RustCrypto normalizes to low-S (EIP-2) and returns the
+            // recovery id. Ethereum's `v` is 27 + recid.
+            match sk.sign_prehash_recoverable(digest) {
+                Ok((sig, recid)) => {
+                    let mut out = sig.to_bytes().to_vec(); // 64 bytes: r‖s
+                    out.push(27u8 + recid.to_byte());
+                    Ok(ok_v(Value::Bytes(out)))
+                }
+                Err(e) => Ok(err_v(Value::Str(
+                    format!("secp256k1_sign_digest: {e}").into()))),
+            }
+        }
+        ("crypto", "secp256k1_recover") => {
+            use k256::ecdsa::{RecoveryId, Signature, VerifyingKey};
+            let digest = expect_bytes(args.first())?;
+            let sig_bytes = expect_bytes(args.get(1))?;
+            if digest.len() != 32 {
+                return Ok(err_v(Value::Str(
+                    "secp256k1_recover: digest must be exactly 32 bytes".into())));
+            }
+            if sig_bytes.len() != 65 {
+                return Ok(err_v(Value::Str(
+                    "secp256k1_recover: signature must be 65 bytes (r‖s‖v)".into())));
+            }
+            let sig = match Signature::from_slice(&sig_bytes[..64]) {
+                Ok(s)  => s,
+                Err(_) => return Ok(err_v(Value::Str(
+                    "secp256k1_recover: malformed r‖s".into()))),
+            };
+            // Accept both Ethereum {27,28} and raw {0,1} encodings of v.
+            let v = sig_bytes[64];
+            let recid_byte = if v >= 27 { v - 27 } else { v };
+            let recid = match RecoveryId::from_byte(recid_byte) {
+                Some(r) => r,
+                None    => return Ok(err_v(Value::Str(
+                    "secp256k1_recover: invalid recovery id".into()))),
+            };
+            match VerifyingKey::recover_from_prehash(digest, &sig, recid) {
+                Ok(vk) => Ok(ok_v(Value::Bytes(
+                    vk.to_encoded_point(false).as_bytes().to_vec()))),
+                Err(e) => Ok(err_v(Value::Str(
+                    format!("secp256k1_recover: {e}").into()))),
+            }
+        }
+        ("crypto", "secp256k1_verify") => {
+            use k256::ecdsa::{signature::hazmat::PrehashVerifier, Signature, VerifyingKey};
+            let public = expect_bytes(args.first())?;
+            let digest = expect_bytes(args.get(1))?;
+            let sig_bytes = expect_bytes(args.get(2))?;
+            if digest.len() != 32 {
+                return Ok(Value::Bool(false));
+            }
+            let vk = match VerifyingKey::from_sec1_bytes(public) {
+                Ok(v)  => v,
+                Err(_) => return Ok(Value::Bool(false)),
+            };
+            // Accept a 65-byte recoverable sig (drop v) or a bare 64-byte r‖s.
+            let rs = if sig_bytes.len() == 65 { &sig_bytes[..64] } else { sig_bytes.as_slice() };
+            let sig = match Signature::from_slice(rs) {
+                Ok(s)  => s,
+                Err(_) => return Ok(Value::Bool(false)),
+            };
+            Ok(Value::Bool(vk.verify_prehash(digest, &sig).is_ok()))
         }
         ("crypto", "base64_encode") => {
             use base64::{Engine, engine::general_purpose::STANDARD};

--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -1346,6 +1346,20 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
                 Err(e) => Ok(err_v(Value::Str(format!("hex: {e}").into()))),
             }
         }
+        // base58 (#658). Bitcoin/Solana alphabet, no Base58Check checksum —
+        // the encoding Solana uses for pubkeys, signatures, and the x402
+        // `exact` payload. Pure, like base64/hex.
+        ("crypto", "base58_encode") => {
+            let data = expect_bytes(args.first())?;
+            Ok(Value::Str(bs58::encode(data).into_string().into()))
+        }
+        ("crypto", "base58_decode") => {
+            let s = expect_str(args.first())?;
+            match bs58::decode(s).into_vec() {
+                Ok(b)  => Ok(ok_v(Value::Bytes(b))),
+                Err(e) => Ok(err_v(Value::Str(format!("base58: {e}").into()))),
+            }
+        }
         ("crypto", "constant_time_eq") | ("crypto", "eq") => {
             use subtle::ConstantTimeEq;
             let a = expect_bytes(args.first())?;

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -834,6 +834,27 @@ impl EffectHandler for DefaultHandler {
             return Ok(err(Value::Str(
                 "crypto.p256_generate: failed to sample a valid scalar".into())));
         }
+        // crypto.secp256k1_generate() — mint a fresh secp256k1 secret key
+        // from the OS RNG (#655) for EVM / EIP-712 / x402 signing. Returns
+        // the 32-byte scalar as `Ok(Bytes)`. Same `[random]` gate and
+        // sample-and-reject loop as `p256_generate` (the curve order is
+        // close enough to 2^256 that a miss is ~2^-128, but the loop
+        // keeps the contract identical).
+        if kind == "crypto" && op == "secp256k1_generate" {
+            self.ensure_kind_allowed("random")?;
+            use k256::ecdsa::SigningKey;
+            use rand::{rngs::SysRng, TryRng};
+            for _ in 0..16 {
+                let mut buf = [0u8; 32];
+                SysRng.try_fill_bytes(&mut buf)
+                    .map_err(|e| format!("crypto.secp256k1_generate: OS RNG: {e}"))?;
+                if let Ok(sk) = SigningKey::from_slice(&buf) {
+                    return Ok(ok(Value::Bytes(sk.to_bytes().to_vec())));
+                }
+            }
+            return Ok(err(Value::Str(
+                "crypto.secp256k1_generate: failed to sample a valid scalar".into())));
+        }
         // `std.http` wire ops (send/get/post) gate on the `net`
         // effect kind, not the module name. This matches the
         // declared signature (`http.get :: Str -> [net] ...`) and

--- a/crates/lex-runtime/tests/std_crypto.rs
+++ b/crates/lex-runtime/tests/std_crypto.rs
@@ -674,3 +674,51 @@ fn secp256k1_generate_without_grant_is_rejected_by_static_policy_walk() {
         "expected static policy walk to reject secp256k1_generate's [random] without grant"
     );
 }
+
+// ─── base58 — Solana / x402 encoding (#658) ──────────────────────────────────
+const B58_SRC: &str = r#"
+import "std.crypto" as crypto
+
+fn enc(data :: Bytes) -> Str { crypto.base58_encode(data) }
+
+fn dec(s :: Str) -> Result[Bytes, Str] { crypto.base58_decode(s) }
+
+# round-trip: decode(encode(x)) == x
+fn roundtrip(data :: Bytes) -> Bool {
+  match crypto.base58_decode(crypto.base58_encode(data)) {
+    Err(_) => false,
+    Ok(back) => crypto.eq(data, back),
+  }
+}
+"#;
+
+#[test]
+fn base58_encodes_32_zero_bytes_as_solana_default_pubkey() {
+    // 32 zero bytes is Solana's "default"/system pubkey: 32 '1' chars.
+    let v = run(B58_SRC, "enc", vec![Value::Bytes(vec![0u8; 32])]);
+    assert_eq!(s(v), "1".repeat(32), "32 zero bytes encode to 32 leading '1's");
+}
+
+#[test]
+fn base58_leading_zeros_become_ones() {
+    // Each leading zero byte maps to one '1'; the rest encodes the value.
+    let v = run(B58_SRC, "enc", vec![Value::Bytes(vec![0, 0, 0])]);
+    assert_eq!(s(v), "111");
+}
+
+#[test]
+fn base58_round_trip() {
+    let ok = run(B58_SRC, "roundtrip",
+        vec![Value::Bytes(b"\x00\x01\x02the quick brown fox".to_vec())]);
+    assert!(is_true(ok), "base58 decode(encode(x)) must equal x");
+}
+
+#[test]
+fn base58_decode_rejects_invalid_char() {
+    // '0', 'O', 'I', 'l' are not in the base58 alphabet.
+    let v = run(B58_SRC, "dec", vec![Value::Str("0OIl".into())]);
+    match v {
+        Value::Variant { name, .. } => assert_eq!(name, "Err", "invalid base58 must Err"),
+        other => panic!("expected Result, got {other:?}"),
+    }
+}

--- a/crates/lex-runtime/tests/std_crypto.rs
+++ b/crates/lex-runtime/tests/std_crypto.rs
@@ -479,3 +479,198 @@ fn p256_generate_without_grant_is_rejected_by_static_policy_walk() {
         "expected static policy walk to reject p256_generate's [random] without grant"
     );
 }
+
+// ─── secp256k1 / keccak256 — EVM (EIP-712 / x402) primitives (#655) ───────────
+const SECP_SRC: &str = r#"
+import "std.crypto" as crypto
+
+fn mint() -> [random] Result[Bytes, Str] { crypto.secp256k1_generate() }
+
+fn pub_of(secret :: Bytes) -> Result[Bytes, Str] { crypto.secp256k1_public_key(secret) }
+
+fn keccak(data :: Bytes) -> Bytes { crypto.keccak256(data) }
+
+fn sign_of(secret :: Bytes, digest :: Bytes) -> Result[Bytes, Str] {
+  crypto.secp256k1_sign_digest(secret, digest)
+}
+
+# sign a digest, recover the pubkey, check it matches the signer's pubkey.
+fn recover_matches(secret :: Bytes, digest :: Bytes) -> Bool {
+  match crypto.secp256k1_public_key(secret) {
+    Err(_) => false,
+    Ok(pk) => match crypto.secp256k1_sign_digest(secret, digest) {
+      Err(_) => false,
+      Ok(sig) => match crypto.secp256k1_recover(digest, sig) {
+        Err(_) => false,
+        Ok(rec) => crypto.eq(pk, rec),
+      },
+    },
+  }
+}
+
+fn verify_roundtrip(secret :: Bytes, digest :: Bytes) -> Bool {
+  match crypto.secp256k1_public_key(secret) {
+    Err(_) => false,
+    Ok(pk) => match crypto.secp256k1_sign_digest(secret, digest) {
+      Err(_) => false,
+      Ok(sig) => crypto.secp256k1_verify(pk, digest, sig),
+    },
+  }
+}
+
+fn verify_wrong_digest(secret :: Bytes, digest :: Bytes, other :: Bytes) -> Bool {
+  match crypto.secp256k1_public_key(secret) {
+    Err(_) => false,
+    Ok(pk) => match crypto.secp256k1_sign_digest(secret, digest) {
+      Err(_) => false,
+      Ok(sig) => crypto.secp256k1_verify(pk, other, sig),
+    },
+  }
+}
+"#;
+
+// A fixed, valid 32-byte secp256k1 scalar (the well-known "1" test key's
+// sibling — any in-range scalar works; this is deterministic for the tests).
+fn secp_test_secret() -> Vec<u8> {
+    hex::decode("4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318")
+        .expect("valid hex")
+}
+
+// A fixed 32-byte digest (stands in for an EIP-712 signing digest).
+fn secp_test_digest() -> Vec<u8> {
+    // keccak256("") — a stable 32-byte value; the signer doesn't re-hash.
+    hex::decode("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
+        .expect("valid hex")
+}
+
+#[test]
+fn keccak256_empty_matches_known_vector() {
+    // The canonical Keccak-256 of the empty input (Ethereum's hash).
+    let v = run(SECP_SRC, "keccak", vec![Value::Bytes(vec![])]);
+    assert_eq!(
+        hex::encode(bytes(v)),
+        "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        "keccak256(\"\") must match the Ethereum constant (not SHA3-256)"
+    );
+}
+
+#[test]
+fn keccak256_is_not_sha3_256() {
+    // SHA3-256("") is a000...80a5; Keccak-256 differs in padding. Guard
+    // against accidentally wiring up Sha3_256 instead of Keccak256.
+    let v = run(SECP_SRC, "keccak", vec![Value::Bytes(vec![])]);
+    assert_ne!(
+        hex::encode(bytes(v)),
+        "a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a",
+        "keccak256 must not equal SHA3-256"
+    );
+}
+
+#[test]
+fn secp256k1_generate_returns_32_byte_secret() {
+    let v = run_with_policy(SECP_SRC, "mint", vec![], random_policy());
+    match v {
+        Value::Variant { name, args } if name == "Ok" => match &args[0] {
+            Value::Bytes(b) => assert_eq!(b.len(), 32, "secp256k1 secret scalar is 32 bytes"),
+            other => panic!("expected Bytes, got {other:?}"),
+        },
+        other => panic!("expected Ok(Bytes), got {other:?}"),
+    }
+}
+
+#[test]
+fn secp256k1_generate_two_calls_differ() {
+    let mint = || match run_with_policy(SECP_SRC, "mint", vec![], random_policy()) {
+        Value::Variant { name, args } if name == "Ok" => bytes(args.into_iter().next().unwrap()),
+        other => panic!("expected Ok, got {other:?}"),
+    };
+    assert_ne!(mint(), mint(), "fresh keys must differ");
+}
+
+#[test]
+fn secp256k1_public_key_is_65_byte_uncompressed_point() {
+    let v = run(SECP_SRC, "pub_of", vec![Value::Bytes(secp_test_secret())]);
+    match v {
+        Value::Variant { name, args } if name == "Ok" => match &args[0] {
+            Value::Bytes(b) => {
+                assert_eq!(b.len(), 65, "uncompressed SEC1 point is 65 bytes");
+                assert_eq!(b[0], 0x04, "uncompressed points start with 0x04");
+            }
+            other => panic!("expected Bytes, got {other:?}"),
+        },
+        other => panic!("expected Ok(Bytes), got {other:?}"),
+    }
+}
+
+#[test]
+fn secp256k1_signature_is_65_bytes_with_eth_v() {
+    let v = run(SECP_SRC, "sign_of",
+        vec![Value::Bytes(secp_test_secret()), Value::Bytes(secp_test_digest())]);
+    match v {
+        Value::Variant { name, args } if name == "Ok" => match &args[0] {
+            Value::Bytes(b) => {
+                assert_eq!(b.len(), 65, "r‖s‖v is 65 bytes");
+                assert!(b[64] == 27 || b[64] == 28, "Ethereum v is 27 or 28, got {}", b[64]);
+            }
+            other => panic!("expected Bytes, got {other:?}"),
+        },
+        other => panic!("expected Ok(Bytes), got {other:?}"),
+    }
+}
+
+#[test]
+fn secp256k1_recover_yields_signer_pubkey() {
+    let ok = run(SECP_SRC, "recover_matches",
+        vec![Value::Bytes(secp_test_secret()), Value::Bytes(secp_test_digest())]);
+    assert!(is_true(ok), "recovered pubkey must equal the signer's pubkey");
+}
+
+#[test]
+fn secp256k1_sign_verify_roundtrip() {
+    let ok = run(SECP_SRC, "verify_roundtrip",
+        vec![Value::Bytes(secp_test_secret()), Value::Bytes(secp_test_digest())]);
+    assert!(is_true(ok), "a valid signature must verify against the signer's pubkey");
+}
+
+#[test]
+fn secp256k1_rejects_wrong_digest() {
+    let other = hex::decode(
+        "1111111111111111111111111111111111111111111111111111111111111111").unwrap();
+    let bad = run(SECP_SRC, "verify_wrong_digest",
+        vec![Value::Bytes(secp_test_secret()), Value::Bytes(secp_test_digest()),
+             Value::Bytes(other)]);
+    assert!(!is_true(bad), "signature must not verify against a different digest");
+}
+
+#[test]
+fn secp256k1_sign_digest_rejects_non_32_byte_digest() {
+    let v = run(SECP_SRC, "sign_of",
+        vec![Value::Bytes(secp_test_secret()), Value::Bytes(vec![0u8; 31])]);
+    match v {
+        Value::Variant { name, .. } => assert_eq!(name, "Err", "31-byte digest must Err"),
+        other => panic!("expected Result, got {other:?}"),
+    }
+}
+
+#[test]
+fn secp256k1_public_key_rejects_bad_length() {
+    let v = run(SECP_SRC, "pub_of", vec![Value::Bytes(vec![1u8; 10])]);
+    match v {
+        Value::Variant { name, .. } => assert_eq!(name, "Err", "10-byte secret must Err"),
+        other => panic!("expected Result, got {other:?}"),
+    }
+}
+
+#[test]
+fn secp256k1_generate_without_grant_is_rejected_by_static_policy_walk() {
+    use lex_runtime::policy::check_program;
+    let prog = parse_source(SECP_SRC).expect("parse");
+    let stages = canonicalize_program(&prog);
+    lex_types::check_program(&stages).expect("type-check");
+    let bc = compile_program(&stages);
+    let policy = Policy::pure(); // no [random] grant
+    assert!(
+        check_program(&bc, &policy).is_err(),
+        "expected static policy walk to reject secp256k1_generate's [random] without grant"
+    );
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -1850,6 +1850,14 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
             fields.insert("hex_decode".into(), Ty::function(
                 vec![Ty::str()], EffectSet::empty(),
                 Ty::Con("Result".into(), vec![Ty::bytes(), Ty::str()])));
+            // base58 (#658) — Bitcoin/Solana alphabet, no checksum. Solana
+            // addresses, mints, signatures and the x402 `exact` payload are
+            // base58; this is the Solana analog of keccak/secp256k1 (#655).
+            fields.insert("base58_encode".into(), Ty::function(
+                vec![Ty::bytes()], EffectSet::empty(), Ty::str()));
+            fields.insert("base58_decode".into(), Ty::function(
+                vec![Ty::str()], EffectSet::empty(),
+                Ty::Con("Result".into(), vec![Ty::bytes(), Ty::str()])));
             // Constant-time equality (for HMAC verification etc.).
             // `eq` / `eq_str` (#382) are the recommended spelling;
             // `constant_time_eq` stays as a deprecated alias.

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -1777,6 +1777,60 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 EffectSet::empty(),
                 Ty::bool(),
             ));
+            // secp256k1 ECDSA + recovery (#655). The EVM curve — backs
+            // EIP-712 typed-data signing (EIP-3009 / x402 `exact`) and
+            // Ethereum address derivation. Unlike `p256_*`/`ed25519_*`,
+            // the sign/verify ops here take a **pre-hashed 32-byte
+            // digest** (EIP-712 already hashes), hence the `_digest`
+            // suffix — they do NOT hash the input again.
+            //
+            // - Secret key: 32-byte scalar.
+            // - Public key: 65-byte UNCOMPRESSED SEC1 point (0x04‖X‖Y),
+            //   so an address is `keccak256(pk[1..])[12..]` with no
+            //   decompression step. (p256 returns compressed; the EVM
+            //   convention is uncompressed.)
+            // - Signature: 65 bytes `r(32)‖s(32)‖v(1)`, v ∈ {27,28}
+            //   (Ethereum), low-S normalized (EIP-2).
+            //
+            //   keccak256(data :: Bytes) -> Bytes
+            //   secp256k1_generate()                          -> [random] Result[Bytes, Str]
+            //   secp256k1_public_key(sk :: Bytes)             -> Result[Bytes, Str]
+            //   secp256k1_sign_digest(sk :: Bytes, digest :: Bytes) -> Result[Bytes, Str]
+            //   secp256k1_recover(digest :: Bytes, sig :: Bytes)    -> Result[Bytes, Str]
+            //   secp256k1_verify(pk :: Bytes, digest :: Bytes, sig :: Bytes) -> Bool
+            //
+            // `secp256k1_generate` mints from the OS RNG, so it carries
+            // the same `[random]` effect as `crypto.random` / `p256_generate`.
+            fields.insert("keccak256".into(), Ty::function(
+                vec![Ty::bytes()],
+                EffectSet::empty(),
+                Ty::bytes(),
+            ));
+            fields.insert("secp256k1_generate".into(), Ty::function(
+                vec![],
+                EffectSet::singleton("random"),
+                Ty::Con("Result".into(), vec![Ty::bytes(), Ty::str()]),
+            ));
+            fields.insert("secp256k1_public_key".into(), Ty::function(
+                vec![Ty::bytes()],
+                EffectSet::empty(),
+                Ty::Con("Result".into(), vec![Ty::bytes(), Ty::str()]),
+            ));
+            fields.insert("secp256k1_sign_digest".into(), Ty::function(
+                vec![Ty::bytes(), Ty::bytes()],
+                EffectSet::empty(),
+                Ty::Con("Result".into(), vec![Ty::bytes(), Ty::str()]),
+            ));
+            fields.insert("secp256k1_recover".into(), Ty::function(
+                vec![Ty::bytes(), Ty::bytes()],
+                EffectSet::empty(),
+                Ty::Con("Result".into(), vec![Ty::bytes(), Ty::str()]),
+            ));
+            fields.insert("secp256k1_verify".into(), Ty::function(
+                vec![Ty::bytes(), Ty::bytes(), Ty::bytes()],
+                EffectSet::empty(),
+                Ty::bool(),
+            ));
             // base64 / hex
             fields.insert("base64_encode".into(), Ty::function(
                 vec![Ty::bytes()], EffectSet::empty(), Ty::str()));

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -294,6 +294,11 @@ Asymmetric signatures:
   encoding, EIP-3009 payloads and the facilitator client live in the
   downstream `lex-x402` package.
 
+Encodings: `base64_encode`/`base64_decode`, `base64url_encode`/`base64url_decode`,
+`hex_encode`/`hex_decode`, and `base58_encode`/`base58_decode` (#658 — Bitcoin/
+Solana alphabet, no checksum; for Solana addresses/signatures and the x402
+Solana `exact` payload). Encoders return `Str`; decoders return `Result[Bytes, Str]`.
+
 ### `std.arrow`
 Apache Arrow `RecordBatch` as a first-class `Value::ArrowTable`. Column
 reductions and slicing run as one Rust call over the flat buffer, bypassing

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -280,6 +280,19 @@ Asymmetric signatures:
   point), `p256_sign :: (Bytes, Bytes) -> Result[Bytes, Str]` (SHA-256 applied
   internally; DER-encoded signature), `p256_verify :: (Bytes, Bytes, Bytes) ->
   Bool`. JWK/PEM serialization lives in the downstream `lex-jose` package.
+- secp256k1 / EVM (#655): the Ethereum curve, for EIP-712 typed-data signing
+  (EIP-3009 / x402 `exact`). `keccak256 :: Bytes -> Bytes` (Ethereum's hash,
+  not SHA3-256), `secp256k1_generate :: () -> [random] Result[Bytes, Str]`
+  (32-byte secret scalar), `secp256k1_public_key :: Bytes -> Result[Bytes, Str]`
+  (65-byte *uncompressed* SEC1 point, so an address is
+  `keccak256(pk[1..])[12..]`), `secp256k1_sign_digest :: (Bytes, Bytes) ->
+  Result[Bytes, Str]` (signs a pre-hashed 32-byte digest — EIP-712 already
+  hashes — returning 65-byte `r‖s‖v`, v ∈ {27,28}, low-S),
+  `secp256k1_recover :: (Bytes, Bytes) -> Result[Bytes, Str]` (recover the
+  65-byte uncompressed pubkey from digest + signature),
+  `secp256k1_verify :: (Bytes, Bytes, Bytes) -> Bool`. EIP-712 struct
+  encoding, EIP-3009 payloads and the facilitator client live in the
+  downstream `lex-x402` package.
 
 ### `std.arrow`
 Apache Arrow `RecordBatch` as a first-class `Value::ArrowTable`. Column


### PR DESCRIPTION
Closes #655. First step of x402 ([x402.org](https://www.x402.org/)) support — the language-level crypto primitives the EVM payment path needs.

## What

Adds the secp256k1 / Keccak-256 surface to `std.crypto`, the same shape of addition as ed25519 (#643) and P-256 / ES256 (#651):

| primitive | signature | notes |
|---|---|---|
| `keccak256` | `Bytes -> Bytes` | Ethereum's hash (Keccak padding, **not** SHA3-256) |
| `secp256k1_generate` | `() -> [random] Result[Bytes, Str]` | 32-byte secret scalar; `[random]` like `p256_generate` |
| `secp256k1_public_key` | `Bytes -> Result[Bytes, Str]` | 65-byte **uncompressed** SEC1 (`0x04‖X‖Y`) |
| `secp256k1_sign_digest` | `(Bytes, Bytes) -> Result[Bytes, Str]` | signs a **pre-hashed 32-byte digest**; returns 65-byte `r‖s‖v`, `v ∈ {27,28}`, low-S (EIP-2) |
| `secp256k1_recover` | `(Bytes, Bytes) -> Result[Bytes, Str]` | recover the uncompressed pubkey from digest + sig |
| `secp256k1_verify` | `(Bytes, Bytes, Bytes) -> Bool` | accepts 33/65-byte pk, 64/65-byte sig |

## Why these shapes

- **Pre-hashed digest** for sign/verify (note the `_digest` suffix): EIP-712 produces the 32-byte digest itself, so the signer must **not** hash again — the key semantic difference from `p256_sign`/`ed25519_sign`.
- **Recovery** (`r‖s‖v`): Ethereum verifiers recover the signer *address* from signature + digest; no separately-transmitted pubkey.
- **Uncompressed** public keys so an address is `keccak256(pk[1..])[12..]` with no decompression step.

## Scope

Primitives only. EIP-712 struct encoding, EIP-3009 payloads, CAIP-2 networks and the facilitator client belong in the new `lex-x402` package (#656); the `lex-guard` executor adapter is [lex-guard#3](https://github.com/alpibrusl/lex-guard/issues/3). The Solana x402 path (ed25519) needs nothing here; this unblocks the EVM path (and AP2's EVM leg).

## Implementation

- Deps: `k256` (ecdsa + recovery: `sign_prehash_recoverable` / `recover_from_prehash`) and `sha3` (`Keccak256`). `secp256k1_generate` reuses the sample-and-reject-from-`SysRng` loop from `p256_generate` — no `rand_core` bridging.
- Type sigs in `crates/lex-types/src/builtins.rs`; pure ops in `crates/lex-runtime/src/builtins.rs`; effectful `secp256k1_generate` + `is_pure_call` exclusion in `handler.rs`; `docs/AGENT.md` table updated.

## Tests

11 new tests in `crates/lex-runtime/tests/std_crypto.rs` — sign/recover/verify round-trips, `v ∈ {27,28}` + 65-byte shape, uncompressed-point shape, wrong-digest rejection, 32-byte-digest enforcement, `keccak256("")` known vector + a guard that it isn't SHA3-256, and the static-policy-walk rejection of `secp256k1_generate`'s `[random]` without a grant. `cargo test -p lex-runtime --test std_crypto` → 40 passed.

> Note: the runtime crate needs rustc ≥ 1.96 to build in this environment (a transitive `libsqlite3-sys 0.38.1` build script uses stabilized `cfg_select!`); this is pre-existing and unrelated to the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3MiF5VTF7jNU5K3Kn35ei

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3MiF5VTF7jNU5K3Kn35ei)_