### PR TITLE
feat(std.str): add O(1) str.char_at builtin (fixes O(n²) string scanning)

### DIFF
--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -82,6 +82,27 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
         // -- str --
         ("str", "is_empty") => Ok(Value::Bool(expect_str(args.first())?.is_empty())),
         ("str", "len") => Ok(Value::Int(expect_str(args.first())?.len() as i64)),
+        // O(1) single-char access. `str.slice(s, i, i+1)` resolves a codepoint
+        // index via `char_indices().nth(i)` — O(i) — so scanning a string
+        // char-by-char is O(n²). `char_at` indexes the UTF-8 bytes directly and
+        // returns the byte as a 1-char Str, letting ASCII-oriented scanners
+        // (e.g. the JSON parser, whose input is pre-sanitised to single bytes)
+        // run in O(n). Returns the char for ASCII bytes (< 128); out-of-range or
+        // a non-ASCII byte yields "" — total, never panics.
+        ("str", "char_at") => {
+            let s = expect_str(args.first())?;
+            let i = expect_int(args.get(1))?;
+            if i < 0 {
+                Ok(Value::Str("".into()))
+            } else {
+                match s.as_bytes().get(i as usize) {
+                    Some(&b) if b < 128 => {
+                        Ok(Value::Str((b as char).to_string().into()))
+                    }
+                    _ => Ok(Value::Str("".into())),
+                }
+            }
+        }
         ("str", "concat") => {
             let a = expect_str(args.first())?;
             let b = expect_str(args.get(1))?;

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -54,6 +54,8 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 Ty::Con("Option".into(), vec![Ty::float()])));
             fields.insert("concat".into(), Ty::function(vec![Ty::str(), Ty::str()], EffectSet::empty(), Ty::str()));
             fields.insert("len".into(), Ty::function(vec![Ty::str()], EffectSet::empty(), Ty::int()));
+            // char_at :: (Str, Int) -> Str  — O(1) single-char access; "" if out of range.
+            fields.insert("char_at".into(), Ty::function(vec![Ty::str(), Ty::int()], EffectSet::empty(), Ty::str()));
             fields.insert("split".into(), Ty::function(
                 vec![Ty::str(), Ty::str()],
                 EffectSet::empty(),


### PR DESCRIPTION
## Problem

Scanning a string char-by-char from Lex code is **O(n²)**. The only per-char accessor is `str.slice(s, i, i+1)`, whose codepoint index resolves through `char_indices().nth(i)` — **O(i)** per call. A hand-rolled scanner that visits every position (e.g. `lex-schema`'s JSON parser in `src/json_value.lex`) therefore costs O(n²), and on multi-KB inputs it exceeds the VM's 10M-step limit and **panics** (`step limit exceeded in ... char_at`).

This surfaced in `lex-loom`: QA verdict JSON embedding large `lex_check`/`lex_run` tool output crashed `jv.parse` mid-sprint.

## Fix

Add `str.char_at(s, i) -> Str`:
- Indexes the UTF-8 bytes directly — **O(1)**.
- Returns the byte as a 1-char `Str` for ASCII (`< 128`); out-of-range or non-ASCII byte yields `""`.
- Total — never panics.

This is the primitive an ASCII-oriented scanner needs to run in O(n). The companion `lex-schema` PR switches its parser's `char_at` to use it: parse time for a 40 KB document drops from **>100 s (then panic)** to **<1 s**, and inputs that previously panicked at ~3–5 KB now parse past 100 KB.

## Testing

- `cargo test -p lex-runtime` — all pass.
- Verified against `lex-schema`'s parser test suites (`test_json_value`, `test_json_extra`, `test_fuzz`, `test_property`) — all green, plus a new large-input regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)