### PR TITLE
release: v0.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+## [0.10.4] — 2026-06-28
+
 ### Fixed
 
 - **`conc.ask`/`conc.tell` from inside a `net.serve` handler** (#698). The actor

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "conformance"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "core-compiler"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "indexmap",
  "lex-ast",
@@ -2534,7 +2534,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lex-api"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "flate2",
@@ -2556,7 +2556,7 @@ dependencies = [
 
 [[package]]
 name = "lex-ast"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "indexmap",
  "lex-syntax",
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "lex-bytecode"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "lex-cli"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "acli",
  "anyhow",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "lex-jit"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "lex-lsp"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "lex-ast",
  "lex-store",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "lex-runtime"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -2720,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "lex-search"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "hex",
  "lex-ast",
@@ -2737,7 +2737,7 @@ dependencies = [
 
 [[package]]
 name = "lex-store"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "fs2",
  "hex",
@@ -2756,7 +2756,7 @@ dependencies = [
 
 [[package]]
 name = "lex-syntax"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "flate2",
  "indexmap",
@@ -2773,7 +2773,7 @@ dependencies = [
 
 [[package]]
 name = "lex-trace"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "indexmap",
  "lex-ast",
@@ -2788,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "lex-types"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "hex",
  "indexmap",
@@ -2802,7 +2802,7 @@ dependencies = [
 
 [[package]]
 name = "lex-vcs"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "ed25519-dalek",
  "getrandom 0.4.2",
@@ -5225,7 +5225,7 @@ dependencies = [
 
 [[package]]
 name = "spec-checker"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "indexmap",
  "lex-ast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.10.3"
+version = "0.10.4"
 edition = "2021"
 license = "EUPL-1.2"
 repository = "https://github.com/alpibrusl/lex-lang"


### PR DESCRIPTION
Cuts **v0.10.4** (patch). Ships the `conc.ask`/`conc.tell`-in-`net.serve` fix (#705 / #698). Together with #696 (already in 0.10.3), this gives lex-ocpi#39 a toolchain where both conformance blockers are fixed.

After merge: tag `v0.10.4` to build binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)