### PR TITLE
Fix Postgres float4/float8 param and column serialization mismatch

### DIFF
--- a/crates/lex-runtime/src/handler.rs
+++ b/crates/lex-runtime/src/handler.rs
@@ -4350,17 +4350,78 @@ mod pg_placeholder_tests {
     }
 }
 
+/// Lex's `PFloat` params are always `f64`, but a placeholder's Postgres
+/// parameter type is inferred from the column it binds to, and Lex SQL
+/// schemas commonly use `REAL` (float4) rather than `DOUBLE PRECISION`
+/// (float8). A plain `f64` only implements `ToSql` for float8, so binding
+/// it against a float4 parameter fails to serialize. This wrapper accepts
+/// either width and encodes to whichever one Postgres actually asked for.
+#[derive(Debug)]
+struct PgFloatParam(f64);
+
+impl postgres::types::ToSql for PgFloatParam {
+    fn to_sql(
+        &self,
+        ty: &postgres::types::Type,
+        out: &mut bytes::BytesMut,
+    ) -> Result<postgres::types::IsNull, Box<dyn std::error::Error + Sync + Send>> {
+        use bytes::BufMut;
+        match *ty {
+            postgres::types::Type::FLOAT4 => out.put_f32(self.0 as f32),
+            _ => out.put_f64(self.0),
+        }
+        Ok(postgres::types::IsNull::No)
+    }
+
+    fn accepts(ty: &postgres::types::Type) -> bool {
+        matches!(*ty, postgres::types::Type::FLOAT4 | postgres::types::Type::FLOAT8)
+    }
+
+    postgres::types::to_sql_checked!();
+}
+
 /// Box `SqlParamValue`s as `dyn ToSql + Sync` for Postgres binding.
 fn pg_param_refs(params: &[SqlParamValue]) -> Vec<Box<dyn postgres::types::ToSql + Sync>> {
     params.iter().map(|p| -> Box<dyn postgres::types::ToSql + Sync> {
         match p {
             SqlParamValue::Text(s)    => Box::new(s.clone()),
             SqlParamValue::Integer(n) => Box::new(*n),
-            SqlParamValue::Real(f)    => Box::new(*f),
+            SqlParamValue::Real(f)    => Box::new(PgFloatParam(*f)),
             SqlParamValue::Bool(b)    => Box::new(*b),
             SqlParamValue::Null       => Box::new(Option::<String>::None),
         }
     }).collect()
+}
+
+#[cfg(test)]
+mod pg_float_param_tests {
+    use super::PgFloatParam;
+    use bytes::{Buf, BytesMut};
+    use postgres::types::{ToSql, Type};
+
+    #[test]
+    fn encodes_float4_as_4_bytes_matching_the_value() {
+        let mut out = BytesMut::new();
+        PgFloatParam(6.5).to_sql(&Type::FLOAT4, &mut out).unwrap();
+        assert_eq!(out.len(), 4);
+        assert_eq!(out.get_f32(), 6.5f32);
+    }
+
+    #[test]
+    fn encodes_float8_as_8_bytes_matching_the_value() {
+        let mut out = BytesMut::new();
+        PgFloatParam(6.5).to_sql(&Type::FLOAT8, &mut out).unwrap();
+        assert_eq!(out.len(), 8);
+        assert_eq!(out.get_f64(), 6.5f64);
+    }
+
+    #[test]
+    fn accepts_only_float4_and_float8() {
+        assert!(PgFloatParam::accepts(&Type::FLOAT4));
+        assert!(PgFloatParam::accepts(&Type::FLOAT8));
+        assert!(!PgFloatParam::accepts(&Type::TEXT));
+        assert!(!PgFloatParam::accepts(&Type::INT8));
+    }
 }
 
 /// Run a statement on SQLite and pack rows into `Value::List(Value::Record(...))`.
