### PR TITLE
release: v0.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+## [0.10.3] — 2026-06-28
+
+### Fixed
+
+- **Postgres `?` placeholders are now translated to `$1,$2,…`** (#703). The
+  Postgres backend passed parameterized statements through verbatim, so any
+  `sql.exec`/`sql.query` using `?` placeholders failed with `syntax error at or
+  near "?"` (only inline-value SQL worked). `pg_rewrite_placeholders` rewrites
+  each `?` placeholder — skipping those inside string literals and handling `''`
+  escapes — at every Postgres SQL site (`exec`, `exec_tx`, `query`, `query_tx`,
+  and the streaming cursor). SQLite paths are unchanged.
+
 ## [0.10.2] — 2026-06-27
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "conformance"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "core-compiler"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "indexmap",
  "lex-ast",
@@ -2534,7 +2534,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lex-api"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "flate2",
@@ -2556,7 +2556,7 @@ dependencies = [
 
 [[package]]
 name = "lex-ast"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "indexmap",
  "lex-syntax",
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "lex-bytecode"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "lex-cli"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "acli",
  "anyhow",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "lex-jit"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "lex-lsp"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "lex-ast",
  "lex-store",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "lex-runtime"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -2720,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "lex-search"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "hex",
  "lex-ast",
@@ -2737,7 +2737,7 @@ dependencies = [
 
 [[package]]
 name = "lex-store"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "fs2",
  "hex",
@@ -2756,7 +2756,7 @@ dependencies = [
 
 [[package]]
 name = "lex-syntax"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "flate2",
  "indexmap",
@@ -2773,7 +2773,7 @@ dependencies = [
 
 [[package]]
 name = "lex-trace"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "indexmap",
  "lex-ast",
@@ -2788,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "lex-types"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "hex",
  "indexmap",
@@ -2802,7 +2802,7 @@ dependencies = [
 
 [[package]]
 name = "lex-vcs"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "ed25519-dalek",
  "getrandom 0.4.2",
@@ -5225,7 +5225,7 @@ dependencies = [
 
 [[package]]
 name = "spec-checker"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "indexmap",
  "lex-ast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.10.2"
+version = "0.10.3"
 edition = "2021"
 license = "EUPL-1.2"
 repository = "https://github.com/alpibrusl/lex-lang"


### PR DESCRIPTION
Cuts **v0.10.3** (patch). Bumps the workspace version 0.10.2 → 0.10.3 (Cargo.toml + Cargo.lock) and adds the changelog entry.

Ships the Postgres `?`→`$n` placeholder translation (#703), so parameterized `sql.exec`/`sql.query` work on Postgres — unblocking Supabase/Postgres as the lex-soft platform DB (lex-ev-fleet#39).

After merge: tag `v0.10.3` to trigger the `release` (cross-platform binaries) and `crates.io publish` workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)