### PR TITLE
feat(std): combinator parity for result/option (#679)

### DIFF
--- a/crates/lex-bytecode/src/compiler.rs
+++ b/crates/lex-bytecode/src/compiler.rs
@@ -1518,6 +1518,7 @@ impl<'a> FnCompiler<'a> {
             ("option", "and_then") => self.emit_variant_map(args, "Some", false),
             ("option", "or_else") => self.emit_variant_or_else(args, "None", 0),
             ("option", "unwrap_or_else") => self.emit_option_unwrap_or_else(args),
+            ("result", "unwrap_or_else") => self.emit_result_unwrap_or_else(args),
             ("list", "map") => self.emit_list_map(args),
             ("list", "par_map") => self.emit_list_par_map(args),
             ("list", "sort_by") => self.emit_list_sort_by(args),
@@ -2557,6 +2558,57 @@ impl<'a> FnCompiler<'a> {
         self.emit(Op::CallClosure { arity: 0, node_id_idx: nid });
 
         // Patch jump-to-end from Some arm.
+        let end_target = self.code.len() as i32;
+        if let Op::Jump(off) = &mut self.code[j_end] {
+            *off = end_target - (j_end as i32 + 1);
+        }
+    }
+
+    /// `result.unwrap_or_else(res, f)` — lazy fallback over the Err payload.
+    ///   Ok(x)  → x        (unwrap; no wrapping)
+    ///   Err(e) → f(e)     (call closure with the error; result returned directly)
+    /// Sibling of `emit_option_unwrap_or_else`; differs only in matching on
+    /// `Ok` and forwarding the `Err` payload to a one-arg closure. (#679)
+    fn emit_result_unwrap_or_else(&mut self, args: &[a::CExpr]) {
+        let ok_idx = self.pool.variant("Ok");
+
+        self.compile_expr(&args[0], false);
+        let val_slot = self.alloc_local("__ruoe_val");
+        self.emit(Op::StoreLocal(val_slot));
+
+        self.compile_expr(&args[1], false);
+        let f_slot = self.alloc_local("__ruoe_f");
+        self.emit(Op::StoreLocal(f_slot));
+
+        // Test whether res is Ok.
+        //   load val ⇒ [v]
+        //   dup      ⇒ [v, v]
+        //   test     ⇒ [v, Bool]
+        //   jumpifnot → Err arm
+        self.emit(Op::LoadLocal(val_slot));
+        self.emit(Op::Dup);
+        self.emit(Op::TestVariant(ok_idx));
+        let j_err = self.code.len();
+        self.emit(Op::JumpIfNot(0));
+
+        // Ok arm: extract the payload from [v] left on the stack.
+        self.emit(Op::GetVariantArg(0));
+        let j_end = self.code.len();
+        self.emit(Op::Jump(0));
+
+        // Err arm: pop the [v] duplicate, call f with the Err payload.
+        let err_target = self.code.len() as i32;
+        if let Op::JumpIfNot(off) = &mut self.code[j_err] {
+            *off = err_target - (j_err as i32 + 1);
+        }
+        self.emit(Op::Pop);
+        self.emit(Op::LoadLocal(f_slot));
+        self.emit(Op::LoadLocal(val_slot));
+        self.emit(Op::GetVariantArg(0));
+        let nid = self.pool.node_id("n_ruoe");
+        self.emit(Op::CallClosure { arity: 1, node_id_idx: nid });
+
+        // Patch jump-to-end from Ok arm.
         let end_target = self.code.len() as i32;
         if let Op::Jump(off) = &mut self.code[j_end] {
             *off = end_target - (j_end as i32 + 1);

--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -316,6 +316,17 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             Value::Variant { name, .. } => Ok(Value::Bool(name == "None")),
             other => Err(format!("option.is_none expected Option, got {other:?}")),
         },
+        // option.ok_or(opt, err): Some(x) -> Ok(x); None -> Err(err). (#679)
+        ("option", "ok_or") => {
+            let opt = first_arg(args)?;
+            let err_val = args.get(1).cloned().unwrap_or(Value::Unit);
+            match opt {
+                Value::Variant { name, args } if name == "Some" && !args.is_empty() =>
+                    Ok(ok_v(args[0].clone())),
+                Value::Variant { name, .. } if name == "None" => Ok(err_v(err_val)),
+                other => Err(format!("option.ok_or expected Option, got {other:?}")),
+            }
+        }
 
         // -- result --
         ("result", "is_ok") => match first_arg(args)? {
@@ -333,6 +344,19 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
                 Value::Variant { name, args } if name == "Ok" && !args.is_empty() => Ok(args[0].clone()),
                 Value::Variant { name, .. } if name == "Err" => Ok(default),
                 other => Err(format!("result.unwrap_or expected Result, got {other:?}")),
+            }
+        }
+        // result.unwrap_or_else: lazy fallback over the Err payload. The
+        // closure call is emitted inline by the bytecode compiler
+        // (`emit_result_unwrap_or_else`); this arm is the interpreter
+        // fallback, with the thunk result pre-evaluated into args[1]. (#679)
+        ("result", "unwrap_or_else") => {
+            let res = first_arg(args)?;
+            match res {
+                Value::Variant { name, args } if name == "Ok" && !args.is_empty() => Ok(args[0].clone()),
+                Value::Variant { name, .. } if name == "Err" =>
+                    Ok(args.get(1).cloned().unwrap_or(Value::Unit)),
+                other => Err(format!("result.unwrap_or_else expected Result, got {other:?}")),
             }
         }
 

--- a/crates/lex-runtime/tests/std_combinators.rs
+++ b/crates/lex-runtime/tests/std_combinators.rs
@@ -1,0 +1,86 @@
+//! Combinator parity for `std.result` / `std.option` (#679).
+//!
+//! These functions had runtime support but were missing type
+//! signatures (so they couldn't be called from Lex source), or were
+//! missing entirely on one of the two types. This pins:
+//!   - result.unwrap_or / unwrap_or_else / is_ok / is_err
+//!   - option.is_some / is_none / ok_or
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::sync::Arc;
+
+const SRC: &str = r#"
+import "std.result" as result
+import "std.option" as option
+import "std.str"    as str
+
+fn r_unwrap_or(r :: Result[Int, Str], d :: Int) -> Int { result.unwrap_or(r, d) }
+
+# Lazy fallback receives the Err payload — here its length.
+fn r_unwrap_or_else(r :: Result[Int, Str]) -> Int {
+  result.unwrap_or_else(r, fn (e :: Str) -> Int { str.len(e) })
+}
+
+fn r_is_ok(r :: Result[Int, Str]) -> Bool { result.is_ok(r) }
+fn r_is_err(r :: Result[Int, Str]) -> Bool { result.is_err(r) }
+
+fn o_is_some(o :: Option[Int]) -> Bool { option.is_some(o) }
+fn o_is_none(o :: Option[Int]) -> Bool { option.is_none(o) }
+fn o_ok_or(o :: Option[Int], e :: Str) -> Result[Int, Str] { option.ok_or(o, e) }
+"#;
+
+fn run(fn_name: &str, args: Vec<Value>) -> Value {
+    let prog = parse_source(SRC).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors:\n{errs:#?}");
+    }
+    let bc = Arc::new(compile_program(&stages));
+    let handler = DefaultHandler::new(Policy::pure()).with_program(Arc::clone(&bc));
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(fn_name, args).unwrap_or_else(|e| panic!("call {fn_name}: {e}"))
+}
+
+fn ok(v: Value) -> Value { Value::Variant { name: "Ok".into(), args: vec![v] } }
+fn err(v: Value) -> Value { Value::Variant { name: "Err".into(), args: vec![v] } }
+fn some(v: Value) -> Value { Value::Variant { name: "Some".into(), args: vec![v] } }
+fn none() -> Value { Value::Variant { name: "None".into(), args: vec![] } }
+
+#[test]
+fn result_unwrap_or() {
+    assert_eq!(run("r_unwrap_or", vec![ok(Value::Int(7)), Value::Int(99)]), Value::Int(7));
+    assert_eq!(run("r_unwrap_or", vec![err(Value::Str("x".into())), Value::Int(99)]), Value::Int(99));
+}
+
+#[test]
+fn result_unwrap_or_else_forwards_err_payload() {
+    // Ok → unwrapped value; the closure must not run.
+    assert_eq!(run("r_unwrap_or_else", vec![ok(Value::Int(7))]), Value::Int(7));
+    // Err → closure runs on the payload "boom" → length 4.
+    assert_eq!(run("r_unwrap_or_else", vec![err(Value::Str("boom".into()))]), Value::Int(4));
+}
+
+#[test]
+fn result_is_ok_is_err() {
+    assert_eq!(run("r_is_ok", vec![ok(Value::Int(1))]), Value::Bool(true));
+    assert_eq!(run("r_is_ok", vec![err(Value::Str("e".into()))]), Value::Bool(false));
+    assert_eq!(run("r_is_err", vec![ok(Value::Int(1))]), Value::Bool(false));
+    assert_eq!(run("r_is_err", vec![err(Value::Str("e".into()))]), Value::Bool(true));
+}
+
+#[test]
+fn option_is_some_is_none() {
+    assert_eq!(run("o_is_some", vec![some(Value::Int(3))]), Value::Bool(true));
+    assert_eq!(run("o_is_some", vec![none()]), Value::Bool(false));
+    assert_eq!(run("o_is_none", vec![some(Value::Int(3))]), Value::Bool(false));
+    assert_eq!(run("o_is_none", vec![none()]), Value::Bool(true));
+}
+
+#[test]
+fn option_ok_or_crosses_into_result() {
+    assert_eq!(run("o_ok_or", vec![some(Value::Int(3)), Value::Str("e".into())]), ok(Value::Int(3)));
+    assert_eq!(run("o_ok_or", vec![none(), Value::Str("e".into())]), err(Value::Str("e".into())));
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -1310,6 +1310,33 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 EffectSet::open_var(6),
                 Ty::Con("Result".into(), vec![Ty::Var(0), Ty::Var(2)]),
             ));
+            // result.unwrap_or :: Result[T, E], T -> T
+            // Eager fallback — the Ok payload, or the supplied default on
+            // Err. Mirrors option.unwrap_or (#679).
+            fields.insert("unwrap_or".into(), Ty::function(
+                vec![Ty::Con("Result".into(), vec![Ty::Var(0), Ty::Var(1)]), Ty::Var(0)],
+                EffectSet::empty(),
+                Ty::Var(0),
+            ));
+            // result.unwrap_or_else :: Result[T, E], (E) -> [Eff] T -> [Eff] T
+            // Lazy fallback — the closure runs only on Err and receives the
+            // error payload (effect-polymorphic on the closure). Mirrors
+            // option.unwrap_or_else (#679).
+            fields.insert("unwrap_or_else".into(), Ty::function(
+                vec![
+                    Ty::Con("Result".into(), vec![Ty::Var(0), Ty::Var(1)]),
+                    Ty::function(vec![Ty::Var(1)], EffectSet::open_var(7), Ty::Var(0)),
+                ],
+                EffectSet::open_var(7),
+                Ty::Var(0),
+            ));
+            // result.is_ok / is_err :: Result[T, E] -> Bool (#679)
+            fields.insert("is_ok".into(), Ty::function(
+                vec![Ty::Con("Result".into(), vec![Ty::Var(0), Ty::Var(1)])],
+                EffectSet::empty(), Ty::bool()));
+            fields.insert("is_err".into(), Ty::function(
+                vec![Ty::Con("Result".into(), vec![Ty::Var(0), Ty::Var(1)])],
+                EffectSet::empty(), Ty::bool()));
             Some(Ty::Record(fields))
         }
         "option" => {
@@ -1362,6 +1389,20 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 ],
                 EffectSet::open_var(4),
                 Ty::Con("Option".into(), vec![Ty::Var(0)]),
