### PR TITLE
refactor(std): remove std.proc; consolidate on std.process (#678)

### DIFF
--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -255,7 +255,7 @@ impl DefaultHandler {
                     _ => return Err("process.spawn: missing or invalid opts record".into()),
                 };
 
-                // Allow-list check, mirroring the existing proc.spawn.
+                // Allow-list check, mirroring process.run below.
                 if !self.policy.allow_proc.is_empty() {
                     let basename = std::path::Path::new(&cmd)
                         .file_name()
@@ -2154,76 +2154,9 @@ impl EffectHandler for DefaultHandler {
                 Ok(Value::List(pairs.into()))
             }
 
-            ("proc", "spawn") => {
-                // The escape hatch effect. Spawns a child process,
-                // collects its stdout/stderr, returns a structured
-                // record. Allow-list is the binary basename: anything
-                // outside `--allow-proc` is rejected pre-spawn.
-                //
-                // What this does NOT validate (per SECURITY.md):
-                // - per-arg content (a script-like CLI invoked via
-                //   --eval=... can run anything)
-                // - environment variables (inherited from the parent)
-                // - working directory (the parent's)
-                //
-                // For untrusted input, layer with OS-level
-                // sandboxing — gVisor / nsjail / a container.
-                let cmd = expect_str(args.first())?.to_string();
-                let raw_args = match args.get(1) {
-                    Some(Value::List(items)) => items,
-                    Some(other) => return Err(format!(
-                        "proc.spawn: args must be List[Str], got {other:?}")),
-                    None => return Err("proc.spawn: missing args list".into()),
-                };
-                let str_args: Vec<String> = raw_args.iter().map(|v| match v {
-                    Value::Str(s) => Ok(s.to_string()),
-                    other => Err(format!("proc.spawn: arg must be Str, got {other:?}")),
-                }).collect::<Result<Vec<_>, _>>()?;
-
-                // Allow-list check: empty list = any binary (escape
-                // hatch); non-empty = basename of cmd must match an
-                // entry exactly.
-                if !self.policy.allow_proc.is_empty() {
-                    let basename = std::path::Path::new(&cmd)
-                        .file_name()
-                        .and_then(|s| s.to_str())
-                        .unwrap_or(&cmd);
-                    if !self.policy.allow_proc.iter().any(|a| a == basename) {
-                        return Ok(err(Value::Str(format!(
-                            "proc.spawn: `{cmd}` not in --allow-proc {:?}",
-                            self.policy.allow_proc
-                        ).into())));
-                    }
-                }
-
-                // Hard caps: the spec doesn't pin numbers, but
-                // unbounded argv is a DoS vector.
-                if str_args.len() > 1024 {
-                    return Ok(err(Value::Str(
-                        SmolStr::new_inline("proc.spawn: arg-count exceeds 1024"))));
-                }
-                if str_args.iter().any(|a| a.len() > 65_536) {
-                    return Ok(err(Value::Str(
-                        "proc.spawn: per-arg length exceeds 64 KiB".into())));
-                }
-
-                let output = std::process::Command::new(&cmd)
-                    .args(&str_args)
-                    .output();
-                match output {
-                    Ok(o) => {
-                        let mut rec = indexmap::IndexMap::new();
-                        rec.insert("stdout".into(), Value::Str(
-                            String::from_utf8_lossy(&o.stdout).into_owned().into()));
-                        rec.insert("stderr".into(), Value::Str(
-                            String::from_utf8_lossy(&o.stderr).into_owned().into()));
-                        rec.insert("exit_code".into(), Value::Int(
-                            o.status.code().unwrap_or(-1) as i64));
-                        Ok(ok(Value::record_dynamic(rec)))
-                    }
-                    Err(e) => Ok(err(Value::Str(format!("spawn `{cmd}`: {e}").into()))),
-                }
-            }
+            // `proc.spawn` was removed with the `std.proc` module (#678);
+            // the blocking-capture path now lives at `process.run`, handled
+            // in the `kind == "process"` block above.
             other => Err(format!("unsupported effect {}.{}", other.0, other.1)),
         }
     }

