### PR TITLE
fix(vm): guard integer div/mod against zero divisor (#696)

### DIFF
--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -82,6 +82,18 @@ pub enum VmError {
         binding: String,
         reason: String,
     },
+    /// Integer division or modulo with a zero divisor (#696). Without
+    /// this guard the host `/`/`%` panics and takes the whole process
+    /// down — the crash report had a conformance harness compute a
+    /// rate over an empty set in teardown, far from any user-visible
+    /// division. Surfacing a catchable `VmError` instead keeps the
+    /// failure inside the language's error model. Float div/mod is
+    /// exempt: IEEE-754 yields inf/NaN rather than trapping.
+    #[error("integer {op} by zero")]
+    DivByZero {
+        /// `"division"` or `"modulo"` — names the offending operator.
+        op: &'static str,
+    },
 }
 
 /// Maximum simultaneous call frames. Defends against unbounded
@@ -2675,8 +2687,8 @@ impl<'a> Vm<'a> {
                 Op::IntAdd => self.bin_int(|a, b| Value::Int(a + b))?,
                 Op::IntSub => self.bin_int(|a, b| Value::Int(a - b))?,
                 Op::IntMul => self.bin_int(|a, b| Value::Int(a * b))?,
-                Op::IntDiv => self.bin_int(|a, b| Value::Int(a / b))?,
-                Op::IntMod => self.bin_int(|a, b| Value::Int(a % b))?,
+                Op::IntDiv => self.bin_int_divmod(false)?,
+                Op::IntMod => self.bin_int_divmod(true)?,
                 Op::IntNeg => {
                     let a = self.pop()?.as_int();
                     self.stack.push(Value::Int(-a));
@@ -2716,8 +2728,8 @@ impl<'a> Vm<'a> {
                 }
                 Op::NumSub => self.bin_num(|a, b| Value::Int(a - b), |a, b| Value::Float(a - b))?,
                 Op::NumMul => self.bin_num(|a, b| Value::Int(a * b), |a, b| Value::Float(a * b))?,
-                Op::NumDiv => self.bin_num(|a, b| Value::Int(a / b), |a, b| Value::Float(a / b))?,
-                Op::NumMod => self.bin_int(|a, b| Value::Int(a % b))?,
+                Op::NumDiv => self.num_divmod(false)?,
+                Op::NumMod => self.num_divmod(true)?,
                 Op::NumNeg => {
                     let v = self.pop()?;
                     match v {
@@ -3090,6 +3102,47 @@ impl<'a> Vm<'a> {
         let a = self.pop()?.as_int();
         self.stack.push(f(a, b));
         Ok(())
+    }
+    /// Guarded integer `/` (`is_mod == false`) or `%` (`is_mod == true`)
+    /// for `Op::IntDiv` / `Op::IntMod` (#696). A zero divisor raises
+    /// `VmError::DivByZero` instead of panicking the host. `wrapping_*`
+    /// also tames the only other panicking input, `i64::MIN / -1` (and
+    /// `i64::MIN % -1`), whose true result overflows `i64`: division
+    /// wraps to `i64::MIN`, modulo to `0`.
+    fn bin_int_divmod(&mut self, is_mod: bool) -> Result<(), VmError> {
+        let b = self.pop()?.as_int();
+        let a = self.pop()?.as_int();
+        if b == 0 {
+            return Err(VmError::DivByZero { op: if is_mod { "modulo" } else { "division" } });
+        }
+        let v = if is_mod { a.wrapping_rem(b) } else { a.wrapping_div(b) };
+        self.stack.push(Value::Int(v));
+        Ok(())
+    }
+    /// Guarded `/` / `%` for the overloaded `Op::NumDiv` / `Op::NumMod`,
+    /// which accept either both-`Int` or both-`Float` operands (#696).
+    /// Integers route through the same zero/overflow guards as
+    /// `bin_int_divmod`; floats keep IEEE-754 semantics (inf/NaN, no
+    /// trap). Mirrors the type checker, which only admits these two
+    /// operand shapes for `%` (int) and `/` (int or float).
+    fn num_divmod(&mut self, is_mod: bool) -> Result<(), VmError> {
+        let b = self.pop()?;
+        let a = self.pop()?;
+        match (a, b) {
+            (Value::Int(x), Value::Int(y)) => {
+                if y == 0 {
+                    return Err(VmError::DivByZero { op: if is_mod { "modulo" } else { "division" } });
+                }
+                let v = if is_mod { x.wrapping_rem(y) } else { x.wrapping_div(y) };
+                self.stack.push(Value::Int(v));
+                Ok(())
+            }
+            (Value::Float(x), Value::Float(y)) => {
+                self.stack.push(Value::Float(if is_mod { x % y } else { x / y }));
+                Ok(())
+            }
+            (a, b) => Err(VmError::TypeMismatch(format!("Num op: {a:?} {b:?}"))),
+        }
     }
     fn bin_float(&mut self, f: impl Fn(f64, f64) -> Value) -> Result<(), VmError> {
         let b = self.pop()?.as_float();

--- a/crates/lex-bytecode/tests/run.rs
+++ b/crates/lex-bytecode/tests/run.rs
@@ -668,3 +668,62 @@ fn pick(flag :: Int, r :: R) -> Int {
     assert_eq!(vm.call("pick", vec![Value::Int(0), mk()]).unwrap(), Value::Int(5));
     assert_eq!(vm.call("pick", vec![Value::Int(1), mk()]).unwrap(), Value::Int(0));
 }
+
+// --- #696: integer division/modulo by zero is a clean VmError, not a
+// host panic. The divisor is passed in as an argument so the value
+// cannot be constant-folded away at compile time — the guard has to
+// fire inside the VM run loop, the exact site (vm.rs IntDiv/IntMod)
+// that took the process down in the 0.10.0 crash report.
+
+#[test]
+fn int_div_by_zero_is_caught_not_panic() {
+    let src = "fn div(a :: Int, b :: Int) -> Int { a / b }\n";
+    let p = compile(src);
+    let mut vm = Vm::new(&p);
+    // Sanity: a real divisor still divides.
+    assert_eq!(vm.call("div", vec![Value::Int(7), Value::Int(2)]).unwrap(), Value::Int(3));
+    let err = vm
+        .call("div", vec![Value::Int(7), Value::Int(0)])
+        .expect_err("expected DivByZero, not a value");
+    match err {
+        VmError::DivByZero { op } => assert_eq!(op, "division"),
+        other => panic!("expected DivByZero, got {other:?}"),
+    }
+}
+
+#[test]
+fn int_mod_by_zero_is_caught_not_panic() {
+    let src = "fn rem(a :: Int, b :: Int) -> Int { a % b }\n";
+    let p = compile(src);
+    let mut vm = Vm::new(&p);
+    assert_eq!(vm.call("rem", vec![Value::Int(7), Value::Int(3)]).unwrap(), Value::Int(1));
+    let err = vm
+        .call("rem", vec![Value::Int(7), Value::Int(0)])
+        .expect_err("expected DivByZero, not a value");
+    match err {
+        VmError::DivByZero { op } => assert_eq!(op, "modulo"),
+        other => panic!("expected DivByZero, got {other:?}"),
+    }
+}
+
+#[test]
+fn int_div_min_by_neg_one_wraps_instead_of_panicking() {
+    // The second host-panic class: i64::MIN / -1 overflows i64 because
+    // the true quotient (2^63) is unrepresentable. The guard routes it
+    // through wrapping_div (-> i64::MIN) / wrapping_rem (-> 0) so it,
+    // too, can never abort the process.
+    let src = "fn div(a :: Int, b :: Int) -> Int { a / b }\n";
+    let p = compile(src);
+    let mut vm = Vm::new(&p);
+    assert_eq!(
+        vm.call("div", vec![Value::Int(i64::MIN), Value::Int(-1)]).unwrap(),
+        Value::Int(i64::MIN),
+    );
+    let src_mod = "fn rem(a :: Int, b :: Int) -> Int { a % b }\n";
+    let p = compile(src_mod);
+    let mut vm = Vm::new(&p);
+    assert_eq!(
+        vm.call("rem", vec![Value::Int(i64::MIN), Value::Int(-1)]).unwrap(),
+        Value::Int(0),
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #696 — the VM panic `attempt to divide by zero` at `crates/lex-bytecode/src/vm.rs:2678`.

`Op::IntDiv` / `Op::IntMod` (and the integer branch of the overloaded `Op::NumDiv` / `Op::NumMod`) executed raw Rust integer `/` / `%`. On a zero divisor Rust **panics**, which unwinds out of the VM run loop and aborts the whole `lex` process — exactly the 0.10.0 crash the `lex-ocpi` conformance harness hit during teardown (computing a rate over an empty set, after its result table had already printed). The panic site, `vm.rs:2678:62`, is the `a / b` in `Op::IntDiv`.

## Root cause

Division by zero in user/stdlib code is a *runtime* condition, but the VM let it reach the host `/`/`%` operators, which are total-or-panic. There is no division in the harness source that's visibly reachable with a zero divisor — it surfaces deep in a stdlib rate/percentage computation, which is precisely why a host panic (rather than a catchable language-level error) is the wrong failure mode.

## Fix

Route the four affected opcodes through new guarded helpers `bin_int_divmod` / `num_divmod`:

- **Zero divisor** → `VmError::DivByZero { op }` (a new, catchable variant), instead of a host panic. The CLI already renders `VmError` via `Display`, so it reports `integer division by zero` cleanly with no match-site changes.
- **`i64::MIN / -1`** (and `% -1`) — the *other* panicking input, whose true quotient `2^63` overflows `i64` — is tamed with `wrapping_div` / `wrapping_rem` (→ `i64::MIN` / `0`), so it can't abort the process either.
- **Float div/mod** is untouched: IEEE-754 yields `inf`/`NaN`, never traps.

## Tests

`crates/lex-bytecode/tests/run.rs`:
- `int_div_by_zero_is_caught_not_panic`
- `int_mod_by_zero_is_caught_not_panic`
- `int_div_min_by_neg_one_wraps_instead_of_panicking`

The divisor is passed as a **runtime argument** so it can't be constant-folded, ensuring the guard fires in the VM run loop (the actual crash site). Full `lex-bytecode` suite (32 tests) and `lex-jit` suite pass; `cargo clippy -p lex-bytecode` is clean.

## Scope note — JIT tier

The default `lex run` path (and the issue repro) use the bytecode VM; this PR fixes that path. The opt-in `--jit` tier lowers `IntDiv`/`IntMod` to Cranelift `sdiv`/`srem`, which also trap on a zero divisor. That's a separate, pre-existing concern behind an experimental flag that already prints a "do not pass untrusted code" warning, and giving the JIT a matching catchable error needs trap-to-`VmError` plumbing it doesn't yet have. Left as a follow-up rather than expanded into this fix.

> Note: `cargo build --workspace` currently fails to compile the third-party `libsqlite3-sys 0.38.1` build script (`cfg_select` unstable feature) under rustc 1.94.1. This is a pre-existing environment/toolchain issue unrelated to this change — `lex-bytecode` and `lex-jit` build and test fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016fuUp4n5PSYZSujcNwa8E9)_