### PR TITLE
fix(std.yaml): wrap Option[T] fields in parse_strict like json/toml (#682)

### DIFF
--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -481,7 +481,7 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
                     if let Err(e) = validate_field_types(&v, &schema) {
                         return Ok(err_v(Value::Str(e.into())));
                     }
-                    Ok(ok_v(json_to_value(&v)))
+                    Ok(ok_v(apply_option_wrapping(json_to_value(&v), &v, &schema)))
                 }
                 Err(e) => Ok(err_v(Value::Str(format!("{e}").into()))),
             }
@@ -498,7 +498,7 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
                     if let Err(e) = validate_field_types(&v, &schema) {
                         return Ok(err_v(Value::Str(e.into())));
                     }
-                    Ok(ok_v(json_to_value(&v)))
+                    Ok(ok_v(apply_option_wrapping(json_to_value(&v), &v, &schema)))
                 }
                 Err(e) => Ok(err_v(Value::Str(format!("{e}").into()))),
             }

--- a/crates/lex-runtime/tests/std_parse_strict.rs
+++ b/crates/lex-runtime/tests/std_parse_strict.rs
@@ -242,3 +242,49 @@ fn option_field_null_produces_none() {
     ]);
     assert_eq!(v, none(), "expected None for null bio, got {v:?}");
 }
+
+// ---- #682: std.yaml must wrap Option[T] fields like json/toml ----------
+//
+// Regression for #682: `yaml.parse_strict`/`parse_strict_typed` skipped
+// `apply_option_wrapping`, so Option[T] fields parsed from YAML were not
+// wrapped in Some/None (diverging from json and toml). These mirror the
+// #577 json tests above against the same logical inputs.
+
+const YAML_OPTION_SRC: &str = r#"
+import "std.yaml" as yaml
+
+type Profile = { name :: Str, bio :: Option[Str] }
+
+fn parse_profile(s :: Str) -> Result[Profile, Str] { yaml.parse(s) }
+
+fn get_bio(s :: Str) -> Option[Str] {
+  match parse_profile(s) {
+    Ok(p) => p.bio,
+    Err(_) => None,
+  }
+}
+"#;
+
+#[test]
+fn yaml_option_field_present_wraps_in_some() {
+    // A present value for an Option[Str] field must be wrapped in Some(...).
+    let v = run_typed(YAML_OPTION_SRC, "get_bio", vec![
+        Value::Str("name: Alice\nbio: developer\n".into()),
+    ]);
+    assert_eq!(v, some(Value::Str("developer".into())),
+        "expected Some(\"developer\") from YAML, got {v:?}");
+}
+
+#[test]
+fn yaml_option_field_absent_produces_none() {
+    // An absent (or null) Option[Str] field must produce None.
+    let v = run_typed(YAML_OPTION_SRC, "get_bio", vec![
+        Value::Str("name: Alice\n".into()),
+    ]);
+    assert_eq!(v, none(), "expected None for absent bio in YAML, got {v:?}");
+
+    let v2 = run_typed(YAML_OPTION_SRC, "get_bio", vec![
+        Value::Str("name: Alice\nbio: null\n".into()),
+    ]);
+    assert_eq!(v2, none(), "expected None for null bio in YAML, got {v2:?}");
+}


### PR DESCRIPTION
Fixes #682.

## Problem

`yaml.parse_strict` and the compiler-emitted `yaml.parse_strict_typed` returned the decoded value straight from `json_to_value`, skipping the `apply_option_wrapping` pass that `json` and `toml` both run. So a record with `Option[T]` fields parsed from YAML did **not** get those fields wrapped in `Some`/`None` — diverging from json/toml, even though the yaml arm's own comment claimed "same shape as toml.parse_strict."

## Fix

Both yaml strict arms now post-process the record:

```rust
Ok(ok_v(apply_option_wrapping(json_to_value(&v), &v, &schema)))
```

identical to the json (`:365`) and toml (`:400`) arms.

## Tests

Added `yaml_option_field_present_wraps_in_some` and `yaml_option_field_absent_produces_none` to `std_parse_strict.rs`, modelled on the existing #577 json tests, covering present → `Some(..)`, absent → `None`, and explicit `null` → `None`.

```
test result: ok. 13 passed; 0 failed
```

Verified locally with `cargo test -p lex-runtime --test std_parse_strict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YESxnpeuCT4kK2Gtuo1uui

---
_Generated by [Claude Code](https://claude.ai/code/session_01YESxnpeuCT4kK2Gtuo1uui)_