### PR TITLE
fix(runtime): conc.ask/tell from a net.serve handler (#698)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`conc.ask`/`conc.tell` from inside a `net.serve` handler** (#698). The actor
+  handler's `(new_state, reply)` tuple is arena-allocated under the serve
+  worker's request scope, but `run_conc_op` only accepted a heap `Value::Tuple`,
+  so it rejected a valid arity-2 `ArenaTuple` with "handler must return a
+  2-tuple". It now materializes arena handles before the check — which also
+  correctly heap-owns `new_state`, since the actor cell outlives the request's
+  arena scope. Worked from `main` already; this fixes the `net.serve` worker
+  path. Regression test: `crates/lex-runtime/tests/conc_ask_in_serve.rs`.
+
 ## [0.10.3] — 2026-06-28
 
 ### Fixed

--- a/crates/lex-bytecode/src/vm.rs
+++ b/crates/lex-bytecode/src/vm.rs
@@ -1022,6 +1022,16 @@ impl<'a> Vm<'a> {
                         // Call handler(state, msg) on this VM — full effect access.
                         let result = self.invoke_closure_value(closure_val, vec![state, msg])
                             .map_err(|e| format!("conc.{op}: handler error: {e:?}"))?;
+                        // #698: when `ask`/`tell` runs inside a `net.serve` worker, an
+                        // arena request-scope is active, so the handler's `(new_state,
+                        // reply)` tuple is allocated as a `Value::ArenaTuple` rather than
+                        // a heap `Value::Tuple` — and the bare match below would reject it.
+                        // Materialize arena handles into heap-owned form NOW, while the
+                        // producing scope is still active: the reply crosses back to the
+                        // caller and `new_state` persists in the actor cell beyond this
+                        // request's arena scope, so both must be heap-owned. Idempotent
+                        // (a no-op walk) when there are no arena handles, e.g. from `main`.
+                        let result = self.materialize_arena_handles(result);
                         // Expect (new_state, reply) tuple.
                         match result {
                             Value::Tuple(mut parts) if parts.len() == 2 => {

--- a/crates/lex-runtime/tests/conc_ask_in_serve.rs
+++ b/crates/lex-runtime/tests/conc_ask_in_serve.rs
@@ -1,0 +1,117 @@
+//! Regression for lex-lang#698: `conc.ask` on an actor, called from inside a
+//! `net.serve_fn` request handler, used to fail with
+//!   "conc.ask: handler must return a 2-tuple (new_state, reply), got ArenaTuple …"
+//! because the handler's `(new_state, reply)` tuple is arena-allocated under the
+//! serve worker's request scope and the validation only accepted a heap
+//! `Value::Tuple`. The fix materializes arena handles before the check. Here we
+//! spawn the actor in `main` and `ask` it from the GET handler; the reply must
+//! come back as the actor's state value, not an internal error.
+
+use lex_ast::canonicalize_program;
+use lex_bytecode::{compile_program, vm::Vm};
+use lex_runtime::{DefaultHandler, Policy};
+use lex_syntax::parse_source;
+use std::collections::BTreeSet;
+use std::io::{Read, Write};
+use std::net::{TcpStream, ToSocketAddrs};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+fn spawn_lex_server(src: &str, entry: &str) {
+    let prog = parse_source(src).expect("parse");
+    let stages = canonicalize_program(&prog);
+    if let Err(errs) = lex_types::check_program(&stages) {
+        panic!("type errors: {errs:#?}");
+    }
+    let bc = Arc::new(compile_program(&stages));
+    let mut policy = Policy::pure();
+    // #698 needs concurrent (actor) + net (serve) + io.
+    policy.allow_effects = ["net", "concurrent", "io"]
+        .into_iter()
+        .map(String::from)
+        .collect::<BTreeSet<_>>();
+    let entry = entry.to_string();
+    thread::spawn(move || {
+        let handler = DefaultHandler::new(policy.clone()).with_program(Arc::clone(&bc));
+        let mut vm = Vm::with_handler(&bc, Box::new(handler));
+        let _ = vm.call(&entry, vec![]);
+    });
+}
+
+fn wait_for_bind(port: u16, timeout: Duration) {
+    let deadline = std::time::Instant::now() + timeout;
+    let mut backoff = Duration::from_millis(20);
+    loop {
+        if let Ok(s) = TcpStream::connect_timeout(
+            &("127.0.0.1", port).to_socket_addrs().unwrap().next().unwrap(),
+            Duration::from_millis(200),
+        ) {
+            drop(s);
+            return;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("server on :{port} did not bind within {timeout:?}");
+        }
+        thread::sleep(backoff);
+        backoff = (backoff * 2).min(Duration::from_millis(200));
+    }
+}
+
+fn http_get(port: u16, path: &str) -> (u16, String) {
+    let mut s = TcpStream::connect(("127.0.0.1", port)).expect("connect");
+    s.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    let req =
+        format!("GET {path} HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n");
+    s.write_all(req.as_bytes()).unwrap();
+    let mut buf = String::new();
+    s.read_to_string(&mut buf).unwrap();
+    let (head, body) = buf.split_once("\r\n\r\n").unwrap_or((&buf, ""));
+    let status = head.split_whitespace().nth(1).unwrap_or("0").parse().unwrap_or(0);
+    (status, body.to_string())
+}
+
+const PROG: &str = r#"
+import "std.conc" as conc
+import "std.net" as net
+import "std.io" as io
+import "std.int" as int
+import "std.map" as map
+
+type St = { n :: Int }
+type M = Bump | Ask
+type R = Done | Val(Int)
+
+fn handler(s :: St, m :: M) -> (St, R) {
+  match m {
+    Bump => ({ n: s.n + 1 }, Done),
+    Ask => (s, Val(s.n)),
+  }
+}
+
+fn main() -> [concurrent, io, net] Unit {
+  let a := conc.spawn({ n: 7 }, handler)
+  let h := fn (req :: Request) -> [concurrent, io, net] Response {
+    let r := match conc.ask(a, Ask) {
+      Val(x) => int.to_str(x),
+      Done => "done",
+    }
+    { status: 200, body: BodyStr(r), headers: map.from_list([]) }
+  }
+  net.serve_fn(9711, h)
+}
+"#;
+
+#[test]
+fn conc_ask_from_serve_handler_returns_reply() {
+    spawn_lex_server(PROG, "main");
+    wait_for_bind(9711, Duration::from_secs(10));
+    let (status, body) = http_get(9711, "/");
+    assert_eq!(status, 200, "unexpected status; body = {body:?}");
+    assert_eq!(
+        body.trim(),
+        "7",
+        "conc.ask from a serve handler should return the actor's state value, \
+         not an internal error (lex-lang#698); got body = {body:?}"
+    );
+}


### PR DESCRIPTION
Closes #698.

## Problem
Calling `conc.ask`/`conc.tell` on an actor **from inside a `net.serve` request handler** failed:
```
internal error: effect handler error: conc.ask: handler must return a 2-tuple (new_state, reply), got ArenaTuple { slab_start: 0, arity: 2 }
```
The handler **does** return an arity-2 tuple — but inside a serve worker an arena request-scope is active, so the tuple is allocated as a `Value::ArenaTuple`, not a heap `Value::Tuple`. `run_conc_op` only matched `Value::Tuple { len == 2 }`, so the valid arena tuple fell through to the error. It worked from `main` (no active arena scope → heap tuple).

## Fix
Materialize arena handles on the handler result before the 2-tuple match (`vm.rs`), using the existing `materialize_arena_handles` boundary helper — called while the producing scope is still active. This also fixes a latent correctness issue: `new_state` is stored in the actor cell, which **outlives** the request's arena scope, so it must be heap-owned (a retained arena handle would read truncated-slab garbage after `exit_request_scope`). Idempotent for already-heap tuples (calls from `main`).

## Tests
- New `crates/lex-runtime/tests/conc_ask_in_serve.rs` — the filed minimal repro: actor spawned in `main`, `ask`ed from the GET handler; asserts the reply (`7`) comes back, not an internal error. **Fails before, passes after.**
- Existing `concurrent_actor` (8) + `conc_registry` (4) still green.

Unblocks **alpibrusl/lex-ocpi#39** (its OCPI conformance eMSP example queries a `conc.spawn`/`ask` callback recorder from a GET handler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)