### PR TITLE
ci(verify-release): wait for release assets instead of racing the build (#661)

### DIFF
--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -6,11 +6,18 @@ name: verify-release
 # asserts `lex --version` returns successfully.
 #
 # Intentionally NOT a gate on the release itself — it triggers on
-# `release: published`, so by the time it runs the artifacts are
-# already public. Failures surface as a red CI status on the tag,
-# not a blocked publish. The reasoning: a packaging regression that
-# slips past the build matrix is rare, and decoupling lets us iterate
-# on the verify logic without risking the release pipeline.
+# `release: published`, so a failure surfaces as a red CI status on
+# the tag, not a blocked publish. The reasoning: a packaging
+# regression that slips past the build matrix is rare, and decoupling
+# lets us iterate on the verify logic without risking the release
+# pipeline.
+#
+# Ordering note (#661): the GitHub Release can be *published* (UI /
+# `gh release create` at tag-push time) before `release.yml` has
+# finished cross-compiling and uploading the 5 platform tarballs
+# (~10–15 min). So this workflow must NOT assume the assets exist the
+# moment it runs — it polls for each asset with backoff and only fails
+# once they're genuinely absent past a generous deadline.
 #
 # Coverage:
 #   - x86_64-unknown-linux-gnu (native, free)
@@ -64,15 +71,48 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y -qq qemu-user-static
 
-      - name: Download artifact + sha256
+      - name: Download artifact + sha256 (wait for assets)
         shell: bash
         run: |
           set -euo pipefail
           TAG="${{ steps.tag.outputs.tag }}"
           NAME="lex-${TAG}-${{ matrix.target }}"
           BASE="https://github.com/${{ github.repository }}/releases/download/${TAG}"
-          curl -sSLO --retry 3 "${BASE}/${NAME}.tar.gz"
-          curl -sSLO --retry 3 "${BASE}/${NAME}.tar.gz.sha256"
+
+          # #661: verify-release can start before release.yml has
+          # uploaded the tarballs (the release is published at tag-push
+          # time, the build takes ~10–15 min). Two failure modes to
+          # avoid:
+          #   1. failing on the first 404 (the asset just isn't up yet);
+          #   2. `curl -sSLO` (no -f) silently saving GitHub's "Not
+          #      Found" HTML *into* the .sha256 file, so `sha256sum -c`
+          #      later reports the misleading "no properly formatted
+          #      checksum lines found" instead of "asset missing".
+          # So: `curl -f` (HTTP errors → non-zero, nothing written) and
+          # poll with backoff until the asset appears or we hit a
+          # deadline comfortably past the build time.
+          fetch() {
+            local url="$1" out="$2"
+            local deadline=$(( SECONDS + 1200 ))   # 20 min
+            local delay=10
+            while true; do
+              if curl -fsSL --retry 3 --retry-all-errors -o "$out" "$url"; then
+                return 0
+              fi
+              if [ "$SECONDS" -ge "$deadline" ]; then
+                echo "::error::release asset not available after 20 min: ${url}"
+                echo "::error::the release.yml build may still be running or have failed — check its run for ${TAG}"
+                return 1
+              fi
+              echo "asset not ready yet (${url}); retrying in ${delay}s…"
+              sleep "$delay"
+              [ "$delay" -lt 80 ] && delay=$(( delay * 2 ))
+            done
+          }
+
+          fetch "${BASE}/${NAME}.tar.gz"        "${NAME}.tar.gz"
+          fetch "${BASE}/${NAME}.tar.gz.sha256" "${NAME}.tar.gz.sha256"
+
           sha256sum -c "${NAME}.tar.gz.sha256"
           tar -xzf "${NAME}.tar.gz"
           # Sanity-check the binary's architecture matches the target.


### PR DESCRIPTION
## What

Fixes **#661** — `verify-release` fails on every release with a misleading `sha256sum: … no properly formatted checksum lines found`, because it races the release build.

## Root cause

`verify-release` triggers on `release: published`, but the GitHub Release is published at **tag-push time** (UI / `gh release create`) while `release.yml` spends ~10–15 min cross-compiling and uploading the 5 platform tarballs via `softprops/action-gh-release`. So `verify-release` runs against a release that has **no assets yet** (confirmed on v0.9.11: all runs fired at 17:17:11 with the build still in progress).

Two compounding bugs, both in the download step:
1. **No barrier** — it failed on the first 404 instead of waiting for the upload.
2. **Silent 404 → poisoned file** — `curl -sSLO` (no `-f`) saved GitHub's "Not Found" HTML *into* `…tar.gz.sha256`, so `sha256sum -c` reported the misleading "no properly formatted checksum lines found" instead of "asset missing".

## Fix (the issue's option #3)

Reworked the **"Download artifact + sha256"** step:
- `curl -fsSL --retry 3 --retry-all-errors` — a 404/5xx now fails cleanly and writes nothing (no poisoned checksum file).
- A `fetch()` poll loop with backoff (10→20→40→80s, ~20 min total — comfortably past the build) waits for each asset to appear, then verifies. If the asset is genuinely absent past the deadline, it fails **loudly**: `release asset not available after 20 min … build may still be running or have failed`.
- Updated the stale header comment that claimed "by the time it runs the artifacts are already public".

## Why #3 over #1

The issue recommends 1+3, but the release here is **published before `action-gh-release` runs** (everything fires at tag-push). So #1 (make `action-gh-release` create a draft then flip to published) wouldn't change the event timing, and toggling `draft` on an already-published release risks momentarily un-publishing it. **#3 is trigger-agnostic**: it resolves the race no matter how/when the release is published, and is self-contained in `verify-release.yml` — zero risk to the release pipeline. If you'd also like the structural guarantee, gating `verify-release` on the build via `workflow_run` (#2) is a clean follow-up.

## Validation

YAML validated (`yaml.safe_load`). Logic is a standard bash retry-with-backoff under `set -euo pipefail`; the real exercise is the next release tag — `workflow_dispatch` with a tag input can rehearse it against an existing release.

Draft — opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ru4nBvtgFnoezcH4Pf3Tf

---
_Generated by [Claude Code](https://claude.ai/code/session_012ru4nBvtgFnoezcH4Pf3Tf)_