### PR TITLE
feat(std): int.{min,max,abs} and duration.{millis,minutes,hours,days} (#681)

### DIFF
--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -211,6 +211,10 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
         // -- int / float --
         ("int", "to_str") => Ok(Value::Str(expect_int(args.first())?.to_string().into())),
         ("int", "to_float") => Ok(Value::Float(expect_int(args.first())? as f64)),
+        // Int scalar helpers (#681) — integer counterparts to math.{abs,min,max}.
+        ("int", "abs") => Ok(Value::Int(expect_int(args.first())?.abs())),
+        ("int", "min") => Ok(Value::Int(expect_int(args.first())?.min(expect_int(args.get(1))?))),
+        ("int", "max") => Ok(Value::Int(expect_int(args.first())?.max(expect_int(args.get(1))?))),
         ("float", "to_int") => Ok(Value::Int(expect_float(args.first())? as i64)),
         ("float", "to_str") => Ok(Value::Str(expect_float(args.first())?.to_string().into())),
         ("str", "to_float") => {
@@ -1715,11 +1719,13 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             let b = expect_int(args.get(1))?;
             Ok(Value::Int(a.cmp(&b) as i64))
         }
-        // #331: Duration scalar extraction.
-        ("duration", "seconds") => {
-            let nanos = expect_int(args.first())?;
-            Ok(Value::Int(nanos / 1_000_000_000))
-        }
+        // #331: Duration scalar extraction (nanoseconds under the hood).
+        // #681 rounds out the unit set; each truncates toward zero.
+        ("duration", "millis")  => Ok(Value::Int(expect_int(args.first())? / 1_000_000)),
+        ("duration", "seconds") => Ok(Value::Int(expect_int(args.first())? / 1_000_000_000)),
+        ("duration", "minutes") => Ok(Value::Int(expect_int(args.first())? / 60_000_000_000)),
+        ("duration", "hours")   => Ok(Value::Int(expect_int(args.first())? / 3_600_000_000_000)),
+        ("duration", "days")    => Ok(Value::Int(expect_int(args.first())? / 86_400_000_000_000)),
 
         ("regex", "split") => {
             let pat = expect_str(args.first())?;

--- a/crates/lex-runtime/tests/std_int_duration.rs
+++ b/crates/lex-runtime/tests/std_int_duration.rs
@@ -1,0 +1,63 @@
+//! Additive scalar gaps (#681):
+//!   - std.int min/max/abs (integer counterparts to the Float-only
+//!     std.math min/max/abs)
+//!   - std.duration millis/minutes/hours/days (the unit set was just
+//!     `seconds`, asymmetric with datetime's duration_* constructors)
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::sync::Arc;
+
+const SRC: &str = r#"
+import "std.int"      as int
+import "std.datetime" as datetime
+import "std.duration" as duration
+
+fn imin(a :: Int, b :: Int) -> Int { int.min(a, b) }
+fn imax(a :: Int, b :: Int) -> Int { int.max(a, b) }
+fn iabs(a :: Int) -> Int { int.abs(a) }
+
+# Build a Duration via the datetime constructors, read it back in
+# each unit. Two days = 48 hours; ninety seconds = 1 minute.
+fn two_days_in_hours() -> Int {
+  duration.hours(datetime.duration_days(2))
+}
+fn ninety_seconds_in_minutes() -> Int {
+  duration.minutes(datetime.duration_seconds(90.0))
+}
+fn ninety_seconds_in_millis() -> Int {
+  duration.millis(datetime.duration_seconds(90.0))
+}
+"#;
+
+fn run(fn_name: &str, args: Vec<Value>) -> Value {
+    let prog = parse_source(SRC).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors:\n{errs:#?}");
+    }
+    let bc = Arc::new(compile_program(&stages));
+    let handler = DefaultHandler::new(Policy::pure()).with_program(Arc::clone(&bc));
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(fn_name, args).unwrap_or_else(|e| panic!("call {fn_name}: {e}"))
+}
+
+#[test]
+fn int_min_max_abs() {
+    assert_eq!(run("imin", vec![Value::Int(3), Value::Int(7)]), Value::Int(3));
+    assert_eq!(run("imax", vec![Value::Int(3), Value::Int(7)]), Value::Int(7));
+    assert_eq!(run("iabs", vec![Value::Int(-5)]), Value::Int(5));
+    assert_eq!(run("iabs", vec![Value::Int(5)]), Value::Int(5));
+    // No lossy Float round-trip: a value beyond f64's exact-integer range.
+    let big = 9_007_199_254_740_993_i64; // 2^53 + 1
+    assert_eq!(run("imax", vec![Value::Int(big), Value::Int(0)]), Value::Int(big));
+}
+
+#[test]
+fn duration_unit_extractors() {
+    assert_eq!(run("two_days_in_hours", vec![]), Value::Int(48));
+    assert_eq!(run("ninety_seconds_in_minutes", vec![]), Value::Int(1));
+    assert_eq!(run("ninety_seconds_in_millis", vec![]), Value::Int(90_000));
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -115,6 +115,14 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
             let mut fields = IndexMap::new();
             fields.insert("to_str".into(), Ty::function(vec![Ty::int()], EffectSet::empty(), Ty::str()));
             fields.insert("to_float".into(), Ty::function(vec![Ty::int()], EffectSet::empty(), Ty::float()));
+            // Int scalar helpers (#681). math.{min,max,abs} are Float-only;
+            // these are the integer equivalents so Int callers don't have to
+            // round-trip through Float (which is lossy for large ints).
+            fields.insert("abs".into(), Ty::function(vec![Ty::int()], EffectSet::empty(), Ty::int()));
+            for name in &["min", "max"] {
+                fields.insert((*name).into(), Ty::function(
+                    vec![Ty::int(), Ty::int()], EffectSet::empty(), Ty::int()));
+            }
             Some(Ty::Record(fields))
         }
         "math" => {
@@ -2113,9 +2121,16 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
         "duration" => {
             let dur = || Ty::Con("Duration".into(), vec![]);
             let mut fields = IndexMap::new();
-            // seconds :: Duration -> Int  (truncates toward zero)
-            fields.insert("seconds".into(), Ty::function(
-                vec![dur()], EffectSet::empty(), Ty::int()));
+            // Scalar extraction from a Duration (nanoseconds under the
+            // hood). Each truncates toward zero. `seconds` shipped with
+            // #331; #681 rounds out the unit set so a Duration built in
+            // days via `datetime.duration_days` can be read back in the
+            // same units rather than only as seconds.
+            // millis / seconds / minutes / hours / days :: Duration -> Int
+            for name in &["millis", "seconds", "minutes", "hours", "days"] {
+                fields.insert((*name).into(), Ty::function(
+                    vec![dur()], EffectSet::empty(), Ty::int()));
+            }
             Some(Ty::Record(fields))
         }
         "process" => {


### PR DESCRIPTION
Addresses the two unambiguous additive gaps from #681.

## `std.int` — `min` / `max` / `abs`
`std.math` only offered `min`/`max`/`abs` on `Float`, so integer callers had to round-trip through `Float` (lossy past 2^53). Added integer equivalents (`(Int, Int) -> Int` / `Int -> Int`).

## `std.duration` — `millis` / `minutes` / `hours` / `days`
The module only had `seconds`, asymmetric with `datetime`'s `duration_seconds` / `duration_minutes` / `duration_days` **constructors** — a Duration built in days could only be read back in seconds. Added the missing unit extractors (nanoseconds under the hood, truncating toward zero).

## Tests
`tests/std_int_duration.rs`: int min/max/abs (incl. a 2^53+1 value to prove no Float round-trip), and `2 days = 48 h`, `90 s = 1 min`, `90 s = 90000 ms`.

```
test result: ok. 2 passed; 0 failed
```

## Deferred (design/cosmetic, not in this PR)
The remaining #681 sub-items are judgment calls better made separately: `std.chat` placement, the `iter.collect`/`to_list` alias policy, the `math`/linalg split, and `Nil`-vs-`Unit` comment naming. I left #681 open to track those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YESxnpeuCT4kK2Gtuo1uui

---
_Generated by [Claude Code](https://claude.ai/code/session_01YESxnpeuCT4kK2Gtuo1uui)_