### PR TITLE
chore(release): prepare 0.9.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+## [0.9.13] — 2026-06-23
+
+### Added
+
+- **`str.char_at(s, i) -> Str` — O(1) single-char access (#674).** Reading a
+  string char-by-char previously meant `str.slice(s, i, i+1)`, whose codepoint
+  index resolves through `char_indices().nth(i)` — O(i) per char. Any hand-rolled
+  scanner (e.g. lex-schema's JSON parser) was therefore O(n²), and on multi-KB
+  inputs it exceeded the VM's 10M-step limit and panicked. `str.char_at` indexes
+  the UTF-8 bytes directly (O(1)) and returns the byte as a 1-char `Str` for
+  ASCII (`< 128`); out-of-range or a non-ASCII byte yields `""`. This lets
+  ASCII-oriented scanners run in O(n). Total — never panics.
+
 ## [0.9.12] — 2026-06-22
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "conformance"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "core-compiler"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "indexmap",
  "lex-ast",
@@ -2534,7 +2534,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lex-api"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "flate2",
@@ -2556,7 +2556,7 @@ dependencies = [
 
 [[package]]
 name = "lex-ast"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "indexmap",
  "lex-syntax",
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "lex-bytecode"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "lex-cli"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "acli",
  "anyhow",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "lex-jit"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "lex-lsp"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "lex-ast",
  "lex-store",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "lex-runtime"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "lex-search"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "hex",
  "lex-ast",
@@ -2736,7 +2736,7 @@ dependencies = [
 
 [[package]]
 name = "lex-store"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "fs2",
  "hex",
@@ -2755,7 +2755,7 @@ dependencies = [
 
 [[package]]
 name = "lex-syntax"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "flate2",
  "indexmap",
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "lex-trace"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "indexmap",
  "lex-ast",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "lex-types"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "hex",
  "indexmap",
@@ -2801,7 +2801,7 @@ dependencies = [
 
 [[package]]
 name = "lex-vcs"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "ed25519-dalek",
  "getrandom 0.4.2",
@@ -5224,7 +5224,7 @@ dependencies = [
 
 [[package]]
 name = "spec-checker"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "indexmap",
  "lex-ast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.9.12"
+version = "0.9.13"
 edition = "2021"
 license = "EUPL-1.2"
 repository = "https://github.com/alpibrusl/lex-lang"


### PR DESCRIPTION
Bumps workspace version 0.9.12 -> 0.9.13 and adds the CHANGELOG section. Ships #674 (str.char_at, O(1) char access — fixes O(n²) string scanning). Unblocks lex-schema#19. Merge order: #674 -> this -> tag v0.9.13 -> bump lex-schema LEX_VERSION.