### PR TITLE
chore(release): prepare 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ bumps may carry breaking changes when justified).
 
 A stdlib-audit release. The minor bump (not a 0.9.x patch) is because three
 of the changes are **breaking**, per this changelog's pre-1.0 SemVer policy.
+All three are caught at `lex check` time — see
+[`docs/MIGRATING-0.10.md`](docs/MIGRATING-0.10.md) for the migration steps.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,73 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+## [0.10.0] — 2026-06-23
+
+A stdlib-audit release. The minor bump (not a 0.9.x patch) is because three
+of the changes are **breaking**, per this changelog's pre-1.0 SemVer policy.
+
+### Removed
+
+- **BREAKING — `std.proc` removed; use `std.process` (#678).** Its single op
+  `proc.spawn(cmd, args)` was byte-for-byte equivalent to `process.run` (same
+  `[proc]` effect, same `{ stdout, stderr, exit_code }` result, same
+  `--allow-proc` allow-list), and `std.process` is a strict superset (streaming
+  `spawn` / `read_*_line` / `wait` / `kill`). Migration is a drop-in rename
+  `proc.spawn` → `process.run`. The `[proc]` effect itself is unchanged.
+
+### Changed
+
+- **BREAKING — `rand.int_in` is now an honest random draw under `[random]`
+  (#677).** It previously declared `[rand]` but returned the deterministic
+  midpoint `(lo + hi) / 2`, silently feeding callers a constant. It now draws a
+  real uniform integer in `[lo, hi]` from the OS RNG and is gated by the same
+  `[random]` effect as `crypto.random` (the separate `rand` effect is gone). For
+  deterministic/replayable randomness use the seeded `std.random`; for
+  cryptographic strength use `crypto.random`.
+- **BREAKING — `http.stream_lines` returns `Stream[Str]` instead of
+  `Iter[Str]` (#683).** The old `Iter` was eager — it buffered the whole
+  response body before returning, so an SSE endpoint that holds the connection
+  open hung. It now returns a lazy `Stream[Str]` read line-by-line off the
+  socket (via ureq's `Body::into_reader()`); consume it with `std.stream`
+  (`stream.next` / `stream.collect`, effect `[stream]`).
+
+### Added
+
+- **`std.result` / `std.option` combinator parity (#679).** Added the missing
+  signatures/impls so the full set is callable: `result.unwrap_or`,
+  `result.unwrap_or_else`, `result.is_ok` / `is_err`, `option.is_some` /
+  `is_none`, and `option.ok_or` (crosses `Option` into `Result`).
+- **`std.int.{min,max,abs}` and `std.duration.{millis,minutes,hours,days}`
+  (#681).** Integer counterparts to the Float-only `math.{min,max,abs}` (no
+  lossy round-trip past 2^53), and the missing Duration unit extractors
+  (previously only `seconds`), restoring symmetry with `datetime`'s
+  `duration_*` constructors.
+- **`NET_SERVE_NAMED` strict lint (#680).** `lex check --strict` now flags the
+  name-based `net.serve` / `serve_tls` / `serve_ws` / `serve_with` /
+  `serve_quic` forms (handler passed as a runtime-looked-up `Str`, whose effect
+  row is invisible to the checker) and steers callers to the effect-polymorphic
+  closure variants (`serve_fn` / `serve_routed` / `serve_ws_fn` / …).
+- **`http.json_body[T]` is now validated (#684).** The type-checker rewrite
+  that turns `json.parse` into a strict, schema-checked decode now also covers
+  `http.json_body`, so a missing or wrong-typed field on an API response
+  surfaces as a `DecodeError` instead of a later field-access panic.
+
+### Fixed
+
+- **`std.yaml` Option-field decoding (#682).** `yaml.parse_strict` /
+  `parse_strict_typed` skipped the `apply_option_wrapping` pass that `json` and
+  `toml` run, so `Option[T]` fields parsed from YAML weren't wrapped in
+  `Some`/`None`. Now consistent across all three.
+- **Absent optional fields wrongly rejected (#684).** The shared decode-schema
+  extraction listed `Option[T]` fields as *required*, so an absent optional
+  field failed validation. Optional fields are now excluded from the required
+  set (across json / toml / yaml / http typed decoding).
+
+### Internal
+
+- `Nil` vs `Unit` naming in `lex-types` builtin doc-comments normalized to
+  `Unit` (#681).
+
 ## [0.9.14] — 2026-06-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "conformance"
-version = "0.9.14"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "core-compiler"
-version = "0.9.14"
+version = "0.10.0"
 dependencies = [
  "indexmap",
  "lex-ast",
@@ -2534,7 +2534,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lex-api"
-version = "0.9.14"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "flate2",
@@ -2556,7 +2556,7 @@ dependencies = [
 
 [[package]]
 name = "lex-ast"
-version = "0.9.14"
+version = "0.10.0"
 dependencies = [
  "indexmap",
  "lex-syntax",
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "lex-bytecode"
-version = "0.9.14"
+version = "0.10.0"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "lex-cli"
-version = "0.9.14"
+version = "0.10.0"
 dependencies = [
  "acli",
  "anyhow",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "lex-jit"
-version = "0.9.14"
+version = "0.10.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "lex-lsp"
-version = "0.9.14"
+version = "0.10.0"
 dependencies = [
  "lex-ast",
  "lex-store",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "lex-runtime"
-version = "0.9.14"
+version = "0.10.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "lex-search"
-version = "0.9.14"
+version = "0.10.0"
 dependencies = [
  "hex",
  "lex-ast",
@@ -2736,7 +2736,7 @@ dependencies = [
 
 [[package]]
 name = "lex-store"
-version = "0.9.14"
+version = "0.10.0"
 dependencies = [
  "fs2",
  "hex",
@@ -2755,7 +2755,7 @@ dependencies = [
 
 [[package]]
 name = "lex-syntax"
-version = "0.9.14"
+version = "0.10.0"
 dependencies = [
  "flate2",
  "indexmap",
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "lex-trace"
-version = "0.9.14"
+version = "0.10.0"
 dependencies = [
  "indexmap",
  "lex-ast",
@@ -2787,7 +2787,7 @@ dependencies = [
 
 [[package]]
 name = "lex-types"
-version = "0.9.14"
+version = "0.10.0"
 dependencies = [
  "hex",
  "indexmap",
@@ -2801,7 +2801,7 @@ dependencies = [
 
 [[package]]
 name = "lex-vcs"
-version = "0.9.14"
+version = "0.10.0"
 dependencies = [
  "ed25519-dalek",
  "getrandom 0.4.2",
@@ -5224,7 +5224,7 @@ dependencies = [
 
 [[package]]
 name = "spec-checker"
-version = "0.9.14"
+version = "0.10.0"
 dependencies = [
  "indexmap",
  "lex-ast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.9.14"
+version = "0.10.0"
 edition = "2021"
 license = "EUPL-1.2"
 repository = "https://github.com/alpibrusl/lex-lang"

--- a/crates/lex-api/Cargo.toml
+++ b/crates/lex-api/Cargo.toml
@@ -16,19 +16,19 @@ serde_json.workspace = true
 anyhow.workspace = true
 indexmap.workspace = true
 tiny_http = "0.12"
-lex-syntax = { path = "../lex-syntax", version = "0.9.6" }
-lex-ast = { path = "../lex-ast", version = "0.9.6" }
-lex-types = { path = "../lex-types", version = "0.9.6" }
-lex-bytecode = { path = "../lex-bytecode", version = "0.9.6" }
+lex-syntax = { path = "../lex-syntax", version = "0.10.0" }
+lex-ast = { path = "../lex-ast", version = "0.10.0" }
+lex-types = { path = "../lex-types", version = "0.10.0" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.10.0" }
 # `default-features = false` drops the `df` (Polars) feature: lex-api
 # and its embedders (lex-hub) never call `std.df`, and polars pulls a
 # heavy dep tree that has conflicted on `chrono`. `std.arrow` is
 # unaffected. Workspace builds that include lex-cli still get `df` via
 # feature unification, so the toolchain is unchanged.
-lex-runtime = { path = "../lex-runtime", version = "0.9.6", default-features = false }
-lex-store = { path = "../lex-store", version = "0.9.6" }
-lex-trace = { path = "../lex-trace", version = "0.9.6" }
-lex-vcs = { path = "../lex-vcs", version = "0.9.6" }
+lex-runtime = { path = "../lex-runtime", version = "0.10.0", default-features = false }
+lex-store = { path = "../lex-store", version = "0.10.0" }
+lex-trace = { path = "../lex-trace", version = "0.10.0" }
+lex-vcs = { path = "../lex-vcs", version = "0.10.0" }
 
 flate2 = "1"
 tar = "0.4"

--- a/crates/lex-ast/Cargo.toml
+++ b/crates/lex-ast/Cargo.toml
@@ -16,4 +16,4 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-syntax = { path = "../lex-syntax", version = "0.9.6" }
+lex-syntax = { path = "../lex-syntax", version = "0.10.0" }

--- a/crates/lex-bytecode/Cargo.toml
+++ b/crates/lex-bytecode/Cargo.toml
@@ -19,11 +19,11 @@ indexmap.workspace = true
 sha2.workspace = true
 arrow-array = "58"
 arrow-schema = "58"
-lex-ast = { path = "../lex-ast", version = "0.9.6" }
-lex-types = { path = "../lex-types", version = "0.9.6" }
+lex-ast = { path = "../lex-ast", version = "0.10.0" }
+lex-types = { path = "../lex-types", version = "0.10.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.9.6" }
+lex-syntax = { path = "../lex-syntax", version = "0.10.0" }
 criterion = { version = "0.8", default-features = false, features = ["cargo_bench_support"] }
 
 [[bench]]

--- a/crates/lex-jit/Cargo.toml
+++ b/crates/lex-jit/Cargo.toml
@@ -24,7 +24,7 @@ cranelift = [
 ]
 
 [dependencies]
-lex-bytecode = { path = "../lex-bytecode", version = "0.9.8" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.10.0" }
 thiserror.workspace = true
 
 cranelift-codegen = { version = "0.132", optional = true }
@@ -34,10 +34,10 @@ cranelift-module = { version = "0.132", optional = true }
 cranelift-native = { version = "0.132", optional = true }
 
 [dev-dependencies]
-lex-bytecode = { path = "../lex-bytecode", version = "0.9.8" }
-lex-syntax = { path = "../lex-syntax", version = "0.9.8" }
-lex-ast = { path = "../lex-ast", version = "0.9.8" }
-lex-types = { path = "../lex-types", version = "0.9.8" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.10.0" }
+lex-syntax = { path = "../lex-syntax", version = "0.10.0" }
+lex-ast = { path = "../lex-ast", version = "0.10.0" }
+lex-types = { path = "../lex-types", version = "0.10.0" }
 indexmap.workspace = true
 criterion = { version = "0.8", default-features = false, features = ["cargo_bench_support"] }
 

--- a/crates/lex-lsp/Cargo.toml
+++ b/crates/lex-lsp/Cargo.toml
@@ -25,12 +25,12 @@ serde_json.workspace = true
 # are rust-analyzer-team-maintained.
 lsp-server = "0.7"
 lsp-types = "0.97"
-lex-syntax = { path = "../lex-syntax", version = "0.9.6" }
-lex-ast = { path = "../lex-ast", version = "0.9.6" }
-lex-types = { path = "../lex-types", version = "0.9.6" }
+lex-syntax = { path = "../lex-syntax", version = "0.10.0" }
+lex-ast = { path = "../lex-ast", version = "0.10.0" }
+lex-types = { path = "../lex-types", version = "0.10.0" }
 # Phase 4 of #304: surface RepairHint attestations from the store.
-lex-vcs = { path = "../lex-vcs", version = "0.9.6" }
-lex-store = { path = "../lex-store", version = "0.9.6" }
+lex-vcs = { path = "../lex-vcs", version = "0.10.0" }
+lex-store = { path = "../lex-store", version = "0.10.0" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/lex-runtime/Cargo.toml
+++ b/crates/lex-runtime/Cargo.toml
@@ -83,7 +83,7 @@ parquet = { version = "58", default-features = false, features = ["arrow", "snap
 # compile. Found the hard way during the arrow-55→58 / polars-0.50→0.53
 # coordinated bump.
 polars = { version = "0.54", optional = true, default-features = false, features = ["lazy", "is_in", "csv", "performant", "strings", "temporal"] }
-lex-bytecode = { path = "../lex-bytecode", version = "0.9.6" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.10.0" }
 smol_str = { workspace = true }
 
 [features]
@@ -102,7 +102,7 @@ df = ["dep:polars"]
 quic = ["dep:quinn", "dep:h3", "dep:h3-quinn", "dep:rustls", "dep:rustls-pemfile", "dep:rcgen"]
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.9.6" }
-lex-ast = { path = "../lex-ast", version = "0.9.6" }
-lex-types = { path = "../lex-types", version = "0.9.6" }
+lex-syntax = { path = "../lex-syntax", version = "0.10.0" }
+lex-ast = { path = "../lex-ast", version = "0.10.0" }
+lex-types = { path = "../lex-types", version = "0.10.0" }
 tempfile = "3"

--- a/crates/lex-search/Cargo.toml
+++ b/crates/lex-search/Cargo.toml
@@ -17,10 +17,10 @@ thiserror.workspace = true
 sha2.workspace = true
 hex.workspace = true
 ureq = { version = "3.3", default-features = false, features = ["rustls", "platform-verifier", "json"] }
-lex-ast = { path = "../lex-ast", version = "0.9.6" }
-lex-store = { path = "../lex-store", version = "0.9.6" }
+lex-ast = { path = "../lex-ast", version = "0.10.0" }
+lex-store = { path = "../lex-store", version = "0.10.0" }
 
 [dev-dependencies]
 tempfile = "3"
 tiny_http = "0.12"
-lex-syntax = { path = "../lex-syntax", version = "0.9.6" }
+lex-syntax = { path = "../lex-syntax", version = "0.10.0" }

--- a/crates/lex-store/Cargo.toml
+++ b/crates/lex-store/Cargo.toml
@@ -21,11 +21,11 @@ hex.workspace = true
 # transitive dep via tempfile; promoting to direct so the lock
 # call sites compile.
 fs2 = "0.4"
-lex-ast = { path = "../lex-ast", version = "0.9.6" }
-lex-trace = { path = "../lex-trace", version = "0.9.6" }
-lex-types = { path = "../lex-types", version = "0.9.6" }
-lex-vcs = { path = "../lex-vcs", version = "0.9.6" }
+lex-ast = { path = "../lex-ast", version = "0.10.0" }
+lex-trace = { path = "../lex-trace", version = "0.10.0" }
+lex-types = { path = "../lex-types", version = "0.10.0" }
+lex-vcs = { path = "../lex-vcs", version = "0.10.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.9.6" }
+lex-syntax = { path = "../lex-syntax", version = "0.10.0" }
 tempfile = "3"

--- a/crates/lex-trace/Cargo.toml
+++ b/crates/lex-trace/Cargo.toml
@@ -16,9 +16,9 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-bytecode = { path = "../lex-bytecode", version = "0.9.6" }
-lex-ast = { path = "../lex-ast", version = "0.9.6" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.10.0" }
+lex-ast = { path = "../lex-ast", version = "0.10.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.9.6" }
-lex-runtime = { path = "../lex-runtime", version = "0.9.6" }
+lex-syntax = { path = "../lex-syntax", version = "0.10.0" }
+lex-runtime = { path = "../lex-runtime", version = "0.10.0" }

--- a/crates/lex-types/Cargo.toml
+++ b/crates/lex-types/Cargo.toml
@@ -17,7 +17,7 @@ sha2.workspace = true
 hex.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-ast = { path = "../lex-ast", version = "0.9.6" }
+lex-ast = { path = "../lex-ast", version = "0.10.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.9.6" }
+lex-syntax = { path = "../lex-syntax", version = "0.10.0" }

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -13,7 +13,7 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
     match name {
         "io" => {
             let mut fields = IndexMap::new();
-            // io.print(line :: Str) -> [io] Nil
+            // io.print(line :: Str) -> [io] Unit
             fields.insert("print".into(), Ty::function(
                 vec![Ty::str()],
                 EffectSet::singleton("io"),
@@ -2060,17 +2060,17 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                     Ty::Unit,
                 ));
             }
-            // set_level :: Str -> [io] Result[Nil, Str]
+            // set_level :: Str -> [io] Result[Unit, Str]
             fields.insert("set_level".into(), Ty::function(
                 vec![Ty::str()],
                 EffectSet::singleton("io"),
                 result_str(Ty::Unit)));
-            // set_format :: Str -> [io] Result[Nil, Str]
+            // set_format :: Str -> [io] Result[Unit, Str]
             fields.insert("set_format".into(), Ty::function(
                 vec![Ty::str()],
                 EffectSet::singleton("io"),
                 result_str(Ty::Unit)));
-            // set_sink :: Str -> [io, fs_write] Result[Nil, Str]
+            // set_sink :: Str -> [io, fs_write] Result[Unit, Str]
             fields.insert("set_sink".into(), Ty::function(
                 vec![Ty::str()],
                 EffectSet {
@@ -2204,7 +2204,7 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
             // wait :: ProcessHandle -> [proc] ProcessExit
             fields.insert("wait".into(), Ty::function(
                 vec![ph()], EffectSet::singleton("proc"), exit_t()));
-            // kill :: ProcessHandle, Str -> [proc] Result[Nil, Str]
+            // kill :: ProcessHandle, Str -> [proc] Result[Unit, Str]
             fields.insert("kill".into(), Ty::function(
                 vec![ph(), Ty::str()],
                 EffectSet::singleton("proc"),
@@ -2286,7 +2286,7 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                     var: None,
                 },
                 Ty::Con("Result".into(), vec![kv_t(), Ty::str()])));
-            // close :: Kv -> [kv] Nil
+            // close :: Kv -> [kv] Unit
             fields.insert("close".into(), Ty::function(
                 vec![kv_t()],
                 EffectSet::singleton("kv"),
@@ -2296,12 +2296,12 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 vec![kv_t(), Ty::str()],
                 EffectSet::singleton("kv"),
                 Ty::Con("Option".into(), vec![Ty::bytes()])));
-            // put :: Kv, Str, Bytes -> [kv] Result[Nil, Str]
+            // put :: Kv, Str, Bytes -> [kv] Result[Unit, Str]
             fields.insert("put".into(), Ty::function(
                 vec![kv_t(), Ty::str(), Ty::bytes()],
                 EffectSet::singleton("kv"),
                 Ty::Con("Result".into(), vec![Ty::Unit, Ty::str()])));
-            // delete :: Kv, Str -> [kv] Result[Nil, Str]
+            // delete :: Kv, Str -> [kv] Result[Unit, Str]
             fields.insert("delete".into(), Ty::function(
                 vec![kv_t(), Ty::str()],
                 EffectSet::singleton("kv"),
@@ -2445,7 +2445,7 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
             // process-wide registry (same pattern as Db in std.sql). All ops carry
             // [net] — Redis is a TCP service; no separate [redis] effect.
             //
-            // subscribe / psubscribe return Nil (= Unit) because they are blocking
+            // subscribe / psubscribe return Unit because they are blocking
             // infinite loops, consistent with net.serve_fn and ws.serve.
             //
             // subscribe/psubscribe open a *dedicated* connection internally —
@@ -2513,7 +2513,7 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 EffectSet::singleton("net"),
                 Ty::int()));
 
-            // subscribe :: ConnRedis, Str, (Str, Str ->[E] Unit) -> [net] Nil
+            // subscribe :: ConnRedis, Str, (Str, Str ->[E] Unit) -> [net] Unit
             // Blocking loop; handler receives (channel, message) on each message.
             // Uses a dedicated connection — Redis disallows non-Pub/Sub commands
             // on a subscribed connection. Handler carries an open effect row so
@@ -2525,9 +2525,9 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
             fields.insert("subscribe".into(), Ty::function(
                 vec![conn_t(), Ty::str(), handler2],
                 EffectSet::singleton("net"),
-                Ty::Unit));  // Nil = Unit
+                Ty::Unit));  // Unit
 
-            // psubscribe :: ConnRedis, Str, (Str, Str, Str ->[E] Unit) -> [net] Nil
+            // psubscribe :: ConnRedis, Str, (Str, Str, Str ->[E] Unit) -> [net] Unit
             // Pattern-subscribe; handler receives (pattern, channel, message).
             // Handler carries an open effect row (same rationale as subscribe).
             let handler3 = Ty::function(
@@ -2537,7 +2537,7 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
             fields.insert("psubscribe".into(), Ty::function(
                 vec![conn_t(), Ty::str(), handler3],
                 EffectSet::singleton("net"),
-                Ty::Unit));  // Nil = Unit
+                Ty::Unit));  // Unit
 
             // ---- List ----------------------------------------------------
 

--- a/crates/lex-vcs/Cargo.toml
+++ b/crates/lex-vcs/Cargo.toml
@@ -11,8 +11,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-lex-ast = { path = "../lex-ast", version = "0.9.6" }
-lex-types = { path = "../lex-types", version = "0.9.6" }
+lex-ast = { path = "../lex-ast", version = "0.10.0" }
+lex-types = { path = "../lex-types", version = "0.10.0" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
@@ -24,4 +24,4 @@ hex.workspace = true
 
 [dev-dependencies]
 tempfile = "3"
-lex-syntax = { path = "../lex-syntax", version = "0.9.6" }
+lex-syntax = { path = "../lex-syntax", version = "0.10.0" }

--- a/crates/spec-checker/Cargo.toml
+++ b/crates/spec-checker/Cargo.toml
@@ -16,11 +16,11 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 indexmap.workspace = true
-lex-syntax = { path = "../lex-syntax", version = "0.9.6" }
-lex-ast = { path = "../lex-ast", version = "0.9.6" }
-lex-types = { path = "../lex-types", version = "0.9.6" }
-lex-bytecode = { path = "../lex-bytecode", version = "0.9.6" }
-lex-runtime = { path = "../lex-runtime", version = "0.9.6" }
+lex-syntax = { path = "../lex-syntax", version = "0.10.0" }
+lex-ast = { path = "../lex-ast", version = "0.10.0" }
+lex-types = { path = "../lex-types", version = "0.10.0" }
+lex-bytecode = { path = "../lex-bytecode", version = "0.10.0" }
+lex-runtime = { path = "../lex-runtime", version = "0.10.0" }
 
 [dev-dependencies]
-lex-syntax = { path = "../lex-syntax", version = "0.9.6" }
+lex-syntax = { path = "../lex-syntax", version = "0.10.0" }

--- a/docs/MIGRATING-0.10.md
+++ b/docs/MIGRATING-0.10.md
@@ -1,0 +1,107 @@
+# Migrating to Lex 0.10.0
+
+0.10.0 is a stdlib-audit release. It carries **three breaking changes**.
+The good news: **all three are caught at `lex check` time** (an unresolved
+import, an effect-row mismatch, or a type mismatch) — nothing breaks
+silently at runtime. Migration is mechanical, and `lex check` is your
+checklist: fix what it flags and you're done.
+
+Downstream repos pin a fixed `lex` version, so nothing upgrades until you
+bump the pin deliberately. When you do, work through the three items below.
+
+---
+
+## 1. `std.proc` removed — use `std.process` (#678)
+
+`std.proc` exposed a single op that was byte-for-byte equivalent to
+`process.run`. It's gone; `std.process` is a strict superset.
+
+**Symptom:** `import "std.proc"` no longer resolves (`lex check` error).
+
+**Fix — drop-in rename:**
+
+```diff
+- import "std.proc" as proc
++ import "std.process" as process
+
+- proc.spawn(cmd, args)
++ process.run(cmd, args)
+```
+
+Same `[proc]` effect, same `{ stdout, stderr, exit_code }` result, same
+`--allow-proc` binary allow-list. The `[proc]` effect itself is unchanged.
+(For streaming, `std.process` also offers `spawn` / `read_*_line` / `wait`
+/ `kill`.)
+
+## 2. `rand.int_in` — honest randomness under `[random]` (#677)
+
+It previously declared `[rand]` but returned the deterministic midpoint
+`(lo + hi) / 2` — a constant. It now draws a real uniform integer in
+`[lo, hi]` from the OS RNG, gated by the same `[random]` effect as
+`crypto.random`. **There are two changes to make:**
+
+**a) Effect rename** (`lex check` flags the mismatch):
+
+```diff
+- fn pick(...) -> [rand] Int { rand.int_in(0, n) }
++ fn pick(...) -> [random] Int { rand.int_in(0, n) }
+```
+
+and at the policy gate: `--allow-effects rand` → `--allow-effects random`.
+The standalone `rand` effect no longer exists.
+
+**b) Behaviour** — it's now actually random. If you depended on the old
+deterministic midpoint (e.g. to get stable test output), switch to:
+
+- **`std.random`** — seeded, pure, replayable (thread an `Rng` value); the
+  idiomatic choice for deterministic randomness, or
+- **`crypto.random`** — cryptographically secure, also `[random]`.
+
+## 3. `http.stream_lines` returns `Stream[Str]`, not `Iter[Str]` (#683)
+
+The old `Iter` was eager: it buffered the whole response before returning,
+so an SSE endpoint that holds the connection open hung. It now returns a
+lazy `Stream[Str]` read line-by-line off the socket.
+
+**Symptom:** a type error where the result was consumed with `iter.*`.
+
+**Fix — consume with `std.stream`:**
+
+```diff
++ import "std.stream" as stream
+
+  match http.stream_lines(url, headers, body) {
+-   Ok(it) => iter.to_list(it),
++   Ok(s)  => stream.collect(s),     # or pull lazily with stream.next(s)
+    Err(e) => ...,
+  }
+```
+
+Add the `[stream]` effect to the consuming fn (and `--allow-effects
+stream`). The new behaviour is strictly better — lines arrive
+incrementally as the server sends them, with no buffering and no hang on
+open-ended streams.
+
+---
+
+## Worth reviewing (not a hard break)
+
+- **`http.json_body[T]` now validates (#684).** When `T` is a record, a
+  missing or wrong-typed field now returns `Err(DecodeError)` instead of an
+  `Ok` with a silently-incomplete record (which used to panic at the later
+  field access). If you handle the `Result` properly this is purely an
+  improvement; just make sure your `Err` arm is meaningful.
+- **`NET_SERVE_NAMED` lint (#680).** `lex check --strict` now warns on the
+  name-based `net.serve` / `serve_tls` / `serve_ws` / `serve_with` /
+  `serve_quic` forms (handler passed by name, effect row unchecked) and
+  points you at the closure variants (`serve_fn` / `serve_routed` /
+  `serve_ws_fn`). It's a `--strict` **warning**, not an error — a plain
+  `lex check` is unaffected.
+
+## New, no action needed
+
+`result.unwrap_or` / `unwrap_or_else` / `is_ok` / `is_err`, `option.is_some`
+/ `is_none` / `ok_or` (#679); `int.min` / `max` / `abs`,
+`duration.millis` / `minutes` / `hours` / `days` (#681); and the
+`std.yaml` `Option[T]` decoding fix (#682). See `CHANGELOG.md` for the full
+list.


### PR DESCRIPTION
Prepares the **0.10.0** release.

## Why 0.10.0 (not a 0.9.14 patch)
`v0.9.14` is already tagged at `d35eff8` — *before* the stdlib-audit merges. Those merges include **breaking changes**, and this changelog's policy is explicit: *"minor bumps may carry breaking changes when justified."* So the next release is a minor bump.

Breaking changes since 0.9.14:
- **Removed `std.proc`** (use `std.process`) — #678
- **`rand.int_in` now an honest `[random]` draw**, not a `[rand]` midpoint stub — #677
- **`http.stream_lines` returns `Stream[Str]`** instead of `Iter[Str]` — #683

## What this PR does
- Bumps `[workspace.package] version` `0.9.14 → 0.10.0`.
- Updates every inter-crate path-dependency pin (`^0.9.x` excluded `0.10.0`) — 49 pins across 12 crates.
- Regenerates `Cargo.lock` (diff is **exactly** the 16 workspace crates bumped, zero dependency churn).
- Adds the `## [0.10.0]` CHANGELOG entry (Removed / Changed / Added / Fixed / Internal, breaking items marked **BREAKING**).
- Folds in the last #681 item: normalize `Nil → Unit` in `lex-types` builtin doc-comments (comment-only).

## Verification
- `cargo metadata --no-deps` resolves the whole workspace at 0.10.0 (exit 0); the failed full build was disk-exhaustion in the sandbox, not a resolution error — cargo got past resolution into compilation of unchanged code.
- The non-version changes are comment-only, so they can't affect compilation; the merged code was already CI-green crate-by-crate and integration-tested together.

## After merge
Tagging `v0.10.0` is the actual release step — left to you (coordinated per `CLAUDE.md`). Say the word and I can also draft release notes from the CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YESxnpeuCT4kK2Gtuo1uui

---
_Generated by [Claude Code](https://claude.ai/code/session_01YESxnpeuCT4kK2Gtuo1uui)_