### PR TITLE
fix(std.rand): honest uniform draw under [random], not a [rand] midpoint stub (#677)

### DIFF
--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -1043,6 +1043,11 @@ impl EffectHandler for DefaultHandler {
         // below, matching the `std.http` precedent.
         if kind == "redis" {
             self.ensure_kind_allowed("net")?;
+        } else if kind == "rand" {
+            // `std.rand.int_in` draws from the OS RNG → `[random]` effect,
+            // the same gate as `crypto.random` (#677). No separate `rand`
+            // effect grant exists.
+            self.ensure_kind_allowed("random")?;
         } else {
             self.ensure_kind_allowed(kind)?;
         }
@@ -1203,10 +1208,23 @@ impl EffectHandler for DefaultHandler {
                 Ok(Value::Unit)
             }
             ("rand", "int_in") => {
-                // Deterministic stub: midpoint of [lo, hi].
+                // Honest uniform draw in [lo, hi] inclusive from the OS RNG
+                // (#677), replacing the old deterministic midpoint stub.
+                // Same entropy source as `crypto.random`; gated `[random]`.
                 let lo = expect_int(args.first())?;
                 let hi = expect_int(args.get(1))?;
-                Ok(Value::Int((lo + hi) / 2))
+                if hi < lo {
+                    return Err(format!("rand.int_in: empty range [{lo}, {hi}]"));
+                }
+                use rand::{rngs::SysRng, TryRng};
+                // span fits in u128 even for the full i64 range; bias from
+                // the modulo over a 128-bit draw is < 2^-64 (negligible).
+                let span = (hi as i128 - lo as i128 + 1) as u128;
+                let mut buf = [0u8; 16];
+                SysRng.try_fill_bytes(&mut buf)
+                    .map_err(|e| format!("rand.int_in: OS RNG: {e}"))?;
+                let draw = (u128::from_le_bytes(buf) % span) as i128;
+                Ok(Value::Int((lo as i128 + draw) as i64))
             }
             // `env.get` returns `Option[Str]` — `None` for unset vars.
             // Per-var scoping (`[env(NAME)]`) arrives with #207's

--- a/crates/lex-runtime/src/policy.rs
+++ b/crates/lex-runtime/src/policy.rs
@@ -86,7 +86,7 @@ impl Policy {
     pub fn permissive() -> Self {
         let mut s = BTreeSet::new();
         for k in [
-            "io", "net", "time", "rand", "llm", "proc", "panic",
+            "io", "net", "time", "llm", "proc", "panic",
             "fs_read", "fs_write", "budget",
             // #184: agent-runtime effects.
             "llm_local", "llm_cloud", "a2a", "mcp",
@@ -333,7 +333,7 @@ mod wildcard_tests {
     fn pure_and_unscoped_effects_are_clean() {
         assert!(Policy::pure().wildcard_scoped_grants().is_empty());
         let p = Policy {
-            allow_effects: effects(&["time", "rand", "panic"]),
+            allow_effects: effects(&["time", "random", "panic"]),
             ..Policy::default()
         };
         assert!(p.wildcard_scoped_grants().is_empty());

--- a/crates/lex-runtime/tests/effect_polymorphism.rs
+++ b/crates/lex-runtime/tests/effect_polymorphism.rs
@@ -156,18 +156,32 @@ fn stamp_opt(o :: Option[Int]) -> [time] Option[Int] {
 
 #[test]
 fn effectful_list_map_runs_end_to_end() {
-    // Use rand.int_in (deterministic stub: midpoint of [lo, hi]) so
-    // we can assert exact output. Closure has [rand]; the surrounding
-    // fn declares [rand]; runtime runs under permissive policy.
+    // rand.int_in now draws honestly under [random] (#677), so assert each
+    // result lands in [0, hi] rather than an exact value. The point of this
+    // test is that an effectful closure threads its effect row through
+    // list.map end-to-end; the closure has [random], the surrounding fn
+    // declares [random], runtime runs under permissive policy.
     let src = r#"
 import "std.list" as list
 import "std.rand" as rand
-fn midpoints(xs :: List[Int]) -> [rand] List[Int] {
-  list.map(xs, fn (hi :: Int) -> [rand] Int { rand.int_in(0, hi) })
+fn draws(xs :: List[Int]) -> [random] List[Int] {
+  list.map(xs, fn (hi :: Int) -> [random] Int { rand.int_in(0, hi) })
 }
 "#;
-    // rand.int_in(0, 10) → 5; rand.int_in(0, 100) → 50; rand.int_in(0, 6) → 3
-    let r = run(src, "midpoints",
-        vec![Value::List(vec![Value::Int(10), Value::Int(100), Value::Int(6)].into())]);
-    assert_eq!(r, Value::List(vec![Value::Int(5), Value::Int(50), Value::Int(3)].into()));
+    let bounds = [10i64, 100, 6];
+    let r = run(src, "draws",
+        vec![Value::List(bounds.iter().map(|&n| Value::Int(n)).collect::<Vec<_>>().into())]);
+    match r {
+        Value::List(items) => {
+            assert_eq!(items.len(), bounds.len());
+            for (it, &hi) in items.iter().zip(bounds.iter()) {
+                match it {
+                    Value::Int(n) => assert!(*n >= 0 && *n <= hi,
+                        "rand.int_in(0, {hi}) returned {n}, out of range"),
+                    other => panic!("expected Int, got {other:?}"),
+                }
+            }
+        }
+        other => panic!("expected List, got {other:?}"),
+    }
 }

--- a/crates/lex-runtime/tests/std_rand.rs
+++ b/crates/lex-runtime/tests/std_rand.rs
@@ -1,0 +1,76 @@
+//! `std.rand.int_in` is an honest uniform draw under the `[random]`
+//! effect (#677) — no longer a deterministic midpoint stub, and gated
+//! by the same `[random]` grant as `crypto.random` (not a separate
+//! `rand` effect).
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+const SRC: &str = r#"
+import "std.rand" as rand
+fn draw(lo :: Int, hi :: Int) -> [random] Int { rand.int_in(lo, hi) }
+"#;
+
+fn policy_with(effects: &[&str]) -> Policy {
+    let mut p = Policy::pure();
+    p.allow_effects = effects.iter().map(|s| s.to_string()).collect::<BTreeSet<_>>();
+    p
+}
+
+fn compile() -> Arc<lex_bytecode::Program> {
+    let prog = parse_source(SRC).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors:\n{errs:#?}");
+    }
+    Arc::new(compile_program(&stages))
+}
+
+fn draw(bc: &Arc<lex_bytecode::Program>, policy: Policy, lo: i64, hi: i64) -> Result<Value, String> {
+    let handler = DefaultHandler::new(policy).with_program(Arc::clone(bc));
+    let mut vm = Vm::with_handler(bc, Box::new(handler));
+    vm.call("draw", vec![Value::Int(lo), Value::Int(hi)]).map_err(|e| e.to_string())
+}
+
+#[test]
+fn draws_stay_within_inclusive_range() {
+    let bc = compile();
+    for _ in 0..200 {
+        match draw(&bc, policy_with(&["random"]), 3, 7).expect("draw") {
+            Value::Int(n) => assert!((3..=7).contains(&n), "draw {n} out of [3, 7]"),
+            other => panic!("expected Int, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn single_point_range_is_exact() {
+    let bc = compile();
+    assert_eq!(draw(&bc, policy_with(&["random"]), 42, 42).expect("draw"), Value::Int(42));
+}
+
+#[test]
+fn draws_are_not_constant() {
+    // The old stub always returned the midpoint; an honest RNG must
+    // produce more than one distinct value over a wide range.
+    let bc = compile();
+    let mut seen = std::collections::BTreeSet::new();
+    for _ in 0..100 {
+        if let Value::Int(n) = draw(&bc, policy_with(&["random"]), 0, 1_000_000).expect("draw") {
+            seen.insert(n);
+        }
+    }
+    assert!(seen.len() > 1, "rand.int_in looks constant: {seen:?}");
+}
+
+#[test]
+fn requires_random_effect_grant() {
+    // Gated under [random]; an empty policy must refuse the call.
+    let bc = compile();
+    let err = draw(&bc, Policy::pure(), 0, 10).expect_err("should be denied without [random]");
+    assert!(err.contains("random"), "error should mention the random effect: {err}");
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -403,12 +403,17 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
             Some(Ty::Record(fields))
         }
         "rand" => {
-            // rand.int_in(lo, hi) -> [rand] Int — currently a deterministic
-            // stub (midpoint) per spec §13; replaced when randomness lands.
+            // rand.int_in(lo, hi) -> [random] Int — honest uniform draw in
+            // [lo, hi] (inclusive) from the OS RNG (#677). Carries the same
+            // `[random]` effect as `crypto.random` rather than a separate
+            // `rand` effect, so a reviewer auditing `--effect random` sees
+            // every non-deterministic draw in one place. For deterministic,
+            // replayable randomness thread a seed through `std.random`
+            // instead; for cryptographic strength use `crypto.random`.
             let mut fields = IndexMap::new();
             fields.insert("int_in".into(), Ty::function(
                 vec![Ty::int(), Ty::int()],
-                EffectSet::singleton("rand"),
+                EffectSet::singleton("random"),
                 Ty::int(),
             ));
             Some(Ty::Record(fields))

--- a/crates/lex-types/tests/effect_soundness.rs
+++ b/crates/lex-types/tests/effect_soundness.rs
@@ -68,7 +68,8 @@ fn prims() -> Vec<Prim> {
         Prim {
             import: "import \"std.rand\" as rand",
             call: "rand.int_in(0, 1)",
-            effect: "rand",
+            // #677: rand.int_in now carries [random], not a separate [rand].
+            effect: "random",
             ret: "Int",
             int_ret: true,
         },
@@ -187,13 +188,13 @@ fn every_member_of_a_multi_effect_body_must_be_declared() {
     let import = "import \"std.time\" as time\nimport \"std.rand\" as rand";
     let body = "let a := time.now()\n  let b := rand.int_in(0, 1)\n  a + b";
 
-    // Honest: declares both effects.
+    // Honest: declares both effects. (#677: rand.int_in carries [random].)
     assert!(
-        checks(&format!("{import}\n{}", func("time, rand", "Int", body))),
+        checks(&format!("{import}\n{}", func("time, random", "Int", body))),
         "declaring both effects should check"
     );
     // Dropping either one, or both, must be rejected.
-    for missing in ["time", "rand", ""] {
+    for missing in ["time", "random", ""] {
         let src = format!("{import}\n{}", func(missing, "Int", body));
         assert!(
             !checks(&src),
@@ -209,7 +210,7 @@ fn every_member_of_a_multi_effect_body_must_be_declared() {
 const FUZZ_PRIMS: &[(&str, &str)] = &[
     ("time.now()", "time"),
     ("time.now_ms()", "time"),
-    ("rand.int_in(0, 1)", "rand"),
+    ("rand.int_in(0, 1)", "random"), // #677
 ];
 
 fn wrap_int(kind: usize, expr: &str) -> String {
@@ -263,7 +264,7 @@ fn composition_sweep_is_sound() {
                     used.push("time");
                 }
                 if used_rand {
-                    used.push("rand");
+                    used.push("random"); // #677: rand.int_in carries [random]
                 }
                 let honest = format!(
                     "{imports}fn f() -> [{}] Int {{\n  {body}\n}}\n",
@@ -273,7 +274,7 @@ fn composition_sweep_is_sound() {
 
                 // Every strict subset of the performed effects must be rejected.
                 let subsets: Vec<&[&str]> = match used.as_slice() {
-                    ["time", "rand"] => vec![&[], &["time"], &["rand"]],
+                    ["time", "random"] => vec![&[], &["time"], &["random"]],
                     _ => vec![&[]], // single effect: only the empty row is a strict subset
                 };
                 for sub in subsets {

--- a/fuzz/fuzz_targets/effect_soundness.rs
+++ b/fuzz/fuzz_targets/effect_soundness.rs
@@ -26,7 +26,7 @@ use libfuzzer_sys::fuzz_target;
 const PRIMS: &[(&str, &str)] = &[
     ("time.now()", "time"),
     ("time.now_ms()", "time"),
-    ("rand.int_in(0, 1)", "rand"),
+    ("rand.int_in(0, 1)", "random"), // #677: rand.int_in carries [random]
 ];
 
 /// A tiny byte-driven chooser so the fuzzer's bytes map to structural
@@ -93,7 +93,7 @@ fuzz_target!(|data: &[u8]| {
         calls.push(call);
         match eff {
             "time" => used_time = true,
-            "rand" => used_rand = true,
+            "random" => used_rand = true,
             _ => unreachable!(),
         }
     }
@@ -116,7 +116,7 @@ fuzz_target!(|data: &[u8]| {
         used.push("time");
     }
     if used_rand {
-        used.push("rand");
+        used.push("random");
     }
 
     // Honest program: declare every performed effect. Must type-check —
@@ -132,9 +132,9 @@ fuzz_target!(|data: &[u8]| {
     // at least one). Each must be rejected — the dropped effect must not
     // escape.
     let subsets: &[&[&str]] = match used.as_slice() {
-        ["time", "rand"] => &[&[], &["time"], &["rand"]],
+        ["time", "random"] => &[&[], &["time"], &["random"]],
         ["time"] => &[&[]],
-        ["rand"] => &[&[]],
+        ["random"] => &[&[]],
         _ => &[],
     };
     for missing_row in subsets {


### PR DESCRIPTION
Fixes #677.

`rand.int_in` declared a `[rand]` effect but the runtime returned the deterministic midpoint `(lo + hi) / 2` — a dishonest effect feeding callers a constant, plus a second randomness effect name distinct from `crypto.random`'s `[random]`.

## Changes
- **Honest draw:** `rand.int_in` now returns a real uniform integer in `[lo, hi]` (inclusive) from the OS RNG (same `SysRng` source as `crypto.random`). Empty ranges (`hi < lo`) return an error.
- **Effect collapsed:** its effect is now `[random]`, gated exactly like `crypto.random`. The handler maps the `rand` module to the `random` effect (mirroring the existing `redis -> net` precedent). No stdlib function emits a separate `rand` effect any more, so `rand` is dropped from `Policy::permissive()` per the #399 "permissive == everything stdlib declares" contract.

Deterministic/replayable randomness remains available via the seeded `std.random`; cryptographic strength via `crypto.random`.

## Tests
- `tests/std_rand.rs` (new): draws stay in `[lo, hi]`, single-point range is exact, output is non-constant (the old stub was constant), and the call is **refused without the `[random]` grant**.
- `effect_polymorphism`: the end-to-end effectful `list.map` test now asserts bounds instead of exact midpoints, and threads `[random]`.
- `effect_soundness` (+ the workspace-excluded fuzz target): `rand.int_in`'s expected effect updated to `random`.

```
std_rand: 4 passed · effect_polymorphism: 9 passed · effect_soundness: 6 passed · trust_lattice: 6 passed · policy: 3 passed
```

All verified locally.

## Note
The `std.rand` **module name** is unchanged (`import "std.rand"` still works) — only its effect and behaviour changed. A reviewer auditing `--effect random` now sees every non-deterministic draw, `rand` and `crypto` alike, in one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YESxnpeuCT4kK2Gtuo1uui

---
_Generated by [Claude Code](https://claude.ai/code/session_01YESxnpeuCT4kK2Gtuo1uui)_