@@ -4433,7 +4494,9 @@ fn pg_row_to_lex_record(row: &postgres::Row) -> indexmap::IndexMap<String, Value
         let ty = col.type_();
         let val = if *ty == Type::INT2 || *ty == Type::INT4 || *ty == Type::INT8 {
             row.get::<_, Option<i64>>(i).map(Value::Int).unwrap_or(Value::Unit)
-        } else if *ty == Type::FLOAT4 || *ty == Type::FLOAT8 {
+        } else if *ty == Type::FLOAT4 {
+            row.get::<_, Option<f32>>(i).map(|f| Value::Float(f as f64)).unwrap_or(Value::Unit)
+        } else if *ty == Type::FLOAT8 {
             row.get::<_, Option<f64>>(i).map(Value::Float).unwrap_or(Value::Unit)
         } else if *ty == Type::BOOL {
             row.get::<_, Option<bool>>(i).map(Value::Bool).unwrap_or(Value::Unit)


### PR DESCRIPTION
## Summary

`sql.exec`/`sql.query` against Postgres bound every Lex `PFloat` param — and
read every `real`/`float4` column — as `f64`, whose `ToSql`/`FromSql` impls
only accept `FLOAT8`. This project's portable-DDL convention (`TEXT / REAL /
BIGINT only`) makes float columns `REAL` (Postgres `float4`), so both
directions were broken:

- **write**: binding a `PFloat` param against a `REAL` column fails with
  `sql.exec: error serializing parameter N` (Postgres infers the placeholder's
  type as `FLOAT4` from the target column; `f64::ToSql` only `accepts(FLOAT8)`).
- **read**: selecting a `REAL` column back into a Lex record panics with
  `error deserializing column N` for the mirror reason (`f64::FromSql` only
  accepts `FLOAT8`).

Fixed in `crates/lex-runtime/src/handler.rs`:
- `pg_param_refs` now boxes `SqlParamValue::Real` as a small `PgFloatParam`
  wrapper that encodes to whichever width (`float4`/`float8`) Postgres
  actually asked for, instead of hardcoding `f64`.
- `pg_row_to_lex_record` now reads `FLOAT4` columns via `f32` (widened to
  `f64`), and `FLOAT8` columns via `f64` as before.

Both call sites are shared by every `sql.exec`/`sql.query`/cursor call
against Postgres — this isn't specific to any one pack.

## How it was found

`lex-ev-fleet`'s coldchain pack (`coldchain.lex`) does
`INSERT INTO coldchain_profiles (... min_c REAL ...) VALUES (?, ...)`. The
`/coldchain/profiles` route existed since the pack shipped but had zero real
callers until an onboarding-wizard frontend PR wired one up — so it was only
ever validated against SQLite in tests, never against Postgres. Once
exercised live, `sql.exec` failed with `error serializing parameter 1` (the
`min_c` param). Fixing that write-side bug surfaced the mirror read-side
panic on the very next request (`/coldchain/readings`, which reads the
profile back before inserting).

## Testing

- `cargo test -p lex-runtime --lib pg_` — 7/7 green, including two new tests
  (`pg_float_param_tests`) that directly assert the corrected FLOAT4/FLOAT8
  wire encoding.
- Live-reproduced and live-verified against a running Postgres-backed
  `lex-soft-node` stack (the actual `lex-ev-fleet` image + a real `postgres:16`
  container): built this branch's `lex` binary for `aarch64-unknown-linux-gnu`,
  swapped it into a throwaway container against a scratch database on the same
  Postgres instance.
  - Before the fix: `POST /coldchain/profiles` → `500`,
    `{"error":"sql.exec: error serializing parameter 1"}`, no row written.
  - After the fix: `POST /coldchain/profiles` → `201`, row present in
    `coldchain_profiles`; `POST /coldchain/readings` → `201` for a normal
    reading and correctly flags `"excursion":true` for a reading outside the
    declared envelope.

## Test plan

- [x] `cargo test -p lex-runtime --lib pg_`
- [x] Live repro against Postgres-backed stack (before/after)
- [ ] CI (`lex check` / `lex fmt` / `lex test` / `lex ci` gate is N/A here —
      this is a runtime/compiler change per this repo's CLAUDE.md; `cargo
      test` is the gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)