### PR TITLE
fix(types): SqlParam PFloat/PBool accept Float/Bool (#669)

### DIFF
--- a/crates/lex-types/src/env.rs
+++ b/crates/lex-types/src/env.rs
@@ -68,8 +68,8 @@ impl TypeEnv {
         let mut sp_variants = IndexMap::new();
         sp_variants.insert("PStr".into(),   Some(Ty::str()));
         sp_variants.insert("PInt".into(),   Some(Ty::int()));
-        sp_variants.insert("PFloat".into(), Some(Ty::Con("Float".into(), vec![])));
-        sp_variants.insert("PBool".into(),  Some(Ty::Con("Bool".into(), vec![])));
+        sp_variants.insert("PFloat".into(), Some(Ty::float()));
+        sp_variants.insert("PBool".into(),  Some(Ty::bool()));
         sp_variants.insert("PNull".into(),  None);
         e.types.insert("SqlParam".into(), TypeDef {
             params: vec![],

--- a/crates/lex-types/tests/sqlparam_constructors_669.rs
+++ b/crates/lex-types/tests/sqlparam_constructors_669.rs
@@ -1,0 +1,42 @@
+//! Regression for #669: the builtin `SqlParam` constructors `PFloat`/`PBool`
+//! must accept plain `Float`/`Bool` values. They were registered as the
+//! nominal `Ty::Con("Float")` / `Ty::Con("Bool")` instead of the primitives
+//! `Ty::float()` / `Ty::bool()`, so `PFloat(1.0)` failed to type-check with a
+//! baffling "expected Float, got Float" (a `Con("Float")` that prints the same
+//! as `Prim(Float)` but won't unify). `PStr`/`PInt` were unaffected because
+//! they correctly used `Ty::str()` / `Ty::int()`.
+
+use lex_ast::canonicalize_program;
+use lex_syntax::parse_source;
+use lex_types::check_program;
+
+fn check(src: &str) -> Result<(), Vec<lex_types::TypeError>> {
+    let p = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&p);
+    check_program(&stages).map(|_| ())
+}
+
+#[test]
+fn all_sqlparam_constructors_type_check() {
+    // Every SqlParam constructor applied to a literal of its payload type,
+    // plus the nullary PNull, must type-check.
+    let src = r#"
+fn p_str()   -> SqlParam { PStr("x") }
+fn p_int()   -> SqlParam { PInt(1) }
+fn p_float() -> SqlParam { PFloat(1.0) }
+fn p_bool()  -> SqlParam { PBool(true) }
+fn p_null()  -> SqlParam { PNull }
+"#;
+    check(src).unwrap_or_else(|errs| panic!("SqlParam constructors should type-check: {errs:#?}"));
+}
+
+#[test]
+fn float_params_in_a_param_list() {
+    // The shape that broke lex-truck-edge: a List[SqlParam] mixing PFloat/PInt/PStr.
+    let src = r#"
+fn params() -> List[SqlParam] {
+  [PFloat(78.0), PInt(1), PStr("driving"), PBool(true)]
+}
+"#;
+    check(src).unwrap_or_else(|errs| panic!("mixed SqlParam list should type-check: {errs:#?}"));
+}


### PR DESCRIPTION
Fixes #669.

## Root cause

In `crates/lex-types/src/env.rs`, the builtin `SqlParam` union registered its `PFloat`/`PBool` variants with **nominal** payload types:

```rust
sp_variants.insert("PFloat".into(), Some(Ty::Con("Float".into(), vec![])));  // wrong
sp_variants.insert("PBool".into(),  Some(Ty::Con("Bool".into(),  vec![])));  // wrong
```

A literal such as `1.0` has type `Ty::Prim(Prim::Float)`, which does **not** unify with `Ty::Con("Float")` — they print identically ("Float") but are distinct types. So `PFloat(1.0)` failed type-checking with the contradictory `expected Float, got Float`. `PStr`/`PInt` were fine because they already used `Ty::str()`/`Ty::int()`.

Introduced in the original `std.sql` typed-param work (#362/#367); never corrected on `main`.

## Fix

Register the primitives, matching `PStr`/`PInt`:

```rust
sp_variants.insert("PFloat".into(), Some(Ty::float()));
sp_variants.insert("PBool".into(),  Some(Ty::bool()));
```

One-line-each change; unification, the `SqlParam` union, and constructor registration are otherwise correct.

## Tests

New `crates/lex-types/tests/sqlparam_constructors_669.rs`:
- `all_sqlparam_constructors_type_check` — every constructor (`PStr`/`PInt`/`PFloat`/`PBool`/`PNull`) against a literal of its payload type.
- `float_params_in_a_param_list` — a mixed `List[SqlParam]` (the shape that broke `lex-truck-edge`).

Verified:
- Both tests **fail** on pre-fix code, **pass** after.
- Full `cargo test -p lex-types` green.
- Built the CLI: `fn t() -> SqlParam { PFloat(1.0) }` (zero imports) now type-checks.

## Notes

The original report also flagged a macOS-vs-linux divergence for the same compiler version. That was a red herring from a locally-built (already-fixed) binary vs. the released ones — the underlying defect is platform-independent and addressed here. Worth a follow-up to cut a release with this fix so downstreams (e.g. `lex-truck-edge`, which currently works around it via `PStr(float.to_str(x))`) can use `PFloat`/`PBool` again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)