### PR TITLE
release: v0.10.1 (std.vcs content store effect)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+## [0.10.1] — 2026-06-26
+
+A point release shipping the `std.vcs` content store effect.
+
 ### Added
 
 - **`std.vcs` — content-addressed blob store effect (#5).** A new `[vcs]`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "conformance"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "core-compiler"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "indexmap",
  "lex-ast",
@@ -2534,7 +2534,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lex-api"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "flate2",
@@ -2556,7 +2556,7 @@ dependencies = [
 
 [[package]]
 name = "lex-ast"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "indexmap",
  "lex-syntax",
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "lex-bytecode"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "lex-cli"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "acli",
  "anyhow",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "lex-jit"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "lex-lsp"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "lex-ast",
  "lex-store",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "lex-runtime"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -2720,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "lex-search"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "hex",
  "lex-ast",
@@ -2737,7 +2737,7 @@ dependencies = [
 
 [[package]]
 name = "lex-store"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "fs2",
  "hex",
@@ -2756,7 +2756,7 @@ dependencies = [
 
 [[package]]
 name = "lex-syntax"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "flate2",
  "indexmap",
@@ -2773,7 +2773,7 @@ dependencies = [
 
 [[package]]
 name = "lex-trace"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "indexmap",
  "lex-ast",
@@ -2788,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "lex-types"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "hex",
  "indexmap",
@@ -2802,7 +2802,7 @@ dependencies = [
 
 [[package]]
 name = "lex-vcs"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "ed25519-dalek",
  "getrandom 0.4.2",
@@ -5225,7 +5225,7 @@ dependencies = [
 
 [[package]]
 name = "spec-checker"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "indexmap",
  "lex-ast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 license = "EUPL-1.2"
 repository = "https://github.com/alpibrusl/lex-lang"


### PR DESCRIPTION
Point release shipping `std.vcs` (#5 / #699): content-addressed blob store effect backed by lex-store, with branch-per-sprint ref namespace.

- Workspace version 0.10.0 → 0.10.1
- CHANGELOG: new [0.10.1] section
- Cargo.lock synced

Tag `v0.10.1` after merge triggers the cross-platform release build.