### PR TITLE
chore(release): prepare 0.9.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+## [0.9.12] — 2026-06-22
+
+### Fixed
+
+- **`SqlParam` `PFloat` / `PBool` now type-check (#669).** The builtin
+  `SqlParam` union registered its `PFloat` / `PBool` variants with the nominal
+  payload types `Ty::Con("Float")` / `Ty::Con("Bool")` instead of the
+  primitives `Ty::float()` / `Ty::bool()`. A `Float`/`Bool` value (e.g. the
+  literal `1.0`) is `Ty::Prim(...)`, which does not unify with the nominal
+  `Ty::Con(...)`, so `PFloat(1.0)` / `PBool(true)` failed type-checking with a
+  contradictory `expected Float, got Float` (the `Con` printed identically to
+  the `Prim`). `PStr` / `PInt` were unaffected because they already used the
+  primitive types. Now all `SqlParam` float/bool params type-check; callers no
+  longer need to stringify floats (`PStr(float.to_str(x))`) as a workaround.
+
 ## [0.9.11] — 2026-06-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "conformance"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "core-compiler"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "indexmap",
  "lex-ast",
@@ -2534,7 +2534,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lex-api"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "flate2",
@@ -2556,7 +2556,7 @@ dependencies = [
 
 [[package]]
 name = "lex-ast"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "indexmap",
  "lex-syntax",
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "lex-bytecode"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "lex-cli"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "acli",
  "anyhow",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "lex-jit"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "lex-lsp"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "lex-ast",
  "lex-store",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "lex-runtime"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "lex-search"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "hex",
  "lex-ast",
@@ -2736,7 +2736,7 @@ dependencies = [
 
 [[package]]
 name = "lex-store"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "fs2",
  "hex",
@@ -2755,7 +2755,7 @@ dependencies = [
 
 [[package]]
 name = "lex-syntax"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "flate2",
  "indexmap",
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "lex-trace"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "indexmap",
  "lex-ast",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "lex-types"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "hex",
  "indexmap",
@@ -2801,7 +2801,7 @@ dependencies = [
 
 [[package]]
 name = "lex-vcs"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "ed25519-dalek",
  "getrandom 0.4.2",
@@ -5224,7 +5224,7 @@ dependencies = [
 
 [[package]]
 name = "spec-checker"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "indexmap",
  "lex-ast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.9.11"
+version = "0.9.12"
 edition = "2021"
 license = "EUPL-1.2"
 repository = "https://github.com/alpibrusl/lex-lang"


### PR DESCRIPTION
Release prep for **0.9.12**.

## Changes
- Bump workspace version `0.9.11` → `0.9.12` (`Cargo.toml`, `Cargo.lock`).
- Add the `[0.9.12]` CHANGELOG section.

## Contents of 0.9.12
- **#669 / #670** — `SqlParam` `PFloat`/`PBool` now type-check. They were registered with nominal `Ty::Con("Float")`/`Ty::Con("Bool")` payloads instead of the `Ty::float()`/`Ty::bool()` primitives, so `PFloat(1.0)`/`PBool(true)` failed with a contradictory `expected Float, got Float`. Downstreams (e.g. `lex-truck-edge`) can drop the `PStr(float.to_str(x))` workaround.

## Cutting the release
After this merges, push the tag to trigger `release.yml` (cross-platform binary build + GitHub Release):

```
git tag v0.9.12 <merge-commit> && git push origin v0.9.12
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)