### PR TITLE
Add crypto.ed25519_is_valid_point for Solana PDA derivation

### DIFF
--- a/crates/lex-runtime/src/builtins.rs
+++ b/crates/lex-runtime/src/builtins.rs
@@ -1284,6 +1284,15 @@ fn dispatch(kind: &str, op: &str, args: &[Value]) -> Result<Value, String> {
             let sig = Signature::from_bytes(&sig_arr);
             Ok(Value::Bool(vk.verify(message, &sig).is_ok()))
         }
+        ("crypto", "ed25519_is_valid_point") => {
+            use ed25519_dalek::VerifyingKey;
+            let candidate = expect_bytes(args.first())?;
+            let arr: [u8; 32] = match candidate.as_slice().try_into() {
+                Ok(a) => a,
+                Err(_) => return Ok(Value::Bool(false)),
+            };
+            Ok(Value::Bool(VerifyingKey::from_bytes(&arr).is_ok()))
+        }
         // P-256 ECDSA / ES256 (#651). Backs the JWT/SD-JWT signing
         // primitives `lex-jose` needs for AP2 mandates. Key minting
         // (`p256_generate`) is effectful (`[random]`) and lives in the
@@ -3493,5 +3502,42 @@ mod bytes_builtin_tests {
         let buf = Value::Bytes(vec![0xFF, 2, 1]);
         let decoded = call("u16_le_at", vec![buf, Value::Int(1)]).unwrap();
         assert_eq!(decoded, ok_v(Value::Int(258)));
+    }
+}
+
+#[cfg(test)]
+mod ed25519_curve_tests {
+    use super::*;
+
+    fn call(op: &str, args: Vec<Value>) -> Result<Value, String> {
+        dispatch("crypto", op, &args)
+    }
+
+    #[test]
+    fn a_real_public_key_is_a_valid_point() {
+        use ed25519_dalek::SigningKey;
+        let seed = [7u8; 32];
+        let sk = SigningKey::from_bytes(&seed);
+        let pk = sk.verifying_key().to_bytes().to_vec();
+        let got = call("ed25519_is_valid_point", vec![Value::Bytes(pk)]).unwrap();
+        assert_eq!(got, Value::Bool(true));
+    }
+
+    #[test]
+    fn wrong_length_is_not_a_valid_point() {
+        let got = call("ed25519_is_valid_point", vec![Value::Bytes(vec![1, 2, 3])]).unwrap();
+        assert_eq!(got, Value::Bool(false));
+    }
+
+    #[test]
+    fn a_non_curve_point_is_rejected() {
+        // 31 bytes of 0x01 followed by a 0x00 sign/high byte does not
+        // decompress to a point on Edwards25519 -- exactly the kind of
+        // candidate a PDA bump search must reject to be sure the address
+        // has no known private key.
+        let mut candidate = [1u8; 32];
+        candidate[31] = 0;
+        let got = call("ed25519_is_valid_point", vec![Value::Bytes(candidate.to_vec())]).unwrap();
+        assert_eq!(got, Value::Bool(false));
     }
 }

--- a/crates/lex-types/src/builtins.rs
+++ b/crates/lex-types/src/builtins.rs
@@ -1814,6 +1814,16 @@ pub fn module_scope(name: &str, _env: &TypeEnv) -> Option<Ty> {
                 EffectSet::empty(),
                 Ty::bool(),
             ));
+            // Whether `bytes` decompresses to a valid point on the Edwards25519
+            // curve (#93 follow-up: Solana Program Derived Address search --
+            // a PDA is valid iff the candidate 32 bytes are NOT a valid point,
+            // so callers try bump seeds until this returns false).
+            //   ed25519_is_valid_point(bytes :: Bytes) -> Bool
+            fields.insert("ed25519_is_valid_point".into(), Ty::function(
+                vec![Ty::bytes()],
+                EffectSet::empty(),
+                Ty::bool(),
+            ));
             // P-256 ECDSA / ES256 (#651). The JWT/SD-JWT signature
             // algorithm for AP2 agent keys; `lex-jose` builds the
             // token layer on top of these primitives. Key bytes are


### PR DESCRIPTION
## Summary
lex-x402's SVM `exact` payment builder needs to auto-create Associated Token Accounts (#93 follow-up), which requires deriving their Program Derived Address -- a bump-seed search valid only once the candidate 32 bytes decompress to NOT a point on Edwards25519. lex-lang already depends on `ed25519-dalek` (for `ed25519_sign`/`verify`); `VerifyingKey::from_bytes` already performs exactly this validity check, so this just exposes it as a pure predicate:

```
crypto.ed25519_is_valid_point(bytes :: Bytes) -> Bool
```

## Test plan
- [x] `cargo test -p lex-runtime ed25519_curve_tests`: 3 passed (a real pubkey is valid, wrong-length input is rejected, a known non-curve-point candidate is rejected)
- [x] Verified from Lex against a real known-valid Solana address (decoded via `base58_decode`): returns `true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)