--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -6,7 +6,6 @@
 
 use lex_bytecode::vm::{EffectHandler, Vm};
 use lex_bytecode::{Program, Value};
-use smol_str::SmolStr;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};

--- a/crates/lex-runtime/tests/proc_effect.rs
+++ b/crates/lex-runtime/tests/proc_effect.rs
@@ -43,16 +43,19 @@ fn variant_args(v: &Value, expected_name: &str) -> Vec<Value> {
     }
 }
 
+// #678: `std.proc` was removed; the blocking-capture path is `process.run`,
+// which carries the same `[proc]` effect and returns the same
+// `{ stdout, stderr, exit_code }` record.
 const SRC: &str = r#"
-import "std.proc" as proc
+import "std.process" as process
 fn echo(args :: List[Str]) -> [proc] Result[{ stdout :: Str, stderr :: Str, exit_code :: Int }, Str] {
-  proc.spawn("echo", args)
+  process.run("echo", args)
 }
 fn forbidden() -> [proc] Result[{ stdout :: Str, stderr :: Str, exit_code :: Int }, Str] {
-  proc.spawn("/usr/bin/whoami", [])
+  process.run("/usr/bin/whoami", [])
 }
 fn falsy() -> [proc] Result[{ stdout :: Str, stderr :: Str, exit_code :: Int }, Str] {
-  proc.spawn("false", [])
+  process.run("false", [])
 }
 "#;
 
@@ -109,6 +112,23 @@ fn proc_spawn_propagates_non_zero_exit() {
         other => panic!("exit_code: {other:?}"),
     };
     assert_ne!(exit, 0, "false should exit non-zero");
+}
+
+#[test]
+fn std_proc_module_is_removed() {
+    // #678: `import "std.proc"` no longer resolves; callers use std.process.
+    let src = r#"
+import "std.proc" as proc
+fn f() -> [proc] Result[{ stdout :: Str, stderr :: Str, exit_code :: Int }, Str] {
+  proc.spawn("echo", [])
+}
+"#;
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    assert!(
+        lex_types::check_program(&stages).is_err(),
+        "import \"std.proc\" should no longer type-check after #678"
+    );
 }
 
 #[test]

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -1219,31 +1219,12 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
 
             Some(Ty::Record(fields))
         }
