### PR TITLE
docs: pin README install snippets to the current release (0.10.7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,10 @@ jobs:
       # binary is enough.
       - run: cargo test -p lex-runtime --features quic --test net_serve_quic
       - run: cargo clippy --workspace --all-targets -- -D warnings
+      # The README's install snippets are copy-pasted by newcomers; a stale
+      # version there hands them an old binary. Keep it pinned to Cargo.toml.
+      - name: README install version matches Cargo.toml
+        run: ./scripts/check-readme-version.sh
       # Manifesto demo: effects are machine-verifiable constraints. The
       # honest effect row type-checks; a [net] call under an [io]
       # signature is rejected. lex-cli is already compiled by the

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Tooling and runtime libraries that extend the Lex platform:
 **Pre-built binaries** for Linux (x86_64 / aarch64), macOS (x86_64 / aarch64), and Windows are on [GitHub Releases](https://github.com/alpibrusl/lex-lang/releases):
 
 ```sh
-tar -xzf lex-v0.9.8-x86_64-unknown-linux-gnu.tar.gz
+tar -xzf lex-v0.10.7-x86_64-unknown-linux-gnu.tar.gz
 mv lex /usr/local/bin/
 lex version
 ```
@@ -172,8 +172,8 @@ lex version
 **Container image** — multi-arch (`linux/amd64` + `linux/arm64`):
 
 ```sh
-docker run -p 4040:4040 -v lex-store:/data ghcr.io/alpibrusl/lex:v0.9.8
-docker run --rm -v "$(pwd):/work" -w /work ghcr.io/alpibrusl/lex:v0.9.8 check src/main.lex
+docker run -p 4040:4040 -v lex-store:/data ghcr.io/alpibrusl/lex:v0.10.7
+docker run --rm -v "$(pwd):/work" -w /work ghcr.io/alpibrusl/lex:v0.10.7 check src/main.lex
 ```
 
 **From source** — requires Rust 1.80+:

--- a/scripts/check-readme-version.sh
+++ b/scripts/check-readme-version.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Fail if README.md advertises an install version other than the workspace's.
+#
+# The install snippets (release tarball, container tags) are copy-pasted by
+# newcomers, so a stale version there hands them an old binary. This check
+# makes the drift a CI failure instead of a silent papercut.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+want="$(grep -m1 '^version' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')"
+[ -n "$want" ] || { echo "could not read version from Cargo.toml"; exit 1; }
+
+# Every `lex-vX.Y.Z-` tarball name and `ghcr.io/alpibrusl/lex:vX.Y.Z` tag.
+found="$(grep -oE 'lex-v[0-9]+\.[0-9]+\.[0-9]+-|ghcr\.io/alpibrusl/lex:v[0-9]+\.[0-9]+\.[0-9]+' README.md \
+         | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | sort -u || true)"
+
+[ -n "$found" ] || { echo "no version references found in README.md — check the patterns in $0"; exit 1; }
+
+status=0
+while read -r v; do
+  if [ "$v" != "$want" ]; then
+    echo "README.md advertises v$v but Cargo.toml is $want"
+    status=1
+  fi
+done <<< "$found"
+
+if [ "$status" -eq 0 ]; then
+  echo "README install version matches Cargo.toml ($want)"
+else
+  echo
+  echo "Fix: update the install snippets in README.md to v$want."
+fi
+exit "$status"


### PR DESCRIPTION
Found while auditing every repo's docs against its code.

**The problem.** The Install section advertised `v0.9.8` — nine releases behind `Cargo.toml`'s `0.10.7` — in three places: the release tarball name and both `ghcr.io/alpibrusl/lex` container tags. Since these are copy-pasted verbatim by newcomers, the front door of the project was handing out an old binary.

**The fix.** Snippets updated to `v0.10.7` (confirmed against the published release assets), plus `scripts/check-readme-version.sh`, run in CI, which fails when the README's advertised version doesn't match `Cargo.toml`. Verified it passes on the fixed README and fails on a deliberately reverted one.

Everything else in this README checked out: all 18 referenced paths exist, and every CLI command used in the examples is a real dispatched subcommand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YQhGburvsFqwHX5knxNWf

---
_Generated by [Claude Code](https://claude.ai/code/session_018YQhGburvsFqwHX5knxNWf)_