### PR TITLE
feat(conc): conc.spawn_thread — detached background tasks (#623)

### DIFF
--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -2614,7 +2614,15 @@ impl<'a> Vm<'a> {
                         // handler closure must run on the calling VM so it can
                         // dispatch arbitrary effects through the same handler
                         // chain (e.g. sql queries inside an actor).
+                        //
+                        // `conc.spawn_thread` (#623) is the one exception: it
+                        // is a genuinely concurrent primitive that must reach
+                        // the effect handler, where `Arc<Program>` + `Policy`
+                        // are available to build a fresh per-thread VM (the VM
+                        // can't move its `Box<dyn EffectHandler>` onto a new
+                        // thread). So it falls through to `dispatch`.
                         None if kind.as_str() == "conc"
+                            && op_name.as_str() != "spawn_thread"
                             => self.run_conc_op(op_name.as_str(), args),
                         None => self.handler.dispatch(&kind, &op_name, args),
                     };

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -165,10 +165,16 @@ impl DefaultHandler {
     }
 
     fn ensure_kind_allowed(&self, kind: &str) -> Result<(), String> {
-        if self.policy.allow_effects.contains(kind) {
+        // For every module kind == effect name, except `conc`: its
+        // effect is named `concurrent` in the type system and policy.
+        // The actor ops (spawn/ask/tell) are intercepted at the VM
+        // level and never reach this gate, but `conc.spawn_thread`
+        // (#623) does, so normalize the kind to the effect it carries.
+        let effect = if kind == "conc" { "concurrent" } else { kind };
+        if self.policy.allow_effects.contains(effect) {
             Ok(())
         } else {
-            Err(format!("effect `{kind}` not in --allow-effects"))
+            Err(format!("effect `{effect}` not in --allow-effects"))
         }
     }
 
@@ -1473,6 +1479,33 @@ impl EffectHandler for DefaultHandler {
                 })?;
                 let policy = self.policy.clone();
                 crate::ws::dial_ws_actor(url, subprotocol, name, on_open, on_message, program, policy)
+            }
+            ("conc", "spawn_thread") => {
+                // #623 — the non-actor escape hatch. Run a zero-arg closure
+                // on a fresh detached OS thread carrying the caller's Policy,
+                // then return Unit immediately. Mirrors the per-thread VM that
+                // net.dial_ws / serve_ws_fn_actor build (the calling VM can't
+                // move its handler across threads). Reaches here because the
+                // VM's `conc` intercept exempts `spawn_thread` (see vm.rs).
+                // Errors/panics in the closure are logged to stderr and end
+                // the thread (detached: no join handle in v1).
+                let closure = match args.into_iter().next() {
+                    Some(c @ Value::Closure { .. }) => c,
+                    other => return Err(format!(
+                        "conc.spawn_thread(f): f must be a zero-arg closure, got {other:?}")),
+                };
+                let program = self.program.clone().ok_or_else(|| {
+                    "conc.spawn_thread requires a Program reference; use DefaultHandler::with_program".to_string()
+                })?;
+                let policy = self.policy.clone();
+                std::thread::spawn(move || {
+                    let handler = DefaultHandler::new(policy).with_program(Arc::clone(&program));
+                    let mut vm = Vm::with_handler(&program, Box::new(handler));
+                    if let Err(e) = vm.invoke_closure_value(closure, vec![]) {
+                        eprintln!("conc.spawn_thread: {e}");
+                    }
+                });
+                Ok(Value::Unit)
             }
             ("chat", "broadcast") => {
                 let registry = self.chat_registry.as_ref()

--- a/crates/lex-runtime/tests/conc_spawn_thread.rs
+++ b/crates/lex-runtime/tests/conc_spawn_thread.rs
@@ -1,0 +1,142 @@
+//! End-to-end tests for #623: `conc.spawn_thread`.
+//!
+//! Unlike the synchronous actor ops (`conc.spawn`/`ask`/`tell`, #381),
+//! `spawn_thread` runs a zero-arg closure on a fresh *detached* OS
+//! thread and returns `Unit` immediately. These tests cover:
+//!  1. the closure actually runs on a background thread, and
+//!     `spawn_thread` returns before it finishes (detached), and
+//!  2. the closure's effect row propagates into the call row
+//!     (`[concurrent, Eff]`), so under-declaring the caller is a
+//!     type error.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+fn type_check(src: &str) -> Result<(), Vec<lex_types::TypeError>> {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    lex_types::check_program(&stages).map(|_| ())
+}
+
+// ── runtime: the closure runs on a detached background thread ────────────────
+
+#[test]
+fn spawn_thread_runs_closure_detached() {
+    // Unique sentinel path so parallel test binaries don't collide.
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let sentinel = std::env::temp_dir().join(format!(
+        "lex_spawn_thread_{}_{nanos}.txt",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&sentinel);
+    let path = sentinel.to_string_lossy().replace('\\', "/");
+
+    // The worker sleeps before writing, so if `spawn_thread` were
+    // synchronous the sentinel would exist by the time `main` returns.
+    let src = format!(
+        r#"
+import "std.conc" as conc
+import "std.io"   as io
+import "std.time" as time
+
+fn worker() -> [io, time] Unit {{
+  let _ := time.sleep_ms(150)
+  let _ := io.write("{path}", "ok")
+  ()
+}}
+
+fn main() -> [concurrent, io, time] Bool {{
+  let _ := conc.spawn_thread(worker)
+  true
+}}
+"#
+    );
+
+    let prog = parse_source(&src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    lex_types::check_program(&stages).expect("type-check");
+    let bc = Arc::new(compile_program(&stages));
+    let policy = Policy::permissive();
+    // `spawn_thread` needs a Program reference to build a per-thread VM.
+    let handler = DefaultHandler::new(policy).with_program(Arc::clone(&bc));
+    let mut vm = Vm::with_handler(bc.as_ref(), Box::new(handler));
+
+    let ret = vm.call("main", vec![]).expect("vm");
+    assert_eq!(ret, Value::Bool(true), "main should return immediately");
+
+    // Detached: the worker sleeps 150ms first, so nothing is written yet.
+    assert!(
+        !sentinel.exists(),
+        "closure ran synchronously — spawn_thread did not detach"
+    );
+
+    // Poll up to ~5s for the background thread to do its write.
+    let mut wrote = false;
+    for _ in 0..500 {
+        if let Ok(s) = std::fs::read_to_string(&sentinel) {
+            if s == "ok" {
+                wrote = true;
+                break;
+            }
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    let _ = std::fs::remove_file(&sentinel);
+    assert!(wrote, "background thread never ran the closure");
+}
+
+// ── types: the closure's effects propagate into the call row ────────────────
+
+#[test]
+fn spawn_thread_propagates_closure_effects() {
+    // worker is [io, time]; the call row is [concurrent, io, time],
+    // which main declares in full → type-checks.
+    let src = r#"
+import "std.conc" as conc
+import "std.io"   as io
+import "std.time" as time
+
+fn worker() -> [io, time] Unit {
+  let _ := time.sleep_ms(1)
+  let _ := io.write("/tmp/x", "y")
+  ()
+}
+
+fn main() -> [concurrent, io, time] Unit {
+  conc.spawn_thread(worker)
+}
+"#;
+    type_check(src).expect("type-check should accept the propagated effects");
+}
+
+#[test]
+fn spawn_thread_under_declared_effects_is_type_error() {
+    // Same worker, but main declares only [concurrent] — the propagated
+    // [io, time] leak, so the caller's signature is under-declared.
+    let src = r#"
+import "std.conc" as conc
+import "std.io"   as io
+import "std.time" as time
+
+fn worker() -> [io, time] Unit {
+  let _ := time.sleep_ms(1)
+  let _ := io.write("/tmp/x", "y")
+  ()
+}
+
+fn main() -> [concurrent] Unit {
+  conc.spawn_thread(worker)
+}
+"#;
+    assert!(
+        type_check(src).is_err(),
+        "under-declared caller should be a type error (effects must propagate)"
+    );
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -1004,6 +1004,30 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 EffectSet::singleton("concurrent"),
                 Ty::List(Box::new(Ty::str())),
             ));
+            // spawn_thread[Eff] :: (() -> [Eff] Unit) -> [concurrent, Eff] Unit
+            //
+            // #623 — the one deliberately *non-actor* primitive in this
+            // module. Runs the zero-arg closure on a fresh detached OS
+            // thread (same Policy as the caller) and returns Unit
+            // immediately; the closure executes concurrently with the
+            // caller. Unlike spawn/ask/tell (synchronous mailbox, #381),
+            // this is the escape hatch for long-running background tasks —
+            // e.g. a `net.dial_ws` loop alongside a foreground
+            // `net.serve_fn`. The closure's effect row `[Eff]` is
+            // propagated into the call row (unioned with `concurrent`),
+            // so effects stay honest and gated by the same Policy.
+            // Errors/panics in the closure are logged to stderr and end
+            // the thread (detached: no join handle in v1). See
+            // AGENT_GUIDELINES "concurrency".
+            fields.insert("spawn_thread".into(), Ty::function(
+                vec![Ty::Function {
+                    params: vec![],
+                    effects: EffectSet::open_var(0),
+                    ret: Box::new(Ty::Unit),
+                }],
+                EffectSet::open_var(0).union(&EffectSet::singleton("concurrent")),
+                Ty::Unit,
+            ));
             Some(Ty::Record(fields))
         }
         "arrow" => {

--- a/docs/AGENT.md
+++ b/docs/AGENT.md
@@ -175,7 +175,17 @@ to bound runaway loops; use process-level scheduling for longer waits.
 ### `std.conc`
 `spawn` [concurrent], `ask` [concurrent], `tell` [concurrent],
 `register` [concurrent], `lookup` [concurrent], `unregister` [concurrent],
-`registered` [concurrent]
+`registered` [concurrent],
+`spawn_thread(() -> [Eff] Unit)` [concurrent, Eff]
+
+`spawn_thread` is the one non-actor primitive: it runs the zero-arg
+closure on a fresh **detached** OS thread and returns `Unit` immediately,
+so a long-running blocking task (e.g. a `net.dial_ws` loop) can run
+alongside a foreground `net.serve_fn`. The closure's effect row
+propagates into the call row and is gated by the same `Policy`; errors
+are logged to stderr; there is no join handle (fire-and-forget). Reach
+for actors first — use `spawn_thread` only for a genuinely concurrent
+background task.
 
 Actors hold per-process state across messages. `spawn(init, handler)`
 returns `Actor[S]`; `ask` / `tell` run `handler(state, msg)` on the

--- a/docs/AGENT_GUIDELINES.md
+++ b/docs/AGENT_GUIDELINES.md
@@ -258,8 +258,21 @@ fn use_counter() -> [concurrent] Int {
 
 `conc.spawn` / `conc.ask` / `conc.tell` are the actor primitives.
 Synchronous mailbox — handler runs on the caller's thread under a
-per-actor mutex. **Do not** try to spawn OS threads via FFI; you can't,
-and you don't need to.
+per-actor mutex. Reach for actors **first**: they are deterministic,
+replayable, and the right tool for message-passing.
+
+The one exception is `conc.spawn_thread(f)` (#623): it runs a zero-arg
+closure `f :: () -> [Eff] Unit` on a fresh **detached** OS thread and
+returns `Unit` immediately. Use it only when you genuinely need a
+long-running *blocking* background task to run concurrently with the
+foreground — the canonical case is a `net.dial_ws` client loop running
+alongside a `net.serve_fn` HTTP server (both block forever, so an actor
+can't host them). It is fire-and-forget: no join handle, the closure's
+effects are gated by the same `Policy`, and errors are logged to stderr.
+Do **not** use it as a general parallelism tool (use `list.par_map` for
+pure work) or as a substitute for actors (use `conc.spawn` for state +
+message passing). Spawning OS threads any *other* way (FFI, etc.) is
+still unsupported.
 
 ### 3.2 SQL: `std.sql` for SQLite and Postgres (MUST)
 
@@ -551,7 +564,7 @@ emit. Avoid.
 | Renaming params after publish | Different SigId; loses attestations | Don't |
 | Auto-retry on HTTP 503 from `lex serve` | Budget cap is intentional | Raise cap or refactor |
 | Mutation via FFI | No FFI; no mutation in user code | Build new values |
-| Spawning OS threads | Not supported; not needed | `std.conc` actors |
+| Spawning OS threads (FFI/raw) | Not supported | `std.conc` actors; `conc.spawn_thread` for a detached blocking task |
 | Bypassing the gate via `proc.exec` | Defeats the sandbox model | Don't; if you need OS access, declare `[proc]` explicitly |
 
 ---


### PR DESCRIPTION
## What

Implements **#623** — `conc.spawn_thread`, a primitive for running a long-running *blocking* task concurrently with the foreground (the canonical case: a `net.dial_ws` client loop alongside a `net.serve_fn` HTTP server, both of which block forever so an actor can't host them).

```
conc.spawn_thread(f :: () -> [Eff] Unit) -> [concurrent, Eff] Unit
```

Runs the zero-arg closure on a fresh **detached** OS thread carrying the caller's `Policy`, and returns `Unit` immediately.

## Design decision (the proposal)

Earlier discussion flagged that this conflicts with the actor model's philosophy (`std.conc` = *synchronous* actors, #381; `AGENT_GUIDELINES` literally said "never spawn OS threads"). This PR resolves the three open questions from the issue's design comment as follows:

1. **Break the VM-intercept invariant for this one op?** Yes, narrowly. `conc.*` ops run on the calling VM to stay synchronous; `spawn_thread` is exempted so it reaches the effect handler (the only place `Arc<Program>` + `Policy` are available to build a fresh per-thread VM — the VM can't move its `Box<dyn EffectHandler>` across threads). The actor mailbox guarantee is untouched: `spawn_thread` creates no actors, and actor cells are already `Arc<Mutex>`.
2. **Detached vs joinable?** **Detached v1**, matching the issue's proposed signature. A joinable `Task[T]` (await/cancel) is noted as a possible follow-up — it would bring effects back under a structured scope, at the cost of a larger surface.
3. **Name / module?** `conc.spawn_thread` (as filed). It's documented as the **fenced, deliberately non-actor escape hatch** rather than blurring the "conc = synchronous actors" story.

## Changes

- **`lex-types/builtins.rs`** — effect-polymorphic signature; the closure's row propagates into the call row (`[concurrent, Eff]`), gated by the same `Policy`.
- **`lex-bytecode/vm.rs`** — exempt `spawn_thread` from the `conc` VM-intercept so it falls through to `dispatch`.
- **`lex-runtime/handler.rs`** — new `("conc", "spawn_thread")` arm (mirrors `net.dial_ws`'s per-thread VM build); errors logged to stderr. Also normalizes the `conc` kind → `concurrent` effect in the policy gate (kind ≠ effect name only for this module — previously moot because actor ops never reached the gate).
- **docs** — `AGENT.md` surface + `AGENT_GUIDELINES` §3.1 / anti-pattern table now describe `spawn_thread` as the sanctioned exception (was an absolute "never spawn threads").
- **tests** — `conc_spawn_thread.rs`: detachment + the closure actually runs on a background thread; plus positive/negative effect-propagation type checks.

## Tests

`cargo test -p lex-runtime --test conc_spawn_thread` → 3 passed. Existing `concurrent_actor`, `conc_registry`, `net_serve_ws_fn_actor`, `effect_polymorphism`, and the `lex-types` suite all still pass.

Draft — opening for design review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ru4nBvtgFnoezcH4Pf3Tf

---
_Generated by [Claude Code](https://claude.ai/code/session_012ru4nBvtgFnoezcH4Pf3Tf)_