### PR TITLE
release: v0.10.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+## [0.10.6] — 2026-07-14
+
+### Added
+
+- **`std.bytes` gains `concat`/`concat_all` and fixed-width integer
+  encode/decode** (`u8`/`u16_le`/`u32_le`/`u64_le` and their `_at` decoders)
+  (#715). Previously the only way to build an arbitrary binary buffer was
+  `from_str`/`to_str`, which only round-trip through UTF-8 text — any real
+  binary wire format (e.g. a Solana transaction) was unbuildable from pure
+  Lex without a second-language dependency.
+- **`crypto.ed25519_is_valid_point(bytes :: Bytes) -> Bool`** (#717): whether
+  `bytes` decompresses to a valid point on the Edwards25519 curve. Exposes
+  `ed25519-dalek`'s existing validity check (already a dependency for
+  `ed25519_sign`/`verify`) as a pure predicate — the primitive a Solana
+  Program Derived Address bump-seed search needs (a PDA is valid iff the
+  candidate is NOT a curve point).
+
 ## [0.10.5] — 2026-07-05
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "conformance"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "core-compiler"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "indexmap",
  "lex-ast",
@@ -2534,7 +2534,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lex-api"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "anyhow",
  "flate2",
@@ -2556,7 +2556,7 @@ dependencies = [
 
 [[package]]
 name = "lex-ast"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "indexmap",
  "lex-syntax",
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "lex-bytecode"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "lex-cli"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "acli",
  "anyhow",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "lex-jit"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "lex-lsp"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "lex-ast",
  "lex-store",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "lex-runtime"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -2720,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "lex-search"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "hex",
  "lex-ast",
@@ -2737,7 +2737,7 @@ dependencies = [
 
 [[package]]
 name = "lex-store"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "fs2",
  "hex",
@@ -2756,7 +2756,7 @@ dependencies = [
 
 [[package]]
 name = "lex-syntax"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "flate2",
  "indexmap",
@@ -2773,7 +2773,7 @@ dependencies = [
 
 [[package]]
 name = "lex-trace"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "indexmap",
  "lex-ast",
@@ -2788,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "lex-types"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "hex",
  "indexmap",
@@ -2802,7 +2802,7 @@ dependencies = [
 
 [[package]]
 name = "lex-vcs"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "ed25519-dalek",
  "getrandom 0.4.2",
@@ -5225,7 +5225,7 @@ dependencies = [
 
 [[package]]
 name = "spec-checker"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "indexmap",
  "lex-ast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.10.5"
+version = "0.10.6"
 edition = "2021"
 license = "EUPL-1.2"
 repository = "https://github.com/alpibrusl/lex-lang"


### PR DESCRIPTION
Bump workspace version 0.10.5 -> 0.10.6 and changelog. Ships two primitives added since 0.10.5 that consumers have so far only been able to use by building lex-lang from source:

- `std.bytes.concat`/`concat_all` + fixed-width int encode/decode (#715)
- `crypto.ed25519_is_valid_point` (#717)

Both are load-bearing for lex-x402's real Solana `exact` payment builder (transaction serialization + Associated Token Account PDA derivation), verified live end-to-end against a real facilitator this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)