### PR TITLE
feat(std.http): validate json_body[T] like json.parse_strict (#684)

### DIFF
--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -1779,6 +1779,38 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
                 Err(e) => Ok(http_decode_err_pure(format!("json parse: {e}"))),
             }
         }
+        // Compiler-emitted typed variant of http.json_body (#684): the
+        // type-checker rewrite injects the required-field list and the type
+        // schema derived from T (when T is a record), so a missing or
+        // wrong-typed field surfaces as a DecodeError instead of a later
+        // field-access panic — the same guarantee json.parse_strict gives,
+        // now on the most common API-decode path. Errors are HttpError
+        // (via http_decode_err_pure), matching json_body's error type.
+        ("http", "json_body_typed") => {
+            let resp = expect_record_pure(args.first())?;
+            let required = required_field_names(args.get(1))?;
+            let schema = extract_type_schema(args.get(2));
+            let body = match resp.get("body") {
+                Some(Value::Bytes(b)) => b.clone(),
+                _ => return Err("http.json_body: HttpResponse.body must be Bytes".into()),
+            };
+            let s = match std::str::from_utf8(&body) {
+                Ok(s) => s,
+                Err(e) => return Ok(http_decode_err_pure(format!("body not UTF-8: {e}"))),
+            };
+            match serde_json::from_str::<serde_json::Value>(s) {
+                Ok(j) => {
+                    if let Err(e) = check_required_fields(&j, &required) {
+                        return Ok(http_decode_err_pure(e));
+                    }
+                    if let Err(e) = validate_field_types(&j, &schema) {
+                        return Ok(http_decode_err_pure(e));
+                    }
+                    Ok(ok_v(apply_option_wrapping(json_to_value(&j), &j, &schema)))
+                }
+                Err(e) => Ok(http_decode_err_pure(format!("json parse: {e}"))),
+            }
+        }
         ("http", "text_body") => {
             let resp = expect_record_pure(args.first())?;
             let body = match resp.get("body") {

--- a/crates/lex-runtime/tests/std_http_json_body.rs
+++ b/crates/lex-runtime/tests/std_http_json_body.rs
@@ -1,0 +1,76 @@
+//! #684: `http.json_body[T]` gets the same required-field / type / Option
+//! validation as `json.parse_strict` when `T` is a record. The
+//! type-checker rewrite turns `http.json_body(resp)` into
+//! `http.json_body_typed(resp, [required], [schema])`; the runtime then
+//! returns a `DecodeError` (HttpError) instead of an `Ok` with a
+//! silently-incomplete record.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::sync::Arc;
+
+const SRC: &str = r#"
+import "std.http"  as http
+import "std.bytes" as bytes
+import "std.map"   as map
+
+type User = { id :: Int, name :: Str, nick :: Option[Str] }
+
+fn decode(body_json :: Str) -> Result[User, HttpError] {
+  http.json_body({ status: 200, headers: map.new(), body: bytes.from_str(body_json) })
+}
+
+fn name_of(body_json :: Str) -> Str {
+  match decode(body_json) { Ok(u) => u.name, Err(_) => "ERR" }
+}
+fn is_err(body_json :: Str) -> Bool {
+  match decode(body_json) { Ok(_) => false, Err(_) => true }
+}
+fn nick_of(body_json :: Str) -> Option[Str] {
+  match decode(body_json) { Ok(u) => u.nick, Err(_) => None }
+}
+"#;
+
+fn run(fn_name: &str, json: &str) -> Value {
+    let prog = parse_source(SRC).expect("parse");
+    let mut stages = canonicalize_program(&prog);
+    lex_types::check_and_rewrite_program(&mut stages)
+        .unwrap_or_else(|errs| panic!("type errors:\n{errs:#?}"));
+    let bc = Arc::new(compile_program(&stages));
+    let handler = DefaultHandler::new(Policy::permissive()).with_program(Arc::clone(&bc));
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(fn_name, vec![Value::Str(json.into())])
+        .unwrap_or_else(|e| panic!("call {fn_name}: {e}"))
+}
+
+#[test]
+fn complete_object_decodes_ok() {
+    assert_eq!(run("name_of", r#"{"id":1,"name":"Alice","nick":"al"}"#),
+        Value::Str("Alice".into()));
+    assert_eq!(run("is_err", r#"{"id":1,"name":"Alice","nick":"al"}"#),
+        Value::Bool(false));
+}
+
+#[test]
+fn missing_required_field_is_decode_error() {
+    // `name` is required (non-Option) but absent → Err, not Ok(incomplete).
+    assert_eq!(run("is_err", r#"{"id":1}"#), Value::Bool(true));
+}
+
+#[test]
+fn wrong_typed_field_is_decode_error() {
+    // `id` must be Int; a string must be rejected.
+    assert_eq!(run("is_err", r#"{"id":"nope","name":"Alice"}"#), Value::Bool(true));
+}
+
+#[test]
+fn option_field_wraps_some_and_none() {
+    assert_eq!(run("nick_of", r#"{"id":1,"name":"Alice","nick":"al"}"#),
+        Value::Variant { name: "Some".into(), args: vec![Value::Str("al".into())] });
+    // Absent optional field → None, and the object still decodes Ok.
+    assert_eq!(run("nick_of", r#"{"id":1,"name":"Alice"}"#),
+        Value::Variant { name: "None".into(), args: vec![] });
+    assert_eq!(run("is_err", r#"{"id":1,"name":"Alice"}"#), Value::Bool(false));
+}

--- a/crates/lex-types/src/checker.rs
+++ b/crates/lex-types/src/checker.rs
@@ -254,11 +254,16 @@ fn rewrite_in_expr(
         match expr {
             a::CExpr::Call { callee, args } => {
                 if let a::CExpr::FieldAccess { field, .. } = callee.as_mut() {
-                    debug_assert_eq!(field, "parse",
-                        "rewrite_in_expr: only `.parse` calls should be in the table");
-                    // Use parse_strict_typed (internal, 3-arg) rather than the
-                    // public 2-arg parse_strict so direct callers aren't broken.
-                    *field = "parse_strict_typed".to_string();
+                    // Map each public decode op to its internal typed variant
+                    // (3-arg: source, required-fields, schema) so direct
+                    // callers of the public op aren't broken.
+                    let typed = match field.as_str() {
+                        "parse" => "parse_strict_typed",     // json / toml / yaml
+                        "json_body" => "json_body_typed",    // http (#684)
+                        other => unreachable!(
+                            "rewrite_in_expr: unexpected decode field `{other}`"),
+                    };
+                    *field = typed.to_string();
                 }
                 // Second argument: List[Str] of required field names.
                 args.push(a::CExpr::ListLit {
@@ -302,9 +307,17 @@ fn extract_record_fields_and_schema(
     let ok_ty = u.resolve(&args[0]);
     let unfolded = unfold_record_alias_static(env, ok_ty);
     if let Ty::Record(fields) = unfolded {
-        let names: Vec<String> = fields.keys().cloned().collect();
         let schema: Vec<(String, String)> = fields.iter()
             .map(|(k, v)| (k.clone(), ty_to_tag(u, v)))
+            .collect();
+        // Only non-Option fields are *required*: an `Option[T]` field is
+        // satisfied by absence (it decodes to `None`), so it must not be
+        // in the required list or an absent optional would wrongly fail
+        // `check_required_fields`. The schema still carries every field
+        // (for type validation + `apply_option_wrapping`).
+        let names: Vec<String> = schema.iter()
+            .filter(|(_, tag)| !tag.starts_with("Option["))
+            .map(|(k, _)| k.clone())
             .collect();
         Some((names, schema))
     } else {
@@ -549,16 +562,23 @@ impl Checker {
         false
     }
 
-    /// Whether `callee` is a `<alias>.parse` field access where
-    /// `<alias>` was imported from one of the stdlib modules whose
-    /// `parse` returns `Result[T, Str]` and whose `parse_strict`
-    /// shape exists for #168 enforcement (json / toml / yaml).
+    /// Whether `callee` is a stdlib decode call eligible for the #168 /
+    /// #322 required-field + type-schema rewrite. Two shapes qualify:
+    ///   - `<alias>.parse` for an alias bound to json / toml / yaml
+    ///     (returns `Result[T, Str]`), and
+    ///   - `<alias>.json_body` for an alias bound to http (#684) — the
+    ///     most common API-decode path, which returns
+    ///     `Result[T, HttpError]` and was previously unvalidated.
+    /// In both cases the rewrite only fires when the inferred `T` is a
+    /// record (see `extract_record_fields_and_schema`).
     fn is_module_parse_call(&self, callee: &a::CExpr) -> bool {
         if let a::CExpr::FieldAccess { value, field } = callee {
-            if field != "parse" { return false; }
             if let a::CExpr::Var { name } = value.as_ref() {
                 if let Some(module) = self.module_aliases.get(name) {
-                    return matches!(module.as_str(), "json" | "toml" | "yaml");
+                    return matches!(
+                        (module.as_str(), field.as_str()),
+                        ("json" | "toml" | "yaml", "parse") | ("http", "json_body")
+                    );
                 }
             }
         }

--- a/crates/lex-types/src/checker.rs
+++ b/crates/lex-types/src/checker.rs
@@ -564,13 +564,12 @@ impl Checker {
 
     /// Whether `callee` is a stdlib decode call eligible for the #168 /
     /// #322 required-field + type-schema rewrite. Two shapes qualify:
-    ///   - `<alias>.parse` for an alias bound to json / toml / yaml
-    ///     (returns `Result[T, Str]`), and
-    ///   - `<alias>.json_body` for an alias bound to http (#684) — the
-    ///     most common API-decode path, which returns
-    ///     `Result[T, HttpError]` and was previously unvalidated.
-    /// In both cases the rewrite only fires when the inferred `T` is a
-    /// record (see `extract_record_fields_and_schema`).
+    /// `<alias>.parse` for an alias bound to json / toml / yaml (returns
+    /// `Result[T, Str]`), and `<alias>.json_body` for an alias bound to
+    /// http (#684) — the most common API-decode path, which returns
+    /// `Result[T, HttpError]` and was previously unvalidated. In both
+    /// cases the rewrite only fires when the inferred `T` is a record
+    /// (see `extract_record_fields_and_schema`).
     fn is_module_parse_call(&self, callee: &a::CExpr) -> bool {
         if let a::CExpr::FieldAccess { value, field } = callee {
             if let a::CExpr::Var { name } = value.as_ref() {


### PR DESCRIPTION
Fixes #684.

`http.json_body` did a plain, unvalidated `serde` parse, reintroducing the #168 "missing/wrong-typed field → later field-access panic" failure on the **most common API-decode path**. The parse family (json/toml/yaml) avoids this via the type-checker rewrite to `parse_strict_typed`; this extends the same mechanism to `http.json_body`.

## Changes
- **checker**: `is_module_parse_call` now also recognises `http.json_body`. The rewrite maps each public decode op to its internal typed variant (`parse → parse_strict_typed`, `json_body → json_body_typed`) and injects the required-field list + type schema derived from `T` (only when `T` is a record).
- **runtime**: new `http.json_body_typed` arm runs `check_required_fields` + `validate_field_types` + `apply_option_wrapping`, surfacing failures as a `DecodeError` (`HttpError`) — matching `json_body`'s error type rather than `Str`.
- **latent-bug fix (shared)**: `Option[T]` fields were placed in the *required* list, so an **absent** optional field wrongly failed validation. Optional fields are now excluded from required (the schema still carries them for type-checking + `Some`/`None` wrapping). This also hardens json/toml/yaml typed parsing.

## Tests
`tests/std_http_json_body.rs`: complete decode → `Ok`; missing required → `DecodeError`; wrong-typed field → `DecodeError`; `Option` field present → `Some`, absent → `None` (and still `Ok`).

```
std_http_json_body: 4 passed · std_parse_strict: 11 · std_parse_typed: 6  (all green)
```

Verified locally (a couple of *additional* regression suites couldn't finish linking locally due to a disk-space limit in my sandbox — not a code issue; CI builds them clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YESxnpeuCT4kK2Gtuo1uui

---
_Generated by [Claude Code](https://claude.ai/code/session_01YESxnpeuCT4kK2Gtuo1uui)_