### PR TITLE
fix(std.http): make stream_lines a truly lazy Stream[Str] (#683)

### DIFF
--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -3820,19 +3820,22 @@ fn err(v: Value) -> Value {
     Value::Variant { name: "Err".into(), args: vec![v] }
 }
 
-/// HTTP POST that buffers the full response body then yields it split into lines.
-/// Intended for LLM provider APIs (OpenAI, Anthropic, Google) that use SSE/NDJSON
-/// and close the connection after sending all events. Connection errors → `Err(Str)`.
+/// Streaming HTTP POST that yields the response body line-by-line as a lazy
+/// `Stream[Str]` (#683). Intended for LLM provider APIs and other SSE/NDJSON
+/// endpoints. Connection errors at request time → `Err(Str)`.
 ///
-/// CAUTION: ureq 3.3's `Body` does not implement `std::io::Read` and exposes no
-/// incremental read API. The entire response is buffered via `read_to_vec()` before
-/// splitting. This means the call blocks until the server closes the connection —
-/// endpoints that hold the connection open indefinitely will hang. True per-line
-/// streaming requires a future HTTP client upgrade.
-fn http_stream_lines_impl(_handler: &DefaultHandler, url: &str, headers_val: &Value, body: &str) -> Value {
+/// Truly incremental: ureq 3.3's `Body::into_reader()` gives a `BodyReader`
+/// (impl `io::Read`), so the returned `Stream[Str]` is a lazy line iterator
+/// directly over the socket. Each `stream.next` reads exactly the next line on
+/// demand — an endpoint that holds the connection open and emits events over
+/// time is consumed event-by-event instead of blocking until the server closes
+/// (the old `read_to_vec()` path buffered the whole body and hung on open-ended
+/// SSE). Because reads only happen when the consumer pulls, there's no extra
+/// buffering; a mid-stream read error / close simply ends the stream.
+fn http_stream_lines_impl(handler: &DefaultHandler, url: &str, headers_val: &Value, body: &str) -> Value {
     let body_bytes = body.as_bytes().to_vec();
-    // Use a 10-minute body-read timeout — local models (Ollama, vLLM) can take
-    // several minutes to generate long thinking traces before closing the stream.
+    // 10-minute body-read timeout — local models (Ollama, vLLM) can take
+    // several minutes between events on long thinking traces.
     let agent = http_stream_agent();
     let mut req = agent.post(url);
     if let Value::Map(headers) = headers_val {
@@ -3848,20 +3851,16 @@ fn http_stream_lines_impl(_handler: &DefaultHandler, url: &str, headers_val: &Va
     }
     match req.send(&body_bytes[..]) {
         Ok(resp) => {
-            let bytes = match resp.into_body().with_config().read_to_vec() {
-                Ok(b) => b,
-                Err(e) => return err(Value::Str(format!("http.stream_lines: body read: {e}").into())),
-            };
-            let raw_text = String::from_utf8_lossy(&bytes).into_owned();
-            let text = decode_unicode_escapes(&raw_text);
-            let items: std::collections::VecDeque<Value> = text.lines()
-                .map(|l| Value::Str(l.to_string().into()))
-                .collect();
-            let iter_val = Value::Variant {
-                name: "__IterEager".into(),
-                args: vec![Value::List(items), Value::Int(0)],
-            };
-            ok(iter_val)
+            use std::io::BufRead;
+            let reader = std::io::BufReader::new(resp.into_body().into_reader());
+            // Lazy: `map_while(ok)` stops at the first read error / EOF; the
+            // \uXXXX un-escaping preserves the pre-#683 decoded-text contract.
+            let lines = reader
+                .lines()
+                .map_while(Result::ok)
+                .map(|l| decode_unicode_escapes(&l));
+            let handle = handler.register_stream(lines);
+            ok(stream_handle_value(handle))
         }
         Err(e) => err(Value::Str(format!("http.stream_lines: {e}").into())),
     }

--- a/crates/lex-runtime/tests/std_http_stream_lines.rs
+++ b/crates/lex-runtime/tests/std_http_stream_lines.rs
@@ -1,0 +1,92 @@
+//! #683: `http.stream_lines` returns a lazy `Stream[Str]` and streams the
+//! response body line-by-line, rather than buffering the whole body into an
+//! eager `Iter[Str]`. Drives a tiny in-process HTTP server so the test needs
+//! no network.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm, Value};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::Arc;
+
+/// Spawn a one-shot HTTP/1.1 server that replies to a single POST with
+/// `body`, then closes. Returns the bound `http://127.0.0.1:PORT/` URL.
+fn spawn_server(body: &'static str) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().unwrap().port();
+    std::thread::spawn(move || {
+        if let Ok((mut sock, _)) = listener.accept() {
+            // Read the request headers (and any body) until the client pauses;
+            // we don't need to parse it, just drain enough not to deadlock.
+            let mut buf = [0u8; 4096];
+            let _ = sock.set_read_timeout(Some(std::time::Duration::from_millis(200)));
+            let _ = sock.read(&mut buf);
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = sock.write_all(resp.as_bytes());
+            let _ = sock.flush();
+        }
+    });
+    format!("http://127.0.0.1:{port}/")
+}
+
+const SRC: &str = r#"
+import "std.http"   as http
+import "std.stream" as stream
+import "std.map"    as map
+
+fn fetch(url :: Str) -> [net, stream] List[Str] {
+  match http.stream_lines(url, map.new(), "") {
+    Ok(s) => stream.collect(s),
+    Err(e) => [e],
+  }
+}
+
+# Pull just the first line via stream.next, proving incremental consumption.
+fn first(url :: Str) -> [net, stream] Str {
+  match http.stream_lines(url, map.new(), "") {
+    Ok(s) => match stream.next(s) {
+      Some(line) => line,
+      None => "EMPTY",
+    },
+    Err(e) => e,
+  }
+}
+"#;
+
+fn run(fn_name: &str, url: &str) -> Value {
+    let prog = parse_source(SRC).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors:\n{errs:#?}");
+    }
+    let bc = Arc::new(compile_program(&stages));
+    let handler = DefaultHandler::new(Policy::permissive()).with_program(Arc::clone(&bc));
+    let mut vm = Vm::with_handler(&bc, Box::new(handler));
+    vm.call(fn_name, vec![Value::Str(url.into())]).unwrap_or_else(|e| panic!("call {fn_name}: {e}"))
+}
+
+#[test]
+fn stream_collect_yields_each_line() {
+    let url = spawn_server("line1\nline2\nline3\n");
+    let v = run("fetch", &url);
+    let lines = match v {
+        Value::List(items) => items.into_iter().map(|x| match x {
+            Value::Str(s) => s.to_string(),
+            other => panic!("expected Str, got {other:?}"),
+        }).collect::<Vec<_>>(),
+        other => panic!("expected List, got {other:?}"),
+    };
+    assert_eq!(lines, vec!["line1", "line2", "line3"]);
+}
+
+#[test]
+fn stream_next_pulls_first_line() {
+    let url = spawn_server("first-event\nsecond-event\n");
+    assert_eq!(run("first", &url), Value::Str("first-event".into()));
+}

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -2834,9 +2834,16 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 EffectSet::empty(),
                 result_he(Ty::str()),
             ));
-            // stream_lines :: Str, Map[Str, Str], Str -> [net] Result[Iter[Str], Str]
-            // Streaming HTTP POST; yields the response body line-by-line for
-            // SSE / NDJSON endpoints. Connection errors surface as Err(Str).
+            // stream_lines :: Str, Map[Str, Str], Str -> [net] Result[Stream[Str], Str]
+            // Streaming HTTP POST that yields the response body line-by-line
+            // for SSE / NDJSON endpoints. Returns a lazy `Stream[Str]` (#683):
+            // each `stream.next` pulls exactly one line off the socket as it
+            // arrives, so an endpoint that holds the connection open and emits
+            // events over time is consumed incrementally instead of blocking
+            // until close. Connection errors at request time surface as
+            // `Err(Str)`; a mid-stream read error / close ends the stream
+            // (next `stream.next` returns `None`). Consume with `std.stream`
+            // (`stream.next` / `stream.collect`), which carries `[stream]`.
             fields.insert("stream_lines".into(), Ty::function(
                 vec![
                     Ty::str(),
@@ -2845,7 +2852,7 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 ],
                 EffectSet::singleton("net"),
                 Ty::Con("Result".into(), vec![
-                    Ty::Con("Iter".into(), vec![Ty::str()]),
+                    Ty::Con("Stream".into(), vec![Ty::str()]),
                     Ty::str(),
                 ]),
             ));


### PR DESCRIPTION
Fixes #683.

`stream_lines` was typed/documented as streaming (`Result[Iter[Str], Str]`, "yields the response body line-by-line for SSE") but the runtime `read_to_vec()`'d the **entire** body before splitting into an eager `Iter` — so on an SSE endpoint that holds the connection open it returned nothing until close (10-minute timeout at best). The CAUTION comment blamed ureq 3.3 lacking an incremental reader, but **`ureq 3.3`'s `Body::into_reader()` returns a `BodyReader` that implements `io::Read`** — so no client swap is needed.

## Change
- Return type is now **`Result[Stream[Str], Str]`**. The `Stream` is a lazy line iterator directly over the socket (`BufReader::lines()` over `into_reader()`), registered in the existing stream registry. Each `stream.next` reads exactly the next line **on demand**, so events are consumed as they arrive — no whole-body buffering, natural backpressure, no hang on open-ended SSE. `map_while(Result::ok)` ends the stream on a mid-stream read error / close; the `\uXXXX` un-escaping is preserved. Consume via `std.stream` (`stream.next` / `stream.collect`, effect `[stream]`).

## Breaking change
`Iter[Str]` → `Stream[Str]`. No in-repo caller used `stream_lines`, and the `Iter` it returned was never actually lazy, so this aligns the type with reality. Downstream callers consuming it via `iter.*` would switch to `stream.*`.

## Tests
`tests/std_http_stream_lines.rs` drives an in-process HTTP server: `stream.collect` yields each line in order, and `stream.next` pulls the first line. (2 passed; clippy clean.)

## Out of scope
`agent.cloud_stream` (mentioned in the issue) is currently a fixture-only stub awaiting a live LLM streaming backend; its `Stream[Str]` surface is already correct and unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YESxnpeuCT4kK2Gtuo1uui

---
_Generated by [Claude Code](https://claude.ai/code/session_01YESxnpeuCT4kK2Gtuo1uui)_