-        "proc" => {
-            // Subprocess dispatch. Effect: [proc]. Returns a Result
-            // with a record on success carrying stdout / stderr /
-            // exit_code. The runtime allow-lists which binary
-            // basenames are spawnable — `cmd` is the program to
-            // run, `args` is the literal argv (no shell parsing).
-            //
-            // Read SECURITY.md before adding [proc] to a policy:
-            // it weakens the "we know what this fn does" claim.
-            let mut fields = IndexMap::new();
-            let mut result_rec = IndexMap::new();
-            result_rec.insert("stdout".into(), Ty::str());
-            result_rec.insert("stderr".into(), Ty::str());
-            result_rec.insert("exit_code".into(), Ty::int());
-            // spawn :: Str, List[Str] -> [proc] Result[{stdout, stderr, exit_code}, Str]
-            fields.insert("spawn".into(), Ty::function(
-                vec![Ty::str(), Ty::List(Box::new(Ty::str()))],
-                EffectSet::singleton("proc"),
-                Ty::Con("Result".into(), vec![
-                    Ty::Record(result_rec),
-                    Ty::str(),
-                ]),
-            ));
-            Some(Ty::Record(fields))
-        }
+        // `std.proc` was removed in favour of `std.process` (#678): its
+        // single op `proc.spawn(cmd, args)` was byte-for-byte equivalent to
+        // `process.run(cmd, args)` — same `[proc]` effect, same
+        // `{ stdout, stderr, exit_code }` result — and `std.process` is a
+        // strict superset (streaming spawn / read / wait / kill). Callers
+        // migrate `proc.spawn` → `process.run`.
         "json" => {
             let mut fields = IndexMap::new();
             // stringify :: T -> Str  (polymorphic on input)
@@ -3157,7 +3138,6 @@ pub fn module_for_import(reference: &str) -> Option<&'static str> {
         "map" => "map",
         "set" => "set",
         "iter" => "iter",
-        "proc" => "proc",
         "crypto" => "crypto",
         "regex" => "regex",
         "parser" => "parser",

--- a/examples/agent_dispatcher.lex
+++ b/examples/agent_dispatcher.lex
@@ -1,7 +1,7 @@
 # An "agent dispatcher" that calls another CLI agent (claude-code,
 # cursor-cli, gemini-cli, ...) over stdout. The signature declares
 # `[proc]`, so the type checker rejects any body that tries to do
-# anything but `proc.spawn`. The runtime gates on which binary
+# anything but `process.run`. The runtime gates on which binary
 # basenames are spawnable via `--allow-proc`.
 #
 # This is the use case agents-orchestrating-agents need: a Lex
@@ -17,15 +17,15 @@
 #   even when [proc] itself is granted. Try:
 #     lex run --allow-effects proc --allow-proc echo \
 #       examples/agent_dispatcher.lex run "rm" "-rf" "/"
-#   → "proc.spawn: `rm` not in --allow-proc [\"echo\"]"
+#   → "process.run: `rm` not in --allow-proc [\"echo\"]"
 #
 #   Exit codes:
 #     0  — sub-binary returned 0 (success)
 #     non-zero (returned in `exit_code`) — sub-binary failed
-#     A `proc.spawn` not-allowed surfaces as Err(...), which we
+#     A `process.run` not-allowed surfaces as Err(...), which we
 #     return as the JSON output of `run`.
 
-import "std.proc" as proc
+import "std.process" as process
 import "std.list" as list
 import "std.str" as str
 import "std.int" as int
@@ -41,7 +41,7 @@ type Output = {
 # Result into a uniform Output record so a parent agent doesn't
 # have to pattern-match on Result + Record.
 fn run(cmd :: Str, args :: List[Str]) -> [proc] Output {
-  match proc.spawn(cmd, args) {
+  match process.run(cmd, args) {
     Ok(r) => {
       ok: r.exit_code == 0,
       exit_code: r.exit_code,


### PR DESCRIPTION
Fixes #678.

`std.proc` exposed one op, `proc.spawn(cmd, args)`, that was byte-for-byte equivalent to `process.run(cmd, args)` — same `[proc]` effect, same `{ stdout, stderr, exit_code }` result, same `--allow-proc` basename allow-list. `std.process` is a strict superset (streaming `spawn` / `read_stdout_line` / `read_stderr_line` / `wait` / `kill` plus the blocking `run`), so two modules covered one capability.

## Changes
- Removed the `std.proc` module: its type signature, the `module_for_import` mapping, and the now-unreachable `("proc","spawn")` runtime arm.
- The **`[proc]` effect is unchanged** — `std.process` still carries it, and `--allow-proc` scoping is untouched.
- `proc.spawn -> process.run` is a drop-in (identical signature/semantics).

## Migrations
- `examples/agent_dispatcher.lex` → `process.run` (prose + the adversarial-output comment updated).
- `tests/proc_effect.rs` → `process.run`, plus a new `std_proc_module_is_removed` test asserting `import "std.proc"` no longer type-checks.

```
proc_effect: 6 passed
```

Verified locally. README's example table row (`[proc]` effect with binary allow-list) remains accurate; no docs reference `std.proc`/`proc.spawn`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YESxnpeuCT4kK2Gtuo1uui

---
_Generated by [Claude Code](https://claude.ai/code/session_01YESxnpeuCT4kK2Gtuo1uui)_