### PR TITLE
release: v0.10.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ bumps may carry breaking changes when justified).
 
 ## [Unreleased]
 
+## [0.10.7] — 2026-07-22
+
+### Fixed
+
+- **Postgres `float4`/`float8` param and column serialization mismatch**
+  (#725). `sql.exec`/`sql.query` bound every `PFloat` param — and read every
+  `real`/`float4` column — as `f64`, whose `ToSql`/`FromSql` impls only
+  accept `FLOAT8`. Any pack following the project's portable-DDL convention
+  (`TEXT / REAL / BIGINT` only, `REAL` = Postgres `float4`) hit
+  `error serializing parameter N` on write and `error deserializing column N`
+  on read the first time a `REAL` column was actually exercised against
+  Postgres — SQLite-only test coverage had masked it. `pg_param_refs` now
+  encodes to whichever width Postgres asks for instead of hardcoding `f64`;
+  `pg_row_to_lex_record` reads `FLOAT4` columns via `f32`. Not specific to
+  any one pack — shared by every Postgres call site.
+
 ## [0.10.6] — 2026-07-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "conformance"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "core-compiler"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "indexmap",
  "lex-ast",
@@ -2534,7 +2534,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lex-api"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "anyhow",
  "flate2",
@@ -2556,7 +2556,7 @@ dependencies = [
 
 [[package]]
 name = "lex-ast"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "indexmap",
  "lex-syntax",
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "lex-bytecode"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "lex-cli"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "acli",
  "anyhow",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "lex-jit"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "lex-lsp"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "lex-ast",
  "lex-store",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "lex-runtime"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -2720,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "lex-search"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "hex",
  "lex-ast",
@@ -2737,7 +2737,7 @@ dependencies = [
 
 [[package]]
 name = "lex-store"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "fs2",
  "hex",
@@ -2756,7 +2756,7 @@ dependencies = [
 
 [[package]]
 name = "lex-syntax"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "flate2",
  "indexmap",
@@ -2773,7 +2773,7 @@ dependencies = [
 
 [[package]]
 name = "lex-trace"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "indexmap",
  "lex-ast",
@@ -2788,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "lex-types"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "hex",
  "indexmap",
@@ -2802,7 +2802,7 @@ dependencies = [
 
 [[package]]
 name = "lex-vcs"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "ed25519-dalek",
  "getrandom 0.4.2",
@@ -5225,7 +5225,7 @@ dependencies = [
 
 [[package]]
 name = "spec-checker"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "indexmap",
  "lex-ast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 exclude = ["fuzz"]
 
 [workspace.package]
-version = "0.10.6"
+version = "0.10.7"
 edition = "2021"
 license = "EUPL-1.2"
 repository = "https://github.com/alpibrusl/lex-lang"


### PR DESCRIPTION
Bump workspace version 0.10.6 -> 0.10.7 and changelog.

Ships the Postgres `float4`/`float8` param and column serialization fix (#725): `sql.exec`/`sql.query` bound every `PFloat` param and read every `REAL` column as `f64`, whose `ToSql`/`FromSql` impls only accept `FLOAT8`, breaking any pack whose portable DDL (`TEXT`/`REAL`/`BIGINT`) exercised a real `REAL` column against Postgres for the first time (surfaced by lex-ev-fleet's coldchain pack, worked around downstream in lex-ev-fleet#216 via a `DOUBLE PRECISION` column migration — this is the proper runtime-level fix).

Next: tag `v0.10.7` after merge to trigger the release build, then bump the pinned `LEX_VERSION` in dependent service Dockerfiles/CI.