### PR TITLE
chore(release): prepare 0.9.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,25 +7,85 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+## [0.9.11] — 2026-06-19
+
 ### Added
 
+- **`lex check` accumulates independent errors within a function body
+  (#566).** Type checking no longer bails at the first error in a body;
+  independent errors in sibling expressions are reported together in a single
+  pass, so agents can repair a whole function in one round instead of
+  recompiling once per diagnostic.
+- **Content-addressed blob store + `ref` namespace (M6.1a, #647).** A generic
+  content-addressed blob store with a `ref` namespace — the storage substrate
+  for upcoming artifact-handoff work.
+- **`std.crypto` ed25519 sign/verify (#643).** The first asymmetric-signature
+  surface in the stdlib: `ed25519_sign` / `ed25519_verify` / key generation.
 - **P-256 ECDSA (ES256) in `std.crypto` (#651).** Four new primitives complete
   the JWT/SD-JWT signing surface that `lex-jose` (and AP2 Checkout/Payment
-  Mandates) needs:
-  - `crypto.p256_generate() -> [random] Result[Bytes, Str]` — mint a fresh
-    secret key (32-byte scalar) from the OS RNG. Carries the same `[random]`
-    effect as `crypto.random`, so key minting stays visible to
-    `lex audit --effect random`. (The issue sketched `[env]`; `[random]` is the
-    dedicated OS-randomness effect in this codebase.)
-  - `crypto.p256_public_key(sk :: Bytes) -> Result[Bytes, Str]` — derive the
-    33-byte SEC1 compressed public point.
-  - `crypto.p256_sign(sk :: Bytes, msg :: Bytes) -> Result[Bytes, Str]` — sign
-    `msg` (SHA-256 applied internally, per ES256); returns a DER-encoded
-    signature.
-  - `crypto.p256_verify(pk :: Bytes, msg :: Bytes, sig :: Bytes) -> Bool`.
+  Mandates) needs: `p256_generate() -> [random] Result[Bytes, Str]` (mints a
+  32-byte scalar from the OS RNG, carrying the `[random]` effect so key minting
+  stays visible to `lex audit --effect random`), `p256_public_key` (33-byte
+  SEC1 compressed point), `p256_sign` (SHA-256 applied internally per ES256;
+  DER signature), and `p256_verify`. Keys/signatures are raw bytes; JWK/PEM
+  serialization is left to the downstream `lex-jose` package. Backed by the
+  RustCrypto `p256` crate.
+- **`std.crypto` x402 EVM signing primitives — secp256k1 + keccak256
+  (#655).** `keccak256` (Ethereum's Keccak padding, *not* SHA3-256) plus the
+  `secp256k1_*` sign/recover/verify surface (65-byte `r‖s‖v`, low-S per
+  EIP-2, uncompressed SEC1 keys). Unblocks the EVM payment path for the
+  forthcoming `lex-x402` package.
+- **`std.crypto` base58 encode/decode (#658).** `base58_encode` /
+  `base58_decode` (Bitcoin alphabet, no checksum) for the Solana x402 leg —
+  addresses, mints, and signatures.
 
-  Keys and signatures are raw bytes; JWK/PEM serialization is left to the
-  downstream `lex-jose` package. Backed by the RustCrypto `p256` crate.
+### Fixed
+
+- **`io.print` newline regression (#645).** `StdoutSink::print_line` had
+  stopped emitting the trailing newline; restored.
+- **`std.http` honors `timeout_ms` on a slow first response (#646).** The
+  client deadline previously only covered connect/headers, so a server slow to
+  send the first body byte could hang past the timeout.
+- **`net` drops bare TCP probes instead of logging a handshake error (#624).**
+  WebSocket listeners no longer emit a spurious handshake-error log line for
+  bare TCP port probes (health checks, scanners); the connection is dropped
+  quietly.
+- **`lex pkg` no longer reports a false version conflict between a git
+  dependency and a sibling path dependency (#637).** The resolver treated the
+  same package reached via a `git` dep and via a sibling `--path` dep as two
+  conflicting versions.
+- **`std.web` `esc()` hardening — single quotes (#553).** `esc()` now also
+  escapes single quotes, and the escaping contract is documented, closing an
+  attribute-context injection gap.
+
+### Dependencies
+
+- **regex 1.12.3 → 1.12.4 (#641).**
+
+## [0.9.10] — 2026-06-12
+
+### Added
+
+- **Supply-chain provenance for packages (#628, #629, #632, #633).**
+  `lex pkg publish` signs capability contracts and publishes them to the
+  registry leg; `--derive-grant` derives a contract's capability grant from
+  the package's typed effects; installs verify registry dependencies against
+  their signed contracts; docs gain a supply-chain provenance section with an
+  end-to-end demo.
+- **Transitive dependency resolution — `lex pkg install` (#634).** Install now
+  resolves the full transitive dependency closure rather than direct deps
+  only.
+- **Bearer-token auth for `lex op push/pull` (#630).**
+- **Durable attestations for capsule installs (#627).** `lex-os` capsule
+  installs are promoted into durable attestations; `ProducerTrust` is exported
+  to the capsule keyring (#626).
+- **CLI surface snapshots (#625, #626).** The `lex skill` / CLI surface is
+  snapshotted to keep the README and CLI reference in sync.
+
+### Fixed
+
+- **`lex vm` skips memoization on arena args (#621).**
+- **`str.slice` codepoint indices (#620).**
 
 ## [0.9.9] — 2026-06-08
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "conformance"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "core-compiler"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "indexmap",
  "lex-ast",
@@ -2534,7 +2534,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lex-api"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "anyhow",
  "flate2",
@@ -2556,7 +2556,7 @@ dependencies = [
 
 [[package]]
 name = "lex-ast"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "indexmap",
  "lex-syntax",
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "lex-bytecode"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "lex-cli"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "acli",
  "anyhow",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "lex-jit"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "lex-lsp"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "lex-ast",
  "lex-store",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "lex-runtime"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "lex-search"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "hex",
  "lex-ast",
@@ -2736,7 +2736,7 @@ dependencies = [
 
 [[package]]
 name = "lex-store"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "fs2",
  "hex",
@@ -2755,7 +2755,7 @@ dependencies = [
 
 [[package]]
 name = "lex-syntax"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "flate2",
  "indexmap",
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "lex-trace"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "indexmap",
  "lex-ast",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "lex-types"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "hex",
  "indexmap",
@@ -2801,7 +2801,7 @@ dependencies = [
 
 [[package]]
 name = "lex-vcs"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "ed25519-dalek",
  "getrandom 0.4.2",
@@ -5224,7 +5224,7 @@ dependencies = [
 
 [[package]]
 name = "spec-checker"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "indexmap",
  "lex-ast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.9.10"
+version = "0.9.11"
 edition = "2021"
 license = "EUPL-1.2"
 repository = "https://github.com/alpibrusl/lex-lang"


### PR DESCRIPTION
## What

Release prep for **0.9.11**:

- Bump workspace version `0.9.10` → `0.9.11` (`Cargo.toml` + `Cargo.lock`, 16 workspace crates).
- Update `CHANGELOG.md`:
  - New `[0.9.11]` section covering everything merged since v0.9.10.
  - Backfill the previously-missing `[0.9.10]` section (the changelog jumped 0.9.9 → 0.9.8).

## What's in 0.9.11

**Added**
- `lex check` accumulates independent errors within a function body (#566)
- Content-addressed blob store + `ref` namespace — M6.1a (#647)
- `std.crypto` ed25519 sign/verify (#643)
- `std.crypto` P-256 ECDSA / ES256 (#651)
- `std.crypto` x402 EVM primitives — secp256k1 + keccak256 (#655)
- `std.crypto` base58 encode/decode for the Solana x402 leg (#658)

**Fixed**
- `io.print` newline regression (#645)
- `std.http` honors `timeout_ms` on slow first response (#646)
- `net` drops bare TCP probes instead of logging a handshake error (#624)
- `lex pkg` false git-vs-path version conflict (#637)
- `std.web` `esc()` single-quote hardening (#553)

**Dependencies**
- regex 1.12.3 → 1.12.4 (#641)

## Notes

- Draft — open for review before tagging. Tag/publish remains a manual step (mirrors how #636 cut 0.9.10).
- Rebased onto current `main` (through #657) to clear a conflict; main's `[Unreleased]` P-256 entry was folded into the `[0.9.11]` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ru4nBvtgFnoezcH4Pf3Tf