+            ));
+            // option.is_some / is_none :: Option[T] -> Bool (#679)
+            fields.insert("is_some".into(), Ty::function(
+                vec![Ty::Con("Option".into(), vec![Ty::Var(0)])],
+                EffectSet::empty(), Ty::bool()));
+            fields.insert("is_none".into(), Ty::function(
+                vec![Ty::Con("Option".into(), vec![Ty::Var(0)])],
+                EffectSet::empty(), Ty::bool()));
+            // option.ok_or :: Option[T], E -> Result[T, E]
+            // Cross from Option into Result, supplying the error for None (#679).
+            fields.insert("ok_or".into(), Ty::function(
+                vec![Ty::Con("Option".into(), vec![Ty::Var(0)]), Ty::Var(1)],
+                EffectSet::empty(),
+                Ty::Con("Result".into(), vec![Ty::Var(0), Ty::Var(1)]),
             ));
             Some(Ty::Record(fields))
         }


### PR DESCRIPTION
Fixes #679.

Rounds out the `std.result` / `std.option` combinator surface so agents don't have to remember which helper lives on which type. Several of these already had **runtime** arms but no **type signature**, so they were uncallable from Lex source.

## Changes

Signatures added (runtime already existed):
- `result.unwrap_or :: Result[T, E], T -> T`
- `result.is_ok` / `result.is_err :: Result[T, E] -> Bool`
- `option.is_some` / `option.is_none :: Option[T] -> Bool`

New end-to-end:
- `result.unwrap_or_else :: Result[T, E], (E) -> [Eff] T -> [Eff] T` — signature, compiler inline codegen (`emit_result_unwrap_or_else`, sibling of `emit_option_unwrap_or_else` but matches `Ok` and forwards the `Err` payload to a 1-arg closure), and an interpreter fallback arm.
- `option.ok_or :: Option[T], E -> Result[T, E]` — signature + runtime arm; crosses `Option` into `Result` (`None -> Err(e)`).

## Tests

`tests/std_combinators.rs` covers all seven, including that `unwrap_or_else` forwards the `Err` payload (closure computes `str.len(e)`) and short-circuits on `Ok`.

```
test result: ok. 5 passed; 0 failed
```

Adjacent suites still green (`std_option_and_then`, `std_parse_strict`: 11 passed). Verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YESxnpeuCT4kK2Gtuo1uui

---
_Generated by [Claude Code](https://claude.ai/code/session_01YESxnpeuCT4kK2Gtuo1uui)_